### PR TITLE
Fix doc links from "editing pencil"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ site_author: "Au team"
 copyright: Copyright &copy; 2022, Aurora Innovation, Inc. All rights reserved
 
 repo_url: https://github.com/aurora-opensource/au
+edit_uri: blob/main/docs
 
 theme:
   name: material


### PR DESCRIPTION
On our doc site (https://aurora-opensource.github.io/au/), there is a
pencil symbol at the top of each page.  Clicking it currently gives a
404 error.  This PR will fix that link so that it points to the source
code for that page.

The docs (https://www.mkdocs.org/user-guide/configuration/#edit_uri)
suggest using `blob` instead of `edit`, so that we can smoothly support
both those who are, and are not, logged into github.

Test plan
---------

Ran `au-docs-serve`.  Clicked the pencil on a displayed page.  Without
this PR, it gives a 404; with this PR, it goes to the correct page.