### PR TITLE
Unlock value member handle with equivalent unit

### DIFF
--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -73,7 +73,7 @@ TEST(QuantityPoint, SupportsDirectAccessWithSameUnit) {
 
 TEST(QuantityPoint, SupportsDirectConstAccessWithSameUnit) {
     const auto p = meters_pt(3.5);
-    EXPECT_TRUE(first_seems_like_data_member_of_second(p.data_in(Meters{}), p));
+    EXPECT_EQ(static_cast<const void *>(&p.data_in(Meters{})), static_cast<const void *>(&p));
 }
 
 TEST(QuantityPoint, SupportsDirectAccessWithEquivalentUnit) {
@@ -87,10 +87,12 @@ TEST(QuantityPoint, SupportsDirectAccessWithEquivalentUnit) {
 
 TEST(QuantityPoint, SupportsDirectConstAccessWithEquivalentUnit) {
     const auto p = milli(meters_pt)(3.5);
-    EXPECT_TRUE(first_seems_like_data_member_of_second(p.data_in(Micro<Kilo<Meters>>{}), p));
+    EXPECT_EQ(static_cast<const void *>(&p.data_in(Micro<Kilo<Meters>>{})),
+              static_cast<const void *>(&p));
 
     // Uncomment to test compile time failure:
-    // EXPECT_TRUE(first_seems_like_data_member_of_second(p.data_in(Micro<Meters>{}), p));
+    // EXPECT_EQ(static_cast<const void *>(&p.data_in(Micro<Meters>{})),
+    //           static_cast<const void *>(&p));
 }
 
 TEST(QuantityPoint, SupportsDirectAccessWithQuantityMakerOfSameUnit) {
@@ -101,7 +103,7 @@ TEST(QuantityPoint, SupportsDirectAccessWithQuantityMakerOfSameUnit) {
 
 TEST(QuantityPoint, SupportsDirectConstAccessWithQuantityMakerOfSameUnit) {
     const auto p = celsius_pt(3.5);
-    EXPECT_TRUE(first_seems_like_data_member_of_second(p.data_in(celsius_pt), p));
+    EXPECT_EQ(static_cast<const void *>(&p.data_in(celsius_pt)), static_cast<const void *>(&p));
 }
 
 TEST(QuantityPoint, SupportsDirectAccessWithQuantityMakerOfEquivalentUnit) {
@@ -115,10 +117,11 @@ TEST(QuantityPoint, SupportsDirectAccessWithQuantityMakerOfEquivalentUnit) {
 
 TEST(QuantityPoint, SupportsDirectConstAccessWithQuantityMakerOfEquivalentUnit) {
     const auto p = milli(meters_pt)(3.5);
-    EXPECT_TRUE(first_seems_like_data_member_of_second(p.data_in(micro(kilo(meters_pt))), p));
+    EXPECT_EQ(static_cast<const void *>(&p.data_in(micro(kilo(meters_pt)))),
+              static_cast<const void *>(&p));
 
     // Uncomment to test compile time failure:
-    // EXPECT_TRUE(first_seems_like_data_member_of_second(p.data_in(meters_pt), p));
+    // EXPECT_EQ(static_cast<const void*>(&p.data_in(meters_pt)), static_cast<const void*>(&p));
 }
 
 TEST(QuantityPoint, HasDefaultConstructor) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -102,7 +102,7 @@ TEST(Quantity, SupportsDirectAccessWithSameUnit) {
 
 TEST(Quantity, SupportsDirectConstAccessWithSameUnit) {
     const auto x = meters(3.5);
-    EXPECT_TRUE(first_seems_like_data_member_of_second(x.data_in(Meters{}), x));
+    EXPECT_EQ(static_cast<const void *>(&x.data_in(Meters{})), static_cast<const void *>(&x));
 }
 
 TEST(Quantity, SupportsDirectAccessWithEquivalentUnit) {
@@ -116,11 +116,12 @@ TEST(Quantity, SupportsDirectAccessWithEquivalentUnit) {
 
 TEST(Quantity, SupportsDirectConstAccessWithEquivalentUnit) {
     const auto x = (milli(meters) / minute)(3.5);
-    EXPECT_TRUE(first_seems_like_data_member_of_second(x.data_in(Meters{} / Kilo<Minutes>{}), x));
+    EXPECT_EQ(static_cast<const void *>(&x.data_in(Meters{} / Kilo<Minutes>{})),
+              static_cast<const void *>(&x));
 
     // Uncomment to test compile time failure:
-    // EXPECT_TRUE(first_seems_like_data_member_of_second(x.data_in(Meters{} / Mega<Minutes>{}),
-    // x));
+    // EXPECT_EQ(static_cast<const void *>(&x.data_in(Meters{} / Mega<Minutes>{})),
+    //           static_cast<const void *>(&x));
 }
 
 TEST(Quantity, SupportsDirectAccessWithQuantityMakerOfSameUnit) {
@@ -131,7 +132,7 @@ TEST(Quantity, SupportsDirectAccessWithQuantityMakerOfSameUnit) {
 
 TEST(Quantity, SupportsDirectConstAccessWithQuantityMakerOfSameUnit) {
     const auto x = meters(3.5);
-    EXPECT_TRUE(first_seems_like_data_member_of_second(x.data_in(meters), x));
+    EXPECT_EQ(static_cast<const void *>(&x.data_in(meters)), static_cast<const void *>(&x));
 }
 
 TEST(Quantity, SupportsDirectAccessWithQuantityMakerOfEquivalentUnit) {
@@ -145,10 +146,12 @@ TEST(Quantity, SupportsDirectAccessWithQuantityMakerOfEquivalentUnit) {
 
 TEST(Quantity, SupportsDirectConstAccessWithQuantityMakerOfEquivalentUnit) {
     const auto x = (milli(meters) / minute)(3.5);
-    EXPECT_TRUE(first_seems_like_data_member_of_second(x.data_in(meters / kilo(minute)), x));
+    EXPECT_EQ(static_cast<const void *>(&x.data_in(meters / kilo(minute))),
+              static_cast<const void *>(&x));
 
     // Uncomment to test compile time failure:
-    // EXPECT_TRUE(first_seems_like_data_member_of_second(x.data_in(meters / mega(minute)), x));
+    // EXPECT_EQ(static_cast<const void *>(&x.data_in(meters / mega(minute))),
+    //           static_cast<const void *>(&x));
 }
 
 TEST(Quantity, SupportsOldStyleInWithTemplates) {

--- a/au/testing.hh
+++ b/au/testing.hh
@@ -48,26 +48,6 @@ void expect_label(const char (&label)[N]) {
     EXPECT_EQ(sizeof(unit_label<Unit>()), N);
 }
 
-// A loose heuristic to see whether the first "seems like" a data member of the second.
-//
-// Its address shouldn't be before its apparent container's address.  And the address of the "next"
-// member of this type shouldn't be before the address of the "next" container.
-//
-// Also, they shouldn't be the same type.
-template <typename First, typename Second>
-bool first_seems_like_data_member_of_second(const First &a, const Second &b) {
-    static_assert(!std::is_same<First, Second>::value,
-                  "This function only makes sense for distinct types");
-
-    const void *start_a = &a;
-    const void *start_b = &b;
-
-    const void *end_a = &a + sizeof(First);
-    const void *end_b = &b + sizeof(Second);
-
-    return (start_a >= start_b) && (end_a <= end_b);
-}
-
 namespace detail {
 // Compute the absolute difference in a specified Unit, with a floating point Rep.
 template <typename ResultUnit, typename Q1, typename Q2>

--- a/au/testing_test.cc
+++ b/au/testing_test.cc
@@ -8,21 +8,6 @@ using ::testing::Not;
 
 namespace au {
 
-struct Compound {
-    int first;
-    double second;
-};
-
-TEST(FirstSeemsLikeDataMemberOfSecond, TrueForEachMember) {
-    constexpr auto compound = Compound{1, 2.3};
-
-    EXPECT_TRUE(first_seems_like_data_member_of_second(compound.first, compound));
-    EXPECT_FALSE(first_seems_like_data_member_of_second(compound, compound.first));
-
-    EXPECT_TRUE(first_seems_like_data_member_of_second(compound.second, compound));
-    EXPECT_FALSE(first_seems_like_data_member_of_second(compound, compound.second));
-}
-
 TEST(SameTypeAndValue, FailsUnlessBothAreSame) {
     EXPECT_THAT(312, SameTypeAndValue(312));
     EXPECT_THAT(312, Not(SameTypeAndValue(314)));


### PR DESCRIPTION
We add a `.data_in(u)` member for `Quantity` and `QuantityPoint`.  This
gives a direct handle to the value member of the underlying numeric type
(Rep).  To "unlock" it, `u` must be an instance of any _equivalent_ Unit
or Q-Maker.  Explicitly:

- For `Quantity`, we use quantity-equivalence, and the "Q-Maker" is
  `QuantityMaker`.
- For `QuantityPoint`, we use point-equivalence, and the "Q-Maker" is
  `QuantityPointMaker`.

In case this sounds too complicated, these examples should clarify.

- If `q = feet(3)`, then `q.data_in(feet)` or `q.data_in(Feet{})` will
  _work_, because we provided the same unit.
- If `q = kilo(hertz)(5)`, then `q.data_in(inverse(milli(seconds)))` or
  `q.data_in(UnitInverseT<Milli<Seconds>>{})` will _work_, because `q`
  is a `Quantity` and these units are _quantity-equivalent_.
- If `p = celsius_pt(20)`, then `p.data_in(celsius_pt)` or
  `p.data_in(Celsius{})` will _work_.  `p.data_in(kelvins_pt)` will
  _not_ work, because `p` is a `QuantityPoint` and Kelvins are _not
  point-equivalent_ to Celsius.

For mutable handles, we test the functions by... well, mutating.  For
const handles, we need to test something about the addresses of the
object, and of its `.data_in()` result.  I tried writing a reasonable
utility, and gave it a few tests of its own.

Unit-based overloads are implemented _in terms of_ Q-maker based
overloads, and not vice versa, because the latter are by far more
common, and we want the commoner case to be faster to compile.

Fixes #26.

Test plan:
- [x] Include unit tests
- [x] Measure compile time impact on benchmarks and real targets