### PR TITLE
Prevent integer division with raw numerics

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -296,7 +296,6 @@ class Quantity {
     // Scalar division.
     template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
     friend constexpr auto operator/(Quantity a, T s) {
-        warn_if_integer_division<T>();
         return make_quantity<UnitT>(a.value_ / s);
     }
     template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -379,7 +379,7 @@ class Quantity {
 
  private:
     template <typename OtherRep>
-    static void warn_if_integer_division() {
+    static constexpr void warn_if_integer_division() {
         constexpr bool uses_integer_division =
             (std::is_integral<Rep>::value && std::is_integral<OtherRep>::value);
         static_assert(!uses_integer_division,

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -399,6 +399,22 @@ constexpr auto integer_quotient(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return make_quantity<UnitQuotientT<U1, U2>>(q1.in(U1{}) / q2.in(U2{}));
 }
 
+// Force integer division beteween an integer Quantity and a raw number.
+template <typename U, typename R, typename T>
+constexpr auto integer_quotient(Quantity<U, R> q, T x) {
+    static_assert(std::is_integral<R>::value && std::is_integral<T>::value,
+                  "integer_quotient() can only be called with integral Rep");
+    return make_quantity<U>(q.in(U{}) / x);
+}
+
+// Force integer division beteween a raw number and an integer Quantity.
+template <typename T, typename U, typename R>
+constexpr auto integer_quotient(T x, Quantity<U, R> q) {
+    static_assert(std::is_integral<T>::value && std::is_integral<R>::value,
+                  "integer_quotient() can only be called with integral Rep");
+    return make_quantity<UnitInverseT<U>>(x / q.in(U{}));
+}
+
 // The modulo operator (i.e., the remainder of an integer division).
 //
 // Only defined whenever (R1{} % R2{}) is defined (i.e., for integral Reps), _and_

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -398,6 +398,11 @@ TEST(Quantity, ScalarDivisionWorks) {
     EXPECT_EQ(pow<-1>(feet)(2.), 20 / x);
 }
 
+TEST(Quantity, ScalarDivisionIsConstexprCompatible) {
+    constexpr auto quotient = feet(10.) / 2;
+    EXPECT_EQ(quotient, feet(5.));
+}
+
 TEST(Quantity, ShortHandAdditionAssignmentWorks) {
     auto d = feet(1.25);
     d += feet(2.75);

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -393,9 +393,9 @@ TEST(Quantity, ProductOfInvertingUnitsIsScalar) {
 }
 
 TEST(Quantity, ScalarDivisionWorks) {
-    constexpr auto x = feet(10);
-    EXPECT_EQ(x / 2, feet(5));
-    EXPECT_EQ(pow<-1>(feet)(2), 20 / x);
+    constexpr auto x = feet(10.);
+    EXPECT_EQ(x / 2, feet(5.));
+    EXPECT_EQ(pow<-1>(feet)(2.), 20 / x);
 }
 
 TEST(Quantity, ShortHandAdditionAssignmentWorks) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -689,6 +689,12 @@ TEST(AreQuantityTypesEquivalent, RequiresSameRepAndEquivalentUnits) {
 TEST(integer_quotient, EnablesIntegerDivision) {
     constexpr auto dt = integer_quotient(meters(60), (miles / hour)(65));
     EXPECT_THAT(dt, QuantityEquivalent((hour * meters / mile)(0)));
+
+    constexpr auto x = integer_quotient(meters(60), 31);
+    EXPECT_THAT(x, SameTypeAndValue(meters(1)));
+
+    constexpr auto freq = integer_quotient(1000, minutes(300));
+    EXPECT_THAT(freq, SameTypeAndValue(inverse(minutes)(3)));
 }
 
 TEST(mod, ComputesRemainderForSameUnits) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -393,9 +393,9 @@ TEST(Quantity, ProductOfInvertingUnitsIsScalar) {
 }
 
 TEST(Quantity, ScalarDivisionWorks) {
-    constexpr auto x = feet(10.);
-    EXPECT_EQ(x / 2, feet(5.));
-    EXPECT_EQ(pow<-1>(feet)(2.), 20 / x);
+    constexpr auto x = feet(10);
+    EXPECT_EQ(x / 2, feet(5));
+    EXPECT_EQ(pow<-1>(feet)(2), 20 / x);
 }
 
 TEST(Quantity, ScalarDivisionIsConstexprCompatible) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -395,7 +395,7 @@ TEST(Quantity, ProductOfInvertingUnitsIsScalar) {
 TEST(Quantity, ScalarDivisionWorks) {
     constexpr auto x = feet(10);
     EXPECT_EQ(x / 2, feet(5));
-    EXPECT_EQ(pow<-1>(feet)(2), 20 / x);
+    EXPECT_EQ(20. / x, inverse(feet)(2.));
 }
 
 TEST(Quantity, ScalarDivisionIsConstexprCompatible) {


### PR DESCRIPTION
This closes a loophole and makes the library more consistent.

Fixes #39.