### PR TITLE
Tweak overflow and inverse thresholds

### DIFF
--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -37,7 +37,7 @@ constexpr bool can_scale_without_overflow(Magnitude<BPs...> m, Rep value) {
 
 namespace detail {
 // Chosen so as to allow populating a `QuantityU32<Hertz>` with an input in MHz.
-constexpr auto OVERFLOW_THRESHOLD = 4'294;
+constexpr auto OVERFLOW_THRESHOLD = 2'147;
 
 // This wrapper for `can_scale_without_overflow<...>(..., OVERFLOW_THRESHOLD)` can prevent an
 // instantiation via short-circuiting, speeding up compile times.

--- a/au/conversion_policy_test.cc
+++ b/au/conversion_policy_test.cc
@@ -55,20 +55,20 @@ TEST(ImplicitRepPermitted, TrueForFloatingPointTypesForVeryWideRanges) {
 
 TEST(ImplicitRepPermitted, TrueForIntegralTypesIfPurelyIntegerAndThresholdWouldNotOverflow) {
     // int16_t max value: roughly 32k.
-    EXPECT_TRUE((ImplicitRepPermitted<int16_t, decltype(mag<7>())>::value));
-    EXPECT_FALSE((ImplicitRepPermitted<int16_t, decltype(mag<8>())>::value));
+    EXPECT_TRUE((ImplicitRepPermitted<int16_t, decltype(mag<15>())>::value));
+    EXPECT_FALSE((ImplicitRepPermitted<int16_t, decltype(mag<16>())>::value));
 
     // uint16_t max value: roughly 65k.
-    EXPECT_TRUE((ImplicitRepPermitted<uint16_t, decltype(mag<15>())>::value));
-    EXPECT_FALSE((ImplicitRepPermitted<uint16_t, decltype(mag<16>())>::value));
+    EXPECT_TRUE((ImplicitRepPermitted<uint16_t, decltype(mag<30>())>::value));
+    EXPECT_FALSE((ImplicitRepPermitted<uint16_t, decltype(mag<31>())>::value));
 
     // int32_t max value: roughly 2.147e3 million.
-    EXPECT_TRUE((ImplicitRepPermitted<int32_t, decltype(mag<500'000>())>::value));
-    EXPECT_FALSE((ImplicitRepPermitted<int32_t, decltype(mag<600'000>())>::value));
+    EXPECT_TRUE((ImplicitRepPermitted<int32_t, decltype(mag<1'000'000>())>::value));
+    EXPECT_FALSE((ImplicitRepPermitted<int32_t, decltype(mag<1'100'000>())>::value));
 
     // uint32_t max value: roughly 4.294e3 million.
-    EXPECT_TRUE((ImplicitRepPermitted<uint32_t, decltype(mag<1'000'000>())>::value));
-    EXPECT_FALSE((ImplicitRepPermitted<uint32_t, decltype(mag<1'100'000>())>::value));
+    EXPECT_TRUE((ImplicitRepPermitted<uint32_t, decltype(mag<2'000'000>())>::value));
+    EXPECT_FALSE((ImplicitRepPermitted<uint32_t, decltype(mag<2'100'000>())>::value));
 }
 
 TEST(ImplicitRepPermitted, FalseForIntegralTypesUnlessRelativeScaleIsIntegral) {

--- a/au/math.hh
+++ b/au/math.hh
@@ -201,9 +201,9 @@ constexpr auto inverse_in(TargetUnits target_units, Quantity<U, R> q) {
 //
 // The value of the "smart" inverse of a Quantity, in a given destination unit.
 //
-// By "smart", we mean that, e.g., you can convert an integral Quantity of Mega<Hertz> to an
+// By "smart", we mean that, e.g., you can convert an integral Quantity of Kilo<Hertz> to an
 // integral Quantity of Nano<Seconds>, without ever leaving the integral domain.  (Under the hood,
-// in this case, the library will know to divide into 1000 instead of dividing into 1.)
+// in this case, the library will know to divide into 1'000'000 instead of dividing into 1.)
 //
 template <typename TargetUnits, typename U, typename R>
 constexpr auto inverse_in(TargetUnits target_units, Quantity<U, R> q) {
@@ -212,10 +212,22 @@ constexpr auto inverse_in(TargetUnits target_units, Quantity<U, R> q) {
     // than 1000 would tend to be stored in the next SI-prefixed unit up, e.g., 1 km instead of 1000
     // m.)
     //
-    // The "bad outcome" here is the inverse of a nonzero value getting represented as 0.  To avoid
-    // this for all integral numbers 1000 and less, the dividend must be at least 1000.
+    // The "bad outcome" here is a lossy conversion.  Since we're mainly worried about the integral
+    // domain (because floating point numbers are already pretty well behaved), this means that:
+    //
+    //    inverse_in(a, inverse_as(b, a(n)))
+    //
+    // should be the identity for all n <= 1000.  For this to be true, we need a threshold of
+    // (1'000 ^ 2) = 1'000'000.
+    //
+    // (An extreme instance of this kind of lossiness would be the inverse of a nonzero value
+    // getting represented as 0, which would happen for values over the threshold.)
+
+    // This will fail at compile time for types that can't hold 1'000'000.
+    constexpr R threshold = 1'000'000;
+
     static_assert(
-        make_quantity<UnitProductT<>>(R{1}).in(associated_unit(target_units) * U{}) >= 1000 ||
+        make_quantity<UnitProductT<>>(R{1}).in(associated_unit(target_units) * U{}) >= threshold ||
             std::is_floating_point<R>::value,
         "Dangerous inversion risking truncation to 0; must supply explicit Rep if truly desired");
 

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -713,8 +713,8 @@ TEST(CeilIn, SupportsDifferentOutputTypes) {
 }
 
 TEST(InverseAs, HandlesIntegerRepCorrectly) {
-    constexpr auto period = inverse_as(milli(seconds), hertz(40));
-    EXPECT_THAT(period, SameTypeAndValue(milli(seconds)(25)));
+    constexpr auto period = inverse_as(micro(seconds), hertz(40));
+    EXPECT_THAT(period, SameTypeAndValue(micro(seconds)(25'000)));
 }
 
 TEST(InverseAs, SupportsDividendLessThanOneThousandForFloatingPointRepOnly) {
@@ -732,8 +732,8 @@ TEST(InverseAs, SupportsDividendLessThanOneThousandForFloatingPointRepOnly) {
 }
 
 TEST(InverseIn, HasSameValueAsInverseAs) {
-    EXPECT_THAT(inverse_in(milli(seconds), hertz(3)),
-                SameTypeAndValue(inverse_as(milli(seconds), hertz(3)).in(milli(seconds))));
+    EXPECT_THAT(inverse_in(micro(seconds), hertz(3)),
+                SameTypeAndValue(inverse_as(micro(seconds), hertz(3)).in(micro(seconds))));
 
     EXPECT_THAT((inverse_in<double>(seconds, hertz(3))),
                 SameTypeAndValue(inverse_as<double>(seconds, hertz(3)).in(seconds)));

--- a/docs/tutorial/103-unit-conversions.md
+++ b/docs/tutorial/103-unit-conversions.md
@@ -188,15 +188,15 @@ types.
                 overflow --- so small that we haven't even _reached_ the next unit --- we should
                 _definitely_ forbid the conversion.
 
-              - On the other hand, we've found it useful to initialize, say, `QuantityU32<Hertz>`
+              - On the other hand, we've found it useful to initialize, say, `QuantityI32<Hertz>`
                 variables with something like `mega(hertz)(500)`.  Thus, we'd like this operation
                 to succeed (although it should probably be near the border of what's allowed).
 
-            Putting it all together, we settled on [a value threshold of 4,294][threshold].  If we
+            Putting it all together, we settled on [a value threshold of 2'147][threshold].  If we
             can convert this value without overflow, then we permit the operation; otherwise, we
             don't.  We picked this value because it satisfies our above criteria nicely.  It will
             prevent operations that can't handle values of 1,000, but it still lets us use
-            $\text{MHz}$ freely when storing $\text{Hz}$ quantities in `uint32_t`.
+            $\text{MHz}$ freely when storing $\text{Hz}$ quantities in `int32_t`.
 
             We can picture this relationship in terms of the _biggest allowable conversion factor_,
             as a function of the _max value of the type_.  This function separates the allowed
@@ -345,7 +345,7 @@ is their policy (paraphrased and simplified):
 And here is our refinement (the _overflow safety surface_):
 
 - If an integral-Rep conversion would overflow the _destination type_ for a _source value_ [as small
-  as `4'294`][threshold], we _forbid_ the conversion.
+  as `2'147`][threshold], we _forbid_ the conversion.
 
 ??? info "Deeper dive: comparing overflow strategies for Au and `chrono`"
     The `std::chrono` library doesn't consider overflow in its conversion policy, because they


### PR DESCRIPTION
The primary motivation is to move to a more defensible policy for
inversions.  Formerly, our policy was "avoid truncating nonzero values
to 0" for any value <= 1000.  The new policy is "keep round-trip
inversion lossless" for any such value.  This amounts to changing the
threshold from 1,000 to 1,000,000.

Unfortunately, if we made this change alone, we'd have poor ergonomics
even for pretty reasonable conversions.  For example:

```cpp
constexpr auto period = inverse_as(micro(seconds), hertz(40));
```

This fails because converting `1` to the (dimensionless) product of the
units multiplies by 1,000,000.  Since we're using `int`, this would
overflow the old threshold of 4,294.  So, these thresholds are
connected.

I've actually been thinking for a while that it would be nice to loosen
that threshold ever so slightly.  It's a nuisance to treat `int32_t` and
`uint32_t` differently, despite a very small difference in their ranges.
So I also make that change in this PR.  Ultimately, I think this will be
a very durable "sweet spot".  It's pleasing that we prioritize values of
up to 1,000 generally, and you can fit 3 factors of 1,000 in an `int`,
with a little room to spare (which we put towards extending the safety
surface).

Fixes #69.

Test plan
---------

- [x] Existing unit tests (subject to appropriate tweaks).
- [x] Tested on Aurora's whole codebase.  No significant errors
      introduced.
- [x] Checked compile time impact: no significant effect.
- [x] Added a test, `QuantityPoint.PreservesRep`, which I had wanted to
      add in #101, but couldn't.