### PR TITLE
Add `//:mike` command for versioned docs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -38,6 +38,23 @@ py_binary(
     ],
 )
 
+py_binary(
+    name = "mike",
+    srcs = ["mike_bin.py"],
+    main = "mike_bin.py",
+    data = [
+        "mkdocs.yml",
+        ":au_hh",
+        ":au_noio_hh",
+    ] + glob(["docs/**"]),
+    deps = [
+        ":update_docs",
+        requirement("mike"),
+        requirement("mkdocs"),
+        requirement("mkdocs-material"),
+    ],
+)
+
 BASE_UNITS = [
     "meters",
     "seconds",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -120,8 +120,17 @@ On the tags page, click the three-dots menu, and select "Create release".
 
 ### Regenerate the doc website
 
-This will update the manifest for `au.hh` and `au_noio.hh`.
+First, create the version of the doc website corresponding to this release.
 
 ```sh
-bazel run //:update_docs -- gh-deploy
+bazel run //:mike -- deploy --push 0.3.1
+```
+
+Next, we need to make sure the manifest for `au.hh` and `au_noio.hh` on the `main` doc website
+includes this latest version tag.  Check out the `main` branch, and run a manual deploy to the
+`main` doc website:
+
+```sh
+git checkout main
+bazel run //:mike -- deploy --push main
 ```

--- a/mike_bin.py
+++ b/mike_bin.py
@@ -1,0 +1,52 @@
+# Copyright 2023 Aurora Operations, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import subprocess
+import sys
+
+from unittest import mock
+import mike.driver
+import mike.mkdocs_utils
+
+
+def override_version():
+    """Retrieve the version in a way that's agnostic to the name of the command.
+
+    Since the `mkdocs` executable isn't installed on our machine, but instead is
+    run through bazel, it turns out that _our_ mkdocs executable thinks it has a
+    different name (since we use a wrapper script).  But mike assumes both that
+    we can call `mkdocs`, _and_ that it thinks its own name is `mkdocs` when we
+    do.
+    """
+    output = subprocess.run(
+        ["mkdocs", "--version"],
+        check=True,
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+    ).stdout.rstrip()
+
+    # Original line:
+    #
+    #    m = re.search('^mkdocs, version (\\S*)', output)
+    #
+    # Changed version:
+    m = re.search("^\\S+, version (\\S*)", output)
+
+    return m.group(1)
+
+
+if __name__ == "__main__":
+    with mock.patch("mike.mkdocs_utils.version", override_version):
+        sys.exit(mike.driver.main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,10 @@ extra_javascript:
 extra_css:
   - tweaks.css
 
+extra:
+  version:
+    provider: mike
+
 markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true

--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -105,6 +105,7 @@ jinja2==3.1.2 \
     --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852 \
     --hash=sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
     # via
+    #   mike
     #   mkdocs
     #   mkdocs-material
 markdown==3.3.7 \
@@ -170,11 +171,16 @@ mergedeep==1.3.4 \
     --hash=sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8 \
     --hash=sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307
     # via mkdocs
+mike==1.1.2 \
+    --hash=sha256:4c307c28769834d78df10f834f57f810f04ca27d248f80a75f49c6fa2d1527ca \
+    --hash=sha256:56c3f1794c2d0b5fdccfa9b9487beb013ca813de2e3ad0744724e9d34d40b77b
+    # via -r ./requirements.in
 mkdocs==1.4.2 \
     --hash=sha256:8947af423a6d0facf41ea1195b8e1e8c85ad94ac95ae307fe11232e0424b11c5 \
     --hash=sha256:c8856a832c1e56702577023cd64cc5f84948280c1c0fcc6af4cd39006ea6aa8c
     # via
     #   -r ./requirements.in
+    #   mike
     #   mkdocs-material
 mkdocs-material==9.1.3 \
     --hash=sha256:0be1b5d76c00efc9b2ecbd2d71014be950351e710f5947f276264878afc82ca0 \
@@ -242,6 +248,7 @@ pyyaml==6.0 \
     --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174 \
     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
     # via
+    #   mike
     #   mkdocs
     #   pymdown-extensions
     #   pyyaml-env-tag
@@ -351,6 +358,10 @@ urllib3==1.26.15 \
     --hash=sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305 \
     --hash=sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42
     # via requests
+verspec==0.1.0 \
+    --hash=sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31 \
+    --hash=sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e
+    # via mike
 watchdog==3.0.0 \
     --hash=sha256:0e06ab8858a76e1219e68c7573dfeba9dd1c0219476c5a44d5333b01d7e1743a \
     --hash=sha256:13bbbb462ee42ec3c5723e1205be8ced776f05b100e4737518c67c8325cf6100 \

--- a/tools/bin/mkdocs
+++ b/tools/bin/mkdocs
@@ -1,4 +1,5 @@
-# Copyright 2022 Aurora Operations, Inc.
+#!/bin/bash
+# Copyright 2023 Aurora Operations, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To grab the latest version of every package, run:
-#
-#    bazel run //:requirements.update -- --upgrade
-#
+if ! pwd | grep -q "execroot"; then
+  echo "This wrapper is only for use inside of 'bazel run //:mike'"
+  exit 1
+fi
 
-mike
-mkdocs
-mkdocs-material
+# We assume that `//:update_docs` (which is our version of `mkdocs`) is built.
+#
+# This will automatically be true if we use `bazel run //:mike`, because we've
+# listed `//:update_docs` as a dependency.
+~/au/bazel-bin/update_docs "$@"


### PR DESCRIPTION
`mike` (https://github.com/jimporter/mike) is a tool for managing versioned documentation when using both mkdocs and GitHub pages (as we do).  The idea is that you render a given version of the docs once, store it in your `gh-pages` branch, and never touch it again.  `mike` will store it in a subfolder with that version's name.  You can also set up a combo box on each page, so users can switch to see the current page at any version of the docs.

This PR is just the first step for #131.  We'll add a new target, `//:mike`, which exposes the tool: to run,

```sh
mike ...
```

you would instead run,

```sh
bazel run //:mike -- ...
```

To prove that it works, we'll cherry-pick this commit onto `0.3.1` and `0.3.2` and generate versions of the documentation website.  (We won't do `0.3.0` or earlier, because those versions predate public availability, and they had pretty embarrasing placeholder content.) We'll publish these doc site versions to `gh-pages`, so they'll be publicly available, but nothing will link to them yet.  We'll also publish a version for `main`.

We also update the instructions for cutting releases to take versioning into account.

Future steps to resolve the "core" of #131:

1. Make another PR so the GitHub action that updates the doc website on every commit to `main` uses `mike`.

2. Set `main` as the "default" in `mike`, which should set up a redirect for the root website.  (This won't be a PR; we'll commit directly to `gh-pages`.)

3. Replace every existing HTML page on the current website with a redirect to `main`, patterned off of the main page.  (This won't be a PR; we'll commit directly to `gh-pages`.)