### PR TITLE
Make default constructors noexcept

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -131,7 +131,7 @@ class Quantity {
     // Construct this Quantity with a value of exactly Zero.
     constexpr Quantity(Zero) : value_{0} {}
 
-    constexpr Quantity() = default;
+    constexpr Quantity() noexcept = default;
 
     // Implicit construction from any exactly-equivalent type.
     template <

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -97,7 +97,7 @@ class QuantityPoint {
     // state.  It exists to give you an object you can assign to.  The main motivating factor for
     // including this is to support `std::atomic`, which requires its types to be
     // default-constructible.
-    constexpr QuantityPoint() : x_{ZERO} {}
+    constexpr QuantityPoint() noexcept : x_{ZERO} {}
 
     template <typename OtherUnit,
               typename OtherRep,


### PR DESCRIPTION
These pretty clearly can't throw.  There may be more `noexcept` we can add in other interfaces, but we can look into that later.

Fixes #119.