### PR TITLE
Underline links in documentation website

### DIFF
--- a/docs/tweaks.css
+++ b/docs/tweaks.css
@@ -42,3 +42,7 @@ td.na {
 td.fair pre, td.poor pre, td.good pre, td.best pre {
     display: inline;
 }
+
+a {
+    text-decoration: underline;
+}


### PR DESCRIPTION
This is generally consistent with best practices for accessibility: it's
good to indicate links by something other than color.

Fixes #189, where we had a user who couldn't find the links for the
pre-generated files.

In practice, it looks like this will make the sections look different
from the links on the nav bar, because the former won't be underlined
but the latter will.  This decreases the "consistent" look and feel...
but that might not be such a bad thing.  I've found that it makes it a
little clearer for me when I navigate.  In any case, we should think
about whether to land this.

![image](https://github.com/aurora-opensource/au/assets/1819744/cb0fefac-3591-4291-886c-cb86f62bf30e)