### PR TITLE
Update alternatives matrix

### DIFF
--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -738,7 +738,7 @@ features.
         <td class="poor">Present in user-facing APIs</td>
         <td class="poor">Present in user-facing APIs</td>
         <td class="fair">Very few, and confined to implementation helpers</td>
-        <td class="good">Confined to outer compatibility layer</td>
+        <td class="fair">Very few, and confined to implementation helpers</td>
         <td class="best">No macros</td>
     </tr>
 </table>

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -435,7 +435,13 @@ features.
                 <li class="x">No fmtlib support</li>
             </ul>
         </td>
-        <td class="best">Supports <code>&lt;iostream&gt;</code> and <code>std::format</code></td>
+        <td class="best">
+            <ul>
+                <li class="check">Supports <code>&lt;iostream&gt;</code></li>
+                <li class="check">Unit labels available even without <code>&lt;iostream&gt;</code></li>
+                <li class="check">Supports <code>std::format</code></li>
+            </ul>
+        </td>
         <td class="fair">
             <ul>
                 <li class="check">Toggleable <code>&lt;iostream&gt;</code> support</li>
@@ -459,6 +465,22 @@ features.
         <td class="good"></td>
         <td class="good"></td>
         <td class="good"></td>
+    </tr>
+    <tr>
+        <td>
+            <details class="criterion">
+                <summary>Unit-aware math</summary>
+                <p>
+                    Unit-aware versions of common mathematical functions (`max`, `abs`, `sin`,
+                    `round`, and so on).
+                </p>
+            </details>
+        </td>
+        <td class="na"></td>
+        <td class="na"></td>
+        <td class="na"></td>
+        <td class="na"></td>
+        <td class="na"></td>
     </tr>
     <tr>
         <td>
@@ -813,18 +835,21 @@ features.
         <td>
             <details class="criterion">
                 <summary>"Kind" Types</summary>
-                <p>Support for reasoning about different "kinds" of the same dimension.</p>
-                <ul>
-                    <li>Safeguards for quantities with different "kind", such as height and width</li>
-                    <li>The ability to express a hierarchy of kinds</li>
-                </ul>
+                <p>
+                    Any feature which supports robustly distinguishing between units that have the
+                    same dimension and magnitude.
+                </p>
+                <p>
+                    For example, "hertz" and "becquerel" both have the same dimension and magnitude
+                    as "inverse seconds", but some libraries may prevent users from mixing them.
+                </p>
             </details>
         </td>
         <td class="na"></td>
         <td class="poor"></td>
         <td class="poor"></td>
         <td class="best"></td>
-        <td class="poor">No plans to support.</td>
+        <td class="poor">No plans at present to support.</td>
     </tr>
     <tr>
         <td>
@@ -848,18 +873,38 @@ features.
     <tr>
         <td>
             <details class="criterion">
-                <summary>Units as types</summary>
+                <summary>Units/Dimensions as types</summary>
                 <p>
-                    Types that represent abstract units (clearly distinct from quantities of that
-                    unit).
+                    <li>
+                        Types that represent abstract units (clearly distinct from quantities of
+                        that unit).
+                    </li>
+                    <li>Types that represent abstract dimensions.</li>
+                    <li>The ability to do arithmetic with instances of these types.</li>
                 </p>
             </details>
         </td>
         <td class="good"></td>
         <td class="fair">Types exist, but conflated with quantity names</td>
         <td class="poor">No separate types for units</td>
-        <td class="good">Can form instances and do arithmetic</td>
-        <td class="good">Can form instances and do arithmetic</td>
+        <td class="good">
+            <ul>
+                <li class="check">Types for units</li>
+                <li class="check">Types for dimensions</li>
+                <li class="check">
+                    Can do arithmetic (compound units on the fly; abstract dimensional analysis)
+                </li>
+            </ul>
+        </td>
+        <td class="good">
+            <ul>
+                <li class="check">Types for units</li>
+                <li class="check">Types for dimensions</li>
+                <li class="check">
+                    Can do arithmetic (compound units on the fly; abstract dimensional analysis)
+                </li>
+            </ul>
+        </td>
     </tr>
     <tr>
         <td>

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -225,10 +225,19 @@ These costs can bring significant benefits, but we still want them to be as smal
         </td>
         <td class="fair">Positional dimensions</td>
         <td class="fair">Alias for unit template</td>
-        <td class="good">Pioneered strong typedefs for units</td>
-        <td class="best">
+        <td class="good">
             <ul>
-                <li class="check">No dimension in type name leads to shorter types</li>
+                <li class="check">Pioneered strong typedefs for units</li>
+                <li class="check"><a
+                href="https://mpusz.github.io/mp-units/2.0/users_guide/framework_basics/interface_introduction/?h=expression+tem#expression-templates">Expression
+                templates</a> produce very readable errors
+                </li>
+            </ul>
+        </td>
+        <td class="good">
+            <ul>
+                <li class="check">Strong unit typenames appear in errors</li>
+                <li class="check">Short namespace minimizes clutter</li>
                 <li class="check">
                     Detailed <a
                     href="https://aurora-opensource.github.io/au/troubleshooting">troubleshooting
