### PR TITLE
Add `tools/bin` to `$PATH` for other tools

### DIFF
--- a/tools/bin/au-docs-serve
+++ b/tools/bin/au-docs-serve
@@ -13,4 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# In case users haven't set up `direnv`.
+export PATH="$PATH:./tools/bin"
+
 bazel run //:update_docs -- serve

--- a/tools/lib/command_from_bazel.sh
+++ b/tools/lib/command_from_bazel.sh
@@ -15,6 +15,9 @@
 
 set -eou pipefail
 
+# In case users haven't set up `direnv`.
+export PATH="$PATH:./tools/bin"
+
 function wrap_bazel () {
   COMMAND="$1"; shift
   TARGET="$1"; shift


### PR DESCRIPTION
Right now, several tools can't be properly invoked for non-`direnv`
users.  These include:

- `au-docs-serve`
- `buildifier`
- `clang-format`

These tools call `bazel`, but `bazel` isn't generally in `$PATH`, so
they simply fail.  We can fix this by adding `tools/bin` to `$PATH` in
any script that calls `bazel`.  This is OK because the `$PATH`
modification won't survive the end of the script.

Test plan:

- [x] Reproduce failure for all 3 tools without `direnv` from root
- [x] Make sure all 3 tools work without `direnv` from root
- [x] Make sure all 3 tools still work with `direnv` from root
- [x] Make sure all 3 tools still work with `direnv` from other folders

The tools won't work without `direnv` from anywhere but root, but that's
not a problem.