### PR TITLE
Update comparison table

### DIFF
--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -44,7 +44,7 @@ indicate which version we considered, and say a few words about why we included 
       used C++ units library to date.
 - [**bernedom/SI**](https://github.com/bernedom/SI) (version: 2.5.1)
     - A newer, C++17-compatible offering with a large number of GitHub stars.
-- [**mp-units**](https://github.com/mpusz/mp-units) (version: 2.0.0:testing)
+- [**mp-units**](https://github.com/mpusz/mp-units) (version: 2.0.0)
     - A library designed to take full advantage of ultra-modern (that is, post-C++20 watershed)
       features, such as concepts and non-template type parameters (NTTPs).
     - mp-units is leading the efforts towards a standard C++ units library, both by field testing
@@ -320,8 +320,8 @@ features.
         <td class="fair"></td>
         <td class="fair"></td>
         <td class="fair"></td>
-        <td class="good">Contains unit-safe interfaces</td>
-        <td class="best">Only contains unit-safe interfaces</td>
+        <td class="good">Only contains unit-safe interfaces</td>
+        <td class="good">Only contains unit-safe interfaces</td>
     </tr>
     <tr>
         <td>
@@ -394,8 +394,24 @@ features.
         <td class="fair"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">Prefix only</a></td>
         <td class="poor"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">No</a></td>
         <td class="poor">No</td>
-        <td class="good">Can compose units, prefixes, dimensions, and quantity types</td>
-        <td class="good">QuantityMaker and PrefixApplier APIs</td>
+        <td class="best">
+            <ul>
+                <li class="check">Can compose units, prefixes, dimensions, and quantity types</li>
+                <li class="check">
+                    C++20's Non-type template parameters (NTTPs) enable composable <i>type names</i>
+                </li>
+            </ul>
+        </td>
+        <td class="good">
+            <ul>
+                <li class="check">
+                    Can compose units, prefixes, dimensions, and quantity (point) makers
+                </li>
+                <li class="x">
+                    Type names clunky to compose: must write <code>decltype</code> or use traits
+                </li>
+            </ul>
+        </td>
     </tr>
     <tr>
         <td>
@@ -613,7 +629,9 @@ features.
             point</a>.
         </td>
         <td class="poor">None; would be hard to add, since units conflated with quantity type</td>
-        <td class="good"></td>
+        <td class="best">
+            Custom origins really easy to use and compose
+        </td>
         <td class="good"></td>
     </tr>
     <tr>
@@ -698,7 +716,7 @@ features.
                 </p>
             </details>
         </td>
-        <td class="poor"></td>
+        <td class="na"></td>
         <td class="good">User-defined literals (UDLs)</td>
         <td class="good">User-defined literals (UDLs)</td>
         <td class="best">
@@ -792,7 +810,12 @@ features.
         </td>
         <td class="fair">Supports <code>copysign()</code>, but no special construction or comparison</td>
         <td class="poor">No special construction or comparison</td>
-        <td class="fair">Has <code>q::zero()</code> member, but no special construction or comparison</td>
+        <td class="good">
+            <li class="check">
+                <a href="https://mpusz.github.io/mp-units/2.1/users_guide/framework_basics/quantity_arithmetics/?h=zero#comparison-against-zero">Special comparison functions</a>
+            </li>
+            <li><code>zero()</code> member</li>
+        </td>
         <td class="best">
             Can use <a
             href="https://aurora-opensource.github.io/au/main/discussion/concepts/zero/"><code>ZERO</code></a>
@@ -820,7 +843,7 @@ features.
                 <li class="x">pi represented as <code>std::ratio</code></li>
             </ul>
         </td>
-        <td class="good"></td>
+        <td class="best">Simultaneous support for both strongly-typed and "pure SI" angles</td>
         <td class="good"></td>
     </tr>
     <tr>
@@ -904,7 +927,7 @@ features.
     <tr>
         <td>
             <details class="criterion">
-                <summary>Units/Dimensions as types</summary>
+                <summary>Abstract Units/Dimensions</summary>
                 <p>
                     <li>
                         Types that represent abstract units (clearly distinct from quantities of

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -391,7 +391,16 @@ features.
                 </p>
             </details>
         </td>
-        <td class="fair"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">Prefix only</a></td>
+        <td class="good">
+            <ul>
+                <li class="check">
+                    Can compose units, prefixes, dimensions, and quantity (point) makers
+                </li>
+                <li class="x">
+                    Type names clunky to compose: must write <code>decltype</code>
+                </li>
+            </ul>
+        </td>
         <td class="poor"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">No</a></td>
         <td class="poor">No</td>
         <td class="best">
@@ -515,9 +524,12 @@ features.
                 <li class="check">
                     Unit-safe APIs for <code>round</code>, <code>ceil</code>, and so on
                 </li>
+                <li class="check">
+                    Smart, unit-aware inverse functions
+                </li>
             </ul>
         </td>
-        <td class="best">
+        <td class="good">
             <ul>
                 <li class="check">Wide variety of functions</li>
                 <li class="check">
@@ -602,11 +614,31 @@ features.
         <td class="fair">No interop with other units libraries</td>
         <td class="fair">No interop with other units libraries</td>
         <td class="good">
-            <a href="https://mpusz.github.io/units/use_cases/interoperability.html">
-                <code>quantity_like_traits</code>
-            </a>
+            <ul>
+                <li class="check">
+                    <a href="https://mpusz.github.io/mp-units/2.1/users_guide/framework_basics/basic_concepts/#QuantityLike">
+                        <code>QuantityLike&lt;T&gt;</code> supports bidirectional conversions
+                    </a>
+                </li>
+                <li class="check">
+                    Can specify implicit or explicit
+                </li>
+            </ul>
         </td>
-        <td class="best">"Equivalent types" feature gives more API compatibility</td>
+        <td class="good">
+            <ul>
+                <li class="check">
+                    <a href="https://aurora-opensource.github.io/au/main/howto/interop/">
+                        <code>CorrespondingQuantity</code> supports bidirectional implicit conversions
+                    </a>
+                </li>
+                <li class="check">
+                    Supports <a
+                    href="https://aurora-opensource.github.io/au/main/reference/corresponding_quantity/#conversions">"two-hop"
+                    conversions</a>
+                </li>
+            </ul>
+        </td>
     </tr>
     <tr>
         <td>
@@ -969,10 +1001,15 @@ features.
                 </p>
             </details>
         </td>
-        <td class="poor">Present in user-facing APIs</td>
-        <td class="poor">Present in user-facing APIs</td>
-        <td class="fair">Very few, and confined to implementation helpers</td>
-        <td class="fair">Very few, and confined to implementation helpers</td>
+        <td class="poor">Common in user-facing APIs</td>
+        <td class="poor">Common in user-facing APIs</td>
+        <td class="good">Very few, and confined to implementation helpers</td>
+        <td class="fair">
+            <ul>
+                <li>Very few, mostly implementation helpers</li>
+                <li>Only one user-facing macro for C++20 backwards compatibility</li>
+            </ul>
+        </td>
         <td class="best">No macros</td>
     </tr>
 </table>


### PR DESCRIPTION
The main goal is to reflect some recent improvements in mp-units.

1. They upgraded their interfaces so that they now _only contain
   unit-safe_ interfaces.  This turns this row into a "tie".

2. They added new API functions to compare against 0.  This is a
   different local optimum in design space for handling this problem
   than our solution, `Zero`.  They considered `Zero` and declined to
   add it because of how it interacts with generic interfaces, but I
   still think `Zero` is a better solution on balance so I'll leave Au
   as "best".

I also re-assessed several other rows, the upshot of which is to turn 3
ties into "best" for mp-units.

1. **Composability.**  NTTPs let mp-units write things like
   `quantity<meter / second>`, whereas we need to write something like
   `Quantity<decltype(Meters{} / Seconds{})>`.  This is amazing!

2. **Point types.**  Au assumes there's one origin (sometimes implicit)
   for each unit.  This was really focused on the temperature use case,
   and maybe atmospheric pressure.  mp-units has APIs to let users set
   the origin.  This gives much richer possibilities for dealing with
   things like altitude, with lots of different possibilities for the
   origin.  Au can _kind of_ do this by making a new unit for each one,
   but I think mp-units' approach is more flexible.

3. **Angles.**  The ability to support both dimensioned angles and
   "current SI" angles gives mp-units the edge.

I also switched boost units to "not assessed" on Abbreviated
Construction, because Mateusz mentioned they have the same syntax as
mp-units.  I had assumed they didn't have anything here because they
don't have literals.  If I can see a godbolt link of boost units code
that uses abbreviated construction, then I'll assess the rating based on
that link.