### PR TITLE
Expand copyright notice for single-file packagings

### DIFF
--- a/tools/bin/make-single-file
+++ b/tools/bin/make-single-file
@@ -11,6 +11,19 @@ import sys
 
 AURORA_COPYRIGHT = "Copyright {year} Aurora Operations, Inc."
 
+APACHE_HEADER = f"""
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License."""
+
 
 def main(argv=None):
     """
@@ -172,6 +185,8 @@ def include_lines(files):
 def print_unified_file(files, args):
     """Print the single-file output to stdout."""
     print(f"// {AURORA_COPYRIGHT.format(year=datetime.datetime.now().year)}")
+    for line in APACHE_HEADER.splitlines():
+        print(f"// {line}")
     print()
     print("#pragma once")
     print()


### PR DESCRIPTION
Files in our repo use a one-line copyright notice, which is sufficient
because they will always be distributed alongside the `LICENSE.txt`
file.

The generated single-file versions of the library are different: they
are intended to be packaged alone.  There will be copies of variants of
these files all over all kinds of machines.  Thus, it makes sense to
include the full copyright notice for these files.

To test this, run `au-docs-serve`, and observe the following header in
the generated files:

```cpp
// Copyright 2023 Aurora Operations, Inc.
//
// Licensed under the Apache License, Version 2.0 (the "License");
// you may not use this file except in compliance with the License.
// You may obtain a copy of the License at
//
//    http://www.apache.org/licenses/LICENSE-2.0
//
// Unless required by applicable law or agreed to in writing, software
// distributed under the License is distributed on an "AS IS" BASIS,
// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
// See the License for the specific language governing permissions and
// limitations under the License.
```