### PR TITLE
Fix traits for num, denom, and integer part

### DIFF
--- a/au/magnitude_test.cc
+++ b/au/magnitude_test.cc
@@ -77,6 +77,17 @@ TEST(Sqrt, TakesSecondRoot) { EXPECT_EQ(sqrt(mag<81>()), mag<9>()); }
 
 TEST(Cbrt, TakesThirdRoot) { EXPECT_EQ(cbrt(mag<27>()), mag<3>()); }
 
+TEST(IntegerPart, IdentityForIntegers) {
+    EXPECT_EQ(integer_part(mag<1>()), mag<1>());
+    EXPECT_EQ(integer_part(mag<2>()), mag<2>());
+    EXPECT_EQ(integer_part(mag<2380>()), mag<2380>());
+}
+
+TEST(IntegerPart, PicksOutIntegersFromNumerator) {
+    // sqrt(32) = 4 * sqrt(2)
+    EXPECT_EQ(integer_part(PI * sqrt(mag<32>()) / mag<15>()), mag<4>());
+}
+
 TEST(Numerator, IsIdentityForInteger) {
     EXPECT_EQ(numerator(mag<2>()), mag<2>());
     EXPECT_EQ(numerator(mag<31415>()), mag<31415>());
@@ -86,8 +97,16 @@ TEST(Numerator, PutsFractionInLowestTerms) {
     EXPECT_EQ(numerator(mag<24>() / mag<16>()), mag<3>());
 }
 
+TEST(Numerator, IncludesNonIntegersWithPositiveExponent) {
+    EXPECT_EQ(numerator(PI * sqrt(mag<24>() / mag<16>())), PI * sqrt(mag<3>()));
+}
+
 TEST(Denominator, PutsFractionInLowestTerms) {
     EXPECT_EQ(denominator(mag<24>() / mag<16>()), mag<2>());
+}
+
+TEST(Denominator, IncludesNonIntegersWithNegativeExponent) {
+    EXPECT_EQ(denominator(sqrt(mag<24>() / mag<16>()) / PI), PI * sqrt(mag<2>()));
 }
 
 TEST(IsRational, TrueForRatios) {

--- a/au/packs.hh
+++ b/au/packs.hh
@@ -426,8 +426,8 @@ template <template <class...> class Pack>
 struct PackProduct<Pack> : stdx::type_identity<Pack<>> {};
 
 // 1-ary case:
-template <template <class...> class Pack, typename T>
-struct PackProduct<Pack, Pack<T>> : stdx::type_identity<Pack<T>> {};
+template <template <class...> class Pack, typename... Ts>
+struct PackProduct<Pack, Pack<Ts...>> : stdx::type_identity<Pack<Ts...>> {};
 
 // 2-ary Base case: two null packs.
 template <template <class...> class Pack>

--- a/au/packs_test.cc
+++ b/au/packs_test.cc
@@ -119,6 +119,7 @@ TEST(UnpackIfSoloT, ReturnsEnclosedElementIfExactlyOne) {
 }
 
 TEST(PackProductT, UnaryProductIsIdentity) {
+    StaticAssertTypeEq<PackProductT<Pack, Pack<>>, Pack<>>();
     StaticAssertTypeEq<PackProductT<Pack, Pack<B<3>>>, Pack<B<3>>>();
 }
 

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -146,9 +146,11 @@ class Quantity {
         constexpr auto ratio = unit_ratio(unit, u);
 
         using Common = std::common_type_t<Rep, NewRep>;
-        constexpr auto num = get_value<Common>(numerator(ratio));
-        constexpr auto den = get_value<Common>(denominator(ratio));
-        constexpr auto irr = get_value<Common>(ratio * denominator(ratio) / numerator(ratio));
+        constexpr auto NUM = integer_part(numerator(ratio));
+        constexpr auto DEN = integer_part(denominator(ratio));
+        constexpr auto num = get_value<Common>(NUM);
+        constexpr auto den = get_value<Common>(DEN);
+        constexpr auto irr = get_value<Common>(ratio * DEN / NUM);
 
         return make_quantity<NewUnit>(
             static_cast<NewRep>(static_cast<Common>(value_) * num / den * irr));

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -226,13 +226,38 @@ does; `false` otherwise).
 - For an _instance_ `m`:
     - `is_rational(m)`
 
+### Integer part
+
+**Result:** The integer part of a `Magnitude`, which is another `Magnitude`.
+
+For example, the "integer part" of $\frac{\sqrt{18}}{5\pi}$ would be $3$, because $\sqrt{27}
+= 3\sqrt{2}$, and $3$ is the integer part of $3\sqrt{2}$.
+
+If the input magnitude is an integer, then this operation is the identity.
+
+If the input magnitude is _not_ an integer, then this operation produces the largest integer factor
+that can be extracted from the numerator (that is, the base powers with positive exponent).[^1]
+
+[^1]: The concept `integer_part()` is conceptually ambiguous when applied to non-integers.  So, too,
+for `numerator()` and `denominator()` applied to irrational numbers.  These utilities serve two
+purposes.  First, they provide a means for checking whether a given magnitude is a member of the
+unambiguous set --- that is, we can check whether a magnitude is an integer by checking whether it's
+equal to its "integer part".  Second, they enable us to automatically construct labels for
+magnitudes, by breaking them into the same kinds of pieces that a human reader would expect.
+
+**Syntax:**
+
+- For a _type_ `M`:
+    - `IntegerPartT<M>`
+- For an _instance_ `m`:
+    - `integer_part(m)`
+
 ### Numerator (integer part)
 
-**Result:** The integer part of the numerator we would have if a `Magnitude` were written as
-a fraction.  This result is another `Magnitude`.
+**Result:** The numerator we would have if a `Magnitude` were written as a fraction.  This result is
+another `Magnitude`.
 
-For example, the "numerator" of $\frac{3\sqrt{3}}{5\pi}$ would be $3$, because it is the integer
-part of $3\sqrt{3}$.
+For example, the "numerator" of $\frac{3\sqrt{3}}{5\pi}$ would be $3\sqrt{3}$.
 
 **Syntax:**
 
@@ -241,17 +266,12 @@ part of $3\sqrt{3}$.
 - For an _instance_ `m`:
     - `numerator(m)`
 
-!!! warning
-    This name and/or convention may be subject to change; see
-    [#83](https://github.com/aurora-opensource/au/issues/83).
-
 ### Denominator (integer part)
 
-**Result:** The integer part of the denominator we would have if a `Magnitude` were written as
-a fraction.  This result is another `Magnitude`.
+**Result:** The denominator we would have if a `Magnitude` were written as a fraction.  This result is
+another `Magnitude`.
 
-For example, the "denominator" of $\frac{3\sqrt{3}}{5\pi}$ would be $5$, because it is the integer
-part of $5\pi$.
+For example, the "denominator" of $\frac{3\sqrt{3}}{5\pi}$ would be $5\pi$.
 
 **Syntax:**
 
@@ -259,7 +279,3 @@ part of $5\pi$.
     - `DenominatorT<M>`
 - For an _instance_ `m`:
     - `denominator(m)`
-
-!!! warning
-    This name and/or convention may be subject to change; see
-    [#83](https://github.com/aurora-opensource/au/issues/83).


### PR DESCRIPTION
The current definitions of numerator and denominator assume we're
talking about the integer part only.  This policy is error-prone and
unclear from the callsite.  It also holds us back from automatically
generating labels for `Magnitude<...>` types, which would improve basic
library usability significantly at the margins.

Of course, we need the current definitions, which is why we added them
in the first place.  To continue meeting our needs, we add a new trait
operation: `integer_part(m)`.  This is equivalent to the old behaviour
of `numerator(m)`: it pulls out the _integer part_ of the numerator of
`m`.  But it frees up `numerator(m)` for a more natural interpretation.

On the implementation side, I took the opportunity to replace a
recursive implementation with one which is expanded inline, which may be
slightly more efficient.  This new approach exposed a bug in our
parameter pack handling: apparently, the unary product only actually
worked for single-element packs.  I added a test to expose this and made
the test pass.

I also grepped for `numerator`, `NumeratorT`, `denominator`, and
`DenominatorT`, to make sure we updated all of our old uses.  This
grepping caught a use case which we can't currently test for: rational
exponents (#116).  There _is_ a commented-out test case here, in the
`sqrt.CanConvertIfConversionFactorRational` case from `//au:math_test`,
which is commented out because it currently fails to compile.  (Note
that even if we had missed this update, it still wouldn't have compiled
because of a safeguard in `magnitude.hh`.)  In any case, I did find and
update this use case, which will save a little work in case we ever
attempt #116.

Testing plan:
- [x] New unit tests
- [x] Grepped existing uses
- [x] Compile time impact measurements

Fixes #83.