### PR TITLE
Make godbolt link more presentable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ In short: if your C++ programs handle physical quantities, Au will make you fast
 effective at your job.  You'll find everything you need in our [full documentation
 website](https://aurora-opensource.github.io/au).
 
+> _Try it out on [Compiler Explorer ("godbolt")](https://godbolt.org/z/KrvfhP4M3)!_
+
 ## Why Au?
 
 There are many other C++ units libraries, several quite well established.  Each of them offers

--- a/docs/install.md
+++ b/docs/install.md
@@ -173,7 +173,7 @@ should get you any other unit you're likely to want.  The units we include are:
     better over time_ (by supporting more and more units out of the box).
 
     Therefore, these files are only for use cases where _you don't care about compile time_.  The
-    primary example is [the Compiler Explorer ("godbolt")](https://godbolt.org/z/687Ef4oqM).
+    primary example is [the Compiler Explorer ("godbolt")](https://godbolt.org/z/KrvfhP4M3).
 
     **If you don't care about compile times**, here are the files:
 


### PR DESCRIPTION
A few changes:
- Add `-O1`, the simplest level of optimization, which gets rid of some
  weirdness in the old link (try writing `meters(1)` for example).
- Use a newer version of gcc (13.2 instead of 7.x).
- Stack the side panes vertically to be a little less claustrophobic.

We also present the godbolt link more prominently on our main README.