### PR TITLE
Add compatibility utility for nholthaus units

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -116,6 +116,15 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.14.0.tar.gz",
 )
 
+http_archive(
+    name = "nholthaus_units",
+    add_prefix = "nholthaus_units",
+    build_file = "@//third_party/nholthaus_units:BUILD",
+    sha256 = "b1f3c1dd11afa2710a179563845ce79f13ebf0c8c090d6aa68465b18bd8bd5fc",
+    strip_prefix = "units-2.3.3/include/",
+    url = "https://github.com/nholthaus/units/archive/refs/tags/v2.3.3.tar.gz",
+)
+
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 python_register_toolchains(

--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 cc_library(
     name = "nholthaus_units",

--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "nholthaus_units",
     hdrs = ["nholthaus_units.hh"],

--- a/compatibility/BUILD
+++ b/compatibility/BUILD
@@ -1,0 +1,35 @@
+# Copyright 2023 Aurora Operations, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cc_library(
+    name = "nholthaus_units",
+    hdrs = ["nholthaus_units.hh"],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "nholthaus_units_test",
+    size = "small",
+    srcs = [
+        "nholthaus_units_example_usage.hh",
+        "nholthaus_units_test.cc",
+    ],
+    deps = [
+        ":nholthaus_units",
+        "//au",
+        "//au:testing",
+        "@com_google_googletest//:gtest_main",
+        "@nholthaus_units",
+    ],
+)

--- a/compatibility/nholthaus_units.hh
+++ b/compatibility/nholthaus_units.hh
@@ -1,0 +1,252 @@
+// Copyright 2023 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// HOW TO USE THIS FILE
+//
+// This file does all of the "heavy lifting" in establishing correspondence between equivalent types
+// in Au and in the nholthaus units library.  HOWEVER, it does NOT include either of those libraries
+// directly.  The reason is simple: there is a wide diversity in the ways people include each of the
+// libraries.  Thus, if we included either directly here, it would fail to compile for many people.
+//
+// What you should do is to make a _new_ file, in your project, which does these things:
+//
+//   1. Include Au (in whatever manner is appropriate for your project).
+//   2. Include the nholthaus units library (in whatever manner is appropriate for your project).
+//   3. Include this present file, AFTER every other file.
+//
+// Relying on the order of includes is a fragile strategy in general.  However, if you confine it to
+// a single file, and then only ever use that new file, then the strategy can work.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <cstddef>
+#include <cstdint>
+#include <ratio>
+
+namespace au {
+
+namespace detail {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// This utility lets us extract a single template parameter.
+
+template <class T>
+struct SoleTemplateParameter;
+template <class T>
+using SoleTemplateParameterT = typename SoleTemplateParameter<T>::type;
+template <template <class> class Temp, class T>
+struct SoleTemplateParameter<Temp<T>> {
+    using type = T;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// These extract the exponent for each base unit from a coherent derived unit (which nholthaus calls
+// "base_unit").
+
+template <class U>
+struct MeterExp;
+template <class U>
+using MeterExpT = typename MeterExp<U>::type;
+template <class M, class Kg, class S, class R, class A, class Ke, class Mo, class C, class B>
+struct MeterExp<units::base_unit<M, Kg, S, R, A, Ke, Mo, C, B>> : stdx::type_identity<M> {};
+
+template <class U>
+struct KilogramExp;
+template <class U>
+using KilogramExpT = typename KilogramExp<U>::type;
+template <class M, class Kg, class S, class R, class A, class Ke, class Mo, class C, class B>
+struct KilogramExp<units::base_unit<M, Kg, S, R, A, Ke, Mo, C, B>> : stdx::type_identity<Kg> {};
+
+template <class U>
+struct SecondExp;
+template <class U>
+using SecondExpT = typename SecondExp<U>::type;
+template <class M, class Kg, class S, class R, class A, class Ke, class Mo, class C, class B>
+struct SecondExp<units::base_unit<M, Kg, S, R, A, Ke, Mo, C, B>> : stdx::type_identity<S> {};
+
+template <class U>
+struct RadianExp;
+template <class U>
+using RadianExpT = typename RadianExp<U>::type;
+template <class M, class Kg, class S, class R, class A, class Ke, class Mo, class C, class B>
+struct RadianExp<units::base_unit<M, Kg, S, R, A, Ke, Mo, C, B>> : stdx::type_identity<R> {};
+
+template <class U>
+struct AmpExp;
+template <class U>
+using AmpExpT = typename AmpExp<U>::type;
+template <class M, class Kg, class S, class R, class A, class Ke, class Mo, class C, class B>
+struct AmpExp<units::base_unit<M, Kg, S, R, A, Ke, Mo, C, B>> : stdx::type_identity<A> {};
+
+template <class U>
+struct KelvinExp;
+template <class U>
+using KelvinExpT = typename KelvinExp<U>::type;
+template <class M, class Kg, class S, class R, class A, class Ke, class Mo, class C, class B>
+struct KelvinExp<units::base_unit<M, Kg, S, R, A, Ke, Mo, C, B>> : stdx::type_identity<Ke> {};
+
+template <class U>
+struct MoleExp;
+template <class U>
+using MoleExpT = typename MoleExp<U>::type;
+template <class M, class Kg, class S, class R, class A, class Ke, class Mo, class C, class B>
+struct MoleExp<units::base_unit<M, Kg, S, R, A, Ke, Mo, C, B>> : stdx::type_identity<Mo> {};
+
+template <class U>
+struct CandelaExp;
+template <class U>
+using CandelaExpT = typename CandelaExp<U>::type;
+template <class M, class Kg, class S, class R, class A, class Ke, class Mo, class C, class B>
+struct CandelaExp<units::base_unit<M, Kg, S, R, A, Ke, Mo, C, B>> : stdx::type_identity<C> {};
+
+template <class U>
+struct ByteExp;
+template <class U>
+using ByteExpT = typename ByteExp<U>::type;
+template <class M, class Kg, class S, class R, class A, class Ke, class Mo, class C, class B>
+struct ByteExp<units::base_unit<M, Kg, S, R, A, Ke, Mo, C, B>> : stdx::type_identity<B> {};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// These versions make sure derived units inherit their exponents from the corresponding base units.
+
+template <class X1, class BaseUnit, class X3, class X4>
+struct MeterExp<units::unit<X1, BaseUnit, X3, X4>> : MeterExp<BaseUnit> {};
+
+template <class X1, class BaseUnit, class X3, class X4>
+struct KilogramExp<units::unit<X1, BaseUnit, X3, X4>> : KilogramExp<BaseUnit> {};
+
+template <class X1, class BaseUnit, class X3, class X4>
+struct SecondExp<units::unit<X1, BaseUnit, X3, X4>> : SecondExp<BaseUnit> {};
+
+template <class X1, class BaseUnit, class X3, class X4>
+struct RadianExp<units::unit<X1, BaseUnit, X3, X4>> : RadianExp<BaseUnit> {};
+
+template <class X1, class BaseUnit, class X3, class X4>
+struct AmpExp<units::unit<X1, BaseUnit, X3, X4>> : AmpExp<BaseUnit> {};
+
+template <class X1, class BaseUnit, class X3, class X4>
+struct KelvinExp<units::unit<X1, BaseUnit, X3, X4>> : KelvinExp<BaseUnit> {};
+
+template <class X1, class BaseUnit, class X3, class X4>
+struct MoleExp<units::unit<X1, BaseUnit, X3, X4>> : MoleExp<BaseUnit> {};
+
+template <class X1, class BaseUnit, class X3, class X4>
+struct CandelaExp<units::unit<X1, BaseUnit, X3, X4>> : CandelaExp<BaseUnit> {};
+
+template <class X1, class BaseUnit, class X3, class X4>
+struct ByteExp<units::unit<X1, BaseUnit, X3, X4>> : ByteExp<BaseUnit> {};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Extract the magnitude of this unit relative to a coherent combination of base units.
+
+// `MagFromRatioT<R>` computes the Magnitude which corresponds to a given `std::ratio` instance `R`.
+template <typename RatioT>
+struct MagFromRatio;
+template <typename RatioT>
+using MagFromRatioT = typename MagFromRatio<RatioT>::type;
+template <std::intmax_t N, std::intmax_t D>
+struct MagFromRatio<std::ratio<N, D>> : stdx::type_identity<decltype(mag<N>() / mag<D>())> {};
+
+// `NholthausUnitMagT<U>` is the scale factor for the nholthaus unit `U`, relative to the coherent
+// combination of base units which has the same dimension.
+template <class NholthausUnit>
+struct NholthausUnitMag;
+template <class NholthausUnit>
+using NholthausUnitMagT = typename NholthausUnitMag<NholthausUnit>::type;
+
+// Implementation for derived units: apply top-level scaling factor to recursive result.
+template <class RationalScale, class BaseUnit, class PiPower, class X4>
+struct NholthausUnitMag<units::unit<RationalScale, BaseUnit, PiPower, X4>>
+    : stdx::type_identity<MagProductT<MagFromRatioT<RationalScale>,
+                                      MagPowerT<Magnitude<Pi>, PiPower::num, PiPower::den>,
+                                      NholthausUnitMagT<BaseUnit>>> {};
+
+// Implementation for base units: always 1 (i.e., the null Magnitude) by definition.
+template <class... Es>
+struct NholthausUnitMag<units::base_unit<Es...>> : stdx::type_identity<Magnitude<>> {};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Compute the au unit which corresponds to a given nholthaus unit.
+
+template <class NholthausUnit>
+struct AuUnit {
+    using NU = NholthausUnit;
+
+    // If you want to use only a subset of units, you can avoid depending on the Au analogues for
+    // all 9 nholthaus base units.  Simply delete the corresponding `UnitPowerT` from the
+    // `decltype()` expression below.
+    //
+    // **NOTE:** For safety, if you do this, make sure that you also add a line like the following
+    // (using moles as an example):
+    //
+    // static_assert(MoleExpT<NU>::num == 0, "Moles not supported");
+
+    using type = decltype(UnitPowerT<Meters, MeterExpT<NU>::num, MeterExpT<NU>::den>{} *
+                          UnitPowerT<Kilo<Grams>, KilogramExpT<NU>::num, KilogramExpT<NU>::den>{} *
+                          UnitPowerT<Seconds, SecondExpT<NU>::num, SecondExpT<NU>::den>{} *
+                          UnitPowerT<Radians, RadianExpT<NU>::num, RadianExpT<NU>::den>{} *
+                          UnitPowerT<Amperes, AmpExpT<NU>::num, AmpExpT<NU>::den>{} *
+                          UnitPowerT<Kelvins, KelvinExpT<NU>::num, KelvinExpT<NU>::den>{} *
+                          UnitPowerT<Bytes, ByteExpT<NU>::num, ByteExpT<NU>::den>{} *
+                          UnitPowerT<Candelas, CandelaExpT<NU>::num, CandelaExpT<NU>::den>{} *
+                          UnitPowerT<Moles, MoleExpT<NU>::num, MoleExpT<NU>::den>{} *
+                          NholthausUnitMagT<NU>{});
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Extract the nholthaus unit from a `units::unit_t`.
+
+template <class NholthausType>
+struct NholthausUnitType;
+template <class U, class R, template <class> class S>
+struct NholthausUnitType<units::unit_t<U, R, S>> : stdx::type_identity<U> {};
+
+}  // namespace detail
+
+// Define 1:1 mapping from each nholthaus type to its corresponding `au::Quantity` type.
+template <class R, class RationalScale, class BaseUnit, class PiPower>
+struct CorrespondingQuantity<
+    units::unit_t<units::unit<RationalScale, BaseUnit, PiPower, std::ratio<0>>,
+                  R,
+                  units::linear_scale>> {
+    using NholthausType = typename detail::SoleTemplateParameter<CorrespondingQuantity>::type;
+    using NholthausUnit = typename detail::NholthausUnitType<NholthausType>::type;
+
+    using Unit = typename detail::AuUnit<NholthausUnit>::type;
+    using Rep = R;
+
+    static constexpr Rep extract_value(NholthausType d) { return d.template to<Rep>(); }
+    static constexpr NholthausType construct_from_value(Rep x) { return NholthausType{x}; }
+};
+
+// nholthaus handles dimensionless values inconsistently, so we must work around it.  See:
+// https://github.com/nholthaus/units/issues/276
+template <typename R>
+struct CorrespondingQuantity<units::unit_t<units::concentration::percent, R, units::linear_scale>> {
+    using Unit = Percent;
+    using Rep = R;
+
+    using NholthausType = typename detail::SoleTemplateParameter<CorrespondingQuantity>::type;
+
+    // This is the workaround: we must manually multiply the value by 100, because the nholthaus
+    // library divides it by 100.  Note the glaring asymmetry between `extract_value()` and
+    // `construct_from_value()`.
+    static constexpr Rep extract_value(NholthausType d) { return 100 * d.template to<Rep>(); }
+
+    static constexpr NholthausType construct_from_value(Rep x) { return NholthausType{x}; }
+};
+
+}  // namespace au

--- a/compatibility/nholthaus_units_example_usage.hh
+++ b/compatibility/nholthaus_units_example_usage.hh
@@ -1,0 +1,44 @@
+// Copyright 2023 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// clang-format off
+
+// First, include your Au installation.
+//
+// For "full install" options, it will likely look like what is included here.
+//
+// For "single file" options, it will simply be your single file.  However, make sure that it
+// includes all of the following units!
+#include "au/au.hh"
+#include "au/units/amperes.hh"
+#include "au/units/bytes.hh"
+#include "au/units/candelas.hh"
+#include "au/units/grams.hh"
+#include "au/units/kelvins.hh"
+#include "au/units/meters.hh"
+#include "au/units/moles.hh"
+#include "au/units/radians.hh"
+#include "au/units/seconds.hh"
+
+// Next, include your nholthaus units installation.
+#include "nholthaus_units/units.h"
+
+// Finally, include the compatibility layer.
+//
+// This file MUST be included AFTER all others.
+#include "compatibility/nholthaus_units.hh"
+
+// clang-format on

--- a/compatibility/nholthaus_units_test.cc
+++ b/compatibility/nholthaus_units_test.cc
@@ -1,0 +1,161 @@
+// Copyright 2023 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/au.hh"
+#include "au/testing.hh"
+#include "au/units/bars.hh"
+#include "au/units/degrees.hh"
+#include "au/units/feet.hh"
+#include "au/units/hertz.hh"
+#include "au/units/hours.hh"
+#include "au/units/liters.hh"
+#include "au/units/miles.hh"
+#include "au/units/minutes.hh"
+#include "au/units/newtons.hh"
+#include "au/units/percent.hh"
+#include "au/units/pounds_force.hh"
+#include "au/units/revolutions.hh"
+#include "au/units/unos.hh"
+#include "au/units/volts.hh"
+#include "au/units/watts.hh"
+#include "compatibility/nholthaus_units_example_usage.hh"
+#include "gtest/gtest.h"
+
+namespace {
+
+using namespace au;
+
+// Usage: `expect_equivalent<::units::dim::specific_unit_t>(specific_unit)`.
+//
+// Here, `specific_unit_t` is the _type_ from the nholthaus library which represents a quantity of
+// that unit.  (The rep, which is universal in that library, is assumed to be `double`.)
+// `specific_unit` is a `QuantityMaker` from the Aurora units library.
+//
+// The meaning of `expect_equivalent<specific_unit_t>(specific_unit)` is that:
+//   - an `as_quantity` mapping exists for `specific_unit_t` to some equivalent `au` Quantity;
+//   - an instance of `specific_unit_t` can be _implicitly_ converted to this mapped type;
+//   - the result of this conversion is equivalent to calling the given QuantityMaker on the
+//     underlying value;
+//   - the mapped type can also be _implicitly_ converted back to `specific_unit_t`, and the round
+//     trip is the identity.
+template <typename NholthausType, typename AuUnit>
+void expect_equivalent(QuantityMaker<AuUnit> expected_au_unit) {
+    const auto original = NholthausType{1.2};
+    const auto equivalent_to_expected_au_unit = QuantityEquivalent(expected_au_unit(1.2));
+
+    // Check that an `as_quantity` mapping _exists_ for this nholthaus type, and that its result is
+    // quantity-equivalent to the given QuantityMaker applied to the same underlying value.
+    const auto converted_to_quantity = as_quantity(original);
+    EXPECT_THAT(converted_to_quantity, equivalent_to_expected_au_unit);
+
+    // Check that this nholthaus type is _implicitly_ convertible to its equivalent type, and that
+    // again, the result is quantity-equivalent to the given QuantityMaker applied to the same
+    // underlying value.
+    const decltype(converted_to_quantity) implicitly_converted_to_quantity = original;
+    EXPECT_THAT(implicitly_converted_to_quantity, equivalent_to_expected_au_unit);
+
+    // Check that the equivalent Quantity type can be _implicitly_ converted back to the original
+    // nholthaus type, and that this round trip is the identity.
+    const NholthausType round_trip = implicitly_converted_to_quantity;
+    EXPECT_EQ(round_trip, original);
+}
+
+TEST(NholthausTypes, MapsBaseUnitsOntoCorrectAuQuantityTypes) {
+    expect_equivalent<::units::length::meter_t>(meters);
+    expect_equivalent<::units::mass::kilogram_t>(kilo(grams));
+    expect_equivalent<::units::time::second_t>(seconds);
+    expect_equivalent<::units::angle::radian_t>(radians);
+    expect_equivalent<::units::current::ampere_t>(amperes);
+    expect_equivalent<::units::temperature::kelvin_t>(kelvins);
+    expect_equivalent<::units::data::byte_t>(bytes);
+}
+
+TEST(NholthausTypes, MapsFactorsOfPiToCorrectMagnitude) {
+    expect_equivalent<::units::angle::degree_t>(degrees);
+}
+
+TEST(NholthausTypes, MapsDerivedUnitsFoundInCodebaseCorrectly) {
+    expect_equivalent<::units::acceleration::feet_per_second_squared_t>(feet / squared(second));
+    expect_equivalent<::units::acceleration::meters_per_second_squared_t>(meters / squared(second));
+
+    expect_equivalent<::units::angular_velocity::degrees_per_second_t>(degrees / second);
+    expect_equivalent<::units::angular_velocity::radians_per_second_t>(radians / second);
+    expect_equivalent<::units::angular_velocity::revolutions_per_minute_t>(revolutions / minute);
+
+    expect_equivalent<::units::area::square_meter_t>(squared(meters));
+
+    expect_equivalent<::units::concentration::percent_t>(percent);
+
+    expect_equivalent<::units::data_transfer_rate::bytes_per_second_t>(bytes / second);
+    expect_equivalent<::units::data_transfer_rate::megabytes_per_second_t>(mega(bytes) / second);
+
+    expect_equivalent<::units::dimensionless::dimensionless_t>(unos);
+    expect_equivalent<::units::dimensionless::scalar_t>(unos);
+
+    expect_equivalent<::units::force::newton_t>(newtons);
+
+    expect_equivalent<::units::frequency::hertz_t>(hertz);
+    expect_equivalent<::units::frequency::megahertz_t>(mega(hertz));
+
+    expect_equivalent<::units::length::centimeter_t>(centi(meters));
+    expect_equivalent<::units::length::foot_t>(feet);
+    expect_equivalent<::units::length::kilometer_t>(kilo(meters));
+    expect_equivalent<::units::length::micrometer_t>(micro(meters));
+    expect_equivalent<::units::length::mile_t>(miles);
+    expect_equivalent<::units::length::millimeter_t>(milli(meters));
+
+    expect_equivalent<::units::power::milliwatt_t>(milli(watts));
+    expect_equivalent<::units::power::watt_t>(watts);
+
+    expect_equivalent<::units::pressure::bar_t>(bars);
+    expect_equivalent<::units::pressure::kilopascal_t>(kilo(pascals));
+    expect_equivalent<::units::pressure::mbar_t>(milli(bars));
+
+    expect_equivalent<::units::time::hour_t>(hours);
+    expect_equivalent<::units::time::microsecond_t>(micro(seconds));
+    expect_equivalent<::units::time::millisecond_t>(milli(seconds));
+    expect_equivalent<::units::time::minute_t>(minutes);
+    expect_equivalent<::units::time::nanosecond_t>(nano(seconds));
+
+    expect_equivalent<::units::torque::newton_meter_t>(newton * meters);
+
+    expect_equivalent<::units::velocity::kilometers_per_hour_t>(kilo(meters) / hour);
+    expect_equivalent<::units::velocity::meters_per_second_t>(meters / second);
+    expect_equivalent<::units::velocity::miles_per_hour_t>(miles / hour);
+
+    expect_equivalent<::units::voltage::volt_t>(volts);
+
+    expect_equivalent<::units::volume::liter_t>(liters);
+
+    expect_equivalent<::units::luminous_intensity::candela_t>(candelas);
+
+    expect_equivalent<::units::substance::mole_t>(moles);
+}
+
+TEST(FootPounds, EquivalentWithinAFewPartsPerBillion) {
+    // Every nholthaus unit derived from the slug is wrong:
+    // https://github.com/nholthaus/units/issues/289
+    //
+    // In our codebase, this affects foot-pounds of torque.
+    const auto original = ::units::torque::foot_pound_t{1.2};
+    constexpr auto foot_pounds = foot * pounds_force;
+
+    const auto converted_to_au = as_quantity(original);
+    EXPECT_THAT(converted_to_au, IsNear((foot_pounds)(1.2), nano(foot_pounds)(4)));
+
+    const ::units::torque::foot_pound_t round_trip = converted_to_au;
+    EXPECT_EQ(round_trip, original);
+}
+
+}  // namespace

--- a/third_party/nholthaus_units/BUILD
+++ b/third_party/nholthaus_units/BUILD
@@ -1,0 +1,19 @@
+# Copyright 2023 Aurora Operations, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cc_library(
+    name = "nholthaus_units",
+    hdrs = ["nholthaus_units/units.h"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This creates a file, `"compatibility/nholthaus_units.hh"`, which makes
it easy to set up a correspondence between each Au Quantity type, and
the corresponding nholthaus units type.  This "correspondence" includes
bidirectional implicit conversions: so, you can pass
`::au::QuantityD<Meters>` to an API expecting
`::units::length::meter_t`, and vice versa.

This correspondence is purely opt-in.  The file also needs to be
included _after_ both of the other two libraries are included.  Since
this is fragile in general, we give instructions and an example for how
to make it _not_ fragile, in `nholthaus_units_example_usage.hh`.

We include a variety of unit tests to show that the quantities are
indeed equivalent between the libraries.  (Actually, this isn't quite
always the case.  These tests uncovered a bug in the nholthaus library,
nholthaus/units#289.)

We reserve the documentation of the corresponding-quantity feature in
general, as well as its application to the nholthaus library, for a
future PR.

Test plan
---------

- [x] Add new unit tests for this file.
- [x] Add example file that shows how to use it.
- [x] Test that the file can replace Aurora's existing implementation.