### PR TITLE
Provide `tools/bin/clang-format`

### DIFF
--- a/tools/bin/clang-format
+++ b/tools/bin/clang-format
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Aurora Innovation, Inc. Proprietary and Confidential. Copyright 2022.
 
-bazel run \
+bazel \
+  --nohome_rc \
+  run \
   --ui_event_filters=-info,-stdout,-stderr \
   --noshow_progress \
   @llvm_14_toolchain_llvm//:bin/clang-format \


### PR DESCRIPTION
This will let users authoritatively use a specific version of
`clang-format` which we know works (specifically, from clang 14).

Users who have set up `direnv` will be able to run it by typing
`clang-format`.  To test that this works, after checking out this
branch, refresh direnv (`cd ~;cd -`), and run `clang-format --version`:
you should get `clang-format version 14.0.0`.