### PR TITLE
Add `--units` parameter to `make-single-file`

### DIFF
--- a/tools/bin/make-single-file
+++ b/tools/bin/make-single-file
@@ -33,7 +33,7 @@ def parse_command_line_args(argv):
 
     parser.add_argument("main_files", nargs="+", help="The main files to aggregate")
 
-    parser.add_argument("--units", nargs="+", help="The units to include")
+    parser.add_argument("--units", nargs="*", default=[], help="The units to include")
 
     parser.add_argument(
         "--prefix",


### PR DESCRIPTION
Now that we've split up the units, adding new units in the single-file
script has become extremely tedious, e.g.,

```sh
make-single-file \
  au/au.hh \
  au/io.hh \
  au/units/meters.hh \
  au/units/seconds.hh \
  au/units/grams.hh \
  au/units/kelvins.hh \
  > ~/au.hh
```

We can simplify this quite a bit by making the above equivalent to this:

```sh
make-single-file \
  au/au.hh \
  au/io.hh \
  --units meters seconds grams kelvins \
  > ~/au.hh
```

I tested this change with a downstream PR, coming soon, which will add
unit tests for the single-file versions we generate for the docs.  I
also verified that we can still call the script with no `--units`
supplied.