### PR TITLE
Update doc website on every push to main

### DIFF
--- a/.github/workflows/deploy-doc-site.yml
+++ b/.github/workflows/deploy-doc-site.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - chiphogg/autodeploy-doc-site
 
 jobs:
   build:


### PR DESCRIPTION
This workflow will keep the documentation website up to date with main,
automatically.

We also used an action which sets the git user to the github-actions
bot, which makes the branch history for `gh-pages` look nicer.

Currently, in order for the manifest in `au.hh` and `au_noio.hh` to be
correct, we must fetch the entire repo (all branches and tags) at the
checkout step.  This will get more expensive over time as the repo
grows.  However, we don't expect huge amounts of growth, _and_ this step
is not very time-sensitive, _and_ we're currently at only 1 second, so
this should be good enough for the foreseeable future.

To test it, we set it up initially to trigger on pull requests, too.
This let us hammer out the kinks.  Check out the recent history of the
`gh-pages` branch (especially activity on Dec 24, 2022) to see the
results: https://github.com/aurora-opensource/au/commits/gh-pages

After this PR was first posted, we also reduced the permissions of the
`GITHUB_TOKEN` globally, to be read-only by default (so we could follow
the principle of least privilege).  This specific workflow needs write
access to the contents of the repository, because we are pushing commits
to the `gh-pages` branch.  Thus, we now include this permission
explicitly.