@@ -357,10 +366,10 @@ features.
         <td class="fair">
             <ul>
                 <li class="check">Implicit conversions with good basic safety</li>
-                <li class="x">
+                <li>
                     <a
-                    href="https://mpusz.github.io/mp-units/2.0/users_guide/examples/hello_units/">Many
-                    headers</a>; hard to guess
+                    href="https://mpusz.github.io/mp-units/2.0/users_guide/examples/hello_units/">Multiple
+                    headers</a>, one per system
                 </li>
                 <li class="x">Longer and more nested namespaces</li>
             </ul>
@@ -385,8 +394,58 @@ features.
         <td class="fair"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">Prefix only</a></td>
         <td class="poor"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">No</a></td>
         <td class="poor">No</td>
-        <td class="good">Can compose both units and prefixes</td>
+        <td class="good">Can compose units, prefixes, dimensions, and quantity types</td>
         <td class="good">QuantityMaker and PrefixApplier APIs</td>
+    </tr>
+    <tr>
+        <td>
+            <details class="criterion">
+                <summary>Unit-aware I/O</summary>
+                <p>
+                    The ability to print quantities along with information about their units.
+                    Examples:
+                </p>
+                <ul>
+                    <li><code>&lt;iostream&gt;</code>, preferrably toggleable</li>
+                    <li>Unit labels available even without <code>&lt;iostream&gt;</code></li>
+                    <li><code>fmtlb</code> (<code>std::format</code> after C++20)</li>
+                </ul>
+            </details>
+        </td>
+        <td class="good">
+            <ul>
+                <li class="check">Toggleable <code>&lt;iostream&gt;</code> support</li>
+                <li class="check">
+                    Impressively configurable output (<code>format_mode</code>,
+                    <code>autoprefix_mode</code>)
+                </li>
+                <li class="x">No fmtlib support</li>
+            </ul>
+        </td>
+        <td class="fair">
+            <ul>
+                <li class="check">Toggleable <code>&lt;iostream&gt;</code> support</li>
+                <li class="x">No fmtlib support</li>
+            </ul>
+        </td>
+        <td class="fair">
+            <ul>
+                <li class="check">Toggleable <code>&lt;iostream&gt;</code> support</li>
+                <li class="check">Unit labels available even without <code>&lt;iostream&gt;</code></li>
+                <li class="x">No fmtlib support</li>
+            </ul>
+        </td>
+        <td class="best">Supports <code>&lt;iostream&gt;</code> and <code>std::format</code></td>
+        <td class="fair">
+            <ul>
+                <li class="check">Toggleable <code>&lt;iostream&gt;</code> support</li>
+                <li class="check">Unit labels available even without <code>&lt;iostream&gt;</code></li>
+                <li class="x">
+                    Plan to add fmtlib support; see <a
+                    href="https://github.com/aurora-opensource/au/issues/149">#149</a>
+                </li>
+            </ul>
+        </td>
     </tr>
     <tr>
         <td>
@@ -567,6 +626,7 @@ features.
             Best choice of all:
             <ul>
                 <li class="check">No "preferred" Rep.</li>
+                <li class="check"><code>sizeof()</code>-friendly unit label representation</li>
                 <li class="check">Safe integer operations.</li>
             </ul>
         </td>
@@ -574,23 +634,20 @@ features.
     <tr>
         <td>
             <details class="criterion">
-                <summary>User-defined literals (UDLs)</summary>
+                <summary>Abbreviated construction</summary>
                 <p>
-                    Concise expressions such as `3_m` for "3 meters", or some comparable
-                    alternative.
+                    The ability to construct a Quantity using the symbol for its unit.
                 </p>
-                <ul>
-                    <li>
-                        Flexibility in the Rep (usually a variety of integral types, and perhaps
-                        <code>float</code>, but rarely <code>double</code>).
-                    </li>
-                    <li>The easy ability to exclude <code>&lt;iostreams&gt;</code>.</li>
-                </ul>
+
+                <p>
+                    This is most commonly done with user-defined literals (UDLs), such as
+                    <code>3_m</code> for "3 meters", but there are other alternatives.
+                </p>
             </details>
         </td>
         <td class="poor"></td>
-        <td class="good">UDLs</td>
-        <td class="good">UDLs</td>
+        <td class="good">User-defined literals (UDLs)</td>
+        <td class="good">User-defined literals (UDLs)</td>
         <td class="best">
             <a
             href="https://mpusz.github.io/units/framework/quantities.html#quantity-references-experimental">Quantity
@@ -598,6 +655,31 @@ features.
         </td>
         <td class="poor">
             Planned to add: <a href="https://github.com/aurora-opensource/au/issues/43">#43</a>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <details class="criterion">
