### PR TITLE
Make most unit traits compatible with unit slots

### DIFF
--- a/au/BUILD
+++ b/au/BUILD
@@ -392,6 +392,7 @@ cc_test(
         ":prefix",
         ":testing",
         ":unit_of_measure",
+        ":units",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -195,47 +195,53 @@ constexpr bool is_unit(T) {
     return IsUnit<T>::value;
 }
 
-// Check whether two objects are Unit types of the same Dimension.
+// `fits_in_unit_slot(T)`: check whether this value is valid for a unit slot.
+template <typename T>
+constexpr bool fits_in_unit_slot(T) {
+    return IsUnit<AssociatedUnitT<T>>::value;
+}
+
+// Check whether the units associated with these objects have the same Dimension.
 template <typename... Us>
 constexpr bool has_same_dimension(Us...) {
-    return HasSameDimension<Us...>::value;
+    return HasSameDimension<AssociatedUnitT<Us>...>::value;
 }
 
 // Check whether two Unit types are exactly quantity-equivalent.
 template <typename U1, typename U2>
 constexpr bool are_units_quantity_equivalent(U1, U2) {
-    return AreUnitsQuantityEquivalent<U1, U2>::value;
+    return AreUnitsQuantityEquivalent<AssociatedUnitT<U1>, AssociatedUnitT<U2>>::value;
 }
 
 // Check whether two Unit types are exactly point-equivalent.
 template <typename U1, typename U2>
 constexpr bool are_units_point_equivalent(U1, U2) {
-    return AreUnitsPointEquivalent<U1, U2>::value;
+    return AreUnitsPointEquivalent<AssociatedUnitT<U1>, AssociatedUnitT<U2>>::value;
 }
 
 // Check whether this value is an instance of a dimensionless Unit.
 template <typename U>
 constexpr bool is_dimensionless(U) {
-    return IsDimensionless<U>::value;
+    return IsDimensionless<AssociatedUnitT<U>>::value;
 }
 
 // Type trait to detect whether a Unit is "the unitless unit".
 template <typename U>
 constexpr bool is_unitless_unit(U) {
-    return IsUnitlessUnit<U>::value;
+    return IsUnitlessUnit<AssociatedUnitT<U>>::value;
 }
 
 // A Magnitude representing the ratio of two same-dimensioned units.
 //
 // Useful in doing unit conversions.
 template <typename U1, typename U2>
-constexpr UnitRatioT<U1, U2> unit_ratio(U1, U2) {
+constexpr UnitRatioT<AssociatedUnitT<U1>, AssociatedUnitT<U2>> unit_ratio(U1, U2) {
     return {};
 }
 
 template <typename U1, typename U2>
 constexpr auto origin_displacement(U1, U2) {
-    return OriginDisplacement<U1, U2>::value();
+    return OriginDisplacement<AssociatedUnitT<U1>, AssociatedUnitT<U2>>::value();
 }
 
 template <typename U>

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -198,9 +198,24 @@ _instance_ `u` and magnitude instance `m`, this operation:
 
 ## Traits
 
+Because units are [monovalue types](./detail/monovalue_types.md), each trait has two forms: one for
+_types_, and another for _instances_.
+
+Additionally, the parameters in the _instance_ forms will usually act as [_unit
+slots_](../discussion/idioms/unit-slots.md).  This means you can, for example, write
+`unit_ratio(feet, meters)`, which can be convenient.
+
+!!! warning
+    The only unit trait whose parameters are _not_ unit slots is `is_unit(u)`.  This is because of
+    its name.  It will return `true` _only_ if you pass a unit type: passing the unit instance
+    `Meters{}` returns `true`, but _passing the quantity maker `meters` returns `false`_.
+
+    If you want to check whether your instance is compatible with a [unit
+    slot](../discussion/idioms/unit-slots.md), use `fits_in_unit_slot(u)`.
+
 Sections describing `bool` traits will be indicated with a trailing question mark, `"?"`.
 
-### Is unit?
+### Is unit? {#is-unit}
 
 **Result:** Indicates whether the argument is a valid unit.
 
@@ -216,6 +231,39 @@ Sections describing `bool` traits will be indicated with a trailing question mar
     - `IsUnit<U>::value`
 - For _instance_ `u`:
     - `is_unit(u)`
+
+!!! warning
+    This will only return true if `u` is an instance of a unit type, such as `Meters{}`. It will
+    return `false` for a quantity maker such as `meters`.
+
+    This is what you want if you are trying to figure out whether the type of your instance would be
+    suitable as the first template parameter for `Quantity` or `QuantityPoint`.
+
+    If you are trying to figure out whether your instance `u` is suitable for a [unit
+    slot](../discussion/idioms/unit-slots.md), call [`fits_in_unit_slot(u)`](#fits-in-unit-slot)
+    instead.
+
+### Fits in unit slot? {#fits-in-unit-slot}
+
+**Result:** Indicates whether the argument can be validly passed to a [unit
+slot](../discussion/idioms/unit-slots.md) in an API.
+
+This trait is _instance-only_: there is no reason to apply this to types, so we do not provide
+a type-based API.
+
+**Syntax:**
+
+- For _instance_ `u`:
+    - `fits_in_unit_slot(u)`
+
+!!! warning
+    This can return true even if `u` is _not_ an instance of a unit type.  For example,
+    `fits_in_unit_slot(meters)` returns true, even though the type of `meters` is
+    `QuantityMaker<Meters>`, and thus, not a unit.
+
+    If you want to stringently check whether `u` is a _unit_ --- say, to determine whether its type
+    is suitable as the first template parameter of `Quantity` --- then call [`is_unit(u)`](#is-unit)
+    instead.
 
 ### Has same dimension?
 


### PR DESCRIPTION
The motivating use case was `unit_ratio`.  I was working with an ad hoc
type for CPU frequency which _only_ had a quantity maker.  See the
example from the issue:

```cpp
constexpr auto cpu_ticks = hertz * mag<400'000'000>();
```

Right now, there's no good way to get the unit ratio between this and
`Nano<Seconds>`.  Enabling `unit_ratio(cpu_ticks, nano(seconds))` seems
like a slam dunk.

There are of course many other unit traits.  I decided to update them
all while I was in there.  `is_unit` felt like it should be an
exception, so I made it one, and explained why in detail in the docs.

I also added test cases to make sure we have the desired behaviour.  In
doing so, I replaced our ad hoc definitions with the direct unit
definitions.  Making a length system based on `Feet` was kind of cute,
but we don't need it.  This also brings in the quantity makers such as
`feet`, which was the real motivation for this change.  I kept `Celsius`
as-is because several tests depend on its exact choice of type for
origin, and they're easier to understand if the definition is in the
same file.

Fixes #167.