### PR TITLE
Check Aurora-internal code before releasing

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,11 @@ Create a draft PR which updates Aurora's internal code to the candidate release.
 the builds pass.  If any fail, check whether the best fix lies with Aurora's internal code, or with
 Au.
 
+GitHub will automatically generate a [tarball](https://github.com/aurora-opensource/au/tarball/main)
+of the latest state of `main`.  The `strip_prefix` for this release will typically be
+`aurora-opensource-au-XXXXXXX`, where `XXXXXXX` is the first 7 characters of the most recent commit.
+Of course, you can also unpack it (`tar -xvzf`) to obtain the `strip_prefix` authoritatively.
+
 ### Gather information for release notes
 
 First, go to the [latest release](https://github.com/aurora-opensource/au/releases/latest).  Click

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,16 @@
 
 ## Preparing the release
 
+These are the steps to take before you actually cut the release.
+
+### Check Aurora's code
+
+Create a draft PR which updates Aurora's internal code to the candidate release.  Make sure all of
+the builds pass.  If any fail, check whether the best fix lies with Aurora's internal code, or with
+Au.
+
+### Gather information for release notes
+
 First, go to the [latest release](https://github.com/aurora-opensource/au/releases/latest).  Click
 the list of "commits to main since this release", found near the top.  Read through the commits, and
 keep track of the main changes as you go.  Use the following categories.


### PR DESCRIPTION
This new step would have prevented the need to cut 0.3.2 just a few days
after cutting 0.3.1.