### PR TITLE
Make Au compatible with `-Wconversion`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,3 +29,5 @@ jobs:
       - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0
       - name: Build and test (${{ inputs.config }})
         run: bazel test --copt=-Werror --config=${{ inputs.config }} //...:all
+      - name: Build and test -Wconversion (${{ inputs.config }})
+        run: bazel test --copt=-Werror --copt=-Wconversion --config=${{ inputs.config }} '//au/...:all except //au:no_wconversion_test'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,5 +29,5 @@ jobs:
       - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0
       - name: Build and test (${{ inputs.config }})
         run: bazel test --copt=-Werror --config=${{ inputs.config }} //...:all
-      - name: Build and test -Wconversion (${{ inputs.config }})
-        run: bazel test --copt=-Werror --copt=-Wconversion --config=${{ inputs.config }} '//au/...:all except //au:no_wconversion_test'
+      - name: Build and test with -Wconversion (${{ inputs.config }})
+        run: bazel test --copt=-Werror --copt=-Wconversion --config=${{ inputs.config }} `bazel query 'kind(".*_test", //au/...:all except //au:no_wconversion_test)'`

--- a/au/BUILD
+++ b/au/BUILD
@@ -230,6 +230,18 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "no_wconversion_test",
+    size = "small",
+    srcs = ["no_wconversion_test.cc"],
+    deps = [
+        ":quantity",
+        ":testing",
+        ":units",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "packs",
     hdrs = ["packs.hh"],

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -278,10 +278,10 @@ using Widen = std::conditional_t<
                        std::conditional_t<std::is_signed<T>::value, std::intmax_t, std::uintmax_t>>,
     T>;
 
-template <typename T, int N, typename B>
+template <typename T, std::intmax_t N, typename B>
 constexpr Widen<T> base_power_value(B base) {
     return (N < 0) ? (Widen<T>{1} / base_power_value<T, -N>(base))
-                   : int_pow(static_cast<Widen<T>>(base), N);
+                   : int_pow(static_cast<Widen<T>>(base), static_cast<std::uintmax_t>(N));
 }
 
 template <typename T, std::size_t N>

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -136,7 +136,7 @@ TEST(clamp, QuantityPointTakesOffsetIntoAccount) {
 TEST(copysign, ReturnsSameTypesAsStdCopysignForSameUnitInputs) {
     auto expect_consistent_with_std_copysign = [](auto mag, auto raw_sgn) {
         for (const auto test_sgn : {-1, 0, +1}) {
-            const auto sgn = test_sgn * raw_sgn;
+            const auto sgn = static_cast<decltype(raw_sgn)>(test_sgn) * raw_sgn;
 
             EXPECT_THAT(copysign(mag, sgn), SameTypeAndValue(std::copysign(mag, sgn)));
 

--- a/au/no_wconversion_test.cc
+++ b/au/no_wconversion_test.cc
@@ -1,0 +1,122 @@
+// Copyright 2023 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/quantity.hh"
+#include "au/testing.hh"
+#include "au/units/feet.hh"
+#include "au/units/hours.hh"
+#include "au/units/miles.hh"
+#include "au/units/yards.hh"
+#include "gtest/gtest.h"
+
+namespace au {
+
+// This file is for any tests which would fail if `-Wconversion` were enabled.
+//
+// In general, the policy for Au is that we will not _add_ `-Wconversion` errors.  We illustrate
+// what this means with two examples.
+//
+// First, suppose a project does not use `-Wconversion`, and contains a computation with
+// `-Wconversion` would not permit.  If that project "wraps" this computation with Au, then it would
+// still fail with `-Wconversion`.  But Au has not "added" this failure.
+//
+// Second, suppose a project does use `-Wconversion`, and "wraps" one of their computations with Au.
+// If this wrapping causes the project to fail the build, then Au _would_ have "added" this failure.
+// This is what we want to avoid.
+//
+// Therefore, we confine all our tests which exercise `-Wconversion`-incompatible logic to this
+// file, and we enable `-Wconversion` when running all other tests in CI.
+
+TEST(Quantity, MultiplicationRespectUnderlyingTypes) {
+    auto expect_multiplication_respects_types = [](auto t, auto u) {
+        const auto t_quantity = (feet / hour)(t);
+        const auto u_quantity = hours(u);
+
+        const auto r = t * u;
+
+        EXPECT_THAT(t_quantity * u_quantity, QuantityEquivalent(feet(r)));
+        EXPECT_THAT(t_quantity * u, QuantityEquivalent((feet / hour)(r)));
+        EXPECT_THAT(t * u_quantity, QuantityEquivalent(hours(r)));
+    };
+
+    expect_multiplication_respects_types(2., 3.);
+    expect_multiplication_respects_types(2., 3.f);
+    expect_multiplication_respects_types(2., 3);
+
+    expect_multiplication_respects_types(2.f, 3.);
+    expect_multiplication_respects_types(2.f, 3.f);
+    expect_multiplication_respects_types(2.f, 3);
+
+    expect_multiplication_respects_types(2, 3.);
+    expect_multiplication_respects_types(2, 3.f);
+    expect_multiplication_respects_types(2, 3);
+}
+
+TEST(Quantity, DivisionRespectsUnderlyingTypes) {
+    auto expect_division_respects_types = [](auto t, auto u) {
+        const auto t_quantity = miles(t);
+        const auto u_quantity = hours(u);
+
+        const auto q = t / u;
+
+        EXPECT_THAT(t_quantity / u_quantity, QuantityEquivalent((miles / hour)(q)));
+        EXPECT_THAT(t_quantity / u, QuantityEquivalent(miles(q)));
+        EXPECT_THAT(t / u_quantity, QuantityEquivalent(pow<-1>(hours)(q)));
+    };
+
+    expect_division_respects_types(2., 3.);
+    expect_division_respects_types(2., 3.f);
+    expect_division_respects_types(2., 3);
+
+    expect_division_respects_types(2.f, 3.);
+    expect_division_respects_types(2.f, 3.f);
+    expect_division_respects_types(2.f, 3);
+
+    // We omit the integer division case, because we forbid it for Quantity.  When combined with
+    // implicit conversions, it is too prone to truncate significantly and surprise users.
+    expect_division_respects_types(2, 3.);
+    expect_division_respects_types(2, 3.f);
+    // expect_division_respects_types(2, 3);
+}
+
+TEST(QuantityShorthandMultiplicationAndDivisionAssignment, RespectUnderlyingTypes) {
+    auto expect_shorthand_assignment_models_underlying_types = [](auto t, auto u) {
+        auto t_quantity = yards(t);
+
+        t_quantity *= u;
+        t *= u;
+        EXPECT_THAT(t_quantity.in(yards), SameTypeAndValue(t));
+
+        t_quantity /= u;
+        t /= u;
+        EXPECT_THAT(t_quantity.in(yards), SameTypeAndValue(t));
+    };
+
+    expect_shorthand_assignment_models_underlying_types(2., 3.);
+    expect_shorthand_assignment_models_underlying_types(2., 3.f);
+    expect_shorthand_assignment_models_underlying_types(2., 3);
+
+    expect_shorthand_assignment_models_underlying_types(2.f, 3.);
+    expect_shorthand_assignment_models_underlying_types(2.f, 3.f);
+    expect_shorthand_assignment_models_underlying_types(2.f, 3);
+
+    // Although a raw integer apparently does support `operator*=(T)` for floating point `T`, we
+    // don't want to allow that because it's error prone and loses precision.  Thus, we comment out
+    // those test cases here.
+    expect_shorthand_assignment_models_underlying_types(2, 3);
+    // expect_shorthand_assignment_models_underlying_types(2, 3.f);
+    // expect_shorthand_assignment_models_underlying_types(2, 3.);
+}
+
+}  // namespace au

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -177,7 +177,7 @@ class Quantity {
               typename = std::enable_if_t<IsUnit<NewUnit>::value>>
     constexpr NewRep in(NewUnit u) const {
         if (are_units_quantity_equivalent(unit, u) && std::is_same<Rep, NewRep>::value) {
-            return value_;
+            return static_cast<NewRep>(value_);
         } else {
             return as<NewRep>(u).in(u);
         }

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -604,89 +604,8 @@ TEST(Quantity, CommonTypeRespectsImplicitRepSafetyChecks) {
     // would fail, rather than failing to compile.
 }
 
-TEST(Quantity, MultiplicationRespectUnderlyingTypes) {
-    auto expect_multiplication_respects_types = [](auto t, auto u) {
-        const auto t_quantity = (feet / hour)(t);
-        const auto u_quantity = hours(u);
-
-        const auto r = t * u;
-
-        EXPECT_THAT(t_quantity * u_quantity, QuantityEquivalent(feet(r)));
-        EXPECT_THAT(t_quantity * u, QuantityEquivalent((feet / hour)(r)));
-        EXPECT_THAT(t * u_quantity, QuantityEquivalent(hours(r)));
-    };
-
-    expect_multiplication_respects_types(2., 3.);
-    expect_multiplication_respects_types(2., 3.f);
-    expect_multiplication_respects_types(2., 3);
-
-    expect_multiplication_respects_types(2.f, 3.);
-    expect_multiplication_respects_types(2.f, 3.f);
-    expect_multiplication_respects_types(2.f, 3);
-
-    expect_multiplication_respects_types(2, 3.);
-    expect_multiplication_respects_types(2, 3.f);
-    expect_multiplication_respects_types(2, 3);
-}
-
-TEST(Quantity, DivisionRespectsUnderlyingTypes) {
-    auto expect_division_respects_types = [](auto t, auto u) {
-        const auto t_quantity = miles(t);
-        const auto u_quantity = hours(u);
-
-        const auto q = t / u;
-
-        EXPECT_THAT(t_quantity / u_quantity, QuantityEquivalent((miles / hour)(q)));
-        EXPECT_THAT(t_quantity / u, QuantityEquivalent(miles(q)));
-        EXPECT_THAT(t / u_quantity, QuantityEquivalent(pow<-1>(hours)(q)));
-    };
-
-    expect_division_respects_types(2., 3.);
-    expect_division_respects_types(2., 3.f);
-    expect_division_respects_types(2., 3);
-
-    expect_division_respects_types(2.f, 3.);
-    expect_division_respects_types(2.f, 3.f);
-    expect_division_respects_types(2.f, 3);
-
-    // We omit the integer division case, because we forbid it for Quantity.  When combined with
-    // implicit conversions, it is too prone to truncate significantly and surprise users.
-    expect_division_respects_types(2, 3.);
-    expect_division_respects_types(2, 3.f);
-    // expect_division_respects_types(2, 3);
-}
-
 TEST(QuantityMaker, ProvidesAssociatedUnit) {
     StaticAssertTypeEq<AssociatedUnitT<QuantityMaker<Hours>>, Hours>();
-}
-
-TEST(QuantityShorthandMultiplicationAndDivisionAssignment, RespectUnderlyingTypes) {
-    auto expect_shorthand_assignment_models_underlying_types = [](auto t, auto u) {
-        auto t_quantity = yards(t);
-
-        t_quantity *= u;
-        t *= u;
-        EXPECT_THAT(t_quantity.in(yards), SameTypeAndValue(t));
-
-        t_quantity /= u;
-        t /= u;
-        EXPECT_THAT(t_quantity.in(yards), SameTypeAndValue(t));
-    };
-
-    expect_shorthand_assignment_models_underlying_types(2., 3.);
-    expect_shorthand_assignment_models_underlying_types(2., 3.f);
-    expect_shorthand_assignment_models_underlying_types(2., 3);
-
-    expect_shorthand_assignment_models_underlying_types(2.f, 3.);
-    expect_shorthand_assignment_models_underlying_types(2.f, 3.f);
-    expect_shorthand_assignment_models_underlying_types(2.f, 3);
-
-    // Although a raw integer apparently does support `operator*=(T)` for floating point `T`, we
-    // don't want to allow that because it's error prone and loses precision.  Thus, we comment out
-    // those test cases here.
-    expect_shorthand_assignment_models_underlying_types(2, 3);
-    // expect_shorthand_assignment_models_underlying_types(2, 3.f);
-    // expect_shorthand_assignment_models_underlying_types(2, 3.);
 }
 
 TEST(AreQuantityTypesEquivalent, RequiresSameRepAndEquivalentUnits) {

--- a/au/utility/string_constant.hh
+++ b/au/utility/string_constant.hh
@@ -215,7 +215,7 @@ struct IToA {
 
         std::size_t i = length - 1;
         do {
-            data[i--] = '0' + (num % 10);
+            data[i--] = '0' + static_cast<char>(num % 10);
             num /= 10;
         } while (num > 0);
 

--- a/au/utility/string_constant.hh
+++ b/au/utility/string_constant.hh
@@ -93,7 +93,7 @@ constexpr std::size_t string_size(int64_t x) {
         return string_size(-x) + 1;
     }
 
-    int digits = 1;
+    std::size_t digits = 1;
     while (x > 9) {
         x /= 10;
         ++digits;


### PR DESCRIPTION
The goal is for Au to not raise any warnings for users who build with
`-Wconversion`.

Note that this is not the same thing as simply enabling `-Wconversion`
by default on all of our builds.  Since Au simply "wraps" the underlying
C++ computations, it will always be easy to "make" Au violate
`-Wconversion`, simply by wrapping a non-complicant computation.
Indeed, we have a couple of tests that do this, and I think they are
important to retain.

The solution is to confine all of these tests to a single new test
target.  Then we add a separate step in the build-and-test jobs that
runs every _other_ test with `-Wconversion` enabled.  This will give us
confidence that we're not re-breaking `-Wconversion` later on.