### PR TITLE
Provide sqrt, etc. for `Dimension` and `Magnitude`

### DIFF
--- a/au/BUILD
+++ b/au/BUILD
@@ -170,7 +170,10 @@ cc_test(
 cc_library(
     name = "dimension",
     hdrs = ["dimension.hh"],
-    deps = [":packs"],
+    deps = [
+        ":packs",
+        ":power_aliases",
+    ],
 )
 
 cc_test(
@@ -188,6 +191,7 @@ cc_library(
     hdrs = ["magnitude.hh"],
     deps = [
         ":packs",
+        ":power_aliases",
         ":stdx",
         ":utility",
         ":zero",
@@ -241,6 +245,22 @@ cc_test(
     srcs = ["packs_test.cc"],
     deps = [
         ":packs",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "power_aliases",
+    hdrs = ["power_aliases.hh"],
+)
+
+cc_test(
+    name = "power_aliases_test",
+    size = "small",
+    srcs = ["power_aliases_test.cc"],
+    deps = [
+        ":packs",
+        ":power_aliases",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -343,6 +363,7 @@ cc_library(
     deps = [
         ":dimension",
         ":magnitude",
+        ":power_aliases",
         ":stdx",
         ":utility",
         ":zero",

--- a/au/dimension.hh
+++ b/au/dimension.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/packs.hh"
+#include "au/power_aliases.hh"
 
 namespace au {
 
@@ -42,6 +43,26 @@ template <typename T, typename U>
 using DimQuotientT = PackQuotientT<Dimension, T, U>;
 template <typename T>
 using DimInverseT = PackInverseT<Dimension, T>;
+
+template <typename... BP1s, typename... BP2s>
+constexpr auto operator*(Dimension<BP1s...>, Dimension<BP2s...>) {
+    return DimProductT<Dimension<BP1s...>, Dimension<BP2s...>>{};
+}
+
+template <typename... BP1s, typename... BP2s>
+constexpr auto operator/(Dimension<BP1s...>, Dimension<BP2s...>) {
+    return DimQuotientT<Dimension<BP1s...>, Dimension<BP2s...>>{};
+}
+
+// Roots and powers for Dimension instances.
+template <std::intmax_t N, typename... BPs>
+constexpr DimPowerT<Dimension<BPs...>, N> pow(Dimension<BPs...>) {
+    return {};
+}
+template <std::intmax_t N, typename... BPs>
+constexpr DimPowerT<Dimension<BPs...>, 1, N> root(Dimension<BPs...>) {
+    return {};
+}
 
 template <typename... Dims>
 struct CommonDimension;

--- a/au/dimension_test.cc
+++ b/au/dimension_test.cc
@@ -39,14 +39,46 @@ TEST(Dimension, AllProvidedBaseDimensionsAreCompatible) {
 
 TEST(Dimension, ProductAndQuotientBehaveAsExpected) {
     StaticAssertTypeEq<DimProductT<Speed, Time>, Length>();
+    StaticAssertTypeEq<decltype(Speed{} * Time{}), Length>();
 
     StaticAssertTypeEq<DimQuotientT<DimProductT<Length, Time>, Length>, Time>();
+    StaticAssertTypeEq<decltype(Length{} / Time{}), Speed>();
 }
 
 TEST(Dimension, PowersBehaveAsExpected) {
     StaticAssertTypeEq<DimQuotientT<DimPowerT<Speed, 2>, Length>, Accel>();
 
     StaticAssertTypeEq<DimProductT<Accel, DimPowerT<Time, 2>>, Length>();
+}
+
+TEST(Inverse, RaisesToPowerNegativeOne) {
+    StaticAssertTypeEq<decltype(inverse(Dimension<>{})), Dimension<>>();
+
+    StaticAssertTypeEq<decltype(inverse(Length{} / Time{})), decltype(Time{} / Length{})>();
+}
+
+TEST(Squared, RaisesToPowerTwo) {
+    StaticAssertTypeEq<decltype(squared(Dimension<>{})), Dimension<>>();
+
+    StaticAssertTypeEq<decltype(squared(Length{})), decltype(Length{} * Length{})>();
+}
+
+TEST(Cubed, RaisesToPowerThree) {
+    StaticAssertTypeEq<decltype(cubed(Dimension<>{})), Dimension<>>();
+
+    StaticAssertTypeEq<decltype(cubed(Length{})), decltype(Length{} * Length{} * Length{})>();
+}
+
+TEST(Sqrt, TakesSecondRoot) {
+    StaticAssertTypeEq<decltype(sqrt(Dimension<>{})), Dimension<>>();
+
+    StaticAssertTypeEq<decltype(sqrt(Length{} * Length{})), decltype(Length{})>();
+}
+
+TEST(Cbrt, TakesThirdRoot) {
+    StaticAssertTypeEq<decltype(cbrt(Dimension<>{})), Dimension<>>();
+
+    StaticAssertTypeEq<decltype(cbrt(Length{} * Length{} * Length{})), decltype(Length{})>();
 }
 
 }  // namespace au

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -16,6 +16,7 @@
 
 #include <limits>
 
+#include "au/power_aliases.hh"
 #include "au/packs.hh"
 #include "au/stdx/utility.hh"
 #include "au/utility/factoring.hh"

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -16,8 +16,8 @@
 
 #include <limits>
 
-#include "au/power_aliases.hh"
 #include "au/packs.hh"
+#include "au/power_aliases.hh"
 #include "au/stdx/utility.hh"
 #include "au/utility/factoring.hh"
 #include "au/zero.hh"

--- a/au/magnitude_test.cc
+++ b/au/magnitude_test.cc
@@ -23,7 +23,7 @@ using ::testing::StaticAssertTypeEq;
 
 namespace au {
 namespace {
-template <typename T>
+template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
 constexpr T cubed(T x) {
     return x * x * x;
 }
@@ -66,6 +66,16 @@ TEST(Pi, HasCorrectValue) {
     EXPECT_TRUE(false) << "M_PIl not available on this architecture";
 #endif
 }
+
+TEST(Inverse, RaisesToPowerNegativeOne) { EXPECT_EQ(inverse(mag<8>()), mag<1>() / mag<8>()); }
+
+TEST(Squared, RaisesToPowerTwo) { EXPECT_EQ(squared(mag<7>()), mag<49>()); }
+
+TEST(Cubed, RaisesToPowerThree) { EXPECT_EQ(cubed(mag<5>()), mag<125>()); }
+
+TEST(Sqrt, TakesSecondRoot) { EXPECT_EQ(sqrt(mag<81>()), mag<9>()); }
+
+TEST(Cbrt, TakesThirdRoot) { EXPECT_EQ(cbrt(mag<27>()), mag<3>()); }
 
 TEST(Numerator, IsIdentityForInteger) {
     EXPECT_EQ(numerator(mag<2>()), mag<2>());

--- a/au/power_aliases.hh
+++ b/au/power_aliases.hh
@@ -1,0 +1,73 @@
+// Copyright 2022 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace au {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Generic mathematical convenience functions.
+//
+// The reason these exist is to be able to make unit expressions easier to read in common cases.
+// They also work for dimensions and magnitudes.
+
+//
+// This section works around an error:
+//
+//    warning: use of function template name with no prior declaration in function call with
+//    explicit template arguments is a C++20 extension [-Wc++20-extensions]
+//
+// We work around it by providing declarations, even though those declarations are never used.
+//
+namespace no_prior_declaration_workaround {
+struct Dummy;
+}  // namespace no_prior_declaration_workaround
+template <std::intmax_t N>
+auto root(no_prior_declaration_workaround::Dummy);
+template <std::intmax_t N>
+auto pow(no_prior_declaration_workaround::Dummy);
+
+// Make "inverse" an alias for "pow<-1>" when the latter exists (for anything).
+template <typename T>
+constexpr auto inverse(T x) -> decltype(pow<-1>(x)) {
+    return pow<-1>(x);
+}
+
+// Make "squared" an alias for "pow<2>" when the latter exists (for anything).
+template <typename T>
+constexpr auto squared(T x) -> decltype(pow<2>(x)) {
+    return pow<2>(x);
+}
+
+// Make "cubed" an alias for "pow<3>" when the latter exists (for anything).
+template <typename T>
+constexpr auto cubed(T x) -> decltype(pow<3>(x)) {
+    return pow<3>(x);
+}
+
+// Make "sqrt" an alias for "root<2>" when the latter exists (for anything).
+template <typename T>
+constexpr auto sqrt(T x) -> decltype(root<2>(x)) {
+    return root<2>(x);
+}
+
+// Make "cbrt" an alias for "root<3>" when the latter exists (for anything).
+template <typename T>
+constexpr auto cbrt(T x) -> decltype(root<3>(x)) {
+    return root<3>(x);
+}
+
+}  // namespace au

--- a/au/power_aliases_test.cc
+++ b/au/power_aliases_test.cc
@@ -1,0 +1,87 @@
+// Copyright 2022 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/power_aliases.hh"
+
+#include <cstdint>
+
+#include "au/packs.hh"
+#include "gtest/gtest.h"
+
+using ::testing::StaticAssertTypeEq;
+
+namespace au {
+
+// An arbitrary monovalue type which we'll enable raising to powers.
+//
+// We'll use the `:packs` machinery as an easy way to write meaningful tests.
+template <typename... BPs>
+struct Vector {};
+
+// "B" is for "Base".
+template <int N>
+struct B {
+    static constexpr int index = N;
+};
+template <int N>
+constexpr int B<N>::index;
+
+// Defining `pow<N>(Vector<...>)` is what unlocks `squared`, `cubed`, and `inverse`.
+template <std::intmax_t N, typename... BPs>
+constexpr PackPowerT<Vector, Vector<BPs...>, N> pow(Vector<BPs...>) {
+    return {};
+}
+
+// Defining `root<N>(Vector<...>)` is what unlocks `sqrt` and `cbrt`.
+template <std::intmax_t N, typename... BPs>
+constexpr PackPowerT<Vector, Vector<BPs...>, 1, N> root(Vector<BPs...>) {
+    return {};
+}
+
+TEST(Inverse, RaisesToPowerNegativeOne) {
+    StaticAssertTypeEq<decltype(inverse(Vector<>{})), Vector<>>();
+
+    StaticAssertTypeEq<decltype(inverse(Vector<B<2>, Pow<B<3>, 8>, RatioPow<B<5>, 1, 2>>{})),
+                       Vector<Pow<B<2>, -1>, Pow<B<3>, -8>, RatioPow<B<5>, -1, 2>>>();
+}
+
+TEST(Squared, RaisesToPowerTwo) {
+    StaticAssertTypeEq<decltype(squared(Vector<>{})), Vector<>>();
+
+    StaticAssertTypeEq<decltype(squared(Vector<B<2>, Pow<B<3>, 8>, RatioPow<B<5>, 1, 2>>{})),
+                       Vector<Pow<B<2>, 2>, Pow<B<3>, 16>, B<5>>>();
+}
+
+TEST(Cubed, RaisesToPowerThree) {
+    StaticAssertTypeEq<decltype(cubed(Vector<>{})), Vector<>>();
+
+    StaticAssertTypeEq<decltype(cubed(Vector<B<2>, Pow<B<3>, 8>, RatioPow<B<5>, 1, 3>>{})),
+                       Vector<Pow<B<2>, 3>, Pow<B<3>, 24>, B<5>>>();
+}
+
+TEST(Sqrt, TakesSecondRoot) {
+    StaticAssertTypeEq<decltype(sqrt(Vector<>{})), Vector<>>();
+
+    StaticAssertTypeEq<decltype(sqrt(Vector<B<2>, Pow<B<3>, 8>, Pow<B<5>, 2>>{})),
+                       Vector<RatioPow<B<2>, 1, 2>, Pow<B<3>, 4>, B<5>>>();
+}
+
+TEST(Cbrt, TakesThirdRoot) {
+    StaticAssertTypeEq<decltype(cbrt(Vector<>{})), Vector<>>();
+
+    StaticAssertTypeEq<decltype(cbrt(Vector<B<2>, Pow<B<3>, 9>, Pow<B<5>, 3>>{})),
+                       Vector<RatioPow<B<2>, 1, 3>, Pow<B<3>, 3>, B<5>>>();
+}
+
+}  // namespace au

--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include "au/power_aliases.hh"
 #include "au/dimension.hh"
 #include "au/magnitude.hh"
+#include "au/power_aliases.hh"
 #include "au/stdx/type_traits.hh"
 #include "au/utility/string_constant.hh"
 #include "au/zero.hh"

--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "au/power_aliases.hh"
 #include "au/dimension.hh"
 #include "au/magnitude.hh"
 #include "au/stdx/type_traits.hh"
@@ -339,41 +340,6 @@ constexpr UnitPowerT<U, Exp> pow(U) {
 template <std::uintmax_t Deg, typename U, typename = std::enable_if_t<IsUnit<U>::value>>
 constexpr UnitPowerT<U, 1, Deg> root(U) {
     return {};
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Generic mathematical convenience functions.
-//
-// The reason these exist is to be able to make Unit expressions easier to read in common cases.
-
-// Make "squared" an alias for "pow<2>" when the latter exists (for anything).
-template <typename T>
-constexpr auto squared(T x) -> decltype(pow<2>(x)) {
-    return pow<2>(x);
-}
-
-// Make "cubed" an alias for "pow<3>" when the latter exists (for anything).
-template <typename T>
-constexpr auto cubed(T x) -> decltype(pow<3>(x)) {
-    return pow<3>(x);
-}
-
-// Make "sqrt" an alias for "root<2>" when the latter exists (for anything).
-template <typename T>
-constexpr auto sqrt(T x) -> decltype(root<2>(x)) {
-    return root<2>(x);
-}
-
-// Make "cubed" an alias for "root<3>" when the latter exists (for anything).
-template <typename T>
-constexpr auto cbrt(T x) -> decltype(root<3>(x)) {
-    return root<3>(x);
-}
-
-// Make "inverse" an alias for "pow<-1>" when the latter exists (for anything).
-template <typename T>
-constexpr auto inverse(T x) -> decltype(pow<-1>(x)) {
-    return pow<-1>(x);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/au/unit_of_measure_test.cc
+++ b/au/unit_of_measure_test.cc
@@ -240,6 +240,26 @@ TEST(Root, FunctionalInterfaceHandlesInstancesCorrectly) {
     EXPECT_TRUE(are_units_quantity_equivalent(cbrt_cubic_inches, Inches{}));
 }
 
+TEST(Inverse, RaisesToPowerNegativeOne) {
+    EXPECT_TRUE(are_units_quantity_equivalent(inverse(Meters{}), pow<-1>(Meters{})));
+}
+
+TEST(Squared, RaisesToPowerTwo) {
+    EXPECT_TRUE(are_units_quantity_equivalent(squared(Meters{}), pow<2>(Meters{})));
+}
+
+TEST(Cubed, RaisesToPowerThree) {
+    EXPECT_TRUE(are_units_quantity_equivalent(cubed(Meters{}), pow<3>(Meters{})));
+}
+
+TEST(Sqrt, TakesSecondRoot) {
+    EXPECT_TRUE(are_units_quantity_equivalent(sqrt(Meters{}), root<2>(Meters{})));
+}
+
+TEST(Cbrt, TakesThirdRoot) {
+    EXPECT_TRUE(are_units_quantity_equivalent(cbrt(Meters{}), root<3>(Meters{})));
+}
+
 TEST(IsDimensionless, PicksOutDimensionlessUnit) {
     EXPECT_FALSE((IsDimensionless<Feet>::value));
 

--- a/docs/reference/detail/dimension.md
+++ b/docs/reference/detail/dimension.md
@@ -15,6 +15,58 @@ and never see them in their compiler errors.  Instead, users will work with [_un
 which each carry their own dimension information.  The main situation where an end user would use
 `Dimension` directly is to define the _first_ unit for a novel _base_ dimension.
 
+## Operations
+
+### Multiplication
+
+**Result:** The product of two `Dimension` values.
+
+**Syntax:**
+
+- For _types_ `D1` and `D2`:
+    - `DimProductT<D1, D2>`
+- For _instances_ `d1` and `d2`:
+    - `d1 * d2`
+
+### Division
+
+**Result:** The quotient of two `Dimension` values.
+
+**Syntax:**
+
+- For _types_ `D1` and `D2`:
+    - `DimQuotientT<D1, D2>`
+- For _instances_ `d1` and `d2`:
+    - `d1 / d2`
+
+### Powers
+
+**Result:** A `Dimension` raised to an integral power.
+
+**Syntax:**
+
+- For a _type_ `D`, and an integral power `N`:
+    - `DimPowerT<D, N>`
+- For an _instance_ `d`, and an integral power `N`:
+    - `pow<N>(d)`
+
+### Roots
+
+**Result:** An integral root of a `Dimension`.
+
+**Syntax:**
+
+- For a _type_ `D`, and an integral root `N`:
+    - `DimPowerT<D, 1, N>` (because the $N^\text{th}$ root is equivalent to the
+      $\left(\frac{1}{N}\right)^\text{th}$ power)
+- For an _instance_ `d`, and an integral root `N`:
+    - `root<N>(d)`
+
+### Helpers for powers and roots
+
+Dimensions support all of the [power helpers](../powers.md#helpers).  So, for example, for
+a dimension instance `d`, you can write `sqrt(d)` as a more readable alternative to `root<2>(d)`.
+
 ## Included base dimensions
 
 Au includes the following base dimensions:

--- a/docs/reference/detail/monovalue_types.md
+++ b/docs/reference/detail/monovalue_types.md
@@ -39,7 +39,7 @@ Here are some canonical examples in Au.
 | `Magnitude<Pi>` | `PI` | <ul><li>Equality comparison with other Magnitudes</li><li>`get_value<T>(PI)`</li></ul> |
 | `Radians` (and other units) | `Radians{}` (no special pre-formed instance) | Arithmetic with other units, such as `Radians{} / Meters{}` |
 
-## Switching between types and values
+## Switching between types and values {#switching}
 
 To get the value of a monovalue type `T`, instantiate the type using `T{}`.
 

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -193,6 +193,11 @@ In what follows, we'll use this convention:
 - For an _instance_ `m`, and an integral root `N`:
     - `root<N>(m)`
 
+### Helpers for powers and roots
+
+Magnitudes support all of the [power helpers](./powers.md#helpers).  So, for example, for
+a magnitude instance `m`, you can write `sqrt(m)` as a more readable alternative to `root<2>(m)`.
+
 ## Traits
 
 These traits provide information, at compile time, about the number represented by a `Magnitude`.

--- a/docs/reference/powers.md
+++ b/docs/reference/powers.md
@@ -1,0 +1,61 @@
+# Powers
+
+Several of our [monovalue types](./detail/monovalue_types.md) (such as [units](./unit.md) and
+[magnitudes](./magnitude.md)) can be raised to powers. This includes negative exponents (such as the
+inverse), and fractional exponents (such as roots).
+
+When [expressed as values](./detail/monovalue_types.md#switching) (as opposed to types), we provide
+the same APIs for each of them.
+
+## General APIs
+
+In what follows, `x` stands for an instance of the appropriate monovalue type.  For example, it
+might be `Meters{}` (a unit), `mag<18>()` (a magnitude), or some other type.
+
+### `pow<N>(x)`
+
+Raise the input `x` to the `N`th power.
+
+**Example signature:**
+
+```cpp
+// T is an appropriate monovalue type (a unit, a magnitude, ...).
+template<std::intmax_t N, typename T>
+constexpr auto pow(T);
+```
+
+**Result:** An instance of the Nth power of the type of `x`.
+
+!!! example
+    `pow<3>(mag<4>())` yields `mag<64>()`.
+
+### `root<N>(x)`
+
+Take the Nth root of the input.
+
+**Example signature:**
+
+```cpp
+// T is an appropriate monovalue type (a unit, a magnitude, ...).
+template<std::intmax_t N, typename T>
+constexpr auto root(T);
+```
+
+**Result:** An instance of the Nth root of the type of `x`.
+
+!!! example
+    `root<2>(mag<49>())` yields `mag<7>()`.
+
+## Helpers (`inverse`, `squared`, `cubed`, `sqrt`, `cbrt`) {#helpers}
+
+Some powers and roots are very common.  It's useful to have shortcuts for these to make the code
+more readable.  The following helpers are available to operate on an instance, `x`, of any
+compatible monovalue type (a unit, a magnitude, ...):
+
+| Helper | Result |
+|--------|--------|
+| `inverse(x)` | `pow<-1>(x)` |
+| `squared(x)` | `pow<2>(x)` |
+| `cubed(x)` | `pow<3>(x)` |
+| `sqrt(x)` | `root<2>(x)` |
+| `cbrt(x)` | `root<3>(x)` |

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -179,20 +179,8 @@ In what follows, we'll use this convention:
 
 ### Helpers for powers and roots
 
-!!! note
-    We plan to make these available for [`Magnitude`](./magnitude.md) and
-    [`Dimension`](./detail/dimension.md) as well.  See
-    [#84](https://github.com/aurora-opensource/au/issues/84) to track progress.
-
-Each of the following helpers are available to operate on a unit instance, `u`:
-
-| Helper | Result |
-|--------|--------|
-| `inverse(u)` | `pow<-1>(u)` |
-| `squared(u)` | `pow<2>(u)` |
-| `cubed(u)` | `pow<3>(u)` |
-| `sqrt(u)` | `root<2>(u)` |
-| `cbrt(u)` | `root<3>(u)` |
+Units support all of the [power helpers](./powers.md#helpers).  So, for example, for a unit instance
+`u`, you can write `sqrt(u)` as a more readable alternative to `root<2>(u)`.
 
 ### Scaling by `Magnitude`
 


### PR DESCRIPTION
I first tried providing these generically, for all parameter packs. That
turned out to be a bad idea, because you get a lot of false positives
for what a "pack" is.  For example, `Milli<Meters>` can look like a
"pack" of `Meters`!

Then I settled on putting them in a new target, `:power_aliases`, which
is easy to opt into.  All you have to do is implement `pow` and `root`,
and include the file.  I did so for `Dimension` and `Magnitude`, and
added unit tests for each.  Along the way, I also added the missing
arithmetic operators `*` and `/` for `Dimension`.

Includes unit tests and doc updates.

Fixes #84.