### PR TITLE
Add core reference docs

### DIFF
--- a/docs/discussion/implementation/index.md
+++ b/docs/discussion/implementation/index.md
@@ -1,0 +1,8 @@
+# Implementation Details
+
+This section provides in-depth discussion about core implementation details of Au.  If you want to
+understand _how_ the library works, this is a good place to go.  Here's a rough guide.
+
+- **[Vector Space Representations](./vector_space.md)**.  We're not talking about position vectors
+  or velocity vectors!  There's a different kind of vector at the heart of every units library.
+  This is the core foundational concept on which we built Au's implementation.

--- a/docs/discussion/implementation/vector_space.md
+++ b/docs/discussion/implementation/vector_space.md
@@ -1,0 +1,181 @@
+# Vector Space Representations
+
+To understand why _vector space representations_ are so important for units libraries, we'll dig
+into the most fundamental example.  After that, we'll look at some other instances of vector space
+representations in our library.
+
+Consider [Dimensions](../../reference/detail/dimension.md).  How can we teach the library to recognize
+that, say, the product of the Dimensions `Speed` and `Time` is the Dimension `Length`?  If these
+three Dimensions are all primitive, irreducible objects, this is very challenging.  However, if
+`Speed` is just an _alias_ for `(Length / Time)`, then it's easy to see that `(Length / Time)
+* Time` reduces to `Length`.
+
+This is what we do: we single out certain Dimensions and call them "Base Dimensions".  Any valid
+choice must fulfill these conditions:
+
+1. **Independence:** no product of rational powers of Base Dimensions is _dimensionless_, unless all
+   exponents are 0.
+
+2. **Completeness:** every Dimension of interest can be represented as some product of rational
+   powers of Base Dimensions.
+
+The reader may recognize these properties of _Base Dimensions_ as analogous to the defining
+properties of [_Basis **Vectors**_](https://en.wikipedia.org/wiki/Basis_(linear_algebra)) in
+a vector space, but with these differences:
+
+- instead of _adding_ vectors, we _multiply_ Base Dimensions
+- instead of _multiplying_ vectors by a scalar, we _raise them to a power_
+
+In fact, we can bridge this gap if we consider the **exponents** of the dimensions to be the
+**scalars** of the vector space.  In a sense, the "logarithms" of the dimensions form a vector
+space; in this case, over the rationals.
+
+This is the "vector space representation" for Dimensions.
+
+## Fleshing out the analogy
+
+How do the [defining properties of vector
+spaces](https://en.wikipedia.org/wiki/Vector_space#Definition_and_basic_properties) manifest
+themselves here?  Let the space of all Dimensions be $\mathscr{D}$.  For any dimensions $D, D_1,
+D_2, D_3 \in \mathscr{D}$, and any rational numbers $a, b \in \mathbb{Q}$, we have:
+
+- **Associativity:** $D_1 \cdot (D_2 \cdot D_3) = (D_1 \cdot D_2) \cdot D_3$
+- **Commutativity:** $D_1 \cdot D_2 = D_2 \cdot D_1$
+- **Identity (Vector):** $\exists \pmb1 \in \mathscr{D}: \,\, \pmb1 \cdot D = D \cdot \pmb1 = D,
+  \,\, \forall D$
+- **Inverse:** $\forall D \in \mathscr{D}, \exists D^{-1} \in \mathscr{D}: \,\, D \cdot D^{-1}
+  = D^{-1} \cdot D = 1$
+- **Scalar/Field Multiplication Compatibility:** $(D^a)^b = D^{(ab)}$
+      - (Recall that "scalar multiplication" in "ordinary" vector spaces corresponds to
+        _exponentiation_ in _our_ vector space.)
+- **Identity (Scalar):**  $\exists 1 \in \mathbb{Q}: \,\, D^1 = D$
+- **Distributivity (Vectors):** $(D_1 \cdot D_2)^a = D_1^a \cdot D_2^a$
+- **Distributivity (Scalars):** $D^{(a + b)} = D^a \cdot D^b$
+
+## C++ Implementation Strategies
+
+The abstract concepts above form the core of basically every C++ units library.  When it comes to
+_implementation_, there are a variety of choices.
+
+### Naive approach: positional arguments
+
+The simplest implementation of a vector space is to use positional template parameters to represent
+the coefficients (exponents) of each basis vector (base dimension).  For example:
+
+```cpp
+// Basic approach (not used in this library)
+template<typename LengthExp, typename TimeExp>
+struct Dimension;
+
+using Length = Dimension<std::ratio<1>, std::ratio<0>>;
+using Time   = Dimension<std::ratio<0>, std::ratio<1>>;
+using Speed  = DimQuotientT<Length, Time>;
+```
+
+This approach is easy to implement, but its simplicity comes at a cost.
+
+- Compiler errors are inscrutable.  (What exactly does
+  `Dimension<std::ratio<1, 1>, std::ratio<-1, 1>>` represent?)
+
+- If we need to add a new basis vector, it will affect an immense number of callsites.
+
+- Some applications need infinitely many basis vectors!  This approach is a complete non-starter.
+
+### Advanced approach: variadic templates
+
+We can solve all of these problems by making `Dimension` a _variadic_ template.
+
+```cpp
+// Advanced approach (the one we use, although simplified here)
+template<typename... BaseDimPowers>
+struct Dimension;
+
+using Length = Dimension<base_dim::Length>;
+using Time   = Dimension<base_dim::Time>;
+using Speed  = DimQuotientT<Length, Time>;  // As before.
+```
+
+Compiler errors are now easy (or at least possible) to read: when we see something like
+`Dimension<base_dim::Length, Pow<base_dim::Time, -1>>`, we can recognize it as "Speed".  And adding
+new basis vectors---even _arbitrarily many_ new ones---doesn't affect any existing callsites.
+
+The downside is that the added complexity incurs new risk.  Now we have to care about the **order**
+of the template parameters; otherwise, we could have _different types_ representing the _same
+conceptual Dimension_.  Fortunately, that's exactly why we built the [`//au:packs`
+target](../../reference/detail/packs.md): to handle these subtleties robustly.
+
+## Other vector space representations
+
+Above, we focused on Dimensions as an example use case for the vector space representation.  Though
+by far the most common in units libraries, it's not the only one that adds value.  Here are some
+others worth recognizing.
+
+### Magnitude
+
+The ratio between two Units of the same Dimension is a positive real number: a "Magnitude".  We use
+a vector space representation for Magnitudes, because then it will naturally support all the same
+operations which Dimensions support.  But then, what are the basis vectors?  What numbers can we use
+that are "independent", in the sense that every Magnitude gets a **unique** representation?
+
+Prime numbers are a great start!  Given any collection of primes, $\{p_1, \ldots, p_N\}$, and
+corresponding rational exponents $\{a_1, \ldots, a_N\}$, the product
+$p_1^{a_1} \cdot (\ldots) \cdot p_N^{a_N}$ is _unique_: no other collection $\{a_1, \ldots, a_N\}$
+can produce the same number[^1].
+
+[^1]: Technically, this is only true for a _finite_ collection of primes, though the collection can
+be arbitrarily large.  If we took an _infinite_ collection of primes, it wouldn't _just_ give some
+numbers multiple representations --- it would give _every_ number _uncountably infinitely many_
+distinct representations!  In practice, this distinction is largely academic, because our library
+currently only targets computers with finite amounts of memory.
+
+This already lets us represent _anything_ we could get with `std::ratio`.  And, unlike a
+`(num, denom)` representation, we're always automatically in lowest terms: any common factors cancel
+out automatically when we represent it via its prime factorization!
+
+In fact, we have _surpassed_ `std::ratio`'s functionality, too.  We can handle very large numbers
+with negligible risk of overflow: `yotta` ($10^{24}$) doesn't even fit in `std::intmax_t`, but
+`pow<24>(mag<10>())`[^2] handles it with ease.  We can even handle radicals: something unthinkable for
+`std::ratio`, like $\sqrt{2}$, is as easy as `root<2>(mag<2>())`[^3].
+
+[^2]: `pow<24>(mag<10>())` expands to `Magnitude<Pow<Prime<2>, 24>, Pow<Prime<5>, 24>>`.
+
+[^3]: `root<2>(mag<2>())` expands to `Magnitude<RatioPow<Prime<2>, 1, 2>>`.
+
+Finally, we can incorporate other irrational numbers, too.  No units library is complete without
+robust support for $\pi$, but `std::ratio` isn't up to the task.  For vector space magnitude
+representations, though, its difficulty becomes a strength.  We know there is no collection of
+exponents $\{a_i\}$ such that $\pi = \prod\limits_{i=1}^N p_i^{a_i}$, for any collection of primes
+$\{p_i\}$.  This means that $\pi$ is **independent**, and we can add it as a new basis vector.  Then
+the ratio of, say, `Degrees` to `Radians` (i.e., $\pi / 180$) could be expressed as
+`PI / mag<180>()`[^4].
+
+[^4]: `PI / mag<180>()` expands to `Magnitude<Pow<Prime<2>, -2>, Pow<Prime<3>, -2>, Pi,
+Pow<Prime<5>, -1>>`.
+
+### Units
+
+If we form a Unit by combining other units---say, `Miles{} / Hours{}`---it's useful to retain the
+identities of the units that went into it.  There are several reasons to prefer this to, say,
+converting everything to a coherent combination of preferred "base units", and some Magnitude for
+scaling.
+
+- It will be easy to generate a compound _label_, by combining the primitive labels for `Miles` and
+  `Hours`.
+
+- Compiler errors will mention only familiar, recognizable Units.
+
+- It promotes cancellation where appropriate: `Miles{} / Hours{}` times `Hours{}` will give simply
+  `Miles{}`.
+
+Our treatment of Units differs from other vector space instances, because we prefer not to use the
+container type (in this case, `UnitProduct<...>`) unless we have to: after all, `Meters` is more
+user-friendly than `UnitProduct<Meters>`, let alone something awful like
+`UnitProduct<RatioPow<Meters, 1, 0>>`!  We support this use case with the following strategy:
+
+- **wrap-if-necessary** on the way **in** (via `AsPackT`)
+
+- **unwrap-if-possible** on the way **out** (via `UnpackIfSoloT`)
+
+This was the only machinery we needed to add: apart from that, we were able to leverage our
+pre-existing [packs](../../reference/detail/packs.md) support to provide a fluent experience for
+compound units.

