### PR TITLE
Treat warnings as errors in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,4 +30,4 @@ jobs:
     steps:
       - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0
       - name: Build and test (${{ matrix.config }})
-        run: bazel test --config=${{ matrix.config }} //...:all
+        run: bazel test --copt=-Werror --config=${{ matrix.config }} //...:all


### PR DESCRIPTION
This will keep Au compiling warning-free in perpetuity.

We do _not_ set this for _local_ builds because it unnecessarily hinders
experimentation (for example, it adds a bunch of hoops to jump through
for Test Driven Development).

Test plan
---------

I'm posting this after #114 but before #113, because this should turn the silent
warnings in the builds into hard errors on the GitHub checks.  After I confirm
this, I'll land #113 and then confirm that it fixes the checks on this PR.