### PR TITLE
Show output by default for failed tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,3 +21,7 @@ build:gcc --config=gcc10
 
 # Compile with clang by default
 build --config=clang14
+
+# Show test output when there are errors.
+# Making this true by default significantly improves developer experience.
+test --test_output=errors


### PR DESCRIPTION
Currently, running `bazel test //...:all` can be a frustrating
experience when any test fails.  Rather than printing the test output
directly, bazel will print out the _path to a log file_ where users can
view that output.

To test this PR, pick a test and make it fail, and then run:

```sh
bazel test //...:all
```

If you do this without this PR, you should see only the overall results.
If you do this _with_ this PR, you'll see the error as well.