### PR TITLE
Mark tutorial executables as `manual`

### DIFF
--- a/tutorial/BUILD
+++ b/tutorial/BUILD
@@ -23,6 +23,7 @@ cc_binary(
     name = "101_quantity_makers",
     testonly = True,
     srcs = ["101_quantity_makers.cc"],
+    tags = ["manual"],
     deps = [
         ":utils",
         "//au",
@@ -42,6 +43,7 @@ cc_test(
     name = "102_api_types_test",
     testonly = True,
     srcs = ["102_api_types_test.cc"],
+    tags = ["manual"],
     deps = [
         ":102_api_types",
         "//au:testing",


### PR DESCRIPTION
When we run `bazel test //...:all`, we currently get this nuisance
warning:

```
tutorial/101_quantity_makers.cc:68:20: warning: unused variable 'track_length' [-Wunused-variable]
    constexpr auto track_length = meters(track_length_m);
                   ^
```

Tutorials should only ever be run manually.  Tagging them as such
prevents this distraction.