### PR TITLE
Run clang-format-lint on pull_request events & pushes to main

### DIFF
--- a/au/zero.hh
+++ b/au/zero.hh
@@ -29,7 +29,7 @@ struct Zero {
     // Implicit conversion to chrono durations.
     template <typename Rep, typename Period>
     constexpr operator std::chrono::duration<Rep, Period>() const {
-        return std::chrono::duration<Rep, Period>{ 0};
+        return std::chrono::duration<Rep, Period>{0};
     }
 };
 


### PR DESCRIPTION
### Summary 

The previous behavior was to trigger `clang-format-lint` on all `push` events.  This worked well for members with write permissions on `au` who pushed their branches to the upstream repo, but won't necessarily trigger on contributors that submit PRs from a fork.  For example, this [test PR checkrun](https://github.com/aurora-opensource/au/pull/61/checks?check_run_id=10439485970) from my fork which introduced a lint error was not run because I hadn't accepted GitHub actions to run in my personal fork:
<img width="715" alt="Screen Shot 2023-01-04 at 11 23 03 AM" src="https://user-images.githubusercontent.com/1063873/210601528-3eadf303-a1ab-4d64-a22f-6db6b5d08fae.png">

Instead, trigger this job on 2 event types:

* pushes to the `main` branch.  this will catch any merge integration issues
* `pull_request` events.  this will trigger on contributors PRs to Aurora's `au`, though it oversubscribes a bit (for example, reruns the action if a PR is closed then reopened even though the HEAD SHA hasn't changed).  based on current duration of builds this isn't too much overhead and will provide au maintainers better signal, so I think it's a worthy tradeoff

### Test Plan

* Temporarily introduced lint failure in [af14606](https://github.com/aurora-opensource/au/pull/62/commits/af14606e305f8a7c3712508a37bad727c2bc26bf) that was caught [here](https://github.com/aurora-opensource/au/actions/runs/3839793143/jobs/6538037204).  
* After landing, will retest on a forked PR