### PR TITLE
Replace Aurora "Innovation" with "Operations"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Au: A C++14-compatible units library, by Aurora
 
-Au (pronounced "ay yoo") is a C++ units library, by
-[Aurora Innovation](https://aurora.tech/).  What the `<chrono>` library did for time
-variables, _Au_ does for _all physical quantities_ (lengths, speeds, voltages, and so on). Namely:
+Au (pronounced "ay yoo") is a C++ units library, by [Aurora](https://aurora.tech/).  What the
+`<chrono>` library did for time variables, _Au_ does for _all physical quantities_ (lengths, speeds,
+voltages, and so on). Namely:
 
 - Catch unit errors at compile time, with **no runtime penalty**.
 - Make unit conversions effortless to get right.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ site_name: "The Au units library"
 site_description: "A C++ units library, by Aurora"
 site_url: https://aurora-opensource.github.io/au
 site_author: "Au team"
-copyright: Copyright &copy; 2022, Aurora Innovation, Inc. All rights reserved
+copyright: Copyright &copy; 2022, Aurora Operations, Inc. All rights reserved
 
 repo_url: https://github.com/aurora-opensource/au
 edit_uri: blob/main/docs


### PR DESCRIPTION
This was requested by legal.

For the main page README, I simply deleted "Innovation," because "by
Aurora" flows better, and we link directly to the main company website
so there's little danger of confusion.