### PR TITLE
Add unit-aware overload for `std::remainder`

### DIFF
--- a/au/math.hh
+++ b/au/math.hh
@@ -35,6 +35,7 @@ using std::fmod;
 using std::isnan;
 using std::max;
 using std::min;
+using std::remainder;
 using std::sin;
 using std::sqrt;
 using std::tan;
@@ -393,6 +394,14 @@ auto min(T x, Zero z) {
     static_assert(std::is_convertible<Zero, T>::value,
                   "Cannot compare type to abstract notion Zero");
     return std::min(x, T{z});
+}
+
+// The (zero-centered) floating point remainder of two values of the same dimension.
+template <typename U1, typename R1, typename U2, typename R2>
+auto remainder(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+    using U = CommonUnitT<U1, U2>;
+    using R = decltype(std::remainder(R1{}, R2{}));
+    return make_quantity<U>(std::remainder(q1.template in<R>(U{}), q2.template in<R>(U{})));
 }
 
 //

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -25,6 +25,7 @@
 #include "au/units/kelvins.hh"
 #include "au/units/meters.hh"
 #include "au/units/ohms.hh"
+#include "au/units/revolutions.hh"
 #include "au/units/seconds.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -208,11 +209,11 @@ TEST(cos, GivesCorrectAnswersForInputsInDegrees) {
     EXPECT_NEAR(cos(degrees(90)), 0.0, TOL);
 }
 
-// Our fmod overload mixes conversions and computations.
+// Our `fmod` and `remainder` overloads mix conversions and computations.
 //
-// If its inputs have the same unit, then there is no conversion, only computation.  In that case,
-// we want to make sure we're doing exactly what std::fmod does w.r.t. input and output types (see:
-// https://en.cppreference.com/w/cpp/numeric/math/fmod).
+// If their inputs have the same unit, then there is no conversion, only computation.  In that case,
+// we want to make sure we're doing exactly what their `std` counterparts do w.r.t. input and output
+// types (e.g., for `fmod`, see: https://en.cppreference.com/w/cpp/numeric/math/fmod).
 template <typename AuFunc, typename StdFunc>
 struct ExpectConsistentWith {
     template <typename U, typename R1, typename R2>
@@ -259,6 +260,43 @@ TEST(fmod, MixedUnitsSupportedWithCasting) {
 
 TEST(fmod, HandlesIrrationalCommonUnit) {
     EXPECT_THAT(fmod(radians(1), degrees(57)), IsNear(degrees(0.2958), degrees(0.0001)));
+}
+
+TEST(remainder, SameAsStdRemainderForNumericTypes) {
+    EXPECT_EQ(remainder(3.5, 3), std::remainder(3.5, 3));
+    EXPECT_EQ(remainder(2.5, 3), std::remainder(2.5, 3));
+}
+
+TEST(remainder, ReturnsSameTypesAsStdRemainderForSameUnitInputs) {
+    const auto expect_consistent_with_std_remainder =
+        expect_consistent_with([](auto x, auto y) { return remainder(x, y); },
+                               [](auto x, auto y) { return std::remainder(x, y); });
+
+    expect_consistent_with_std_remainder(meters(4), meters(3));
+    expect_consistent_with_std_remainder(meters(4.f), meters(3.f));
+    expect_consistent_with_std_remainder(meters(4.), meters(3.));
+    expect_consistent_with_std_remainder(meters(4.l), meters(3.l));
+    expect_consistent_with_std_remainder(meters(4), meters(3.f));
+    expect_consistent_with_std_remainder(meters(4), meters(3.l));
+    expect_consistent_with_std_remainder(meters(4.), meters(3.l));
+}
+
+TEST(remainder, MixedUnitsSupportedWithCasting) {
+    constexpr auto a = meters(1);
+    constexpr auto b = centi(meters)(11);
+    constexpr auto expected_result = centi(meters)(1);
+
+    EXPECT_THAT(remainder(a, b), IsNear(expected_result, make_quantity<Nano<Meters>>(1)));
+}
+
+TEST(remainder, HandlesIrrationalCommonUnit) {
+    EXPECT_THAT(remainder(radians(1), degrees(57)), IsNear(degrees(+0.2958), degrees(0.0001)));
+    EXPECT_THAT(remainder(radians(1), degrees(58)), IsNear(degrees(-0.7042), degrees(0.0001)));
+}
+
+TEST(remainder, CenteredAroundZero) {
+    EXPECT_THAT(remainder(degrees(90), revolutions(1)), IsNear(degrees(90), degrees(1e-9)));
+    EXPECT_THAT(remainder(degrees(270), revolutions(1)), IsNear(degrees(-90), degrees(1e-9)));
 }
 
 TEST(max, ReturnsLarger) {

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -682,7 +682,8 @@ example, `std::numeric_limits<Quantity<Hours, int>>::max()` is exactly equal to
 
 #### `fmod`
 
-A unit-aware adaptation of `std::fmod`, giving the remainder of the division of the two inputs.
+A unit-aware adaptation of `std::fmod`, giving the positive remainder of the division of the two
+inputs.
 
 As with the [integer modulus](./quantity.md#mod), we first express the inputs in their [common
 unit](../discussion/concepts/common_unit.md).
@@ -692,6 +693,24 @@ unit](../discussion/concepts/common_unit.md).
 ```cpp
 template <typename U1, typename R1, typename U2, typename R2>
 auto fmod(Quantity<U1, R1> q1, Quantity<U2, R2> q2);
+```
+
+**Returns:** The remainder of `q1 / q2`, in the type `Quantity<U, R>`, where `U` is the common unit
+of `U1` and `U2`, and `R` is the common type of `R1` and `R2`.
+
+#### `remainder`
+
+A unit-aware adaptation of `std::remainder`, giving the zero-centered remainder of the division of
+the two inputs.
+
+As with the [integer modulus](./quantity.md#mod), we first express the inputs in their [common
+unit](../discussion/concepts/common_unit.md).
+
+**Signature:**
+
+```cpp
+template <typename U1, typename R1, typename U2, typename R2>
+auto remainder(Quantity<U1, R1> q1, Quantity<U2, R2> q2);
 ```
 
 **Returns:** The remainder of `q1 / q2`, in the type `Quantity<U, R>`, where `U` is the common unit


### PR DESCRIPTION
This is basically like `std::fmod`, but it's zero-centered.  It's really
handy for things like rectifying angles when we'd rather express
`degrees(270)` as `degrees(-90)`.

To make this change, I grepped the codebase for `fmod`, and simply made
whatever change was reasonable.  One of these changes was to factor out
a helper to make it more generic; I did this in a separate "checkpoint
commit" on the PR to make it easier to review.