### PR TITLE
Ensure that `Rep` is `std::is_arithmetic`

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -113,6 +113,9 @@ class Quantity {
     using Unit = UnitT;
     static constexpr auto unit = Unit{};
 
+    static_assert(std::is_arithmetic<Rep>::value,
+                  "Rep must be built-in numeric type for now; see #52");
+
     // IMPLICIT constructor for another Quantity of the same Dimension.
     template <typename OtherUnit,
               typename OtherRep,

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -93,6 +93,9 @@ class QuantityPoint {
     static constexpr Unit unit{};
     using Diff = Quantity<Unit, Rep>;
 
+    static_assert(std::is_arithmetic<Rep>::value,
+                  "Rep must be built-in numeric type for now; see #52");
+
     // The default constructor produces a QuantityPoint in a valid but contractually unspecified
     // state.  It exists to give you an object you can assign to.  The main motivating factor for
     // including this is to support `std::atomic`, which requires its types to be

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -93,9 +93,6 @@ class QuantityPoint {
     static constexpr Unit unit{};
     using Diff = Quantity<Unit, Rep>;
 
-    static_assert(std::is_arithmetic<Rep>::value,
-                  "Rep must be built-in numeric type for now; see #52");
-
     // The default constructor produces a QuantityPoint in a valid but contractually unspecified
     // state.  It exists to give you an object you can assign to.  The main motivating factor for
     // including this is to support `std::atomic`, which requires its types to be


### PR DESCRIPTION
This applies to both `Quantity` and `QuantityPoint`.  Most users tend
not to hit this use case, but when they do, it can be pretty confusing.
This `static_assert` will give a direct, readable error message.

It turns out we really only need/want to add this to `Quantity`, not
`QuantityPoint`.  If we add it to both, we get a double error message for
`QuantityPoint`.

Fixes #38.

Test plan
---------

I tried some silly test cases, like `meters(meters(3))`, and
`meters_pt(meters_pt(3))`.  They fail to compile both with and without
this PR in both cases, but the error message with this PR is _much_
shorter and more direct.