+                <summary>Linear algebra</summary>
+                <p>
+                    Good interoperability with matrix and vector libraries, such as Eigen
+                </p>
+                <p>
+                    Most libraries can work with Eigen, but only if Eigen is patched: Quantity types
+                    break several of Eigen's deeply embedded assumptions.
+                </p>
+            </details>
+        </td>
+        <td class="fair"></td>
+        <td class="fair"></td>
+        <td class="fair"></td>
+        <td class="best">
+            Experimental support for <a
+            href="https://mpusz.github.io/mp-units/2.0/users_guide/framework_basics/character_of_a_quantity/">Quantity
+            Character</a>; can use matrix types as Rep
+        </td>
+        <td class="fair">
+            Planned to add: <a href="https://github.com/aurora-opensource/au/issues/70">#70</a>
         </td>
     </tr>
     <tr>
@@ -691,6 +773,29 @@ features.
     <tr>
         <td>
             <details class="criterion">
+                <summary>Physical constants</summary>
+                <ul>
+                    <li>How good is the core library support?</li>
+                    <li>Does the library include built-in constants?</li>
+                </ul>
+            </details>
+        </td>
+        <td class="good">Includes built-in constants as quantities</td>
+        <td class="good">Includes built-in constants as quantities</td>
+        <td class="poor"></td>
+        <td class="best">
+            <a
+            href="https://mpusz.github.io/mp-units/2.0/users_guide/framework_basics/faster_than_lightspeed_constants/">"Faster
+            than lightspeed" constants</a>
+        </td>
+        <td class="poor">
+            Plan to support someday; see
+            <a href="https://github.com/aurora-opensource/au/issues/90">#90</a>.
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <details class="criterion">
                 <summary>Non-linear scales (such as dB)</summary>
                 <p>Support for logarithmic "units", such as decibels or nepers</p>
             </details>
@@ -708,10 +813,11 @@ features.
         <td>
             <details class="criterion">
                 <summary>"Kind" Types</summary>
-                <p>
-                    Support for distinguishing different "kinds" of the same dimension, such as
-                    a length from a width.
-                </p>
+                <p>Support for reasoning about different "kinds" of the same dimension.</p>
+                <ul>
+                    <li>Safeguards for quantities with different "kind", such as height and width</li>
+                    <li>The ability to express a hierarchy of kinds</li>
+                </ul>
             </details>
         </td>
         <td class="na"></td>
@@ -752,8 +858,8 @@ features.
         <td class="good"></td>
         <td class="fair">Types exist, but conflated with quantity names</td>
         <td class="poor">No separate types for units</td>
-        <td class="good"></td>
-        <td class="best">Can form instances and do arithmetic</td>
+        <td class="good">Can form instances and do arithmetic</td>
+        <td class="good">Can form instances and do arithmetic</td>
     </tr>
     <tr>
         <td>

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -205,7 +205,7 @@ These costs can bring significant benefits, but we still want them to be as smal
             </a>
         </td>
         <td class="fair">Positional dimensions</td>
-        <td class="na"></td>
+        <td class="fair">Alias for unit template</td>
         <td class="good">Pioneered strong typedefs for units</td>
         <td class="best">
             <ul>
@@ -252,10 +252,12 @@ features.
             </details>
         </td>
         <td class="good"></td>
-        <td class="fair">
+        <td class="poor">
             Integer Reps <a href="https://github.com/nholthaus/units/issues/225">unsafe</a>
         </td>
-        <td class="na"></td>
+        <td class="poor">
+            Integer Reps <a href="https://github.com/bernedom/SI/issues/122">unsafe</a>
+        </td>
         <td class="good">
             Policy <a
             href="https://mpusz.github.io/units/framework/conversions_and_casting.html">consistent
@@ -282,7 +284,7 @@ features.
         </td>
         <td class="fair"></td>
         <td class="fair"></td>
-        <td class="na"></td>
+        <td class="fair"></td>
         <td class="fair"></td>
         <td class="best">Only contains unit-safe interfaces</td>
     </tr>
@@ -309,8 +311,17 @@ features.
                 </li>
             </ul>
         </td>
-        <td class="na"></td>
-        <td class="good"></td>
+        <td class="fair">
+            <ul>
+                <li class="check">Single, short namespace</li>
+                <li class="check">Implicit conversions (which can be turned off)</li>
+            </ul>
+        </td>
+        <td class="fair">
+            <ul>
+                <li class="check">Implicit conversions with good basic safety</li>
+            </ul>
+        </td>
         <td class="best">
             <ul>
                 <li class="check">Namespaces: just one, and it's short</li>
@@ -330,7 +341,7 @@ features.
         </td>
         <td class="fair"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">Prefix only</a></td>
         <td class="poor"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">No</a></td>
-        <td class="na"></td>
+        <td class="poor">No</td>
         <td class="fair">
             <a
             href="https://mpusz.github.io/units/framework/quantities.html#quantity-references-experimental">Quantity
@@ -347,7 +358,7 @@ features.
         </td>
         <td class="good"></td>
         <td class="fair">Possible, but user-facing types use a global "preferred" Rep.</td>
-        <td class="na"></td>
+        <td class="good"></td>
         <td class="good"></td>
         <td class="good"></td>
     </tr>