--- a/docs/discussion/index.md
+++ b/docs/discussion/index.md
@@ -1,0 +1,15 @@
+# Discussion Docs
+
+This section is for docs that illuminate Au's underpinnings.  The kinds of docs that go here include
+philosophy and principles, deep dives on design choices, explanations of core concepts, and more.
+
+In terms of the [four categories of documentation](https://documentation.divio.com/) --- which we
+try to follow --- this is also known as
+"[explanation](https://documentation.divio.com/explanation/)".  It's most useful when you're
+**studying**, rather than working, and it focuses on **theoretical** rather than practical
+knowledge.
+
+Here's a guide to the main categories.
+
+- **[Implementation details](./implementation/index.md).**  Concepts and design discussions that
+  help you understand _how_ we made Au.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,8 +31,11 @@ effectively:
   error, what they mean, and how to fix them.  Take key snippets from your compiler errors, and
   use in-page search to get help!
 
-- **[How-to guides](./howto/index.md).**  Detailed instructions for common tasks you may encounter
-  in using the library.
+- **[How-to guides](./howto/index.md).**  Step-by-step instructions for accomplishing common tasks
+  you may encounter in using the library.
+
+- **[Reference](./reference/index.md).**  Detailed reference documentation on `Quantity`,
+  `QuantityPoint`, units, magnitudes, and other core library abstractions.
 
 We also have a [GitHub Issues](https://github.com/aurora-opensource/au/issues) page for tracking
 problems and future work.  If you have a bug report or feature request, check the existing issues to
@@ -41,17 +44,13 @@ _resolution_, we will do our best to respond quickly so you know you've been hea
 stand on the issue.
 
 !!! tip
-    Feel free to vote for existing issues by reacting to the main post with the :+1: emoji: we'll take
-    this into account in prioritizing what to work on!
+    Feel free to vote for existing issues by reacting to the main post with the :+1: emoji: we'll
+    take this into account in prioritizing what to work on!
 
-## Planned future content
+## Shoring up foundations
 
-While Au has had plenty of production experience internally at Aurora, its life as a public open
-source library is just beginning.  Here are some sections we know we'll need to add.
+When you're looking to understand the library better (as opposed to actively trying to accomplish
+some task), these docs will help you strengthen your foundations.
 
-- **Reference.**  Detailed reference documentation on `Quantity`, `QuantityPoint`, units,
-  magnitudes, and other core library abstractions.
-
-- **Explanation.**  There's plenty we'd love to share about the design choices that underpin the
-  library. While launching Au, we've de-prioritized this section in favor of the more directly
-  practical parts --- but while it may be less _urgent_, it's no less _important_.
+- **[Discussion](./discussion/index.md).**  Philosophy and principles, deep dives on design choices,
+  explanations of core concepts, and more.

--- a/docs/install.md
+++ b/docs/install.md
@@ -105,13 +105,12 @@ Au!
 
 Every single-file package automatically includes the following features:
 
-!!! warning
-    Before public release, we should ensure each of the following items has a documentation page,
-    and link to that page here:
+!!! warning "TODO"
+    As reference docs become available for each of the following, we should link to them.
 
 - Basic "unit container" types: `Quantity`, `QuantityPoint`
-- Magnitude types and values, including the constant `PI`, and constants for any integer such as
-  `mag<5280>()`.
+- [Magnitude](./reference/magnitude.md) types and values, including the constant `PI`, and constants
+  for any integer such as `mag<5280>()`.
 - All prefixes for SI (`kilo`, `mega`, ...) and informational (`kibi`, `mebi`, ...) quantities.
 - Math functions, including unit-aware rounding and inverses, trigonometric functions, square roots,
   and so on.

--- a/docs/reference/detail/dimension.md
+++ b/docs/reference/detail/dimension.md
@@ -1,0 +1,33 @@
+# Dimension
+
+`Dimension` is a family of [monovalue types](./monovalue_types.md) representing equivalence classes
+of units.  Each class defines a collection of units which can be meaningfully added, subtracted, and
+compared with each other.  Familiar examples of `Dimension` include length, time, temperature,
+speed, and so on.
+
+Dimensions form a [vector space](../../discussion/implementation/vector_space.md).  We choose
+certain "base dimensions" as the basis vectors for this space.  As with other vector spaces in our
+library, `Dimension` values can be multiplied, divided, and raised to (rational) powers, and this
+arithmetic always takes place at compile time.
+
+_`Dimension` is an implementation detail._  Most end users will never name dimensions in their code,
+and never see them in their compiler errors.  Instead, users will work with [_units_](../unit.md),
+which each carry their own dimension information.  The main situation where an end user would use
+`Dimension` directly is to define the _first_ unit for a novel _base_ dimension.
+
+## Included base dimensions
+
+Au includes the following base dimensions:
+
+- `Length`
+- `Mass`
+- `Time`
+- `Current`
+- `Temperature`
+- `Angle`
+- `Information`
+- `AmountOfSubstance`
+- `LuminousIntensity`
+
+These comprise each of the seven base dimensions in the SI, with the addition of `Angle` and
+`Information`.

--- a/docs/reference/detail/index.md
+++ b/docs/reference/detail/index.md
@@ -3,6 +3,9 @@
 This section is for reference docs which most end users won't often encounter directly.  We collect
 these docs in this subfolder to keep the main folder less cluttered.  Here's a guide to the content:
 
+- **[Dimensions](./dimension.md).**  This is how we keep track of which units are mutually
+  compatible, in the sense that they can be compared and converted with each other.
+
 - **[Monovalue Types](./monovalue_types.md).**  This isn't a _specific type_ in the library; rather,
   it's a "concept" (loosely defined)[^1] which many core library types model.
 

--- a/docs/reference/detail/index.md
+++ b/docs/reference/detail/index.md
@@ -1,0 +1,15 @@
+# Implementation Details
+
+This section is for reference docs which most end users won't often encounter directly.  We collect
+these docs in this subfolder to keep the main folder less cluttered.  Here's a guide to the content:
+
+- **[Monovalue Types](./monovalue_types.md).**  This isn't a _specific type_ in the library; rather,
+  it's a "concept" (loosely defined)[^1] which many core library types model.
+
+- **[Parameter Packs](./packs.md).**  The most critical foundation for the library is _parameter
+  packs_, because this is how we implement the [vector
+  spaces](../../discussion/implementation/vector_space.md) which underpin
+  [dimensions](./dimension.md), [magnitudes](../magnitude.md), and compound units.
+
+[^1]: We're using "concept" in a loose, conceptual sense, rather than in the sense of the [language
+element](https://en.cppreference.com/w/cpp/language/constraints) which was added in C++20.

--- a/docs/reference/detail/monovalue_types.md
+++ b/docs/reference/detail/monovalue_types.md
@@ -1,0 +1,78 @@
+# Monovalue Types
+
+A "monovalue type" is a type which can only hold a single value.  This means that knowing the type
+is _equivalent_ to knowing the value, and vice versa.  We can convert back and forth between
+representing it as a type, and as a value, depending on our needs.
+
+We named this concept because it occurs again and again in Au, and the name makes it easier to refer
+to.  The "monovalue" name is based on
+[`std::monostate`](https://en.cppreference.com/w/cpp/utility/variant/monostate), which has these
+properties.  However, "monostate" could have been confused with the [monostate
+_pattern_](https://www.simplethread.com/the-monostate-pattern/), which exposes actual, changeable,
+global state to its users.  "Monovalue" also emphasizes _value semantics_, which is a core property
+of these types.
+
+## Identifying monovalue types
+
+A type `T` is a monovalue type when it fulfills these conditions.
+
+1. `T` can be instantiated.
+2. Every instance of `T` behaves identically to every other instance, in every way, and this
+   behavior does not depend on any program state.
+3. Instances of `T` support some set of operations with other types.
+
+These properties mean we can freely convert a monovalue object between its "type" and "value"
+representations.  This is a core feature of monovalue types.
+
+The second property also distinguishes monovalue types from the monostate pattern mentioned above.
+
+The third property means there has to be something you can _do_ with the instances.
+
+## Examples of monovalue types
+
+Here are some canonical examples in Au.
+
+| Type | Instance | Example Operations |
+|------|----------|------------|
+| `Zero` | `ZERO` | Comparing to any `Quantity` |
+| `Magnitude<>` | `ONE` | <ul><li>Equality comparison with other Magnitudes</li><li>`get_value<T>(ONE)`</li></ul> |
+| `Magnitude<Pi>` | `PI` | <ul><li>Equality comparison with other Magnitudes</li><li>`get_value<T>(PI)`</li></ul> |
+| `Radians` (and other units) | `Radians{}` (no special pre-formed instance) | Arithmetic with other units, such as `Radians{} / Meters{}` |
+
+## Switching between types and values
+
+To get the value of a monovalue type `T`, instantiate the type using `T{}`.
+
+To get the type of a monovalue type value `t`, pass it to `decltype(t)`.  However, if `t` is `const`
+(including `constexpr`), you'll need to use `std::decay_t<decltype(t)>`.
+
+??? info "More details on when to use `std::decay_t`"
+    It's common to provide `constexpr` instances of monovalue types, like the following.
+
+    ```cpp
+    static constexpr auto ZERO = Zero{};
+    ```
+
+    In this case, `decltype(ZERO)` would be `const Zero`, not simply `Zero`.  If we tried comparing
+    this to `Zero` in a type trait, it could fail.
+
+    Using `std::decay_t` is a concise way to avoid this problem.  However, it only arises for
+    `const` or `constexpr` instances --- and only when comparing types for exact equality --- so
+    most users won't need to worry about this most of the time.
+
+This diagram summarizes how to go back and forth using `{}` and `decltype()`.
+
+```mermaid
+flowchart LR
+
+subgraph "#quot;Realm of Types#quot;"
+  Type
+end
+
+subgraph "#quot;Realm of Instances#quot;"
+  value
+end
+
+Type -->|"auto value =<br>Type{}"| value -->|"using Type =<br>decltype(value)"| Type
+```
+

--- a/docs/reference/detail/packs.md
+++ b/docs/reference/detail/packs.md
@@ -1,0 +1,132 @@
+# Parameter packs
+
+Products of base powers are the foundation for the Au library.  We use them for:
+
+  - The [Dimension](./dimension.md) of a Unit.
+  - The [Magnitude](../magnitude.md) of a Unit.
+  - Making _compound_ Units (products of powers of units, e.g., $\text{m} \cdot \text{s}^{-2}$).
+
+We represent them as variadic parameter packs.  Each pack element represents a "base power": this is
+some "base", raised to some rational exponent.  For a base power `BP`, `BaseT<BP>` retrieves its
+base, and `ExpT<BP>` retrieves its exponent (as a `std::ratio`).
+
+!!! note
+    This approach, with products of base powers, is known as the [_vector space
+    representation_](../../discussion/implementation/vector_space.md) for Dimensions, Magnitudes,
+    and so on. The `//au:packs` target, which this page describes, is our tool for implementing
+    these vector spaces robustly.
+
+## Representing powers {#powers}
+
+These packs show up in compiler errors, and we want those errors to be as friendly as possible.
+Clutter is our enemy!  Thus, we canonicalize each base power to its simplest form.  Consider an
+arbitrary base type, `B`; here is how it shows up in the pack:
+
+  | This power of $B$...                | ...shows up in a pack as: |
+  |-------------------------------------|---------------------------|
+  | $B ^ 0$                             | (omitted)                 |
+  | $B ^ 1$                             | `B`                       |
+  | $B ^ N$, with $N$ any other integer | `Pow<B, N>`               |
+  | $B^{ N / D }$, with $D > 1$         | `RatioPow<B, N, D>`       |
+
+Canonicalizing in this way keeps our compiler errors more concise and readable.
+
+## Strict total ordering
+
+The above canonicalization tells us _what items_ to store.  We also need to be careful about _which
+order_ to store them in.  We are modeling multiplication, and in our applications, $(A \times B)$ is
+always the same as $(B \times A)$.  However, `Pack<A, B>` is _not_ the same **type** as `Pack<B, A>`!
+Thus, we are going to need a way to define whether `A` or `B` should come first inside of a `Pack`.
+
+What we need is a [_strict total ordering_](https://mathworld.wolfram.com/StrictOrder.html), which
+applies to _all types_ which might represent a Base in a given kind of Pack.  This is a critical
+foundational concept for the library, so we use explicit traits for each kind of pack.  There are
+two main elements to this API:
+
+- `InOrderFor<Pack, A, B>` is for _generic algorithms_.  It's how we **check** whether `A` and `B`
+  are in the right order for `Pack`.
+
+- `LexicographicTotalOrdering<A, B, Orderings...>` is for _implementing_ `InOrderFor` for a given
+  `Pack`.  It's how we **define** whether `A` and `B` are in order for `Pack`.
+
+The point in using `LexicographicTotalOrdering` is that it guards against the most common failure
+mode in our application: namely, two _distinct_ types which compare as _equivalent_.
+`LexicographicTotalOrdering` tries `A` and `B` against every comparator in `Orderings...`, in
+sequence.  If any comparator knows how to order `A` and `B`, we use it.  _If we run out of
+comparators, but `A` is not the same as `B`,_ then we produce a hard error.  The fix is to add a new
+comparator to "break the tie".
+
+??? example "Example: defining the ordering for a Pack"
+
+    Suppose we have a particular pack, `Pack`, and our bases are `std::ratio` instances.  We need to
+    define _some_ canonical ordering.  Let's say that we want to order first by
+    denominator---integers first, then halves, thirds, etc---and then by numerator.  We can define
+    traits for those orderings, and then combine those traits using `LexicographicTotalOrdering` to
+    implement `InOrderFor<Pack, ...>`.  Specifically:
+
+    ```cpp
+    template <typename A, typename B>
+    struct OrderByDenom : stdx::bool_constant<(A::den < B::den)> {};
+
+    template <typename A, typename B>
+    struct OrderByNum : stdx::bool_constant<(A::num < B::num)> {};
+
+    template <typename A, typename B>
+    struct InOrderFor<Pack, A, B> :
+        LexicographicTotalOrdering<A, B, OrderByDenom, OrderByNum> {};
+    ```
+
+    With this definition, something like `Pack<std::ratio<-1>, std::ratio<8>, std::ratio<1, 2>>`
+    would be _in-order_.
+
+## Validation
+
+We validate packs using type traits.  `IsValidPack<Pack, T>` is the "overall" validator.  It
+verifies that `T` is an instance of `Pack<...>`, and that its parameters satisfy the necessary
+conditions.  Specifically, those conditions are:
+
+- `AreBasesInOrder<Pack, T>`: assuming `T` is `Pack<BPs...>`, verifies that all consecutive elements
+  in `BaseT<BPs>...` are all properly ordered (according to `InOrderFor<Pack, ...>`, naturally).
+
+- `AreAllPowersNonzero<Pack, T>`: assuming `T` is `Pack<BPs...>`, verifies that
+  `Exp<BPs>::num` is nonzero for every element in `BPs`.
+
+## Algebra on Packs
+
+The whole reason we built `//au:packs` was to support exact symbolic algebra for two operations:
+_products_, and _rational powers_.  This section explains how we do that.  Our strategy is:
+
+- **The `//au:packs` target** provides _generic_ versions of these operations that are pre-built, but
+  _cumbersome_.
+
+    - (What makes them cumbersome?  They need an extra parameter to specify _which Pack_ they
+      operate on.  This is much like `InOrderFor`, which defines the ordering _for a specific type
+      of Pack_.)
+
+- **Client targets** provide _aliases_ which "hide" the extra parameter (because they know what
+  value it should take!).
+
+Let's take the "pack product" operation as an example, using `Dimension` as our Pack:
+
+```cpp
+// The `//au:packs` library provides this:
+template <template <class...> typename Pack, typename... Ts>
+using PackProductT = /* (implementation; irrelevant here) */;
+
+// A _particular_ Pack (say, `Dimension`) would expose it to their users like this:
+template <typename... Dims>
+using DimProductT = PackProductT<Dimension, Dims...>;
+
+// End users would use the _latter_, e.g.:
+using Length = DimProductT<Speed, Time>;
+```
+
+### Supported algebraic operations
+
+Here are the operations we support:
+
+- `PackProductT<Pack, Ps...>`: the product of arbitrarily many (0 or more) `Pack<...>` instances,
+  `Ps...`.
+- `PackQuotientT<Pack, P1, P2>`: the quotient `P1 / P2`.
+- `PackPowerT<Pack, P, N, D=1>`: raise the Pack `P` to the rational power `N / D`.
+- `PackInverseT<Pack, P>`: the Pack that gives the null pack when multiplied with the Pack `P`.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,6 @@
+# Reference Docs
+
+This section contains detailed reference documentation on `Quantity`, `QuantityPoint`, units,
+dimensions, magnitudes, and other core library abstractions.  The main folder is reserved for things
+that end users will routinely interact with.  Implementation details will be documented in
+a `detail` sub-folder.

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -1,0 +1,260 @@
+# Magnitude
+
+`Magnitude` is a family of [monovalue types](./detail/monovalue_types.md) representing positive real
+numbers.  These values can be multiplied, divided, and raised to (rational) powers, and this
+arithmetic always takes place at compile time.  Values can also be converted to more standard
+numeric types, such as `double` and `int`, as long as the receiving type can represent the
+magnitude's value faithfully.
+
+The core motivation is to represent ratios of different units that have the same dimension.  As
+a corollary, any unit can be scaled by a `Magnitude` to make a new unit of the same dimension.
+
+## Forming magnitudes
+
+There are 3 **valid** ways for end users to form a `Magnitude` instance.
+
+1. :heavy_check_mark: Using the `mag<N>()` helper to form the canonical representation of the
+   integer `N`.
+2. :heavy_check_mark: Writing `Magnitude<MyConstant>{}`, where `MyConstant` is a valid _irrational
+   magnitude base_.  (See the _custom bases_ section below for more details.)
+3. :heavy_check_mark: Forming products, quotients, powers, and roots of other valid `Magnitude`
+   instances.
+
+End users can also use pre-formed `Magnitude` instances from the library, such as `PI` and `ONE`.
+
+The following is a **valid, but dis-preferred way** to form a `Magnitude`.
+
+- :warning: `Magnitude<>`.
+    - **Explanation:**  This represents the number 1, but it's less readable than writing
+      `mag<1>()`.
+
+The following are **not valid** ways to form a `Magnitude`.
+
+- :x: `Magnitude<Pi, MyConstant>`.
+    - **Explanation:** Do not supply a manual sequence of template parameters.  `Magnitude` has
+      strict ordering requirements on its template parameters.  The approved methods listed above
+      are guaranteed to satisfy these requirements.
+- :x: `Magnitude<Prime<3>>`.
+    - **Explanation:** Do not supply integer bases manually.  Integers are represented by their
+      prime factorization, which is performed automatically.  Instead, form integers, rationals, and
+      their powers only by starting with valid `Magnitude` instances, and performing arithmetic
+      operations as in option 3 above.
+
+Below, we give more details on several concepts mentioned above.
+
+### `mag<N>()`
+
+`mag<N>()` gives an instance of the unique, canonical `Magnitude` type that represents the positive
+integer `N`.
+
+??? info "More detail on integral `Magnitude` representations"
+    Integers are stored as their prime factorization.  For example, `18` would be stored as the type
+    `Magnitude<Prime<2>, Pow<Prime<3>, 2>>`, because $18 = 2 \cdot 3^2$.
+
+    `mag<N>()` automatically performs the prime factorization of `N`, and constructs a well-formed
+    `Magnitude`.
+
+### Custom bases
+
+`Magnitude` can handle some irrational numbers.  This even includes some transcendental numbers,
+such as $\pi$.  Because `Magnitude` is closed under products and rational powers, this means that we
+also automatically support related values such as $\pi^2$, $\frac{1}{\sqrt{2\pi}}$, and so on.
+
+??? question "What irrational numbers can `Magnitude` _not_ handle?"
+    A common example is any that are formed by addition.  For example, $(1 + \sqrt{2})$ cannot be
+    represented by `Magnitude`.  Recall that `Magnitude` is designed to support products and
+    rational powers, since these are the most important operations in quantity calculus.
+
+    It is tempting to want a better representation --- one which supports full symbolic algebra.
+    Perhaps such a representation could be designed.  However, we haven't seen any real world use
+    cases for it.  The current `Magnitude` implementation already handles the most critical use
+    cases, such as handling $\pi$, which most units libraries have traditionally struggled to
+    support.
+
+Because of its importance for angular variables, $\pi$ is supported natively in the library --- you
+don't need to define it yourself.  The constant `PI` is a `Magnitude` _instance_.  It's based on the
+(natively included) irrational magnitude base, `Pi`.  (Concretely: `PI` is defined as
+`Magnitude<Pi>{}`, in accordance with option 2 above.)
+
+If you need to represent an irrational number which can't be formed via any product of powers of the
+existing `Magnitude` types --- namely, integers and $\pi$ --- then you can define a new irrational
+magnitude base.  This is a `struct` with the following member:
+
+- `static constexpr long double value()`: the best approximation of your constant's value in the
+  `long double` storage type.
+
+??? warning "Important information for defining your own constant"
+    If you return a literal, you must add `L` on the end.  Otherwise it will be interpreted as
+    `double`, and will lose precision.
+
+    Here are the results of one example which was run on an arbitrary development machine.
+
+    | | No suffix | `L` suffix |
+    |-|------------------------|-------------------------|
+    | Literal | `3.141592653589793238` | `3.141592653589793238L` |
+    | Actual Value | `3.141592653589793115` | `3.141592653589793238` |
+
+    The un-suffixed version has lost several digits of precision.  (The precise amount will depend
+    on the computer architecture being used.)
+
+Each time you add a new irrational magnitude base, you must make sure that it's **independent:**
+that is, that it can't be formed as any product of rational powers of existing `Magnitude` types.
+
+## Extracting values
+
+As a [monovalue type](./detail/monovalue_types.md), `Magnitude` can only hold one value.  There are
+no computations we can perform at runtime; everything happens at compile time.  What we _can_ do is
+to extract that represented value, and store it in a more conventional numeric type, such as `int`
+or `double`.
+
+To extract the value of a `Magnitude` instance `m` into a given numeric type `T`, call
+`get_value<T>(m)`.  Here are some important aspects of this utility.
+
+1. The computation takes place completely at compile time.
+2. The computation takes place in the widest type of the same kind.  (That is, when `T` is floating
+   point we use `long double`, and when `T` is integral we use `std::intmax_t` or `std::uintmax_t`
+   according to the signedness of `T`.)
+3. If `T` cannot hold the value represented by `m`, we produce a compile time error.
+
+??? example "Example: `float` and $\pi^3$"
+    Suppose you are running on an architecture which has hardware support for `float`, but uses slow
+    software emulation for `double` and `long double`.  With `Magnitude` and `get_value`, you can
+    get the best of both worlds:
+
+    - The **computation** gets performed _at compile time_ in `long double`, giving extra precision.
+    - The **result** gets cast to `float` and stored as a program constant.
+
+    Thus, `get_value<float>(pow<3>(PI))` will be much more accurate than storing $\pi$ in a `float`,
+    and cubing it --- yet, there will be no loss in performance.
+
+## Operations
+
+These are the operations which `Magnitude` supports.  Because it is a [monovalue
+type](./detail/monovalue_types.md), the value can take the form of either a _type_ or an _instance_.
+In what follows, we'll use this convention:
+
+- **Capital** identifiers (`M`, `M1`, `M2`, ...) refer to **types**.
+- **Lowercase** identifiers (`m`, `m1`, `m2`, ...) refer to **instances**.
+
+### Equality comparison
+
+**Result:** A `bool` indicating whether two `Magnitude` values represent the same number.
+
+**Syntax:**
+
+- For _types_ `M1` and `M2`:
+    - `std::is_same<M1, M2>::value`
+- For _instances_ `m1` and `m2`:
+    - `m1 == m2` (equality comparison)
+    - `m1 != m2` (inequality comparison)
+
+### Multiplication
+
+**Result:** The product of two `Magnitude` values.
+
+**Syntax:**
+
+- For _types_ `M1` and `M2`:
+    - `MagProductT<M1, M2>`
+- For _instances_ `m1` and `m2`:
+    - `m1 * m2`
+
+### Division
+
+**Result:** The quotient of two `Magnitude` values.
+
+**Syntax:**
+
+- For _types_ `M1` and `M2`:
+    - `MagQuotientT<M1, M2>`
+- For _instances_ `m1` and `m2`:
+    - `m1 / m2`
+
+### Powers
+
+**Result:** A `Magnitude` raised to an integral power.
+
+**Syntax:**
+
+- For a _type_ `M`, and an integral power `N`:
+    - `MagPowerT<M, N>`
+- For an _instance_ `m`, and an integral power `N`:
+    - `pow<N>(m)`
+
+### Roots
+
+**Result:** An integral root of a `Magnitude`.
+
+**Syntax:**
+
+- For a _type_ `M`, and an integral root `N`:
+    - `MagPowerT<M, 1, N>` (because the $N^\text{th}$ root is equivalent to the
+      $\left(\frac{1}{N}\right)^\text{th}$ power)
+- For an _instance_ `m`, and an integral root `N`:
+    - `root<N>(m)`
+
+## Traits
+
+These traits provide information, at compile time, about the number represented by a `Magnitude`.
+
+### Integer test
+
+**Result:** A `bool` indicating whether a `Magnitude` represents an _integer_ (`true` if it does;
+`false` otherwise).
+
+**Syntax:**
+
+- For a _type_ `M`:
+    - `IsInteger<M>::value`
+- For an _instance_ `m`:
+    - `is_integer(m)`
+
+### Rational test
+
+**Result:** A `bool` indicating whether a `Magnitude` represents a _rational number_ (`true` if it
+does; `false` otherwise).
+
+**Syntax:**
+
+- For a _type_ `M`:
+    - `IsRational<M>::value`
+- For an _instance_ `m`:
+    - `is_rational(m)`
+
+### Numerator (integer part)
+
+**Result:** The integer part of the numerator we would have if a `Magnitude` were written as
+a fraction.  This result is another `Magnitude`.
+
+For example, the "numerator" of $\frac{3\sqrt{3}}{5\pi}$ would be $3$, because it is the integer
+part of $3\sqrt{3}$.
+
+**Syntax:**
+
+- For a _type_ `M`:
+    - `NumeratorT<M>`
+- For an _instance_ `m`:
+    - `numerator(m)`
+
+!!! warning
+    This name and/or convention may be subject to change; see
+    [#83](https://github.com/aurora-opensource/au/issues/83).
+
+### Denominator (integer part)
+
+**Result:** The integer part of the denominator we would have if a `Magnitude` were written as
+a fraction.  This result is another `Magnitude`.
+
+For example, the "denominator" of $\frac{3\sqrt{3}}{5\pi}$ would be $5$, because it is the integer
+part of $5\pi$.
+
+**Syntax:**
+
+- For a _type_ `M`:
+    - `DenominatorT<M>`
+- For an _instance_ `m`:
+    - `denominator(m)`
+
+!!! warning
+    This name and/or convention may be subject to change; see
+    [#83](https://github.com/aurora-opensource/au/issues/83).

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -1,0 +1,344 @@
+# Unit
+
+A _unit_ is a type which represents a unit of measure.  Examples include `Meters`, `Radians`,
+`Hours`, and so on.
+
+Users can work with units as either _types_ or _instances_, and can freely convert between these
+representations.  That is to say: units are [_monovalue types_](./detail/monovalue_types.md).
+
+## Identifying unit types
+
+A unit is _not_ forced to be a specialization of some central type template, such as a hypothetical
+`Unit<...>`. Rather, it's more open ended: a unit can be **any** type which fulfills certain
+defining properties.
+
+To be a unit, a type `U`:
+
+1. **Must** contain a public type alias, `U::Dim`, which refers to a valid [dimension
+   type](./detail/dimension.md).
+
+2. **Must** contain a public type alias, `U::Mag`, which refers to a valid [magnitude
+   type](./magnitude.md).
+
+3. **Must** be a [monovalue type](./detail/monovalue_types.md).
+
+4. **May** contain a `static constexpr` member named `label`, which is a C-style `const char[]`
+   (**not** a `const char*`).[^1]
+
+5. **May** contain a `static constexpr` member function `origin()`, which returns a quantity whose
+   dimension type is `U::Dim`.
+
+A custom `origin()` is very rarely needed.  Both [labels](#labels) and [origins](#origins) will be
+discussed further below.
+
+[^1]: Unit types defined by the library may also use `au::detail::StringConstant<N>` for some
+integer length `N`.  Since this is in the `detail` namespace, we wanted to de-emphasize it in this
+document.
+
+### Making unit types
+
+Although every unit type needs `Dim` and `Mag` members, users won't need to add them directly.
+Rather, the best way to make a unit type is by _combining existing unit types_ via [supported
+operations](#operations).  This approach has two key advantages relative to defining your unit as
+a fully manual `struct`.
+
+1. If your input types are all valid units, your output type will be too.
+
+2. It makes the definition more readable and physically meaningful.
+
+To give your unit type the best ergonomics, follow our [how-to guide for defining new
+units](../howto/new-units.md).
+
+## Unit labels {#labels}
+
+Every unit has a label.  Its label is a `constexpr const char[]` of the appropriate size.
+
+For a unit type `U`, or instance `u`, we can access the label as follows:
+
+- `unit_label<U>()`
+- `unit_label(u)`
+
+This function returns a reference to the array, which again is a compile time constant.
+
+Note especially that the type is an _array_ (`[]`).  A pointer (`*`) is _not_ acceptable.  This is
+so that we can support `sizeof(unit_label(u))`.
+
+Using C-style `char` arrays for our labels makes Au more friendly for embedded users, because it
+gives them full access to the labels without forcing them to depend on `<string>` or `<iostream>`.
+
+### `[UNLABELED_UNIT]`
+
+If a unit does not have an explicit label, we will try to generate one automatically.  If we're
+unable to do so, we fall back to the "default label", which is `"[UNLABELED_UNIT]"`.
+
+This is a label just like any other: we do not attempt to "propagate the un-labeled-ness".  As
+a concrete example, if `Foos` is an unlabeled unit, then the label for `Nano<Foos>{} / Seconds{}`
+would be `"n[UNLABELED_UNIT] / s"`.  This is to preserve as much structure as possible for end
+users, so they have the best chance of recognizing the offending unit, and perhaps upgrading it.
+
+!!! note
+    A key design goal is for every combination of meaningfully labeled units, by every supported
+    operation, to produce a meaningfully labeled unit.  Right now, the only missing operation is
+    scaling a unit by a magnitude.  We are tracking this in
+    [#85](https://github.com/aurora-opensource/au/issues/85).
+
+## Unit origins {#origins}
+
+The "origin" of a unit is only useful for `QuantityPoint`, our [affine space
+type](http://videocortex.io/2018/Affine-Space-Types/).  Even then, the origin by itself is not
+meaningful.  Only the difference between the origins of two units is meaningful.
+
+You would use this to implement an "offset" unit, such as `Celsius` or `Fahrenheit`.  However, note
+that both of these are already implemented in the library.
+
+The origin defaults to `ZERO` if not supplied.
+
+## Types for combined units
+
+A core tenet of Au's design philosophy is to avoid giving any units special status.  Every named
+unit enters into a unit computation on equal footing.  We will keep track of the accumulated powers
+of each named unit, cancelling as appropriate.  The final form will follow these rules.
+
+1. Every power of a named unit will be represented according to the [representation
+   table](./detail/packs.md#powers).  That is, it will be omitted if its power is zero, and will
+   otherwise appear as one of `Pow`, `RatioPow`, or the bare unit itself.
+
+2. If only one named unit remains with nonzero power, then that named unit power (as represented in
+   the previous rule) is the _complete_ type.
+
+3. If multiple named units remain with nonzero power, then their representations (according to rule
+   1) are combined as the elements of a variadic `UnitProduct<...>` pack.
+
+!!! warning
+    The ordering of the bases is deterministic, but is implementation defined, and can change at any
+    time.  It is a programming error to write code that assumes any specific ordering of the units
+    in a pack.
+
+??? example "A few examples"
+    We have omitted the `au::` namespace in the following examples for greater clarity.
+
+    | Unit expression | Resulting unit type |
+    |-----------------|----------------|
+    | `squared(Meters{})` | `Pow<Meters, 2>` |
+    | `Meters{} / Seconds{}` | `UnitProduct<Meters, Pow<Seconds, -1>>` |
+    | `Seconds{} * Meters{} / Seconds{}` | `Meters` |
+
+## Operations {#operations}
+
+These are the operations which each unit type supports.  Because a unit must be a [monovalue
+type](./detail/monovalue_types.md), it can take the form of either a _type_ or an _instance_.
+In what follows, we'll use this convention:
+
+- **Capital** identifiers (`U`, `U1`, `U2`, ...) refer to **types**.
+- **Lowercase** identifiers (`u`, `u1`, `u2`, ...) refer to **instances**.
+
+### Multiplication
+
+**Result:** The product of two units.
+
+**Syntax:**
+
+- For _types_ `U1` and `U2`:
+    - `UnitProductT<U1, U2>`
+- For _instances_ `u1` and `u2`:
+    - `u1 * u2`
+
+### Division
+
+**Result:** The quotient of two units.
+
+**Syntax:**
+
+- For _types_ `U1` and `U2`:
+    - `UnitQuotientT<U1, U2>`
+- For _instances_ `u1` and `u2`:
+    - `u1 / u2`
+
+### Powers
+
+**Result:** A unit raised to an integral power.
+
+**Syntax:**
+
+- For a _type_ `U`, and an integral power `N`:
+    - `UnitPowerT<U, N>`
+- For an _instance_ `u`, and an integral power `N`:
+    - `pow<N>(u)`
+
+### Roots
+
+**Result:** An integral root of a unit.
+
+**Syntax:**
+
+- For a _type_ `U`, and an integral root `N`:
+    - `UnitPowerT<U, 1, N>` (because the $N^\text{th}$ root is equivalent to the
+      $\left(\frac{1}{N}\right)^\text{th}$ power)
+- For an _instance_ `u`, and an integral root `N`:
+    - `root<N>(u)`
+
+### Helpers for powers and roots
+
+!!! note
+    We plan to make these available for [`Magnitude`](./magnitude.md) and
+    [`Dimension`](./detail/dimension.md) as well.  See
+    [#84](https://github.com/aurora-opensource/au/issues/84) to track progress.
+
+Each of the following helpers are available to operate on a unit instance, `u`:
+
+| Helper | Result |
+|--------|--------|
+| `inverse(u)` | `pow<-1>(u)` |
+| `squared(u)` | `pow<2>(u)` |
+| `cubed(u)` | `pow<3>(u)` |
+| `sqrt(u)` | `root<2>(u)` |
+| `cbrt(u)` | `root<3>(u)` |
+
+### Scaling by `Magnitude`
+
+**Result:** A new unit which has been scaled by the given magnitude.  More specifically, for a unit
+_instance_ `u` and magnitude instance `m`, this operation:
+
+- **Preserves** the _dimension_ of `u`.
+- **Scales** the _magnitude_ of `u` by a factor of `m`.
+- **Deletes** the _label_ of `u`.
+- **Preserves** the _origin_ of `u`.
+
+**Syntax:**
+
+- `u * m`
+
+## Traits
+
+Sections describing `bool` traits will be indicated with a trailing question mark, `"?"`.
+
+### Is unit?
+
+**Result:** Indicates whether the argument is a valid unit.
+
+!!! warning
+    We don't currently have a trait that can detect whether or not a type is a [monovalue
+    type](./detail/monovalue_types.md).  Thus, the current implementation only checks whether the
+    dimension and magnitude are valid.  Until we get such a trait, authors of unit types are
+    responsible for satisfying the monovalue type requirement.
+
+**Syntax:**
+
+- For _type_ `U`:
+    - `IsUnit<U>::value`
+- For _instance_ `u`:
+    - `is_unit(u)`
+
+### Has same dimension?
+
+**Result:** Indicates whether two units have the same dimension.
+
+**Syntax:**
+
+- For _types_ `U1` and `U2`:
+    - `HasSameDimension<U1, U2>::value`
+- For _instances_ `u1` and `u2`:
+    - `has_same_dimension(u1, u2)`
+
+### Are units quantity-equivalent?
+
+**Result:** Indicates whether two units are quantity-equivalent.  This means that they have the same
+dimension and same magnitude.  Quantities of quantity-equivalent units may be trivially converted to
+each other with no conversion factor.
+
+For example, `Meters{} * Hertz{}` is not the _same unit_ as `Meters{} / Seconds{}`, but they _are_
+**quantity-equivalent**.
+
+**Syntax:**
+
+- For _types_ `U1` and `U2`:
+    - `AreUnitsQuantityEquivalent<U1, U2>::value`
+- For _instances_ `u1` and `u2`:
+    - `are_units_quantity_equivalent(u1, u2)`
+
+### Are units point-equivalent?
+
+**Result:** Indicates whether two units are point-equivalent.  This means that they have the same
+dimension, same magnitude, _and_ same origin.  `QuantityPoint` instances of point-equivalent units
+may be trivially converted to each other with no conversion factor and no additive offset.
+
+For example, while `Celsius` and `Kelvins` are quantity-equivalent, they are _not_
+**point-equivalent**.
+
+**Syntax:**
+
+- For _types_ `U1` and `U2`:
+    - `AreUnitsPointEquivalent<U1, U2>::value`
+- For _instances_ `u1` and `u2`:
+    - `are_units_point_equivalent(u1, u2)`
+
+### Is dimensionless?
+
+**Result:** Indicates whether the argument is a dimensionless unit.
+
+**Syntax:**
+
+- For _type_ `U`:
+    - `IsDimensionless<U>::value`
+- For _instance_ `u`:
+    - `is_dimensionless(u)`
+
+### Is unitless unit?
+
+**Result:** Indicates whether the argument is a "unitless unit": that is, a _dimensionless_ unit
+whose _magnitude_ is 1.
+
+**Syntax:**
+
+- For _type_ `U`:
+    - `IsUnitlessUnit<U>::value`
+- For _instance_ `u`:
+    - `is_unitless_unit(u)`
+
+### Unit ratio
+
+**Result:** The [magnitude](./magnitude.md) representing the ratio of the input units' magnitudes.
+
+For units with non-trivial dimension, there is no such thing as "the" magnitude of a unit: it is not
+physically meaningful or observable.  However, the _ratio_ of units' magnitudes _is_ well defined,
+and that is what this trait produces.
+
+For example, the unit ratio of `Feet` and `Inches` is `mag<12>()`, because a foot is 12 times as big
+as an inch.
+
+**Syntax:**
+
+- For _types_ `U1` and `U2`:
+    - `UnitRatioT<U1, U2>::value`
+- For _instances_ `u1` and `u2`:
+    - `unit_ratio(u1, u2)`
+
+### Origin displacement
+
+**Result:** The displacement from the first unit's origin to the second unit's origin.
+
+Recall that there is no such thing as "the" origin of a unit: it is not physically meaningful or
+observable.  However, the _displacement_ from one unit's origin to another _is_ well defined, and
+that is what this trait produces.
+
+For example, the origin displacement from `Kelvins` to `Celsius` is equivalent to
+$273.15 \,\text{K}$.
+
+**Syntax:**
+
+- For _types_ `U1` and `U2`:
+    - `OriginDisplacement<U1, U2>::value()`
+- For _instances_ `u1` and `u2`:
+    - `origin_displacement(u1, u2)`
+
+### Associated unit
+
+!!! warning "TODO: this is a stub."
+
+### Common unit
+
+!!! warning "TODO: this is a stub."
+
+### Common point unit
+
+!!! warning "TODO: this is a stub."

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -596,11 +596,8 @@ sufficient condition: for example, even `UnitInverseT<Seconds>` and `Hertz` won'
 ??? info "More background info on why this error exists"
     In case you want to understand more, here is the gist.
 
-    Au is _heavily_ based on parameter packs.  Some of these packs, such as `UnitProduct<...>` and
-    `CommonUnit<...>`, take _units_ as their arguments.
-
-    !!! warning "TODO"
-        Make a doc page for parameter packs, and link to it here.
+    Au is _heavily_ based on [parameter packs](./reference/detail/packs.md).  Some of these packs,
+    such as `UnitProduct<...>` and `CommonUnit<...>`, take _units_ as their arguments.
 
     Every parameter pack needs an unambiguous canonical ordering for any possible set of input
     arguments.  Therefore, we need to create a _strict total ordering_ for the (infinitely many!)


### PR DESCRIPTION
This PR creates both the `reference` section and the `discussion`
section: two of the four major categories of documentation.  Since these
pages tend to reference each other a lot, I decided to combine them in a
single PR which we could use as foundational.

The vector space doc is migrated from the version in Aurora's repo,
almost unmodified.

In the reference section, I wanted to make sure to hit Dimension,
Magnitude, and Unit.  All three of these types share a common property:
namely, that we often create instances of them, and that there is only
one possible value for the instances, so that types and values are
effectively completely interchangeable representations of the same
"thing".  I decided to invent a name, "monovalue types", to describe
this concept, because it turns out to be foundational to Au.  Speaking
of foundational, I migrated the parameter packs documentation from
Aurora's repo as well.

I updated the installation instructions to replace the "before public
release" language with a `TODO` that will age better.

The last three subsections of the unit doc are also `TODO`, because I
ran out of steam.