### PR TITLE
Port XKCD 2585 test to Au repo

### DIFF
--- a/au/au_test.cc
+++ b/au/au_test.cc
@@ -16,8 +16,14 @@
 
 #include "au/prefix.hh"
 #include "au/testing.hh"
+#include "au/units/fathoms.hh"
+#include "au/units/furlongs.hh"
 #include "au/units/hertz.hh"
+#include "au/units/hours.hh"
+#include "au/units/knots.hh"
 #include "au/units/meters.hh"
+#include "au/units/miles.hh"
+#include "au/units/yards.hh"
 #include "gtest/gtest.h"
 
 using ::testing::StaticAssertTypeEq;
@@ -47,6 +53,50 @@ TEST(Conversions, SupportIntMHzToU32Hz) {
 
 TEST(CommonUnit, HandlesPrefixesReasonably) {
     StaticAssertTypeEq<CommonUnitT<Kilo<Meters>, Meters>, Meters>();
+}
+
+template <typename U, typename R>
+constexpr auto round_sequentially(Quantity<U, R> q) {
+    std::cout << q << std::endl;
+    return q;
+}
+
+template <typename U, typename R, typename FirstUnit, typename... NextUnits>
+constexpr auto round_sequentially(Quantity<U, R> q, FirstUnit first_unit, NextUnits... next_units) {
+    std::cout << q << "\n `-> ";
+    return round_sequentially(round_as(first_unit, q), next_units...);
+}
+
+TEST(RoundAs, ReproducesXkcd2585) {
+    constexpr auto true_speed = (miles / hour)(17);
+
+    const auto rounded_speed = round_sequentially(true_speed,
+                                                  meters / second,
+                                                  knots,
+                                                  fathoms / second,
+                                                  furlongs / minute,
+                                                  fathoms / second,
+                                                  kilo(meters) / hour,
+                                                  knots,
+                                                  kilo(meters) / hour,
+                                                  furlongs / hour,
+                                                  miles / hour,
+                                                  meters / second,
+                                                  furlongs / minute,
+                                                  yards / second,
+                                                  fathoms / second,
+                                                  meters / second,
+                                                  miles / hour,
+                                                  furlongs / minute,
+                                                  knots,
+                                                  yards / second,
+                                                  fathoms / second,
+                                                  knots,
+                                                  furlongs / minute,
+                                                  miles / hour);
+
+    // Authoritative reference: https://xkcd.com/2585/
+    EXPECT_EQ((miles / hour)(45), rounded_speed);
 }
 
 }  // namespace au

--- a/au/units/fathoms.hh
+++ b/au/units/fathoms.hh
@@ -1,0 +1,24 @@
+// Copyright 2022 Aurora Operations, Inc.
+
+#pragma once
+
+#include "au/quantity.hh"
+#include "au/units/feet.hh"
+
+namespace au {
+
+// DO NOT follow this pattern to define your own units.  This is for library-defined units.
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+template <typename T>
+struct FathomsLabel {
+    static constexpr const char label[] = "ftm";
+};
+template <typename T>
+constexpr const char FathomsLabel<T>::label[];
+struct Fathoms : decltype(Feet{} * mag<6>()), FathomsLabel<void> {
+    using FathomsLabel<void>::label;
+};
+constexpr auto fathom = SingularNameFor<Fathoms>{};
+constexpr auto fathoms = QuantityMaker<Fathoms>{};
+
+}  // namespace au

--- a/au/units/fathoms.hh
+++ b/au/units/fathoms.hh
@@ -1,4 +1,16 @@
 // Copyright 2022 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 

--- a/au/units/furlongs.hh
+++ b/au/units/furlongs.hh
@@ -1,0 +1,24 @@
+// Copyright 2022 Aurora Operations, Inc.
+
+#pragma once
+
+#include "au/quantity.hh"
+#include "au/units/miles.hh"
+
+namespace au {
+
+// DO NOT follow this pattern to define your own units.  This is for library-defined units.
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+template <typename T>
+struct FurlongsLabel {
+    static constexpr const char label[] = "fur";
+};
+template <typename T>
+constexpr const char FurlongsLabel<T>::label[];
+struct Furlongs : decltype(Miles{} / mag<8>()), FurlongsLabel<void> {
+    using FurlongsLabel<void>::label;
+};
+constexpr auto furlong = SingularNameFor<Furlongs>{};
+constexpr auto furlongs = QuantityMaker<Furlongs>{};
+
+}  // namespace au

--- a/au/units/furlongs.hh
+++ b/au/units/furlongs.hh
@@ -1,4 +1,16 @@
 // Copyright 2022 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 

--- a/au/units/knots.hh
+++ b/au/units/knots.hh
@@ -1,0 +1,25 @@
+// Copyright 2022 Aurora Operations, Inc.
+
+#pragma once
+
+#include "au/quantity.hh"
+#include "au/units/hours.hh"
+#include "au/units/nautical_miles.hh"
+
+namespace au {
+
+// DO NOT follow this pattern to define your own units.  This is for library-defined units.
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+template <typename T>
+struct KnotsLabel {
+    static constexpr const char label[] = "kn";
+};
+template <typename T>
+constexpr const char KnotsLabel<T>::label[];
+struct Knots : decltype(NauticalMiles{} / Hours{}), KnotsLabel<void> {
+    using KnotsLabel<void>::label;
+};
+constexpr auto knot = SingularNameFor<Knots>{};
+constexpr auto knots = QuantityMaker<Knots>{};
+
+}  // namespace au

--- a/au/units/knots.hh
+++ b/au/units/knots.hh
@@ -1,4 +1,16 @@
 // Copyright 2022 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 