@@ -375,7 +386,7 @@ features.
             href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#nic-units.usage.example">Generic
             templates, constrained with traits</a>
         </td>
-        <td class="na"></td>
+        <td class="fair">Generic templates, constrained with traits</td>
         <td class="best">Concepts excel here</td>
         <td class="fair">
             Currently clunky.  Could be better by adding concepts in extra
@@ -400,7 +411,7 @@ features.
                 <li class="x"><a href="https://github.com/nholthaus/units/issues/131">Can't add dimensions</a></li>
             </ul>
         </td>
-        <td class="na"></td>
+        <td class="good">Can add new units and dimensions</td>
         <td class="best">Can even handle, e.g., systems of "natural" units</td>
         <td class="good">
             Can add <a href="https://aurora-opensource.github.io/au/howto/new-units">new units</a>
@@ -422,7 +433,7 @@ features.
         </td>
         <td class="fair">No interop with other units libraries</td>
         <td class="fair">No interop with other units libraries</td>
-        <td class="na"></td>
+        <td class="fair">No interop with other units libraries</td>
         <td class="good">
             <a href="https://mpusz.github.io/units/use_cases/interoperability.html">
                 <code>quantity_like_traits</code>
@@ -450,7 +461,7 @@ features.
             href="https://github.com/nholthaus/units/issues/240">can't distinguish quantity from
             point</a>.
         </td>
-        <td class="na"></td>
+        <td class="poor">None; would be hard to add, since units conflated with quantity type</td>
         <td class="good"></td>
         <td class="good"></td>
     </tr>
@@ -475,7 +486,7 @@ features.
         <td class="fair">
             Uses ratio plus "pi powers": good angle handling, but vulnerable to overflow
         </td>
-        <td class="na"></td>
+        <td class="poor">`std::ratio` only, with no solution for pi</td>
         <td class="good">
             Full support for <a
             href="https://mpusz.github.io/units/framework/magnitudes.html">Magnitudes</a>
@@ -497,7 +508,7 @@ features.
                         Flexibility in the Rep (usually a variety of integral types, and perhaps
                         <code>float</code>, but rarely <code>double</code>).
                     </li>
-                    <li>The easy ability to exclude <code>&lt;iostreams&gt;</code>.</li>
+                    <li>The easy ability to exclude <code>&lt;iostream&gt;</code>.</li>
                 </ul>
             </details>
         </td>
@@ -505,7 +516,13 @@ features.
         <td class="fair">
             Can trim by excluding <code>&lt;iostream&gt;</code>, but integer-Rep support is poor.
         </td>
-        <td class="na"></td>
+        <td class="fair">
+            <ul>
+                <li class="check"><code>&lt;iostream&gt;</code> not automatically included</li>
+                <li class="check">Supports integral rep</li>
+                <li class="x">Integral rep conversions unsafe</li>
+            </ul>
+        </td>
         <td class="good">Assumed to be good, based on mixed-Rep support</td>
         <td class="best">
             Best choice of all:
@@ -534,7 +551,7 @@ features.
         </td>
         <td class="poor"></td>
         <td class="good">UDLs</td>
-        <td class="na"></td>
+        <td class="good">UDLs</td>
         <td class="best">
             UDLs and <a
             href="https://mpusz.github.io/units/framework/quantities.html#quantity-references-experimental">Quantity
@@ -561,7 +578,14 @@ features.
             Effectively floating-point only (integer types <a
             href="https://github.com/nholthaus/units/issues/225">unsafe</a>)
         </td>
-        <td class="na"></td>
+        <td class="fair">
+            <ul>
+                <li class="check">No "default" rep</li>
+                <li class="x">
+                    Integer reps <a href="https://github.com/bernedom/SI/issues/122">unsafe</a>
+                </li>
+            </ul>
+        </td>
         <td class="best">
             Well defined
             <a href="https://mpusz.github.io/units/reference/core/concepts.html#_CPPv4I0EN5units14RepresentationE">Representation
@@ -593,9 +617,13 @@ features.
             default constructor</a> to construct, but no special facility for comparison
         </td>
         <td class="fair">Supports <code>copysign()</code>, but no special construction or comparison</td>
-        <td class="na"></td>
+        <td class="poor">No special construction or comparison</td>
         <td class="fair">Has <code>q::zero()</code> member, but no special construction or comparison</td>
-        <td class="best">Can use <code>ZERO</code> to construct or compare any quantity</td>
+        <td class="best">
+            Can use <a
+            href="https://aurora-opensource.github.io/au/main/discussion/concepts/zero/"><code>ZERO</code></a>
+            to construct or compare any quantity
+        </td>
     </tr>
     <tr>
         <td>
@@ -612,7 +640,12 @@ features.
             value </a>
         </td>
         <td class="good"></td>
-        <td class="na"></td>
+        <td class="fair">
+            <ul>
+                <li class="check">Supports degrees and radians</li>
+                <li class="x">pi represented as <code>std::ratio</code></li>
+            </ul>
+        </td>
         <td class="good"></td>
         <td class="good"></td>
     </tr>
