### PR TITLE
Implement `clamp(v, lo, hi)`

### DIFF
--- a/au/math.hh
+++ b/au/math.hh
@@ -147,6 +147,26 @@ auto arctan2(Quantity<U1, R1> y, Quantity<U2, R2> x) {
     return arctan2(y.in(common_unit), x.in(common_unit));
 }
 
+// Clamp the first quantity to within the range of the second two.
+template <typename UV, typename ULo, typename UHi, typename RV, typename RLo, typename RHi>
+constexpr auto clamp(Quantity<UV, RV> v, Quantity<ULo, RLo> lo, Quantity<UHi, RHi> hi) {
+    using U = CommonUnitT<UV, ULo, UHi>;
+    using R = std::common_type_t<RV, RLo, RHi>;
+    using ResultT = Quantity<U, R>;
+    return (v < lo) ? ResultT{lo} : (hi < v) ? ResultT{hi} : ResultT{v};
+}
+
+// Clamp the first point to within the range of the second two.
+template <typename UV, typename ULo, typename UHi, typename RV, typename RLo, typename RHi>
+constexpr auto clamp(QuantityPoint<UV, RV> v,
+                     QuantityPoint<ULo, RLo> lo,
+                     QuantityPoint<UHi, RHi> hi) {
+    using U = CommonPointUnitT<UV, ULo, UHi>;
+    using R = std::common_type_t<RV, RLo, RHi>;
+    using ResultT = QuantityPoint<U, R>;
+    return (v < lo) ? ResultT{lo} : (hi < v) ? ResultT{hi} : ResultT{v};
+}
+
 // Copysign where the magnitude has units.
 template <typename U, typename R, typename T>
 constexpr auto copysign(Quantity<U, R> mag, T sgn) {


### PR DESCRIPTION
This is similar to `std::clamp(v, lo, hi)`, introduced in C++17, but
with some interesting twists due to handling units.  Similar to `min`
and `max`, we express the return value in the common unit of all inputs.
Once again, this also means we return by value instead of reference.

One consequence, which may be counterintuitive at first, is that the
return type can be different from the type of the value we're clamping!
However, this makes sense after more careful consideration.  If we ask
to clamp a value in, say, _meters_, to a range whose bounds we express
in _millimeters_, then if the value falls outside this range, _of
course_ we'll need to express it in millimeters.  Since the return type
can't depend on whether the value is outside the range, this is
sufficient.

(Of course, I expect the usual case when units are different is that the
value is already more precise than the bounds.  And I expect the usual
_usual_ case is that the units are _not_ different.)

`QuantityPoint` is even more interesting.  It turns out we need to take
the origin offset into account whenever it exists.  Imagine clamping 0
degrees Celsius to within two values in Kelvins.  We can't compare the
value to the bounds without adding the relative offset, which can't be
expressed more coarsely than 1/20 Kelvins.  Fortunately, our "common
point unit" machinery handles this case with ease.

Includes unit tests for both `Quantity` and `QuantityPoint`, as well as
reference documentation.

Fixes #42.