### PR TITLE
Keep QuantityPoint conversion within its Rep

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -415,6 +415,14 @@ constexpr auto rep_cast(Quantity<Unit, Rep> q) {
     return q.template as<NewRep>(Unit{});
 }
 
+// Help Zero act more faithfully like a Quantity.
+//
+// Casting Zero to any "Rep" is trivial, because it has no Rep, and is already consistent with all.
+template <typename NewRep>
+constexpr auto rep_cast(Zero z) {
+    return z;
+}
+
 //
 // Quantity aliases to set a particular Rep.
 //

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -33,7 +33,7 @@ constexpr QuantityMaker<Kelvins> kelvins{};
 constexpr QuantityPointMaker<Kelvins> kelvins_pt{};
 
 struct Celsius : Kelvins {
-    static constexpr auto origin() { return centi(kelvins)(273'15); }
+    static constexpr auto origin() { return (kelvins / mag<20>())(273'15 / 5); }
 };
 constexpr QuantityMaker<Celsius> celsius_qty{};
 constexpr QuantityPointMaker<Celsius> celsius_pt{};
@@ -270,7 +270,7 @@ TEST(QuantityPoint, CanCompareUnitsWithDifferentOrigins) {
 }
 
 TEST(QuantityPoint, CanSubtractIntegralInputsWithNonintegralOriginDifference) {
-    EXPECT_THAT(celsius_pt(0) - kelvins_pt(273), QuantityEquivalent(centi(kelvins)(15)));
+    EXPECT_EQ(celsius_pt(0) - kelvins_pt(273), centi(kelvins)(15));
 }
 
 TEST(QuantityPoint, InheritsOverflowSafetySurfaceFromUnderlyingQuantityTypes) {
@@ -304,4 +304,34 @@ TEST(QuantityPointMaker, CanScaleByMagnitude) {
     StaticAssertTypeEq<decltype(kelvins_pt / mag<5>()),
                        QuantityPointMaker<decltype(Kelvins{} / mag<5>())>>();
 }
+
+namespace detail {
+TEST(OriginDisplacementFitsIn, CanRetrieveValueInGivenRep) {
+    EXPECT_TRUE((OriginDisplacementFitsIn<uint64_t, Kelvins, Celsius>::value));
+    EXPECT_TRUE((OriginDisplacementFitsIn<int64_t, Kelvins, Celsius>::value));
+
+    EXPECT_TRUE((OriginDisplacementFitsIn<uint32_t, Kelvins, Celsius>::value));
+    EXPECT_TRUE((OriginDisplacementFitsIn<int32_t, Kelvins, Celsius>::value));
+
+    EXPECT_TRUE((OriginDisplacementFitsIn<uint16_t, Kelvins, Celsius>::value));
+    EXPECT_TRUE((OriginDisplacementFitsIn<int16_t, Kelvins, Celsius>::value));
+
+    EXPECT_FALSE((OriginDisplacementFitsIn<uint8_t, Kelvins, Celsius>::value));
+    EXPECT_FALSE((OriginDisplacementFitsIn<int8_t, Kelvins, Celsius>::value));
+}
+
+TEST(OriginDisplacementFitsIn, AlwaysTrueForZero) {
+    EXPECT_TRUE((OriginDisplacementFitsIn<uint64_t, Celsius, Celsius>::value));
+    EXPECT_TRUE((OriginDisplacementFitsIn<int64_t, Celsius, Celsius>::value));
+
+    EXPECT_TRUE((OriginDisplacementFitsIn<uint32_t, Celsius, Celsius>::value));
+    EXPECT_TRUE((OriginDisplacementFitsIn<int32_t, Celsius, Celsius>::value));
+
+    EXPECT_TRUE((OriginDisplacementFitsIn<uint16_t, Celsius, Celsius>::value));
+    EXPECT_TRUE((OriginDisplacementFitsIn<int16_t, Celsius, Celsius>::value));
+
+    EXPECT_TRUE((OriginDisplacementFitsIn<uint8_t, Celsius, Celsius>::value));
+    EXPECT_TRUE((OriginDisplacementFitsIn<int8_t, Celsius, Celsius>::value));
+}
+}  // namespace detail
 }  // namespace au

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -33,6 +33,10 @@ constexpr QuantityMaker<Kelvins> kelvins{};
 constexpr QuantityPointMaker<Kelvins> kelvins_pt{};
 
 struct Celsius : Kelvins {
+    // We must divide by 100 to turn the integer value of `273'15` into the decimal `273.15`.  We
+    // split that division between the unit and the value.  The goal is to divide the unit by as
+    // little as possible (while still keeping the value an integer), because that will make the
+    // conversion factor as small as possible in converting to the common-point-unit.
     static constexpr auto origin() { return (kelvins / mag<20>())(273'15 / 5); }
 };
 constexpr QuantityMaker<Celsius> celsius_qty{};
@@ -332,6 +336,16 @@ TEST(OriginDisplacementFitsIn, AlwaysTrueForZero) {
 
     EXPECT_TRUE((OriginDisplacementFitsIn<uint8_t, Celsius, Celsius>::value));
     EXPECT_TRUE((OriginDisplacementFitsIn<int8_t, Celsius, Celsius>::value));
+}
+
+TEST(OriginDisplacementFitsIn, FailsNegativeDisplacementForUnsignedRep) {
+    EXPECT_FALSE((OriginDisplacementFitsIn<uint64_t, Celsius, Kelvins>::value));
+    EXPECT_FALSE((OriginDisplacementFitsIn<uint32_t, Celsius, Kelvins>::value));
+    EXPECT_FALSE((OriginDisplacementFitsIn<uint16_t, Celsius, Kelvins>::value));
+
+    EXPECT_TRUE((OriginDisplacementFitsIn<int64_t, Celsius, Kelvins>::value));
+    EXPECT_TRUE((OriginDisplacementFitsIn<int32_t, Celsius, Kelvins>::value));
+    EXPECT_TRUE((OriginDisplacementFitsIn<int16_t, Celsius, Kelvins>::value));
 }
 }  // namespace detail
 }  // namespace au


### PR DESCRIPTION
If we call `celsius_pt(x).in(kelvins_pt / mag<20>())`, the result should
have the same type as `x`.  Currently, that's not the case for two
reasons, both of which stem from the underlying operation of
_subtracting the origin displacement_.

1. The origin itself typically has `int` Rep.

2. Even if it didn't, C++'s integer promotion rules would take us
   outside the realm of shorter integral types.

Part of the solution is to cast the origin displacement Rep to the
desired Rep type explicitly.  There's an opportunity for a safety check
here, so we add it (including unit tests).

The rest of the solution is simply to `rep_cast` at the end to "undo"
any integer promotion that may have happened.

Along the way, we also changed the operation from _subtraction_ of one
origin displacement, to _addition_ of the inverse displacement.  Now
that we're being more careful about checking whether the origin
displacement fits in the Rep, this would have broken unsigned type
support if we hadn't made this change.  (What I think was happening
before with the unsigned types was probably promotion to signed integers
--- so, no "incorrect" results, but probably an unexpected Rep.)

We also needed to add a trivial `rep_cast` overload for `Zero`.  This
helps it "stand in" for arbitrary quantities in one more way.

Fixes #100.

Test plan
---------

- [x] Added new test cases for `OriginDisplacementFitsIn`.
- [x] Uncommented the test case broken in #100, and verified that it
      fails for the right reason.
- [x] Test that there is no unacceptable compile time penalty.