### PR TITLE
Trim trailing whitespace from copyright header

### DIFF
--- a/tools/bin/make-single-file
+++ b/tools/bin/make-single-file
@@ -186,7 +186,7 @@ def print_unified_file(files, args):
     """Print the single-file output to stdout."""
     print(f"// {AURORA_COPYRIGHT.format(year=datetime.datetime.now().year)}")
     for line in APACHE_HEADER.splitlines():
-        print(f"// {line}")
+        print(f"// {line}".rstrip())
     print()
     print("#pragma once")
     print()


### PR DESCRIPTION
This is a quick follow-on to #67.  I noticed that the generated C++ file
contains trailing whitespace in its blank lines.  Adding a simple
`.rstrip()` takes care of this.

I tested by running `au-docs-serve`, and downloading a generated
single-file package.  I verified the trailing whitespace was gone.