### PR TITLE
Add Rep-named aliases for `int`, `unsigned int`

### DIFF
--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -36,7 +36,7 @@ constexpr bool can_scale_without_overflow(Magnitude<BPs...> m, Rep value) {
 }
 
 namespace detail {
-// Chosen so as to allow populating a `QuantityU32<Hertz>` with an input in MHz.
+// Chosen so as to allow populating a `QuantityI32<Hertz>` with an input in MHz.
 constexpr auto OVERFLOW_THRESHOLD = 2'147;
 
 // This wrapper for `can_scale_without_overflow<...>(..., OVERFLOW_THRESHOLD)` can prevent an

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -456,6 +456,10 @@ using QuantityD = Quantity<UnitT, double>;
 template <typename UnitT>
 using QuantityF = Quantity<UnitT, float>;
 template <typename UnitT>
+using QuantityI = Quantity<UnitT, int>;
+template <typename UnitT>
+using QuantityU = Quantity<UnitT, unsigned int>;
+template <typename UnitT>
 using QuantityI32 = Quantity<UnitT, int32_t>;
 template <typename UnitT>
 using QuantityU32 = Quantity<UnitT, uint32_t>;

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -308,6 +308,10 @@ using QuantityPointD = QuantityPoint<UnitT, double>;
 template <typename UnitT>
 using QuantityPointF = QuantityPoint<UnitT, float>;
 template <typename UnitT>
+using QuantityPointI = QuantityPoint<UnitT, int>;
+template <typename UnitT>
+using QuantityPointU = QuantityPoint<UnitT, unsigned int>;
+template <typename UnitT>
 using QuantityPointI32 = QuantityPoint<UnitT, int32_t>;
 template <typename UnitT>
 using QuantityPointU32 = QuantityPoint<UnitT, uint32_t>;

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -42,6 +42,17 @@ struct Celsius : Kelvins {
 constexpr QuantityMaker<Celsius> celsius_qty{};
 constexpr QuantityPointMaker<Celsius> celsius_pt{};
 
+TEST(Quantity, HasCorrectRepNamedAliases) {
+    StaticAssertTypeEq<QuantityPointD<Meters>, QuantityPoint<Meters, double>>();
+    StaticAssertTypeEq<QuantityPointF<Meters>, QuantityPoint<Meters, float>>();
+    StaticAssertTypeEq<QuantityPointI<Meters>, QuantityPoint<Meters, int>>();
+    StaticAssertTypeEq<QuantityPointU<Meters>, QuantityPoint<Meters, unsigned int>>();
+    StaticAssertTypeEq<QuantityPointI32<Meters>, QuantityPoint<Meters, int32_t>>();
+    StaticAssertTypeEq<QuantityPointU32<Meters>, QuantityPoint<Meters, uint32_t>>();
+    StaticAssertTypeEq<QuantityPointI64<Meters>, QuantityPoint<Meters, int64_t>>();
+    StaticAssertTypeEq<QuantityPointU64<Meters>, QuantityPoint<Meters, uint64_t>>();
+}
+
 TEST(QuantityPoint, HasExpectedDiffType) {
     StaticAssertTypeEq<QuantityPointI32<Kelvins>::Diff, QuantityI32<Kelvins>>();
     StaticAssertTypeEq<QuantityPointF<Celsius>::Diff, QuantityF<Celsius>>();

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -70,6 +70,17 @@ TEST(Quantity, IsItaniumAbiRegisterCompatible) {
     EXPECT_TRUE(std::is_trivially_move_constructible<QuantityD<Feet>>::value);
 }
 
+TEST(Quantity, HasCorrectRepNamedAliases) {
+    StaticAssertTypeEq<QuantityD<Feet>, Quantity<Feet, double>>();
+    StaticAssertTypeEq<QuantityF<Feet>, Quantity<Feet, float>>();
+    StaticAssertTypeEq<QuantityI<Feet>, Quantity<Feet, int>>();
+    StaticAssertTypeEq<QuantityU<Feet>, Quantity<Feet, unsigned int>>();
+    StaticAssertTypeEq<QuantityI32<Feet>, Quantity<Feet, int32_t>>();
+    StaticAssertTypeEq<QuantityU32<Feet>, Quantity<Feet, uint32_t>>();
+    StaticAssertTypeEq<QuantityI64<Feet>, Quantity<Feet, int64_t>>();
+    StaticAssertTypeEq<QuantityU64<Feet>, Quantity<Feet, uint64_t>>();
+}
+
 TEST(Quantity, CanCreateAndReadValuesByNamingUnits) {
     constexpr auto x = feet(3.14);
     constexpr double output_value = x.in(feet);

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -30,6 +30,8 @@ aliases", so you can express the rep more precisely, and put the visual focus on
 |-----------------|----------------|
 | `QuantityD<U>` | `Quantity<U, double>` |
 | `QuantityF<U>` | `Quantity<U, float>` |
+| `QuantityI<U>` | `Quantity<U, int>` |
+| `QuantityU<U>` | `Quantity<U, unsigned int>` |
 | `QuantityI32<U>` | `Quantity<U, int32_t>` |
 | `QuantityU32<U>` | `Quantity<U, uint32_t>` |
 | `QuantityI64<U>` | `Quantity<U, int64_t>` |

--- a/docs/tutorial/102-api-types.md
+++ b/docs/tutorial/102-api-types.md
@@ -54,6 +54,8 @@ a table of the ones we support out of the box:
 |-----|-------|
 | `double` | `QuantityD` |
 | `float` | `QuantityF` |
+| `int` | `QuantityI` |
+| `unsigned int` | `QuantityU` |
 | `int32_t` | `QuantityI32` |
 | `uint32_t` | `QuantityU32` |
 | `int64_t` | `QuantityI64` |


### PR DESCRIPTION
This is all about the ability to express intent.  Despite their reduced
specificity compared to, e.g., `int32_t`, `unsigned int` and `int` are
very common for end users to write in code.  But right now it's
disproportionately hard for them to spell the corresponding `Quantity`
type concisely.  I'm not sure if we'll add other aliases such as `long`
or `long long`, but these two seem like a clear improvement.

I also updated an obsolete comment which no longer referred to the
correct Rep-named alias.