### PR TITLE
Support `Zero` in `min`, `max`, and `clamp`

### DIFF
--- a/au/math.hh
+++ b/au/math.hh
@@ -156,6 +156,26 @@ constexpr auto clamp(Quantity<UV, RV> v, Quantity<ULo, RLo> lo, Quantity<UHi, RH
     return (v < lo) ? ResultT{lo} : (hi < v) ? ResultT{hi} : ResultT{v};
 }
 
+// `clamp` overloads for when either boundary is `Zero`.
+//
+// NOTE: these will not work if _both_ boundaries are `Zero`, or if the quantity being clamped is
+// `Zero`.  We do not think these use cases are very useful, but we're open to revisiting this if we
+// receive a persuasive argument otherwise.
+template <typename UV, typename UHi, typename RV, typename RHi>
+constexpr auto clamp(Quantity<UV, RV> v, Zero z, Quantity<UHi, RHi> hi) {
+    using U = CommonUnitT<UV, UHi>;
+    using R = std::common_type_t<RV, RHi>;
+    using ResultT = Quantity<U, R>;
+    return (v < z) ? ResultT{z} : (hi < v) ? ResultT{hi} : ResultT{v};
+}
+template <typename UV, typename ULo, typename RV, typename RLo>
+constexpr auto clamp(Quantity<UV, RV> v, Quantity<ULo, RLo> lo, Zero z) {
+    using U = CommonUnitT<UV, ULo>;
+    using R = std::common_type_t<RV, RLo>;
+    using ResultT = Quantity<U, R>;
+    return (v < lo) ? ResultT{lo} : (z < v) ? ResultT{z} : ResultT{v};
+}
+
 // Clamp the first point to within the range of the second two.
 template <typename UV, typename ULo, typename UHi, typename RV, typename RLo, typename RHi>
 constexpr auto clamp(QuantityPoint<UV, RV> v,
@@ -313,6 +333,23 @@ auto max(QuantityPoint<U, R> a, QuantityPoint<U, R> b) {
     return std::max(a, b);
 }
 
+// `max` overloads for when Zero is one of the arguments.
+//
+// NOTE: these will not work if _both_ arguments are `Zero`, but we don't plan to support this
+// unless we find a compelling use case.
+template <typename T>
+auto max(Zero z, T x) {
+    static_assert(std::is_convertible<Zero, T>::value,
+                  "Cannot compare type to abstract notion Zero");
+    return std::max(T{z}, x);
+}
+template <typename T>
+auto max(T x, Zero z) {
+    static_assert(std::is_convertible<Zero, T>::value,
+                  "Cannot compare type to abstract notion Zero");
+    return std::max(x, T{z});
+}
+
 // The minimum of two values of the same dimension.
 //
 // Unlike std::min, returns by value rather than by reference, because the types might differ.
@@ -339,6 +376,23 @@ auto min(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
 template <typename U, typename R>
 auto min(QuantityPoint<U, R> a, QuantityPoint<U, R> b) {
     return std::min(a, b);
+}
+
+// `min` overloads for when Zero is one of the arguments.
+//
+// NOTE: these will not work if _both_ arguments are `Zero`, but we don't plan to support this
+// unless we find a compelling use case.
+template <typename T>
+auto min(Zero z, T x) {
+    static_assert(std::is_convertible<Zero, T>::value,
+                  "Cannot compare type to abstract notion Zero");
+    return std::min(T{z}, x);
+}
+template <typename T>
+auto min(T x, Zero z) {
+    static_assert(std::is_convertible<Zero, T>::value,
+                  "Cannot compare type to abstract notion Zero");
+    return std::min(x, T{z});
 }
 
 //

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -19,6 +19,7 @@
 #include "au/units/celsius.hh"
 #include "au/units/degrees.hh"
 #include "au/units/fahrenheit.hh"
+#include "au/units/feet.hh"
 #include "au/units/hertz.hh"
 #include "au/units/inches.hh"
 #include "au/units/kelvins.hh"
@@ -131,6 +132,18 @@ TEST(clamp, QuantityPointTakesOffsetIntoAccount) {
     constexpr auto celsius_origin = clamp(celsius_pt(0), kelvins_pt(200), kelvins_pt(300));
     ASSERT_TRUE(is_integer(unit_ratio(Kelvins{} / mag<20>(), decltype(celsius_origin)::unit)));
     EXPECT_EQ(celsius_origin, centi(kelvins_pt)(273'15));
+}
+
+TEST(clamp, SupportsZeroForLowerBoundaryArgument) {
+    EXPECT_THAT(clamp(feet(-1), ZERO, inches(18)), SameTypeAndValue(inches(0)));
+    EXPECT_THAT(clamp(feet(+1), ZERO, inches(18)), SameTypeAndValue(inches(12)));
+    EXPECT_THAT(clamp(feet(+2), ZERO, inches(18)), SameTypeAndValue(inches(18)));
+}
+
+TEST(clamp, SupportsZeroForUpperBoundaryArgument) {
+    EXPECT_THAT(clamp(feet(-2), inches(-18), ZERO), SameTypeAndValue(inches(-18)));
+    EXPECT_THAT(clamp(feet(-1), inches(-18), ZERO), SameTypeAndValue(inches(-12)));
+    EXPECT_THAT(clamp(feet(+1), inches(-18), ZERO), SameTypeAndValue(inches(0)));
 }
 
 TEST(copysign, ReturnsSameTypesAsStdCopysignForSameUnitInputs) {
@@ -273,6 +286,16 @@ TEST(max, SameAsStdMaxForNumericTypes) {
     EXPECT_EQ(&b, &max_result);
 }
 
+TEST(max, SupportsZeroForFirstArgument) {
+    EXPECT_THAT(max(ZERO, meters(8)), SameTypeAndValue(meters(8)));
+    EXPECT_THAT(max(ZERO, meters(-8)), SameTypeAndValue(meters(0)));
+}
+
+TEST(max, SupportsZeroForSecondArgument) {
+    EXPECT_THAT(max(meters(8), ZERO), SameTypeAndValue(meters(8)));
+    EXPECT_THAT(max(meters(-8), ZERO), SameTypeAndValue(meters(0)));
+}
+
 TEST(min, ReturnsSmaller) { EXPECT_EQ(min(centi(meters)(1), inches(1)), centi(meters)(1)); }
 
 TEST(min, HandlesDifferentOriginQuantityPoints) {
@@ -306,6 +329,16 @@ TEST(min, SameAsStdMinForNumericTypes) {
     const auto &min_result = min(a, b);
 
     EXPECT_EQ(&a, &min_result);
+}
+
+TEST(min, SupportsZeroForFirstArgument) {
+    EXPECT_THAT(min(ZERO, meters(8)), SameTypeAndValue(meters(0)));
+    EXPECT_THAT(min(ZERO, meters(-8)), SameTypeAndValue(meters(-8)));
+}
+
+TEST(min, SupportsZeroForSecondArgument) {
+    EXPECT_THAT(min(meters(8), ZERO), SameTypeAndValue(meters(0)));
+    EXPECT_THAT(min(meters(-8), ZERO), SameTypeAndValue(meters(-8)));
 }
 
 TEST(int_pow, OutputRepMatchesInputRep) {


### PR DESCRIPTION
We focus on the use cases that provide the clearest value: that is,
either argument for `min` and `max`, and either boundary argument for
`clamp`.

There are other use cases --- for example, both arguments `Zero` for
`max`, or the 6 remaining combinatoric possibilities for `clamp`.  But
we don't plan to support them because they don't seem very useful.

I don't think this needs a doc update, because the point of this PR is
to make these APIs act the way that users probably already expect.

Fixes #179.