--- a/au/units/nautical_miles.hh
+++ b/au/units/nautical_miles.hh
@@ -1,4 +1,16 @@
 // Copyright 2022 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 

--- a/au/units/nautical_miles.hh
+++ b/au/units/nautical_miles.hh
@@ -1,0 +1,24 @@
+// Copyright 2022 Aurora Operations, Inc.
+
+#pragma once
+
+#include "au/quantity.hh"
+#include "au/units/meters.hh"
+
+namespace au {
+
+// DO NOT follow this pattern to define your own units.  This is for library-defined units.
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+template <typename T>
+struct NauticalMilesLabel {
+    static constexpr const char label[] = "nmi";
+};
+template <typename T>
+constexpr const char NauticalMilesLabel<T>::label[];
+struct NauticalMiles : decltype(Meters{} * mag<1'852>()), NauticalMilesLabel<void> {
+    using NauticalMilesLabel<void>::label;
+};
+constexpr auto nautical_mile = SingularNameFor<NauticalMiles>{};
+constexpr auto nautical_miles = QuantityMaker<NauticalMiles>{};
+
+}  // namespace au

--- a/au/units/test/fathoms_test.cc
+++ b/au/units/test/fathoms_test.cc
@@ -1,0 +1,27 @@
+// Copyright 2022 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/units/fathoms.hh"
+
+#include "au/testing.hh"
+#include "au/units/feet.hh"
+#include "gtest/gtest.h"
+
+namespace au {
+
+TEST(Fathoms, HasExpectedLabel) { expect_label<Fathoms>("ftm"); }
+
+TEST(Fathoms, EquivalentTo6Feet) { EXPECT_EQ(fathoms(1), feet(6)); }
+
+}  // namespace au

--- a/au/units/test/furlongs_test.cc
+++ b/au/units/test/furlongs_test.cc
@@ -1,0 +1,27 @@
+// Copyright 2022 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/units/furlongs.hh"
+
+#include "au/testing.hh"
+#include "au/units/miles.hh"
+#include "gtest/gtest.h"
+
+namespace au {
+
+TEST(Furlongs, HasExpectedLabel) { expect_label<Furlongs>("fur"); }
+
+TEST(Furlongs, EquivalentToOneEighthMile) { EXPECT_EQ(furlongs(8), miles(1)); }
+
+}  // namespace au

--- a/au/units/test/knots_test.cc
+++ b/au/units/test/knots_test.cc
@@ -1,0 +1,29 @@
+// Copyright 2022 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/units/knots.hh"
+
+#include "au/testing.hh"
+#include "au/units/hours.hh"
+#include "au/units/knots.hh"
+#include "au/units/meters.hh"
+#include "gtest/gtest.h"
+
+namespace au {
+
+TEST(Knots, HasExpectedLabel) { expect_label<Knots>("kn"); }
+
+TEST(Knots, EquivalentToNauticalMilesPerHour) { EXPECT_EQ(knots(1), (nautical_miles / hour)(1)); }
+
+}  // namespace au

--- a/au/units/test/nautical_miles_test.cc
+++ b/au/units/test/nautical_miles_test.cc
@@ -1,0 +1,31 @@
+// Copyright 2022 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/units/nautical_miles.hh"
+
+#include "au/testing.hh"
+#include "au/units/hours.hh"
+#include "au/units/knots.hh"
+#include "au/units/meters.hh"
+#include "gtest/gtest.h"
+
+namespace au {
+
+TEST(NauticalMiles, HasExpectedLabel) { expect_label<NauticalMiles>("nmi"); }
+
+TEST(NauticalMiles, EquivalentTo1852Meters) { EXPECT_EQ(nautical_miles(1), meters(1'852)); }
+
+TEST(NauticalMiles, EquivalentToKnotHours) { EXPECT_EQ(nautical_miles(1), (knot * hours)(1)); }
+
+}  // namespace au


### PR DESCRIPTION
A lot has happened since we first reproduced XKCD 2585[1] in our units
library[2].  At the time, the library where we added the test was just
"Aurora's units library".  The library Au, which started out as a
drop-in replacement for "Aurora's units library" and has now been open
sourced, wouldn't even be conceived of for another month or so.

Now that Au is out, it's time to reimagine this unit test to take
advantage of its more fluent, natural interfaces.  Instead of clunky
`quotient_t` metafunctions and template parameters, we have simple
division and function parameters.  We can also form compound units on
the fly by composition --- for example, `kilo(meters) / hour` instead of
`KilometersPerHour`.

This results in the addition of four more units to the library, so of
course they get their own (rather less whimsical) unit tests, too.

[1] https://xkcd.com/2585/
[2] https://mobile.twitter.com/openMindedSkep/status/1496964956390137858

Test plan
---------

I added printing code to this implementation, so we could check the
intermediate results, too --- taking advantage of Au's automatic unit
label generation facilities.  Compare this output with the authoritative
source (https://xkcd.com/2585/):

```
[ RUN      ] RoundAs.ReproducesXkcd2585
17 mi / h
 `-> 8 m / s
 `-> 16 kn
 `-> 5 ftm / s
 `-> 3 fur / min
 `-> 6 ftm / s
 `-> 40 km / h
 `-> 22 kn
 `-> 41 km / h
 `-> 204 fur / h
 `-> 26 mi / h
 `-> 12 m / s
 `-> 4 fur / min
 `-> 15 yd / s
 `-> 8 ftm / s
 `-> 15 m / s
 `-> 34 mi / h
 `-> 5 fur / min
 `-> 33 kn
 `-> 19 yd / s
 `-> 10 ftm / s
 `-> 36 kn
 `-> 6 fur / min
 `-> 45 mi / h
[       OK ] RoundAs.ReproducesXkcd2585 (0 ms)
```