### PR TITLE
Upgrade bazelisk to 1.16.0

### DIFF
--- a/third_party/bazelisk/bazelisk.py
+++ b/third_party/bazelisk/bazelisk.py
@@ -17,7 +17,6 @@ limitations under the License.
 
 import base64
 from contextlib import closing
-from distutils.version import LooseVersion
 import hashlib
 import json
 import netrc
@@ -171,15 +170,18 @@ def read_remote_text_file(url):
 
 
 def get_version_history(bazelisk_directory):
-    ordered = sorted(
+    return sorted(
         (
-            LooseVersion(release["tag_name"])
+            release["tag_name"]
             for release in get_releases_json(bazelisk_directory)
             if not release["prerelease"]
         ),
+        # This only handles versions with numeric components, but that is fine
+        # since prerelease versions have been excluded.
+        key=lambda version: tuple(int(component)
+                                  for component in version.split('.')),
         reverse=True,
     )
-    return [str(v) for v in ordered]
 
 
 def resolve_latest_version(version_history, offset):
@@ -256,6 +258,8 @@ def normalized_machine_arch_name():
     machine = platform.machine().lower()
     if machine == "amd64":
         machine = "x86_64"
+    elif machine == "aarch64":
+        machine = "arm64"
     return machine
 
 

--- a/third_party/bazelisk/download.sh
+++ b/third_party/bazelisk/download.sh
@@ -3,7 +3,7 @@
 
 set -eux
 
-BAZELISK_V="1.14.0"
+BAZELISK_V="1.16.0"
 BAZELISK_TARBALL="v${BAZELISK_V}.tar.gz"
 BAZELISK_DIR="bazelisk-${BAZELISK_V}"
 


### PR DESCRIPTION
This fixes the deprecation warning for the distutils library.