@@ -625,7 +658,7 @@ features.
         </td>
         <td class="poor"></td>
         <td class="best"></td>
-        <td class="na"></td>
+        <td class="poor"></td>
         <td class="poor"></td>
         <td class="poor">
             Plan to support someday; see
@@ -644,7 +677,7 @@ features.
         </td>
         <td class="na"></td>
         <td class="poor"></td>
-        <td class="na"></td>
+        <td class="poor"></td>
         <td class="best"></td>
         <td class="poor">No plans to support.</td>
     </tr>
@@ -660,7 +693,7 @@ features.
         </td>
         <td class="good"></td>
         <td class="poor">Single, implicit global system</td>
-        <td class="na"></td>
+        <td class="poor"></td>
         <td class="good"></td>
         <td class="poor">
             Single, implicit global system. (Intentional design tradeoff: reduces learning curve,
@@ -679,7 +712,7 @@ features.
         </td>
         <td class="good"></td>
         <td class="fair">Types exist, but conflated with quantity names</td>
-        <td class="na"></td>
+        <td class="poor">No separate types for units</td>
         <td class="good"></td>
         <td class="best">Can form instances and do arithmetic</td>
     </tr>
@@ -694,7 +727,7 @@ features.
         </td>
         <td class="poor">Present in user-facing APIs</td>
         <td class="poor">Present in user-facing APIs</td>
-        <td class="na"></td>
+        <td class="fair">Very few, and confined to implementation helpers</td>
         <td class="good">Confined to outer compatibility layer</td>
         <td class="best">No macros</td>
     </tr>

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -94,6 +94,7 @@ at all, and if so, how hard it will be to obtain.
         <th></th>
         <th>Boost</th>
         <th>nholthaus</th>
+        <th>bernedom/SI</th>
         <th>mp-units</th>
         <th class="highlight">Au</th>
     </tr>
@@ -109,6 +110,7 @@ at all, and if so, how hard it will be to obtain.
             (unclear which, but best in either case)
         </td>
         <td class="good">C++14</td>
+        <td class="fair">C++17</td>
         <td class="poor">C++20</td>
         <td class="good">C++14</td>
     </tr>
@@ -121,7 +123,8 @@ at all, and if so, how hard it will be to obtain.
         </td>
         <td class="fair">Part of boost</td>
         <td class="good">Single, self-contained header</td>
-        <td class="fair">First class conan support; available on vcpkg</td>
+        <td class="fair">Available on conan</td>
+        <td class="fair">Available on conan and vcpkg</td>
         <td class="best">
             <p>Supports single-header delivery, with features:
             <ul>
@@ -159,6 +162,7 @@ These costs can bring significant benefits, but we still want them to be as smal
         <th></th>
         <th>Boost</th>
         <th>nholthaus</th>
+        <th>bernedom/SI</th>
         <th>mp-units</th>
         <th class="highlight">Au</th>
     </tr>
@@ -176,6 +180,7 @@ These costs can bring significant benefits, but we still want them to be as smal
         </td>
         <td class="na"></td>
         <td class="poor">Very slow, but can be <i>greatly</i> improved by removing I/O support and most units</td>
+        <td class="na"></td>
         <td class="na"></td>
         <td class="good">Possibly "best", but will need to assess all libraries on the same code</td>
     </tr>
@@ -200,6 +205,7 @@ These costs can bring significant benefits, but we still want them to be as smal
             </a>
         </td>
         <td class="fair">Positional dimensions</td>
+        <td class="na"></td>
         <td class="good">Pioneered strong typedefs for units</td>
         <td class="best">
             <ul>
@@ -230,6 +236,7 @@ features.
         <th></th>
         <th>Boost</th>
         <th>nholthaus</th>
+        <th>bernedom/SI</th>
         <th>mp-units</th>
         <th class="highlight">Au</th>
     </tr>
@@ -248,6 +255,7 @@ features.
         <td class="fair">
             Integer Reps <a href="https://github.com/nholthaus/units/issues/225">unsafe</a>
         </td>
+        <td class="na"></td>
         <td class="good">
             Policy <a
             href="https://mpusz.github.io/units/framework/conversions_and_casting.html">consistent
@@ -274,6 +282,7 @@ features.
         </td>
         <td class="fair"></td>
         <td class="fair"></td>
+        <td class="na"></td>
         <td class="fair"></td>
         <td class="best">Only contains unit-safe interfaces</td>
     </tr>
@@ -300,6 +309,7 @@ features.
                 </li>
             </ul>
         </td>
+        <td class="na"></td>
         <td class="good"></td>
         <td class="best">
             <ul>
@@ -320,6 +330,7 @@ features.
         </td>
         <td class="fair"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">Prefix only</a></td>
         <td class="poor"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">No</a></td>
+        <td class="na"></td>
         <td class="fair">
             <a
             href="https://mpusz.github.io/units/framework/quantities.html#quantity-references-experimental">Quantity
@@ -336,6 +347,7 @@ features.
         </td>
         <td class="good"></td>
         <td class="fair">Possible, but user-facing types use a global "preferred" Rep.</td>
+        <td class="na"></td>
         <td class="good"></td>
         <td class="good"></td>
     </tr>
@@ -363,6 +375,7 @@ features.
             href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#nic-units.usage.example">Generic
             templates, constrained with traits</a>
         </td>
+        <td class="na"></td>
         <td class="best">Concepts excel here</td>
         <td class="fair">
             Currently clunky.  Could be better by adding concepts in extra
@@ -387,6 +400,7 @@ features.
                 <li class="x"><a href="https://github.com/nholthaus/units/issues/131">Can't add dimensions</a></li>
             </ul>
         </td>
+        <td class="na"></td>
         <td class="best">Can even handle, e.g., systems of "natural" units</td>
         <td class="good">
             Can add <a href="https://aurora-opensource.github.io/au/howto/new-units">new units</a>
@@ -408,6 +422,7 @@ features.
         </td>
         <td class="fair">No interop with other units libraries</td>
         <td class="fair">No interop with other units libraries</td>
+        <td class="na"></td>
         <td class="good">
             <a href="https://mpusz.github.io/units/use_cases/interoperability.html">
                 <code>quantity_like_traits</code>
@@ -435,6 +450,7 @@ features.
             href="https://github.com/nholthaus/units/issues/240">can't distinguish quantity from
             point</a>.
         </td>
+        <td class="na"></td>
         <td class="good"></td>
         <td class="good"></td>
     </tr>
@@ -459,6 +475,7 @@ features.
         <td class="fair">
             Uses ratio plus "pi powers": good angle handling, but vulnerable to overflow
         </td>
+        <td class="na"></td>
         <td class="good">
             Full support for <a
             href="https://mpusz.github.io/units/framework/magnitudes.html">Magnitudes</a>
@@ -488,6 +505,7 @@ features.
         <td class="fair">
             Can trim by excluding <code>&lt;iostream&gt;</code>, but integer-Rep support is poor.
         </td>
+        <td class="na"></td>
         <td class="good">Assumed to be good, based on mixed-Rep support</td>
         <td class="best">
             Best choice of all:
@@ -516,6 +534,7 @@ features.
         </td>
         <td class="poor"></td>
         <td class="good">UDLs</td>
+        <td class="na"></td>
         <td class="best">
             UDLs and <a
             href="https://mpusz.github.io/units/framework/quantities.html#quantity-references-experimental">Quantity
@@ -542,6 +561,7 @@ features.
             Effectively floating-point only (integer types <a
             href="https://github.com/nholthaus/units/issues/225">unsafe</a>)
         </td>
+        <td class="na"></td>
         <td class="best">
             Well defined
             <a href="https://mpusz.github.io/units/reference/core/concepts.html#_CPPv4I0EN5units14RepresentationE">Representation
@@ -573,6 +593,7 @@ features.
             default constructor</a> to construct, but no special facility for comparison
         </td>
         <td class="fair">Supports <code>copysign()</code>, but no special construction or comparison</td>
+        <td class="na"></td>
         <td class="fair">Has <code>q::zero()</code> member, but no special construction or comparison</td>
         <td class="best">Can use <code>ZERO</code> to construct or compare any quantity</td>
     </tr>
@@ -591,6 +612,7 @@ features.
             value </a>
         </td>
         <td class="good"></td>
+        <td class="na"></td>
         <td class="good"></td>
         <td class="good"></td>
     </tr>
@@ -603,6 +625,7 @@ features.
         </td>
         <td class="poor"></td>
         <td class="best"></td>
+        <td class="na"></td>
         <td class="poor"></td>
         <td class="poor">
             Plan to support someday; see
@@ -621,6 +644,7 @@ features.
         </td>
         <td class="na"></td>
         <td class="poor"></td>
+        <td class="na"></td>
         <td class="best"></td>
         <td class="poor">No plans to support.</td>
     </tr>
@@ -636,6 +660,7 @@ features.
         </td>
         <td class="good"></td>
         <td class="poor">Single, implicit global system</td>
+        <td class="na"></td>
         <td class="good"></td>
         <td class="poor">
             Single, implicit global system. (Intentional design tradeoff: reduces learning curve,
@@ -654,6 +679,7 @@ features.
         </td>
         <td class="good"></td>
         <td class="fair">Types exist, but conflated with quantity names</td>
+        <td class="na"></td>
         <td class="good"></td>
         <td class="best">Can form instances and do arithmetic</td>
     </tr>
@@ -668,6 +694,7 @@ features.
         </td>
         <td class="poor">Present in user-facing APIs</td>
         <td class="poor">Present in user-facing APIs</td>
+        <td class="na"></td>
         <td class="good">Confined to outer compatibility layer</td>
         <td class="best">No macros</td>
     </tr>

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -105,10 +105,7 @@ at all, and if so, how hard it will be to obtain.
                 <p>The minimum C++ standard required to use the library.</p>
             </details>
         </td>
-        <td class="best">
-            C++98 or C++03<br>
-            (unclear which, but best in either case)
-        </td>
+        <td class="best">C++98</td>
         <td class="good">C++14</td>
         <td class="fair">C++17</td>
         <td class="poor">C++20</td>
@@ -300,7 +297,17 @@ features.
                 </ul>
             </details>
         </td>
-        <td class="fair"></td>
+        <td class="poor">
+            <ul>
+                <li class="x">Generally high learning curve</li>
+                <li class="x">
+                    No (<a
+                    href="https://www.boost.org/doc/libs/1_79_0/doc/html/boost_units/Quantities.html#boost_units.Quantities.Quantity_Construction_and_Conversion">non-trivial</a>)
+                    implicit conversions
+                </li>
+                <li class="x">Many headers; hard to guess</li>
+            </ul>
+        </td>
         <td class="good">
             <ul>
                 <li class="check">Single file is very easy</li>
@@ -314,7 +321,8 @@ features.
         <td class="fair">
             <ul>
                 <li class="check">Single, short namespace</li>
-                <li class="check">Implicit conversions (which can be turned off)</li>
+                <li class="check">Implicit conversions</li>
+                <li>Multiple headers, but easy to guess (one per dimension)</li>
             </ul>
         </td>
         <td class="fair">

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -285,7 +285,7 @@ features.
         <td class="fair"></td>
         <td class="fair"></td>
         <td class="fair"></td>
-        <td class="fair"></td>
+        <td class="good">Contains unit-safe interfaces</td>
         <td class="best">Only contains unit-safe interfaces</td>
     </tr>
     <tr>
@@ -320,6 +320,12 @@ features.
         <td class="fair">
             <ul>
                 <li class="check">Implicit conversions with good basic safety</li>
+                <li class="x">
+                    <a
+                    href="https://mpusz.github.io/mp-units/2.0/users_guide/examples/hello_units/">Many
+                    headers</a>; hard to guess
+                </li>
+                <li class="x">Longer and more nested namespaces</li>
             </ul>
         </td>
         <td class="best">
@@ -342,12 +348,8 @@ features.
         <td class="fair"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">Prefix only</a></td>
         <td class="poor"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">No</a></td>
         <td class="poor">No</td>
-        <td class="fair">
-            <a
-            href="https://mpusz.github.io/units/framework/quantities.html#quantity-references-experimental">Quantity
-            References</a> compose; prefixes don't
-        </td>
-        <td class="best">QuantityMaker and PrefixApplier APIs</td>
+        <td class="good">Can compose both units and prefixes</td>
+        <td class="good">QuantityMaker and PrefixApplier APIs</td>
     </tr>
     <tr>
         <td>
@@ -553,7 +555,7 @@ features.
         <td class="good">UDLs</td>
         <td class="good">UDLs</td>
         <td class="best">
-            UDLs and <a
+            <a
             href="https://mpusz.github.io/units/framework/quantities.html#quantity-references-experimental">Quantity
             References</a>
         </td>

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -41,14 +41,14 @@ indicate which version we considered, and say a few words about why we included 
 - [**nholthaus/units**](https://github.com/nholthaus/units) (version: 2.3.3)
     - Kicked off the revolution in modern (that is, post-C++11 watershed) units libraries.
     - Its laser-sharp focus on accessibility and low friction have made it probably the most widely
-      used C++ units library ever.
+      used C++ units library to date.
 - [**bernedom/SI**](https://github.com/bernedom/SI) (version: 2.5.1)
-    - A newer, C++17-compatible offering with a large number of stars.
+    - A newer, C++17-compatible offering with a large number of GitHub stars.
 - [**mp-units**](https://github.com/mpusz/mp-units) (version: 2.0.0:testing)
     - A library designed to take full advantage of ultra-modern (that is, post-C++20 watershed)
       features, such as concepts and non-template type parameters (NTTPs).
-    - mp-units is leading the efforts towards a standard C++ units library, both by trialling new
-      API designs, and by coordinating with the authors of other leading units libraries.
+    - mp-units is leading the efforts towards a standard C++ units library, both by field testing
+      new API designs, and by coordinating with the authors of other leading units libraries.
 
 ## Detailed comparison matrices
 
@@ -260,9 +260,9 @@ Now we're ready to compare the libraries "as units libraries" --- that is, in te
 features.
 
 !!! note
-    The features are listed, _very_ roughly, in order of importance.  Counting up the colours in
-    each column won't give an accurate picture.  The rows near the top matter more --- sometimes,
-    _much_ more --- than the rows further down.
+    The features are listed, _very_ roughly, in order of importance.  Counting up the colors in each
+    column won't give an accurate picture.  The rows near the top matter more --- sometimes, _much_
+    more --- than the rows further down.
 
     Of course, what matters the most for _you_ are _your_ use cases and criteria!
 

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -28,9 +28,31 @@ to the mature and widely available C++14 standard. Key features include:
 - Intelligent, unit-aware functions for rounding and computing inverses.
 - Minimal friction by using a single, short namespace: everything's in `au::`.
 
+## Alternatives considered here
+
+We'll consider several of the most prominent alternatives in more detail.  While there are [many
+more libraries](https://github.com/topics/dimensional-analysis?l=c%2B%2B), the ones we consider here
+are included for being especially pioneering or popular (or both).  Here, we list those libraries,
+indicate which version we considered, and say a few words about why we included it in the analysis.
+
+- [**Boost Units**](https://www.boost.org/doc/libs/1_82_0/doc/html/boost_units.html) (version:
+  1.82.0)
+    - One of the longest-standing C++ unit libraries, and the most prominent pre-C++14 option.
+- [**nholthaus/units**](https://github.com/nholthaus/units) (version: 2.3.3)
+    - Kicked off the revolution in modern (that is, post-C++11 watershed) units libraries.
+    - Its laser-sharp focus on accessibility and low friction have made it probably the most widely
+      used C++ units library ever.
+- [**bernedom/SI**](https://github.com/bernedom/SI) (version: 2.5.1)
+    - A newer, C++17-compatible offering with a large number of stars.
+- [**mp-units**](https://github.com/mpusz/mp-units) (version: 2.0.0:testing)
+    - A library designed to take full advantage of ultra-modern (that is, post-C++20 watershed)
+      features, such as concepts and non-template type parameters (NTTPs).
+    - mp-units is leading the efforts towards a standard C++ units library, both by trialling new
+      API designs, and by coordinating with the authors of other leading units libraries.
+
 ## Detailed comparison matrices
 
-Here's a more detailed comparison to the most prominent alternatives.  We'll use the following
+Here's a more detailed comparison to the alternatives listed above.  We'll use the following
 legend[^1]:
 
 [^1]: Users may have expected a "traffic light" style, green/yellow/red color scheme.  However,
@@ -227,6 +249,13 @@ At this point, you've assessed:
 
 Now we're ready to compare the libraries "as units libraries" --- that is, in terms of their core
 features.
+
+!!! note
+    The features are listed, _very_ roughly, in order of importance.  Counting up the colours in
+    each column won't give an accurate picture.  The rows near the top matter more --- sometimes,
+    _much_ more --- than the rows further down.
+
+    Of course, what matters the most for _you_ are _your_ use cases and criteria!
 
 <table>
     <tr>

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -476,11 +476,42 @@ features.
                 </p>
             </details>
         </td>
-        <td class="na"></td>
-        <td class="na"></td>
-        <td class="na"></td>
-        <td class="na"></td>
-        <td class="na"></td>
+        <td class="fair">
+            <ul>
+                <li class="check">Wide variety of functions</li>
+                <li class="x">
+                    <code>round</code>, <code>ceil</code>, and so on are not unit-safe
+                </li>
+            </ul>
+        </td>
+        <td class="fair">
+            <ul>
+                <li class="check">Wide variety of functions</li>
+                <li class="x">
+                    <code>round</code>, <code>ceil</code>, and so on are not unit-safe
+                </li>
+            </ul>
+        </td>
+        <td class="poor">No</td>
+        <td class="good">
+            <ul>
+                <li class="check">Wide variety of functions</li>
+                <li class="check">
+                    Unit-safe APIs for <code>round</code>, <code>ceil</code>, and so on
+                </li>
+            </ul>
+        </td>
+        <td class="best">
+            <ul>
+                <li class="check">Wide variety of functions</li>
+                <li class="check">
+                    Unit-safe APIs for <code>round</code>, <code>ceil</code>, and so on
+                </li>
+                <li class="check">
+                    Smart, unit-aware inverse functions
+                </li>
+            </ul>
+        </td>
     </tr>
     <tr>
         <td>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ theme:
   logo: assets/au-logo.png
   features:
     - navigation.footer
+    - toc.integrate
 
 extra_javascript:
   - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML


### PR DESCRIPTION
Our alternatives matrix is long overdue for a refresh.

The first core change is to explicitly list each library, indicate which
version we evaluated, and link to it.  We also say a few words about why
that library made our shortlist.  Along this vein, we add a new library,
bernedom/SI, to the list.  It's an impressively popular library (400
GitHub stars!) which didn't get included when we released the library
simply because it wasn't on my radar: at the time, it didn't have the
`dimensional-analysis` tag which most of the others had, so it didn't
show up in my searches.  This fixes #108.

We also clarify for the first time that the rows in our "big" matrix are
ordered (very roughly) by importance, which is a critical piece of
context for the reader.

We add several new rows to our comparison, namely:

- Unit-aware I/O
- Unit-aware math
- Linear algebra
- Physical constants

Next, I updated the results for mp-units for the first time since its
major 2.0 API upgrade.  mp-units improved significantly, and those
improvements were concentrated in the more important categories, such as
"Unit Safety" and "Composability".  (It also regressed in "Macros", but
that's the least important category.)

Finally, I made a few tweaks for previous assessments that I couldn't
really justify in retrospect.