### PR TITLE
Add coercing versions of conversion functions

### DIFF
--- a/au/prefix_test.cc
+++ b/au/prefix_test.cc
@@ -46,7 +46,7 @@ TEST(PrefixApplier, ConvertsQuantityMakerToMakerOfCorrespondingPrefixedType) {
     constexpr auto d = inches(2);
     EXPECT_THAT(d.in(make_milli(inches)), SameTypeAndValue(2'000));
 
-    EXPECT_THAT(make_milli(inches)(5'777).in<int>(inches), SameTypeAndValue(5));
+    EXPECT_THAT(make_milli(inches)(5'777).coerce_in(inches), SameTypeAndValue(5));
 }
 
 TEST(PrefixApplier, ConvertsSingularNameForToCorrespondingPrefixedType) {

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -242,6 +242,28 @@ class Quantity {
         return in<R>(U{});
     }
 
+    // "Forcing" conversions, which explicitly ignore safety checks for overflow and truncation.
+    template <typename NewUnit>
+    constexpr auto coerce_as(NewUnit) const {
+        // Usage example: `q.coerce_as(new_units)`.
+        return as<Rep>(NewUnit{});
+    }
+    template <typename NewRep, typename NewUnit>
+    constexpr auto coerce_as(NewUnit) const {
+        // Usage example: `q.coerce_as<T>(new_units)`.
+        return as<NewRep>(NewUnit{});
+    }
+    template <typename NewUnit>
+    constexpr auto coerce_in(NewUnit) const {
+        // Usage example: `q.coerce_in(new_units)`.
+        return in<Rep>(NewUnit{});
+    }
+    template <typename NewRep, typename NewUnit>
+    constexpr auto coerce_in(NewUnit) const {
+        // Usage example: `q.coerce_in<T>(new_units)`.
+        return in<NewRep>(NewUnit{});
+    }
+
     // Direct access to the underlying value member, with any Quantity-equivalent Unit.
     //
     // Mutable access, QuantityMaker input.

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -194,6 +194,28 @@ class QuantityPoint {
         return in<R>(U{});
     }
 
+    // "Forcing" conversions, which explicitly ignore safety checks for overflow and truncation.
+    template <typename NewUnit>
+    constexpr auto coerce_as(NewUnit) const {
+        // Usage example: `p.coerce_as(new_units)`.
+        return as<Rep>(NewUnit{});
+    }
+    template <typename NewRep, typename NewUnit>
+    constexpr auto coerce_as(NewUnit) const {
+        // Usage example: `p.coerce_as<T>(new_units)`.
+        return as<NewRep>(NewUnit{});
+    }
+    template <typename NewUnit>
+    constexpr auto coerce_in(NewUnit) const {
+        // Usage example: `p.coerce_in(new_units)`.
+        return in<Rep>(NewUnit{});
+    }
+    template <typename NewRep, typename NewUnit>
+    constexpr auto coerce_in(NewUnit) const {
+        // Usage example: `p.coerce_in<T>(new_units)`.
+        return in<NewRep>(NewUnit{});
+    }
+
     // Direct access to the underlying value member, with any Point-equivalent Unit.
     //
     // Mutable access, QuantityPointMaker input.

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -28,6 +28,12 @@ struct Meters : UnitImpl<Length> {};
 constexpr QuantityMaker<Meters> meters{};
 constexpr QuantityPointMaker<Meters> meters_pt{};
 
+struct Inches : decltype(Centi<Meters>{} * mag<254>() / mag<100>()) {};
+constexpr auto inches_pt = QuantityPointMaker<Inches>{};
+
+struct Feet : decltype(Inches{} * mag<12>()) {};
+constexpr auto feet_pt = QuantityPointMaker<Feet>{};
+
 struct Kelvins : UnitImpl<Temperature> {};
 constexpr QuantityMaker<Kelvins> kelvins{};
 constexpr QuantityPointMaker<Kelvins> kelvins_pt{};
@@ -174,14 +180,59 @@ TEST(QuantityPoint, CanRequestOutputRepWhenCallingIn) {
 }
 
 TEST(QuantityPoint, CanCastToUnitWithDifferentMagnitude) {
-    EXPECT_THAT(centi(meters_pt)(75).as<int>(meters_pt), SameTypeAndValue(meters_pt(0)));
+    EXPECT_THAT(centi(meters_pt)(75).coerce_as(meters_pt), SameTypeAndValue(meters_pt(0)));
 
     EXPECT_THAT(centi(meters_pt)(75.0).as(meters_pt), SameTypeAndValue(meters_pt(0.75)));
 }
 
 TEST(QuantityPoint, CanCastToUnitWithDifferentOrigin) {
     EXPECT_THAT(celsius_pt(10.).as(kelvins_pt), IsNear(kelvins_pt(283.15), nano(kelvins)(1)));
-    EXPECT_THAT(celsius_pt(10).as<int>(Kelvins{}), SameTypeAndValue(kelvins_pt(283)));
+    EXPECT_THAT(celsius_pt(10).coerce_as(Kelvins{}), SameTypeAndValue(kelvins_pt(283)));
+}
+
+TEST(QuantityPoint, CoerceAsWillForceLossyConversion) {
+    // Truncation.
+    EXPECT_THAT(inches_pt(30).coerce_as(feet_pt), SameTypeAndValue(feet_pt(2)));
+
+    // Unsigned overflow.
+    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    EXPECT_THAT(feet_pt(uint8_t{30}).coerce_as(inches_pt),
+                SameTypeAndValue(inches_pt(uint8_t{104})));
+}
+
+TEST(QuantityPoint, CoerceAsExplicitRepSetsOutputType) {
+    // Coerced truncation.
+    EXPECT_THAT(inches_pt(30).coerce_as<std::size_t>(feet_pt),
+                SameTypeAndValue(feet_pt(std::size_t{2})));
+
+    // Exact answer for floating point destination type.
+    EXPECT_THAT(inches_pt(30).coerce_as<float>(feet_pt), SameTypeAndValue(feet_pt(2.5f)));
+
+    // Coerced unsigned overflow.
+    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    EXPECT_THAT(feet_pt(30).coerce_as<uint8_t>(inches_pt),
+                SameTypeAndValue(inches_pt(uint8_t{104})));
+}
+
+TEST(QuantityPoint, CoerceInWillForceLossyConversion) {
+    // Truncation.
+    EXPECT_THAT(inches_pt(30).coerce_in(feet_pt), SameTypeAndValue(2));
+
+    // Unsigned overflow.
+    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    EXPECT_THAT(feet_pt(uint8_t{30}).coerce_in(inches_pt), SameTypeAndValue(uint8_t{104}));
+}
+
+TEST(QuantityPoint, CoerceInExplicitRepSetsOutputType) {
+    // Coerced truncation.
+    EXPECT_THAT(inches_pt(30).coerce_in<std::size_t>(feet_pt), SameTypeAndValue(std::size_t{2}));
+
+    // Exact answer for floating point destination type.
+    EXPECT_THAT(inches_pt(30).coerce_in<float>(feet_pt), SameTypeAndValue(2.5f));
+
+    // Coerced unsigned overflow.
+    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    EXPECT_THAT(feet_pt(30).coerce_in<uint8_t>(inches_pt), SameTypeAndValue(uint8_t{104}));
 }
 
 TEST(QuantityPoint, ComparisonsWorkAsExpected) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -194,6 +194,48 @@ TEST(Quantity, SupportsDirectConstAccessWithQuantityMakerOfEquivalentUnit) {
     //           static_cast<const void *>(&x));
 }
 
+TEST(Quantity, CoerceAsWillForceLossyConversion) {
+    // Truncation.
+    EXPECT_THAT(inches(30).coerce_as(feet), SameTypeAndValue(feet(2)));
+
+    // Unsigned overflow.
+    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    EXPECT_THAT(feet(uint8_t{30}).coerce_as(inches), SameTypeAndValue(inches(uint8_t{104})));
+}
+
+TEST(Quantity, CoerceAsExplicitRepSetsOutputType) {
+    // Coerced truncation.
+    EXPECT_THAT(inches(30).coerce_as<std::size_t>(feet), SameTypeAndValue(feet(std::size_t{2})));
+
+    // Exact answer for floating point destination type.
+    EXPECT_THAT(inches(30).coerce_as<float>(feet), SameTypeAndValue(feet(2.5f)));
+
+    // Coerced unsigned overflow.
+    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    EXPECT_THAT(feet(30).coerce_as<uint8_t>(inches), SameTypeAndValue(inches(uint8_t{104})));
+}
+
+TEST(Quantity, CoerceInWillForceLossyConversion) {
+    // Truncation.
+    EXPECT_THAT(inches(30).coerce_in(feet), SameTypeAndValue(2));
+
+    // Unsigned overflow.
+    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    EXPECT_THAT(feet(uint8_t{30}).coerce_in(inches), SameTypeAndValue(uint8_t{104}));
+}
+
+TEST(Quantity, CoerceInExplicitRepSetsOutputType) {
+    // Coerced truncation.
+    EXPECT_THAT(inches(30).coerce_in<std::size_t>(feet), SameTypeAndValue(std::size_t{2}));
+
+    // Exact answer for floating point destination type.
+    EXPECT_THAT(inches(30).coerce_in<float>(feet), SameTypeAndValue(2.5f));
+
+    // Coerced unsigned overflow.
+    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    EXPECT_THAT(feet(30).coerce_in<uint8_t>(inches), SameTypeAndValue(uint8_t{104}));
+}
+
 TEST(Quantity, CanImplicitlyConvertToDifferentUnitOfSameDimension) {
     constexpr QuantityI32<Inches> x = yards(2);
     EXPECT_EQ(x.in(inches), 72);
@@ -506,20 +548,20 @@ TEST(Quantity, UnitCastRequiresExplicitTypeForDangerousReps) {
 
     // Unsafe instances: small integral types.
     //
-    // To "test" these, try replacing `.as<Rep>(...)` with `.as(...)`.  Make sure it fails with a
+    // To "test" these, try replacing `.coerce_as(...)` with `.as(...)`.  Make sure it fails with a
     // readable `static_assert`.
-    EXPECT_THAT(feet(uint16_t{1}).as<uint16_t /* must include */>(centi(feet)),
+    EXPECT_THAT(feet(uint16_t{1}).coerce_as(centi(feet)),
                 SameTypeAndValue(centi(feet)(uint16_t{100})));
 }
 
 TEST(Quantity, CanCastToDifferentUnit) {
-    EXPECT_THAT(inches(6).as<int>(feet), SameTypeAndValue(feet(0)));
+    EXPECT_THAT(inches(6).coerce_as(feet), SameTypeAndValue(feet(0)));
     EXPECT_THAT(inches(6.).as(feet), SameTypeAndValue(feet(0.5)));
 }
 
 TEST(Quantity, QuantityCastSupportsConstexprAndConst) {
     constexpr auto eighteen_inches_double = inches(18.);
-    constexpr auto one_foot_int = eighteen_inches_double.as<int>(feet);
+    constexpr auto one_foot_int = eighteen_inches_double.coerce_as<int>(feet);
     EXPECT_THAT(one_foot_int, SameTypeAndValue(feet(1)));
 }
 
@@ -544,7 +586,8 @@ TEST(Quantity, QuantityCastAvoidsPreventableOverflowWhenGoingToSmallerType) {
     // Make sure we don't overflow in uint64_t.
     ASSERT_EQ(lots_of_nanoinches.in(nano(inches)), would_overflow_uint32);
 
-    EXPECT_THAT(lots_of_nanoinches.as<uint32_t>(inches), SameTypeAndValue(inches(uint32_t{9})));
+    EXPECT_THAT(lots_of_nanoinches.coerce_as<uint32_t>(inches),
+                SameTypeAndValue(inches(uint32_t{9})));
 }
 
 TEST(Quantity, CommonTypeMagnitudeEvenlyDividesBoth) {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -172,15 +172,12 @@ operation (at least in this format).
    floating point is what you want anyway, just use it.  `giga(hertz)(1.0).as(hertz)` produces
    `hertz(1'000'000'000.0)`.
 
-2. **Use "explicit Rep" form**.  The "Rep" is the storage type for the Quantity.  If you pass it as
-   a template parameter, it is "morally equivalent" to a `static_cast`, and has the same "forcing"
-   semantics.  `inches(24).as<int>(feet)` produces `feet(2)`.
+2. **Use the "coercing" version**.  `inches(24).coerce_as(feet)` produces `feet(2)`.
 
 !!! warning
-    Stop and think before using the explicit Rep version.  If you're reviewing code that uses it,
-    ask about it.  The library is trying to protect you from an error prone operation.  The
-    mechanism exists because sometimes you can know that it's OK, but remember to stop and check
-    first!
+    Stop and think before using the coercing version.  If you're reviewing code that uses it, ask
+    about it.  The library is trying to protect you from an error prone operation.  The mechanism
+    exists because sometimes you can know that it's OK, but remember to stop and check first!
 
 !!! example
     **Code**
@@ -203,13 +200,13 @@ operation (at least in this format).
         giga(hertz)(1.0).as(hertz);
         ```
 
-    === "Fixed (2. Explicit Rep)"
+    === "Fixed (2. Coercing version)"
         ```cpp
-        // A (FIXED): 2. provide explicit Rep.
-        inches(24).as<int>(feet);
+        // A (FIXED): 2. use coercing version.
+        inches(24).coerce_as(feet);
 
-        // B (FIXED): 2. provide explicit Rep.
-        giga(hertz)(1).as<int>(hertz);
+        // B (FIXED): 2. use coercing version.
+        giga(hertz)(1).coerce_as(hertz);
         ```
 
 

--- a/docs/tutorial/exercise/103-unit-conversions.md
+++ b/docs/tutorial/exercise/103-unit-conversions.md
@@ -188,7 +188,7 @@ numbers at all.
         // inches.  For example, `inches(17)` would be decomposed into `Height{feet(1), inches(5)}`.
         Height decompose_height(QuantityU32<Inches> total_height) {
             Height h;
-            h.feet = total_height.as<uint32_t>(feet);  // NOTE: truncation is intended.
+            h.feet = total_height.coerce_as(feet);  // NOTE: truncation is intended.
             h.inches = total_height - h.feet.as(inches);
             return h;
         }


### PR DESCRIPTION


These are variants of `.as` and `.in` for both `Quantity` and
`QuantityPoint`.  When we precede these with the "coerce" vocabulary
word, they become forcing, ignoring the safety checks for truncation and
overflow.

This new syntax has two major advantages over the explicit-Rep version.
First, it makes the intent clearer.  Second, it stops forcing users to
repeat the rep when they want the same rep they started with, which I
think is the usual case.  (Thus, without these APIs, explicit-rep
obscures intent: one never knows whether the author wanted a cast, or
wanted to bypass the safety checks.)

It also unlocks another, later improvement: we will be able to extend
the safety checks to the explicit-rep versions!  But we won't attempt
that for a while because that's a breaking change.

There may be other APIs that would benefit from using the "coerce"
vocabulary word instead of explicit-rep.  However, we'll start with just
these, both because they're the overwhelmingly most common use case, and
because it gives us a chance to try out these ideas in practice for a
while.

To test this PR, I added new unit tests to cover all of the use cases.
I also rendered the docs locally and checked that the links worked as
intended.

Helps #122.