### PR TITLE
Update links to point to main doc website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ maximize the chance of delivering its value!
 
 - All remote builds must pass before any PR is landed.
 
-See our [development setup guide](https://aurora-opensource.github.io/au/develop/) to get started
-with building and testing the code and documentation!
+See our [development setup guide](https://aurora-opensource.github.io/au/main/develop/) to get
+started with building and testing the code and documentation!
 
 ### Style guide
 

--- a/README.md
+++ b/README.md
@@ -45,18 +45,18 @@ usability and reliability. This **includes embedded support**: Aurora's embedded
 first class customers since the library's inception.
 
 To learn more about our place in the C++ units library ecosystem, see our [detailed library
-comparison](https://aurora-opensource.github.io/au/alternatives).
+comparison](https://aurora-opensource.github.io/au/main/alternatives/).
 
 ## Getting started
 
-Our [installation instructions](https://aurora-opensource.github.io/au/install) can have you up and
-running in minutes, in any project that supports C++14 or newer.
+Our [installation instructions](https://aurora-opensource.github.io/au/main/install/) can have you
+up and running in minutes, in any project that supports C++14 or newer.
 
 To use the library effectively, we recommend working through the
-[tutorials](https://aurora-opensource.github.io/au/tutorial/), starting with [Au 101: Quantity
-Makers](https://aurora-opensource.github.io/au/tutorial/101-quantity-makers).  To
+[tutorials](https://aurora-opensource.github.io/au/main/tutorial/), starting with [Au 101: Quantity
+Makers](https://aurora-opensource.github.io/au/main/tutorial/101-quantity-makers/).  To
 get set up with the tutorials — or, to contribute to the library — check out our [development
-guide](https://aurora-opensource.github.io/au/develop).
+guide](https://aurora-opensource.github.io/au/main/develop/).
 
 ## As seen at CppCon 2021
 

--- a/au/units/amperes.hh
+++ b/au/units/amperes.hh
@@ -19,7 +19,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct AmperesLabel {
     static constexpr const char label[] = "A";

--- a/au/units/bars.hh
+++ b/au/units/bars.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct BarsLabel {
     static constexpr const char label[] = "bar";

--- a/au/units/becquerel.hh
+++ b/au/units/becquerel.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct BecquerelLabel {
     static constexpr const char label[] = "Bq";

--- a/au/units/bits.hh
+++ b/au/units/bits.hh
@@ -19,7 +19,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct BitsLabel {
     static constexpr const char label[] = "b";

--- a/au/units/bytes.hh
+++ b/au/units/bytes.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct BytesLabel {
     static constexpr const char label[] = "B";

--- a/au/units/candelas.hh
+++ b/au/units/candelas.hh
@@ -19,7 +19,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct CandelasLabel {
     static constexpr const char label[] = "cd";

--- a/au/units/celsius.hh
+++ b/au/units/celsius.hh
@@ -22,7 +22,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct CelsiusLabel {
     static constexpr const char label[] = "degC";

--- a/au/units/coulombs.hh
+++ b/au/units/coulombs.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct CoulombsLabel {
     static constexpr const char label[] = "C";

--- a/au/units/days.hh
+++ b/au/units/days.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct DaysLabel {
     static constexpr const char label[] = "d";

--- a/au/units/degrees.hh
+++ b/au/units/degrees.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct DegreesLabel {
     static constexpr const char label[] = "deg";

--- a/au/units/fahrenheit.hh
+++ b/au/units/fahrenheit.hh
@@ -22,7 +22,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct FahrenheitLabel {
     static constexpr const char label[] = "degF";

--- a/au/units/farads.hh
+++ b/au/units/farads.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct FaradsLabel {
     static constexpr const char label[] = "F";

--- a/au/units/fathoms.hh
+++ b/au/units/fathoms.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct FathomsLabel {
     static constexpr const char label[] = "ftm";

--- a/au/units/feet.hh
+++ b/au/units/feet.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct FeetLabel {
     static constexpr const char label[] = "ft";

--- a/au/units/furlongs.hh
+++ b/au/units/furlongs.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct FurlongsLabel {
     static constexpr const char label[] = "fur";

--- a/au/units/grams.hh
+++ b/au/units/grams.hh
@@ -19,7 +19,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct GramsLabel {
     static constexpr const char label[] = "g";

--- a/au/units/grays.hh
+++ b/au/units/grays.hh
@@ -22,7 +22,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct GraysLabel {
     static constexpr const char label[] = "Gy";

--- a/au/units/henries.hh
+++ b/au/units/henries.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct HenriesLabel {
     static constexpr const char label[] = "H";

--- a/au/units/hertz.hh
+++ b/au/units/hertz.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct HertzLabel {
     static constexpr const char label[] = "Hz";

--- a/au/units/hours.hh
+++ b/au/units/hours.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct HoursLabel {
     static constexpr const char label[] = "h";

--- a/au/units/inches.hh
+++ b/au/units/inches.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct InchesLabel {
     static constexpr const char label[] = "in";

--- a/au/units/joules.hh
+++ b/au/units/joules.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct JoulesLabel {
     static constexpr const char label[] = "J";

--- a/au/units/katals.hh
+++ b/au/units/katals.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct KatalsLabel {
     static constexpr const char label[] = "kat";

--- a/au/units/kelvins.hh
+++ b/au/units/kelvins.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct KelvinsLabel {
     static constexpr const char label[] = "K";

--- a/au/units/knots.hh
+++ b/au/units/knots.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct KnotsLabel {
     static constexpr const char label[] = "kn";

--- a/au/units/liters.hh
+++ b/au/units/liters.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct LitersLabel {
     static constexpr const char label[] = "L";

--- a/au/units/lumens.hh
+++ b/au/units/lumens.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct LumensLabel {
     static constexpr const char label[] = "lm";

--- a/au/units/lux.hh
+++ b/au/units/lux.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct LuxLabel {
     static constexpr const char label[] = "lx";

--- a/au/units/meters.hh
+++ b/au/units/meters.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct MetersLabel {
     static constexpr const char label[] = "m";

--- a/au/units/miles.hh
+++ b/au/units/miles.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct MilesLabel {
     static constexpr const char label[] = "mi";

--- a/au/units/minutes.hh
+++ b/au/units/minutes.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct MinutesLabel {
     static constexpr const char label[] = "min";

--- a/au/units/moles.hh
+++ b/au/units/moles.hh
@@ -19,7 +19,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct MolesLabel {
     static constexpr const char label[] = "mol";

--- a/au/units/nautical_miles.hh
+++ b/au/units/nautical_miles.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct NauticalMilesLabel {
     static constexpr const char label[] = "nmi";

--- a/au/units/newtons.hh
+++ b/au/units/newtons.hh
@@ -23,7 +23,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct NewtonsLabel {
     static constexpr const char label[] = "N";

--- a/au/units/ohms.hh
+++ b/au/units/ohms.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct OhmsLabel {
     static constexpr const char label[] = "ohm";

--- a/au/units/pascals.hh
+++ b/au/units/pascals.hh
@@ -22,7 +22,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct PascalsLabel {
     static constexpr const char label[] = "Pa";

--- a/au/units/percent.hh
+++ b/au/units/percent.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct PercentLabel {
     static constexpr const char label[] = "%";

--- a/au/units/pounds_force.hh
+++ b/au/units/pounds_force.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct PoundsForceLabel {
     static constexpr const char label[] = "lbf";

--- a/au/units/pounds_mass.hh
+++ b/au/units/pounds_mass.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct PoundsMassLabel {
     static constexpr const char label[] = "lb";

--- a/au/units/radians.hh
+++ b/au/units/radians.hh
@@ -19,7 +19,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct RadiansLabel {
     static constexpr const char label[] = "rad";

--- a/au/units/revolutions.hh
+++ b/au/units/revolutions.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct RevolutionsLabel {
     static constexpr const char label[] = "rev";

--- a/au/units/seconds.hh
+++ b/au/units/seconds.hh
@@ -19,7 +19,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct SecondsLabel {
     static constexpr const char label[] = "s";

--- a/au/units/siemens.hh
+++ b/au/units/siemens.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct SiemensLabel {
     static constexpr const char label[] = "S";

--- a/au/units/slugs.hh
+++ b/au/units/slugs.hh
@@ -22,7 +22,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct SlugsLabel {
     static constexpr const char label[] = "slug";

--- a/au/units/standard_gravity.hh
+++ b/au/units/standard_gravity.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct StandardGravityLabel {
     static constexpr const char label[] = "g_0";

--- a/au/units/steradians.hh
+++ b/au/units/steradians.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct SteradiansLabel {
     static constexpr const char label[] = "sr";

--- a/au/units/tesla.hh
+++ b/au/units/tesla.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct TeslaLabel {
     static constexpr const char label[] = "T";

--- a/au/units/unos.hh
+++ b/au/units/unos.hh
@@ -19,7 +19,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct UnosLabel {
     static constexpr const char label[] = "U";

--- a/au/units/volts.hh
+++ b/au/units/volts.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct VoltsLabel {
     static constexpr const char label[] = "V";

--- a/au/units/watts.hh
+++ b/au/units/watts.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct WattsLabel {
     static constexpr const char label[] = "W";

--- a/au/units/webers.hh
+++ b/au/units/webers.hh
@@ -21,7 +21,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct WebersLabel {
     static constexpr const char label[] = "Wb";

--- a/au/units/yards.hh
+++ b/au/units/yards.hh
@@ -20,7 +20,7 @@
 namespace au {
 
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
-// Instead, follow instructions at (https://aurora-opensource.github.io/au/howto/new-units).
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
 struct YardsLabel {
     static constexpr const char label[] = "yd";

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -240,7 +240,7 @@ These costs can bring significant benefits, but we still want them to be as smal
                 <li class="check">Short namespace minimizes clutter</li>
                 <li class="check">
                     Detailed <a
-                    href="https://aurora-opensource.github.io/au/troubleshooting">troubleshooting
+                    href="https://aurora-opensource.github.io/au/main/troubleshooting/">troubleshooting
                     guide</a>
                 </li>
             </ul>
@@ -593,7 +593,7 @@ features.
         <td class="good">Can add new units and dimensions</td>
         <td class="best">Can even handle, e.g., systems of "natural" units</td>
         <td class="good">
-            Can add <a href="https://aurora-opensource.github.io/au/howto/new-units">new units</a>
+            Can add <a href="https://aurora-opensource.github.io/au/main/howto/new-units/">new units</a>
             and dimensions
         </td>
     </tr>


### PR DESCRIPTION
Several months ago, we versioned our documentation using `mike`.  This
means that any legacy links that don't provide a specific version will
be redirected to the `0.3.2` version of the documentation website.  (Try
this out on our main README page with the alternatives comparison, for
example.)  Only the main landing page is an exception:
(https://aurora-opensource.github.io/au) automatically redirects to
(https://aurora-opensource.github.io/au/main/), so we don't need to
update those.

This PR goes through and updates every link to a non-main page of our
doc website, so that it points directly to the `main` version of the
docs.