### PR TITLE
Strip comments touching Aurora copyright line

### DIFF
--- a/tools/bin/make-single-file
+++ b/tools/bin/make-single-file
@@ -62,9 +62,7 @@ def filenames(main_files, units, include_io):
     The script will be sure to include all of these, and will also include any
     transitive dependencies from within the project.
     """
-    names = (
-        ["au/au.hh"] + [f"au/units/{unit}.hh" for unit in units] + main_files
-    )
+    names = ["au/au.hh"] + [f"au/units/{unit}.hh" for unit in units] + main_files
     if include_io:
         names.append("au/io.hh")
     return names
@@ -125,13 +123,20 @@ class SourceFile:
         self.graph_includes = []
         self.lines = []
 
+        in_copyright_header = False
         with open(filename) as f:
             was_last_line_blank = False
             for line in f:
                 if line.startswith("#pragma once"):
                     continue
                 if re.search(AURORA_COPYRIGHT.format(year="20.."), line):
+                    in_copyright_header = True
                     continue
+                if in_copyright_header:
+                    if line.startswith("//"):
+                        continue
+                    else:
+                        in_copyright_header = False
 
                 # Collapse consecutive blank lines into one.
                 if line.strip():


### PR DESCRIPTION
Now that we're using the full Apache copyright header, the single-file
versions have exploded in size.  This PR fixes that by stripping all
comments that are contiguous with the Aurora copyright header line.
Since we never have non-copyright comments contiguous with the copyright
(and in fact it would be wrong to do so), this is a safe solution.

Test plan
---------

I ran this command before and after this change:

```sh
make-single-file --units meters seconds | gview -
```

I verified that the only changes were to the version identifier
(specifically, appending `-dirty`), and that all copyright headers
_except the first_ were removed.