### PR TITLE
Add stub prefix reference, and new SI prefixes

### DIFF
--- a/au/prefix.hh
+++ b/au/prefix.hh
@@ -52,6 +52,22 @@ struct PrefixApplier {
 // SI Prefixes.
 
 template <typename U>
+struct Quetta : decltype(U{} * pow<30>(mag<10>())) {
+    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("Q", unit_label<U>());
+};
+template <typename U>
+constexpr detail::ExtendedLabel<1, U> Quetta<U>::label;
+constexpr auto quetta = PrefixApplier<Quetta>{};
+
+template <typename U>
+struct Ronna : decltype(U{} * pow<27>(mag<10>())) {
+    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("R", unit_label<U>());
+};
+template <typename U>
+constexpr detail::ExtendedLabel<1, U> Ronna<U>::label;
+constexpr auto ronna = PrefixApplier<Ronna>{};
+
+template <typename U>
 struct Yotta : decltype(U{} * pow<24>(mag<10>())) {
     static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("Y", unit_label<U>());
 };
@@ -210,6 +226,22 @@ struct Yocto : decltype(U{} * pow<-24>(mag<10>())) {
 template <typename U>
 constexpr detail::ExtendedLabel<1, U> Yocto<U>::label;
 constexpr auto yocto = PrefixApplier<Yocto>{};
+
+template <typename U>
+struct Ronto : decltype(U{} * pow<-27>(mag<10>())) {
+    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("r", unit_label<U>());
+};
+template <typename U>
+constexpr detail::ExtendedLabel<1, U> Ronto<U>::label;
+constexpr auto ronto = PrefixApplier<Ronto>{};
+
+template <typename U>
+struct Quecto : decltype(U{} * pow<-30>(mag<10>())) {
+    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("q", unit_label<U>());
+};
+template <typename U>
+constexpr detail::ExtendedLabel<1, U> Quecto<U>::label;
+constexpr auto quecto = PrefixApplier<Quecto>{};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Binary Prefixes.

--- a/au/prefix_test.cc
+++ b/au/prefix_test.cc
@@ -86,6 +86,8 @@ TEST(SiPrefixes, HaveCorrectAbsoluteValues) {
 TEST(SiPrefixes, PrefixAppliersPredefined) {
     constexpr QuantityMaker<Inches> inches{};
 
+    EXPECT_EQ(quetta(inches)(1), ronna(inches)(1000));
+    EXPECT_EQ(ronna(inches)(1), yotta(inches)(1000));
     EXPECT_EQ(yotta(inches)(1), zetta(inches)(1000));
     EXPECT_EQ(zetta(inches)(1), exa(inches)(1000));
     EXPECT_EQ(exa(inches)(1), peta(inches)(1000));
@@ -96,7 +98,9 @@ TEST(SiPrefixes, PrefixAppliersPredefined) {
 
     EXPECT_EQ(kilo(inches)(1), hecto(inches)(10));
     EXPECT_EQ(hecto(inches)(1), deka(inches)(10));
-    EXPECT_EQ(deka(inches)(1), deci(inches)(100));
+    EXPECT_EQ(deka(inches)(1), inches(10));
+
+    EXPECT_EQ(inches(1), deci(inches)(10));
     EXPECT_EQ(deci(inches)(1), centi(inches)(10));
     EXPECT_EQ(centi(inches)(1), milli(inches)(10));
 
@@ -107,6 +111,8 @@ TEST(SiPrefixes, PrefixAppliersPredefined) {
     EXPECT_EQ(femto(inches)(1), atto(inches)(1000));
     EXPECT_EQ(atto(inches)(1), zepto(inches)(1000));
     EXPECT_EQ(zepto(inches)(1), yocto(inches)(1000));
+    EXPECT_EQ(yocto(inches)(1), ronto(inches)(1000));
+    EXPECT_EQ(ronto(inches)(1), quecto(inches)(1000));
 }
 
 TEST(SiPrefixes, CorrectlyLabelUnits) {
@@ -119,6 +125,8 @@ TEST(SiPrefixes, CorrectlyLabelUnits) {
     expect_label<Exa<XeroxedBytes>>("EX");
     expect_label<Zetta<XeroxedBytes>>("ZX");
     expect_label<Yotta<XeroxedBytes>>("YX");
+    expect_label<Ronna<XeroxedBytes>>("RX");
+    expect_label<Quetta<XeroxedBytes>>("QX");
     expect_label<Milli<XeroxedBytes>>("mX");
     expect_label<Micro<XeroxedBytes>>("uX");
     expect_label<Nano<XeroxedBytes>>("nX");
@@ -127,6 +135,8 @@ TEST(SiPrefixes, CorrectlyLabelUnits) {
     expect_label<Atto<XeroxedBytes>>("aX");
     expect_label<Zepto<XeroxedBytes>>("zX");
     expect_label<Yocto<XeroxedBytes>>("yX");
+    expect_label<Ronto<XeroxedBytes>>("rX");
+    expect_label<Quecto<XeroxedBytes>>("qX");
     expect_label<Hecto<XeroxedBytes>>("hX");
     expect_label<Deka<XeroxedBytes>>("daX");
     expect_label<Deci<XeroxedBytes>>("dX");

--- a/docs/install.md
+++ b/docs/install.md
@@ -111,7 +111,8 @@ Every single-file package automatically includes the following features:
 - Basic "unit container" types: `Quantity`, `QuantityPoint`
 - [Magnitude](./reference/magnitude.md) types and values, including the constant `PI`, and constants
   for any integer such as `mag<5280>()`.
-- All prefixes for SI (`kilo`, `mega`, ...) and informational (`kibi`, `mebi`, ...) quantities.
+- All [prefixes](./reference/prefix.md) for SI (`kilo`, `mega`, ...) and informational (`kibi`,
+  `mebi`, ...) quantities.
 - Math functions, including unit-aware rounding and inverses, trigonometric functions, square roots,
   and so on.
 - Bidirectional implicit conversion between `Quantity` types and any equivalent counterparts in the

--- a/docs/reference/prefix.md
+++ b/docs/reference/prefix.md
@@ -1,0 +1,24 @@
+# Prefix
+
+A "prefix" scales a [unit](./unit.md) by some [magnitude](./magnitude.md), and prepends a _prefix
+symbol_ to the unit's label.
+
+!!! warning "TODO: this page is a stub"
+
+We will provide a full-fledged reference for prefixes later.  For now, here are the basics:
+
+1. We support every [SI prefix](https://www.nist.gov/pml/owm/metric-si-prefixes) and [binary
+   prefix](https://en.wikipedia.org/wiki/Binary_prefix).
+
+2. To apply a prefix to a [_unit type_](./unit.md), spell the prefix using `CamelCase` (just like
+   any other type in Au), and pass the unit type as a _template parameter_.
+
+    - **Example:** `Meters` is a unit type; so is `Centi<Meters>`.  You can form
+      a `QuantityD<Centi<Meters>>`.
+
+3. To apply a prefix to a [_quantity maker_](../tutorial/101-quantity-makers.md), spell the prefix
+   using `snake_case` (just like the quantity maker itself), and pass the quantity maker as
+   a _function parameter_.
+
+    - **Example:** `meters` is a quantity maker; so is `centi(meters)`.  If you call
+      `centi(meters)(2.54)`, it will create a quantity of centimeters.


### PR DESCRIPTION
This should be enough to get people started.

I was writing the doc: "We support every SI prefix..." --- wait, no we
don't!  Four new ones got added in 2022.  So I added support for these
newcomers (including tests) in order to make the docs true.