### PR TITLE
Improve dimensionless nholthaus unit support

### DIFF
--- a/compatibility/nholthaus_units_test.cc
+++ b/compatibility/nholthaus_units_test.cc
@@ -96,6 +96,9 @@ TEST(NholthausTypes, MapsDerivedUnitsFoundInCodebaseCorrectly) {
     expect_equivalent<::units::area::square_meter_t>(squared(meters));
 
     expect_equivalent<::units::concentration::percent_t>(percent);
+    expect_equivalent<::units::concentration::ppm_t>(unos / mag<1'000'000>());
+    expect_equivalent<::units::concentration::ppb_t>(unos / mag<1'000'000'000>());
+    expect_equivalent<::units::concentration::ppt_t>(unos / mag<1'000'000'000'000>());
 
     expect_equivalent<::units::data_transfer_rate::bytes_per_second_t>(bytes / second);
     expect_equivalent<::units::data_transfer_rate::megabytes_per_second_t>(mega(bytes) / second);


### PR DESCRIPTION
Previously, we had a special implementation for `percent` only.  This PR
switches it to a more general solution that will handle every
dimensionless value.  (Note that the existing `percent` tests still
pass, unmodified.)

This change uncovered the fact that some nholthaus units (including
`ppb_t`) are defined in terms of other `unit<...>` specializations,
_not_ directly in terms of a `base_unit<...>`.  I added a new generic
pattern to deal with this case recursively.