### PR TITLE
Add stub refs for Quantity, QuantityPoint

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -108,7 +108,8 @@ Every single-file package automatically includes the following features:
 !!! warning "TODO"
     As reference docs become available for each of the following, we should link to them.
 
-- Basic "unit container" types: `Quantity`, `QuantityPoint`
+- Basic "unit container" types: [`Quantity`](./reference/quantity.md),
+  [`QuantityPoint`](./reference/quantity_point.md)
 - [Magnitude](./reference/magnitude.md) types and values, including the constant `PI`, and constants
   for any integer such as `mag<5280>()`.
 - All [prefixes](./reference/prefix.md) for SI (`kilo`, `mega`, ...) and informational (`kibi`,

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -1,0 +1,26 @@
+# Quantity
+
+`Quantity` is our workhorse type for safely storing quantities of a given unit in some underlying
+numeric variable.
+
+!!! warning "TODO: this page is a stub"
+
+We will provide a full-fledged reference for quantities later.  For now, here are the basics.
+
+1. `Quantity<U, R>` stores a value of numeric type `R` (called the "Rep"), whose units are the [unit
+   type](./unit.md) `U`.
+
+    - **Example:** `Quantity<Meters, double>` stores a length in `Meters`, in a `double` variable.
+
+2. We provide "Rep-named aliases" for better ergonomics.
+
+    - **Example:** `QuantityD<Meters>` is an alias for `Quantity<Meters, double>`.
+
+3. You cannot get values into or out of `Quantity` without _explicitly naming the unit, at the
+   callsite_.  For full details, see our tutorials, starting with the first: [Au 101: Quantity
+   Makers](../tutorial/101-quantity-makers.md).
+
+??? tip "Handling temperatures"
+    If you are working with temperatures --- in the sense of "what temperature is it?", rather than
+    "how much did the temperature change?" --- you will want to use
+    [`QuantityPoint`](./quantity_point.md) instead of `Quantity`.

--- a/docs/reference/quantity_point.md
+++ b/docs/reference/quantity_point.md
@@ -1,0 +1,31 @@
+# QuantityPoint
+
+`QuantityPoint` is our [affine space type](http://videocortex.io/2018/Affine-Space-Types/).  The
+core use cases include:
+
+- **Temperatures.**  Specifically, when you want to represent "what temperature is it?" rather than
+  "how much did the temperature change?"
+
+- **Mile markers.**  That is to say, points along a linear path which are indexed by distances.  It
+  wouldn't make sense to _add_ two mile markers, but you can _subtract_ them and obtain a _distance_
+  (which is a [`Quantity`](./quantity.md), not a `QuantityPoint`).
+
+!!! warning "TODO: this page is a stub"
+
+We will provide a full-fledged reference for quantity points later.  For now, here are the basics.
+
+1. `QuantityPoint<U, R>` stores a value of numeric type `R` (called the "Rep"), whose units are the
+   [unit type](./unit.md) `U`.
+
+    - **Example:** `QuantityPoint<Meters, double>` represents an along-path point, whose distance is
+      measured in `Meters`, in a `double` variable.
+
+2. We provide "Rep-named aliases" for better ergonomics.
+
+    - **Example:** `QuantityPointD<Meters>` is an alias for `QuantityPoint<Meters, double>`.
+
+3. You cannot get values into or out of `QuantityPoint` without _explicitly naming the unit, at the
+   callsite_.  We do not have tutorials for this yet, but it works the same as `Quantity`.  In the
+   meantime, you can read [the `QuantityPoint` unit
+   tests](https://github.com/aurora-opensource/au/blob/main/au/quantity_point_test.cc) to see some
+   practical examples.


### PR DESCRIPTION
This should be an acceptable placeholder.

For `Quantity`, we link to the tutorials, which I think should be pretty
useful.  We also point people to the `QuantityPoint` page specifically
for temperatures.

For `QuantityPoint`, we don't have any tutorials to link to, but the
unit tests should be a pretty good stopgap.