### PR TITLE
Fix compiler errors on MSVC v142

### DIFF
--- a/au/math.hh
+++ b/au/math.hh
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <type_traits>
 
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"

--- a/au/math.hh
+++ b/au/math.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 


### PR DESCRIPTION
Changes include:

- Replacing function template overloads with struct template
  specializations
- Taking values directly in `all_true()`, instead of forcing end users
  to construct a `std::array`

I believe our previous code was valid standard C++14, but happily, these
changes look like strict improvements in their own right.

The second change enabled us to get rid of `<array>` in `:packs`.
Apparently, this exposed an IWYU violation in `:math`, so we needed to
add `<algorithm>`.  However, this also seems like a net win.

Fixes #143.