### PR TITLE
Replace copy initialization with direct initialization

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -380,7 +380,7 @@ class Quantity {
  private:
     constexpr Quantity(Rep value) : value_{value} {}
 
-    Rep value_ = 0;
+    Rep value_{0};
 };
 
 // Force integer division beteween two integer Quantities, in a callsite-obvious way.


### PR DESCRIPTION
This is for the default member initializer of the `value_` member in the
`Quantity` template.

For reasons which are unclear to me, and which I cannot reproduce in a
standalone unit test, #120 has broken a couple of callsites for Quantity
instances with non-arithmetic Rep.  Using direct initialization fixes
the builds.

What I know about the errors is:

- They happen at _template class instantiation_ time.
- They are of the form, `could not convert '0' from 'int' to 'T'`, where
  `T` is the non-arithmetic Rep.