### PR TITLE
Use more descriptive job names

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ on:
         type: string
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/buildifier-lint.yml
+++ b/.github/workflows/buildifier-lint.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint-buildifier:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0

--- a/.github/workflows/check-license-headers.yml
+++ b/.github/workflows/check-license-headers.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint-check-license-headers:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint-clang-format:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/clang11-ubuntu.yml
+++ b/.github/workflows/clang11-ubuntu.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-and-test-clang11:
     uses: ./.github/workflows/build-and-test.yml
     with:
       config: clang11

--- a/.github/workflows/clang14-ubuntu.yml
+++ b/.github/workflows/clang14-ubuntu.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-and-test-clang14:
     uses: ./.github/workflows/build-and-test.yml
     with:
       config: clang14

--- a/.github/workflows/deploy-doc-site.yml
+++ b/.github/workflows/deploy-doc-site.yml
@@ -20,7 +20,7 @@ on:
       - main
 
 jobs:
-  build:
+  deploy-doc-site:
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/ensure-sha-pinned-actions.yml
+++ b/.github/workflows/ensure-sha-pinned-actions.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  ensure-sha-pinned-actions:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0

--- a/.github/workflows/gcc10-ubuntu.yml
+++ b/.github/workflows/gcc10-ubuntu.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-and-test-gcc10:
     uses: ./.github/workflows/build-and-test.yml
     with:
       config: gcc10

--- a/.github/workflows/msvc-x64-19-29-30151.yml
+++ b/.github/workflows/msvc-x64-19-29-30151.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-and-test-msvc-19-29:
     uses: ./.github/workflows/single-file-build-and-test.yml
     with:
       windows_version: windows-2019

--- a/.github/workflows/msvc-x64-19-35-32217-1.yml
+++ b/.github/workflows/msvc-x64-19-35-32217-1.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-and-test-msvc-19-35:
     uses: ./.github/workflows/single-file-build-and-test.yml
     with:
       windows_version: windows-2022

--- a/.github/workflows/single-file-build-and-test.yml
+++ b/.github/workflows/single-file-build-and-test.yml
@@ -22,7 +22,7 @@ on:
         type: string
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ${{ inputs.windows_version }}
 
     steps:


### PR DESCRIPTION
On a recent PR (#154), basically every job's status was reported as
either "build", or "build / build".  We should make these more
descriptive so it's easier to tell what's what.