### PR TITLE
Remove TODO warning in forking instructions

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -32,11 +32,6 @@ up after the fact.  We'll provide detailed instructions below.
     You can directly use the instructions below, which we adapted from [this
     guide](https://admcpr.com/what-the-fork/).
 
-    !!! warning "TODO"
-        We need to try these instructions, in detail, to make sure they work.  Somebody should
-        create a PR to remove this warning---and do so from a clone which was originally tracking
-        the main repository, but which transitioned to a fork by following these very instructions.
-
     1. **[Create the fork][fork] on GitHub.**
 
            You will need to note the name of your fork, in the format `user_name/repo_name`.


### PR DESCRIPTION
This PR was created from a clone of the main repository, which was
transitioned to a personal fork which was created after the fact.  I
followed the instructions in the development guide.  Therefore, if this
PR works, then we should be confident enough in these Instructions to
remove the TODO warning.

As it turns out, I was able to smoothly transition my local clone to
track the fork.  What's more, I was able to upload a branch I created on
my personal laptop, with no problems.  However, one wrinkle is that in
the process of actually creating the PR, I was asked to SSO for
`aurora-opensource`.  I assume this will _not_ be the case for users who
are not _members_ of `aurora-opensource`.  However, even if it is, that
seems like a separate issue which doesn't impact the correctness of the
switch-to-fork instructions.