### PR TITLE
Enable `--config=clangX` for compiling with Clang X

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,14 @@
+# Use platforms for compiling C/C++ code.
+build --incompatible_enable_cc_toolchain_resolution
+
+# Allow the user to switch to various Clang version for compiling everything.
+build:clang11 --platform_suffix=clang11
+build:clang11 --//build:requested_compiler_flag=clang11
+build:clang14 --platform_suffix=clang14
+build:clang14 --//build:requested_compiler_flag=clang14
+
+# Add a generic alias if the user doesn't care about the exact version.
+build:clang --config=clang14
+
+# Compile with clang by default
+build --config=clang14

--- a/README.md
+++ b/README.md
@@ -10,15 +10,23 @@ This is very much a work in progress and the top priority for improvement right 
 the following command:
 
 ```sh
-bazel test //au/...:all --cxxopt='-std=c++14'
+bazel test //au/...:all
 ```
 
 This assumes you have set up `direnv` or installed `bazel` on your system.  If you haven't done
 either of those, then run `./tools/bin/bazel` instead of `bazel`.  (But you should probably set up
 `direnv`; it makes your life much easier!)
 
-The build will likely use whatever toolchain components you happen to have on your system.  Our
-immediate goal is to add one hermetic toolchain for each officially supported target platform, and
-to be able to select them by passing, say, `--config=clang11`, `--config=gcc10`, etc. While getting
-this to work, we have added only enough code to be able to kick the tires on the build process.
-Once we have it working, we'll add the rest of the code.
+The build will use a hermetic clang toolchain by default.
+
+### Available compilers
+
+Use the following `--config` settings to switch to different compilers.
+
+| Compiler | Config option |
+| --- | --- |
+| Latest supported Clang | `--config=clang` |
+| Clang 11 | `--config=clang11` |
+| Clang 14 | `--config=clang14` |
+
+Note that the sandboxed compilers do not use a sysroot.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,64 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+    ],
+    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
+BAZEL_TOOLCHAIN_REF = "056aeaa01900f5050a9fed9b11e2d365a684831a"
+BAZEL_TOOLCHAIN_SHA = "93aa940bcaa2bfdd8153d4d029bad1ccc6c0601e29ffff3a23e1d89aba5f61fa"
+
+http_archive(
+    name = "com_grail_bazel_toolchain",
+    sha256 = BAZEL_TOOLCHAIN_SHA,
+    strip_prefix = "bazel-toolchain-{ref}".format(ref = BAZEL_TOOLCHAIN_REF),
+    canonical_id = BAZEL_TOOLCHAIN_REF,
+    url = "https://github.com/grailbio/bazel-toolchain/archive/{ref}.tar.gz".format(ref = BAZEL_TOOLCHAIN_REF),
+)
+
+load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
+
+bazel_toolchain_dependencies()
+
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+
+llvm_toolchain(
+    name = "llvm_11_toolchain",
+    llvm_version = "11.1.0",
+    cxx_standard = {
+        "": "c++14",
+    },
+    target_settings = {
+        "": ["@//build:clang11_requested"],
+    },
+)
+
+load("@llvm_11_toolchain//:toolchains.bzl", llvm_11_register_toolchains="llvm_register_toolchains")
+
+llvm_11_register_toolchains()
+
+llvm_toolchain(
+    name = "llvm_14_toolchain",
+    llvm_version = "14.0.0",
+    cxx_standard = {
+        "": "c++14",
+    },
+    target_settings = {
+        "": ["@//build:clang14_requested"],
+    },
+)
+
+load("@llvm_14_toolchain//:toolchains.bzl", llvm_14_register_toolchains="llvm_register_toolchains")
+
+llvm_14_register_toolchains()
+
+http_archive(
     name = "com_google_googletest",
     sha256 = "24564e3b712d3eb30ac9a85d92f7d720f60cc0173730ac166f27dda7fed76cb2",
     strip_prefix = "googletest-release-1.12.1",

--- a/build/BUILD
+++ b/build/BUILD
@@ -1,0 +1,22 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+string_flag(
+    name = "requested_compiler_flag",
+    build_setting_default = "",
+    values = [
+        "clang11",
+        "clang14",
+    ],
+)
+
+config_setting(
+    name = "clang11_requested",
+    flag_values = {"requested_compiler_flag": "clang11"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "clang14_requested",
+    flag_values = {"requested_compiler_flag": "clang14"},
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This patch adds a few config settings. The `--config=clang11` setting
allows the user to compile with Clang 11. The `--config=clang14`
setting lets folks compile with Clang 14. The `--config=clang` setting
will serve as an alias for the latest version of Clang we support.

The new `--config=clang` option is the default.

    $ bazel test //au/...
    INFO: Analyzed 2 targets (53 packages loaded, 1901 targets configured).
    INFO: Found 1 target and 1 test target...
    INFO: Elapsed time: 5.931s, Critical Path: 3.95s
    INFO: 23 processes: 3 internal, 20 linux-sandbox.
    INFO: Build completed successfully, 23 total actions
    //au:zero_test                                                           PASSED in 0.1s

    INFO: Build completed successfully, 23 total actions

You can verify this with `bazel aquery`:

    $ bazel aquery //au:zero_test 2>/dev/null | grep 'Command Line'
      Command Line: (exec external/llvm_14_toolchain/bin/cc_wrapper.sh \
      Command Line: (exec external/llvm_14_toolchain/bin/cc_wrapper.sh \
      Command Line: (exec external/llvm_14_toolchain/bin/llvm-strip \
      Command Line: (exec external/bazel_tools/tools/test/test-setup.sh \

and:

    $ bazel aquery --config=clang11 //au:zero_test 2>/dev/null | grep 'Command Line'
      Command Line: (exec external/llvm_11_toolchain/bin/cc_wrapper.sh \
      Command Line: (exec external/llvm_11_toolchain/bin/cc_wrapper.sh \
      Command Line: (exec external/llvm_11_toolchain/bin/llvm-strip \
      Command Line: (exec external/bazel_tools/tools/test/test-setup.sh \
