### PR TITLE
Add style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Au follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppg
 from the explicit exceptions we enumerate below.  Please make sure your PR conforms to this modified
 style guide before landing.
 
-Here are the modifications we've made to the Google style guide for Au:
+Here are the modifications we've made to the Google C++ Style Guide for Au:
 
 1. The `.clang-format` file in the repository supersedes the Google style guide in all matters of
    code formatting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,3 +48,29 @@ maximize the chance of delivering its value!
 
 See our [development setup guide](https://aurora-opensource.github.io/au/develop/) to get started
 with building and testing the code and documentation!
+
+### Style guide
+
+Au follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html), apart
+from the explicit exceptions we enumerate below.  Please make sure your PR conforms to this modified
+style guide before landing.
+
+Here are the modifications we've made to the Google style guide for Au:
+
+1. The `.clang-format` file in the repository supersedes the Google style guide in all matters of
+   code formatting.
+
+2. Our header files use the `.hh` extension, not
+   [`.h`](https://google.github.io/styleguide/cppguide.html#Header_Files).
+
+3. Use `#pragma once` instead of [`#define`
+   guards](https://google.github.io/styleguide/cppguide.html#The__define_Guard).
+
+4. We permit [implicit
+   conversions](https://google.github.io/styleguide/cppguide.html#Implicit_Conversions) that perform
+   unit conversions we expect to be safe.
+
+5. We do not use the [`kConstantName`
+   convention](https://google.github.io/styleguide/cppguide.html#Constant_Names) for our constants.
+   Instead, we use the `UPPER_SNAKE_CASE` convention.  This also applies to [enumerator
+   names](https://google.github.io/styleguide/cppguide.html#Enumerator_Names).


### PR DESCRIPTION
I skimmed through the Google C++ style guide, and looked for any
differences in how we do things.  I called out the ones I found.  We can
add more here as we encounter them.

The result can be previewed here:
https://github.com/aurora-opensource/au/blob/style-guide%2322/CONTRIBUTING.md#style-guide

To test, I clicked every link.  They all go to the right anchor,
although some of the later ones seemed to be a little "off" to me in
their location.  However, the link is definitely correct, so I think
this is a quirk we can't do anything about.

Fixes #22.