### PR TITLE
Refactor `get_value<T>(m)` to enable success query

### DIFF
--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -327,35 +327,76 @@ constexpr bool safe_to_cast_to(InputT x) {
     return SafeCastingChecker<T>{}(x);
 }
 
-}  // namespace detail
+enum class MagRepresentationOutcome {
+    OK,
+    ERR_NON_INTEGER_IN_INTEGER_TYPE,
+    ERR_RATIONAL_POWERS,
+    ERR_CANNOT_FIT,
+};
+
+template <typename T>
+struct MagRepresentationOrError {
+    MagRepresentationOutcome outcome;
+
+    // Only valid/meaningful if `outcome` is `OK`.
+    T value = {0};
+};
 
 template <typename T, typename... BPs>
-constexpr T get_value(Magnitude<BPs...>) {
-    using namespace detail;
-
+constexpr MagRepresentationOrError<T> get_value_result(Magnitude<BPs...>) {
     // Representing non-integer values in integral types is something we never plan to support.
     constexpr bool REPRESENTING_NON_INTEGER_IN_INTEGRAL_TYPE =
         stdx::conjunction<std::is_integral<T>, stdx::negation<IsInteger<Magnitude<BPs...>>>>::value;
-    static_assert(!REPRESENTING_NON_INTEGER_IN_INTEGRAL_TYPE,
-                  "Cannot represent non-integer in integral destination type");
+    if (REPRESENTING_NON_INTEGER_IN_INTEGRAL_TYPE) {
+        return {MagRepresentationOutcome::ERR_NON_INTEGER_IN_INTEGER_TYPE};
+    }
 
     // Computing values for rational base powers is something we would _like_ to support, but we
     // need a `constexpr` implementation of `powl()` first.
-    static_assert(all({(ExpT<BPs>::den == 1)...}),
-                  "Computing values for rational powers not yet supported");
+    if (!all({(ExpT<BPs>::den == 1)...})) {
+        return {MagRepresentationOutcome::ERR_RATIONAL_POWERS};
+    }
 
     // Force the expression to be evaluated in a constexpr context.
     constexpr auto widened_result =
         product({base_power_value<T, (ExpT<BPs>::num / ExpT<BPs>::den)>(BaseT<BPs>::value())...});
 
-    static_assert(safe_to_cast_to<T>(widened_result), "Value outside range of destination type");
-    return static_cast<T>(widened_result);
+    if (!safe_to_cast_to<T>(widened_result)) {
+        return {MagRepresentationOutcome::ERR_CANNOT_FIT};
+    }
+
+    return {MagRepresentationOutcome::OK, static_cast<T>(widened_result)};
 }
 
 // This simple overload avoids edge cases with creating and passing zero-sized arrays.
 template <typename T>
-constexpr T get_value(Magnitude<>) {
-    return 1;
+constexpr MagRepresentationOrError<T> get_value_result(Magnitude<>) {
+    return {MagRepresentationOutcome::OK, static_cast<T>(1)};
+}
+}  // namespace detail
+
+template <typename T, typename... BPs>
+constexpr bool representable_in(Magnitude<BPs...> m) {
+    using namespace detail;
+
+    return get_value_result<T>(m).outcome == MagRepresentationOutcome::OK;
+}
+
+template <typename T, typename... BPs>
+constexpr T get_value(Magnitude<BPs...> m) {
+    using namespace detail;
+
+    constexpr auto result = get_value_result<T>(m);
+
+    static_assert(result.outcome != MagRepresentationOutcome::ERR_NON_INTEGER_IN_INTEGER_TYPE,
+                  "Cannot represent non-integer in integral destination type");
+    static_assert(result.outcome != MagRepresentationOutcome::ERR_RATIONAL_POWERS,
+                  "Computing values for rational powers not yet supported");
+    static_assert(result.outcome != MagRepresentationOutcome::ERR_CANNOT_FIT,
+                  "Value outside range of destination type");
+
+    static_assert(result.outcome == MagRepresentationOutcome::OK, "Unknown error occurred");
+    return result.value;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/au/magnitude_test.cc
+++ b/au/magnitude_test.cc
@@ -136,6 +136,20 @@ TEST(IsInteger, FalseForInexactFractions) {
 
 TEST(IsInteger, FalseForIrrationalBase) { EXPECT_FALSE(is_integer(PI)); }
 
+TEST(RepresentableIn, DocumentationExamplesAreCorrect) {
+    EXPECT_TRUE(representable_in<int>(mag<1>()));
+
+    // (1 / 2) is not an integer.
+    EXPECT_FALSE(representable_in<int>(mag<1>() / mag<2>()));
+
+    EXPECT_TRUE(representable_in<float>(mag<1>() / mag<2>()));
+
+    EXPECT_TRUE(representable_in<uint32_t>(mag<4'000'000'000>()));
+
+    // 4 billion is larger than the max value representable in `int32_t`.
+    EXPECT_FALSE(representable_in<int32_t>(mag<4'000'000'000>()));
+}
+
 TEST(GetValue, SupportsIntegerOutputForIntegerMagnitude) {
     constexpr auto m = mag<412>();
     EXPECT_THAT(get_value<int>(m), SameTypeAndValue(412));

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -127,6 +127,38 @@ To extract the value of a `Magnitude` instance `m` into a given numeric type `T`
     Thus, `get_value<float>(pow<3>(PI))` will be much more accurate than storing $\pi$ in a `float`,
     and cubing it --- yet, there will be no loss in performance.
 
+### Checking for representability
+
+If you need to check whether your magnitude `m` can be represented in a type `T`, you can call
+`representable_in<T>(m)`.  This function is `constexpr` compatible.
+
+??? example "Example: integer and non-integer values"
+
+    Here are some example test cases which will pass.
+
+    ```cpp
+    EXPECT_TRUE(representable_in<int>(mag<1>()));
+
+    // (1 / 2) is not an integer.
+    EXPECT_FALSE(representable_in<int>(mag<1>() / mag<2>()));
+
+    EXPECT_TRUE(representable_in<float>(mag<1>() / mag<2>()));
+    ```
+
+??? example "Example: range of the type"
+    Here are some example test cases which will pass.
+
+    ```cpp
+    EXPECT_TRUE(representable_in<uint32_t>(mag<4'000'000'000>()));
+
+    // 4 billion is larger than the max value representable in `int32_t`.
+    EXPECT_FALSE(representable_in<int32_t>(mag<4'000'000'000>()));
+    ```
+
+Note that this function's return value also depends on _whether we can compute_ the value, not just
+whether it is repreesntable.   For example, `representable_in<double>(sqrt(mag<2>()))` is currently
+`false`, because we haven't yet added support for computing rational base powers.
+
 ## Operations
 
 These are the operations which `Magnitude` supports.  Because it is a [monovalue


### PR DESCRIPTION
Right now, `get_value<T>(m)` for a magnitude `m` either produces the
requested value, or invokes a hard compiler error via `static_assert`.
It would be nice if we had a way to ask whether this operation would
succeed.  For this purpose, we now provide `representable_in<T>(m)`.

It turns out that we can't actually answer this question without
effectively doing all of the work to compute the value.  We won't want
to do this twice, because that would uselessly slow down compile times.
Therefore, we extract all of our logic into a common implementation
function.  The logic is basically equivalent to the pre-existing version
of `get_value<T>(m)`, except that instead of each `static_cast`, we
return a unique value of a new `enum` we created for this purpose.

This means that each function can get its result efficiently.  For
`get_value`, we change the trigger for each `static_assert` to the
corresponding enum value.  For `representable_in`, we simply check
whether that enum has the `OK` value.

This PR helps pave the way for #90.  When we make our `Constant` class
implicitly convertible to `Quantity` types, it turns out that we can do
better than the "overflow safety surface"... because we know the exact
value!  We can achieve perfect compile-time checking.  This PR will give
us a single function that we can call in our implementation for that.

Includes docs and tests.