### PR TITLE
Add mixins to help with constants and symbols

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -433,6 +433,27 @@ cc_test(
 )
 
 cc_library(
+    name = "wrapper_operations",
+    hdrs = ["wrapper_operations.hh"],
+    deps = [
+        ":quantity",
+        ":stdx",
+    ],
+)
+
+cc_test(
+    name = "wrapper_operations_test",
+    size = "small",
+    srcs = ["wrapper_operations_test.cc"],
+    deps = [
+        ":testing",
+        ":units",
+        ":wrapper_operations",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "zero",
     hdrs = ["zero.hh"],
 )

--- a/au/wrapper_operations.hh
+++ b/au/wrapper_operations.hh
@@ -1,0 +1,246 @@
+// Copyright 2023 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/quantity.hh"
+#include "au/stdx/type_traits.hh"
+
+// "Mixin" classes to add operations for a "unit wrapper" --- that is, a template with a _single
+// template parameter_ that is a unit.
+//
+// The operations are multiplication and division.  The mixins will specify what types the wrapper
+// can combine with in this way, and what the resulting type will be.  They also take care of
+// getting the resulting unit correct.  Finally, they handle integer division carefully.
+//
+// Every mixin has at least two template parameters.
+//
+//   1. The unit wrapper (a template template parameter).
+//   2. The specific unit that it's wrapping (for convenience in the implementation).
+//
+// For mixins that compose with something that is _not_ a unit wrapper --- e.g., a raw number, or a
+// magnitude --- this is all they need.  Other mixins compose with _other unit wrappers_, and these
+// take two more template parameters: the wrapper we're composing with, and the resulting wrapper.
+
+namespace au {
+namespace detail {
+
+// A SFINAE helper that is the identity, but only if we think a type is a valid rep.
+//
+// For now, we are restricting this to arithmetic types.  This doesn't mean they're the only reps we
+// support; it just means they're the only reps we can _construct via this method_.  Later on, we
+// would like to have a well-defined concept that defines what is and is not an acceptable rep for
+// our `Quantity`.  Once we have that, we can simply constrain on that concept.  For more on this
+// idea, see: https://github.com/aurora-opensource/au/issues/52
+struct NoTypeMember {};
+template <typename T>
+struct TypeIdentityIfLooksLikeValidRep
+    : std::conditional_t<std::is_arithmetic<T>::value, stdx::type_identity<T>, NoTypeMember> {};
+template <typename T>
+using TypeIdentityIfLooksLikeValidRepT = typename TypeIdentityIfLooksLikeValidRep<T>::type;
+
+//
+// A mixin that enables turning a raw number into a Quantity by multiplying or dividing.
+//
+template <template <typename U> class UnitWrapper, typename Unit>
+struct MakesQuantityFromNumber {
+    // (N * W), for number N and wrapper W.
+    template <typename T>
+    friend constexpr auto operator*(T x, UnitWrapper<Unit>)
+        -> Quantity<Unit, TypeIdentityIfLooksLikeValidRepT<T>> {
+        return make_quantity<Unit>(x);
+    }
+
+    // (W * N), for number N and wrapper W.
+    template <typename T>
+    friend constexpr auto operator*(UnitWrapper<Unit>, T x)
+        -> Quantity<Unit, TypeIdentityIfLooksLikeValidRepT<T>> {
+        return make_quantity<Unit>(x);
+    }
+
+    // (N / W), for number N and wrapper W.
+    template <typename T>
+    friend constexpr auto operator/(T x, UnitWrapper<Unit>)
+        -> Quantity<UnitInverseT<Unit>, TypeIdentityIfLooksLikeValidRepT<T>> {
+        return make_quantity<UnitInverseT<Unit>>(x);
+    }
+
+    // (W / N), for number N and wrapper W.
+    template <typename T>
+    friend constexpr auto operator/(UnitWrapper<Unit>, T x)
+        -> Quantity<Unit, TypeIdentityIfLooksLikeValidRepT<T>> {
+        static_assert(!std::is_integral<T>::value,
+                      "Dividing by an integer value disallowed: would almost always produce 0");
+        return make_quantity<Unit>(T{1} / x);
+    }
+};
+
+//
+// A mixin that enables scaling the units of a Quantity by multiplying or dividing.
+//
+template <template <typename U> class UnitWrapper, typename Unit>
+struct ScalesQuantity {
+    // (W * Q), for wrapper W and quantity Q.
+    template <typename U, typename R>
+    friend constexpr auto operator*(UnitWrapper<Unit>, Quantity<U, R> q) {
+        return make_quantity<UnitProductT<Unit, U>>(q.in(U{}));
+    }
+
+    // (Q * W), for wrapper W and quantity Q.
+    template <typename U, typename R>
+    friend constexpr auto operator*(Quantity<U, R> q, UnitWrapper<Unit>) {
+        return make_quantity<UnitProductT<U, Unit>>(q.in(U{}));
+    }
+
+    // (Q / W), for wrapper W and quantity Q.
+    template <typename U, typename R>
+    friend constexpr auto operator/(Quantity<U, R> q, UnitWrapper<Unit>) {
+        return make_quantity<UnitQuotientT<U, Unit>>(q.in(U{}));
+    }
+
+    // (W / Q), for wrapper W and quantity Q.
+    template <typename U, typename R>
+    friend constexpr auto operator/(UnitWrapper<Unit>, Quantity<U, R> q) {
+        static_assert(!std::is_integral<R>::value,
+                      "Dividing by an integer value disallowed: would almost always produce 0");
+        return make_quantity<UnitQuotientT<Unit, U>>(R{1} / q.in(U{}));
+    }
+};
+
+// A mixin to compose `op(U, O)` into a new unit wrapper, for "main" wrapper `U` and "other" wrapper
+// `O`.  (Implementation detail helper for `ComposesWith`.)
+template <template <typename U> class UnitWrapper,
+          typename Unit,
+          template <typename U>
+          class OtherWrapper,
+          template <typename U>
+          class ResultWrapper>
+struct PrecomposesWith {
+    // (U * O), for "main" wrapper U and "other" wrapper O.
+    template <typename U>
+    friend constexpr ResultWrapper<UnitProductT<Unit, U>> operator*(UnitWrapper<Unit>,
+                                                                    OtherWrapper<U>) {
+        return {};
+    }
+
+    // (U / O), for "main" wrapper U and "other" wrapper O.
+    template <typename U>
+    friend constexpr ResultWrapper<UnitQuotientT<Unit, U>> operator/(UnitWrapper<Unit>,
+                                                                     OtherWrapper<U>) {
+        return {};
+    }
+};
+
+// A mixin to compose `op(O, U)` into a new unit wrapper, for "main" wrapper `U` and "other" wrapper
+// `O`.  (Implementation detail helper for `ComposesWith`.)
+template <template <typename U> class UnitWrapper,
+          typename Unit,
+          template <typename U>
+          class OtherWrapper,
+          template <typename U>
+          class ResultWrapper>
+struct PostcomposesWith {
+    // (O * U), for "main" wrapper U and "other" wrapper O.
+    template <typename U>
+    friend constexpr ResultWrapper<UnitProductT<U, Unit>> operator*(OtherWrapper<U>,
+                                                                    UnitWrapper<Unit>) {
+        return {};
+    }
+
+    // (O / U), for "main" wrapper U and "other" wrapper O.
+    template <typename U>
+    friend constexpr ResultWrapper<UnitQuotientT<U, Unit>> operator/(OtherWrapper<U>,
+                                                                     UnitWrapper<Unit>) {
+        return {};
+    }
+};
+
+// An empty version of `PostcomposesWith` for when `UnitWrapper` is the same as `OtherWrapper`.
+// In this case, if we left it non-empty, the definitions would be ambiguous/redundant with the ones
+// in `PrecoposesWith`.
+template <template <typename U> class UnitWrapper,
+          typename Unit,
+          template <typename U>
+          class ResultWrapper>
+struct PostcomposesWith<UnitWrapper, Unit, UnitWrapper, ResultWrapper> {};
+
+//
+// A mixin to compose two unit wrappers into a new unit wrapper.
+//
+template <template <typename U> class UnitWrapper,
+          typename Unit,
+          template <typename U>
+          class OtherWrapper,
+          template <typename U>
+          class ResultWrapper>
+struct ComposesWith : PrecomposesWith<UnitWrapper, Unit, OtherWrapper, ResultWrapper>,
+                      PostcomposesWith<UnitWrapper, Unit, OtherWrapper, ResultWrapper> {};
+
+//
+// A mixin to enable scaling a unit wrapper by a magnitude.
+//
+template <template <typename U> class UnitWrapper, typename Unit>
+struct CanScaleByMagnitude {
+    // (M * W), for magnitude M and wrapper W.
+    template <typename... BPs>
+    friend constexpr auto operator*(Magnitude<BPs...> m, UnitWrapper<Unit>) {
+        return UnitWrapper<decltype(Unit{} * m)>{};
+    }
+
+    // (W * M), for magnitude M and wrapper W.
+    template <typename... BPs>
+    friend constexpr auto operator*(UnitWrapper<Unit>, Magnitude<BPs...> m) {
+        return UnitWrapper<decltype(Unit{} * m)>{};
+    }
+
+    // (M / W), for magnitude M and wrapper W.
+    template <typename... BPs>
+    friend constexpr auto operator/(Magnitude<BPs...> m, UnitWrapper<Unit>) {
+        return UnitWrapper<decltype(UnitInverseT<Unit>{} * m)>{};
+    }
+
+    // (W / M), for magnitude M and wrapper W.
+    template <typename... BPs>
+    friend constexpr auto operator/(UnitWrapper<Unit>, Magnitude<BPs...> m) {
+        return UnitWrapper<decltype(Unit{} / m)>{};
+    }
+};
+
+//
+// A mixin to explicitly delete operations that we want to forbid.
+//
+template <template <typename U> class UnitWrapper,
+          typename Unit,
+          template <typename... Us>
+          class OtherWrapper>
+struct ForbidsComposingWith {
+    // (W * O), for wrapper W and wrapper O.
+    template <typename... Us>
+    friend constexpr void operator*(UnitWrapper<Unit>, OtherWrapper<Us...>) = delete;
+
+    // (W / O), for wrapper W and wrapper O.
+    template <typename... Us>
+    friend constexpr void operator/(UnitWrapper<Unit>, OtherWrapper<Us...>) = delete;
+
+    // (O * W), for wrapper W and wrapper O.
+    template <typename... Us>
+    friend constexpr void operator*(OtherWrapper<Us...>, UnitWrapper<Unit>) = delete;
+
+    // (O / W), for wrapper W and wrapper O.
+    template <typename... Us>
+    friend constexpr void operator/(OtherWrapper<Us...>, UnitWrapper<Unit>) = delete;
+};
+
+}  // namespace detail
+}  // namespace au

--- a/au/wrapper_operations_test.cc
+++ b/au/wrapper_operations_test.cc
@@ -1,0 +1,163 @@
+// Copyright 2023 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/wrapper_operations.hh"
+
+#include "au/testing.hh"
+#include "au/units/liters.hh"
+#include "au/units/meters.hh"
+#include "au/units/moles.hh"
+#include "gtest/gtest.h"
+
+using ::testing::StaticAssertTypeEq;
+
+namespace au {
+namespace detail {
+namespace {
+
+template <typename Unit>
+struct UnitWrapper : MakesQuantityFromNumber<UnitWrapper, Unit>,
+                     ScalesQuantity<UnitWrapper, Unit>,
+                     ComposesWith<UnitWrapper, Unit, UnitWrapper, UnitWrapper>,
+                     ComposesWith<UnitWrapper, Unit, QuantityMaker, QuantityMaker>,
+                     ForbidsComposingWith<UnitWrapper, Unit, QuantityPointMaker>,
+                     ForbidsComposingWith<UnitWrapper, Unit, QuantityPoint>,
+                     CanScaleByMagnitude<UnitWrapper, Unit> {};
+
+TEST(MakesQuantityFromNumber, MakesQuantityWhenPostMultiplyingNumericValue) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    EXPECT_THAT(1.0f * mol, SameTypeAndValue(moles(1.0f)));
+}
+
+TEST(MakesQuantityFromNumber, MakesQuantityWhenPreMultiplyingNumericValue) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    EXPECT_THAT(mol * 35u, SameTypeAndValue(moles(35u)));
+}
+
+TEST(MakesQuantityFromNumber, MakesQuantityOfInverseUnitWhenDividingIntoNumericValue) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    EXPECT_THAT(10 / mol, SameTypeAndValue(inverse(moles)(10)));
+}
+
+TEST(MakesQuantityFromNumber, MakesQuantityWhenDividingNumericValue) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    EXPECT_THAT(mol / 4.0, SameTypeAndValue(moles(0.25)));
+
+    // The following must not compile, because it would use integer division with an implicit
+    // numerator of `1`, and would therefore almost always be zero.
+    //
+    // Uncomment to make sure the compilation fails.  (We set it up with incorrect values as a
+    // failsafe, so that even if it does compile, the test will still fail.)
+    //
+    //    EXPECT_THAT((mol / 2), SameTypeAndValue(mol / 1));
+}
+
+TEST(ScalesQuantity, ChangesQuantityUnitsWhenPreMultiplying) {
+    constexpr auto L = UnitWrapper<Liters>{};
+    EXPECT_THAT(L * moles(5), SameTypeAndValue((liter * moles)(5)));
+}
+
+TEST(ScalesQuantity, ChangesQuantityUnitsWhenPostMultiplying) {
+    constexpr auto L = UnitWrapper<Liters>{};
+    EXPECT_THAT(moles(5) * L, SameTypeAndValue((mole * liters)(5)));
+}
+
+TEST(ScalesQuantity, ChangesQuantityUnitsWhenDividingInto) {
+    constexpr auto L = UnitWrapper<Liters>{};
+    EXPECT_THAT(moles(3u) / L, SameTypeAndValue((moles / liter)(3u)));
+}
+
+TEST(ScalesQuantity, ChangesUnitsAndInvertsQuantityWhenDividing) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    EXPECT_THAT(mol / liters(0.5), SameTypeAndValue((moles / liter)(2.0)));
+
+    // The following must not compile, because it would use integer division with an implicit
+    // numerator of `1`, and would therefore almost always be zero.
+    //
+    // Uncomment to make sure the compilation fails.  (We set it up with incorrect values as a
+    // failsafe, so that even if it does compile, the test will still fail.)
+    //
+    //    EXPECT_THAT((mol / liters(2)), SameTypeAndValue(mol / liters(1)));
+}
+
+TEST(ComposesWith, ComposesWithSelf) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    StaticAssertTypeEq<decltype(mol * mol), UnitWrapper<UnitProductT<Moles, Moles>>>();
+    StaticAssertTypeEq<decltype(mol / mol), UnitWrapper<UnitProductT<>>>();
+}
+
+TEST(ComposesWith, ComposesWithOtherSpecializationsOfSameWrapper) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    constexpr auto L = UnitWrapper<Liters>{};
+    StaticAssertTypeEq<decltype(mol * L), UnitWrapper<UnitProductT<Moles, Liters>>>();
+    StaticAssertTypeEq<decltype(mol / L), UnitWrapper<UnitQuotientT<Moles, Liters>>>();
+}
+
+TEST(ComposesWith, MakesScaledQuantityMakerWhenPreMultiplyingQuantityMaker) {
+    constexpr auto L = UnitWrapper<Liters>{};
+    StaticAssertTypeEq<decltype(L * moles), QuantityMaker<UnitProductT<Moles, Liters>>>();
+}
+
+TEST(ComposesWith, MakesScaledQuantityMakerWhenPostMultiplyingQuantityMaker) {
+    constexpr auto L = UnitWrapper<Liters>{};
+    StaticAssertTypeEq<decltype(moles * L), QuantityMaker<UnitProductT<Moles, Liters>>>();
+}
+
+TEST(ComposesWith, MakesScaledQuantityMakerWhenDividingIntoQuantityMaker) {
+    constexpr auto L = UnitWrapper<Liters>{};
+    StaticAssertTypeEq<decltype(moles / L), QuantityMaker<UnitQuotientT<Moles, Liters>>>();
+}
+
+TEST(ComposesWith, MakesScaledQuantityMakerWhenDividingQuantityMaker) {
+    constexpr auto L = UnitWrapper<Liters>{};
+    StaticAssertTypeEq<decltype(L / moles), QuantityMaker<UnitQuotientT<Liters, Moles>>>();
+}
+
+TEST(CanScaleByMagnitude, MakesScaledWrapperWhenPreMultiplyingByMagnitude) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    StaticAssertTypeEq<decltype(mag<3>() * mol), UnitWrapper<decltype(Moles{} * mag<3>())>>();
+}
+
+TEST(CanScaleByMagnitude, MakesScaledWrapperWhenPostMultiplyingByMagnitude) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    StaticAssertTypeEq<decltype(mol * mag<3>()), UnitWrapper<decltype(Moles{} * mag<3>())>>();
+}
+
+TEST(CanScaleByMagnitude, MakesScaledWrapperOfInverseUnitWhenDividingIntoMagnitude) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    StaticAssertTypeEq<decltype(PI / mol), UnitWrapper<decltype(inverse(Moles{}) * PI)>>();
+}
+
+TEST(CanScaleByMagnitude, MakesScaledWrapperWhenDividingByMagnitude) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    StaticAssertTypeEq<decltype(mol / PI), UnitWrapper<decltype(Moles{} / PI)>>();
+}
+
+TEST(ForbidsComposingWith, FailsToCompileWhenMultiplyingOrDividingWithForbiddenWrapper) {
+    // Uncomment each line below individually to verify.
+
+    // UnitWrapper<Meters>{} * meters_pt;
+    // UnitWrapper<Meters>{} / meters_pt;
+    // meters_pt *UnitWrapper<Meters>{};
+    // meters_pt / UnitWrapper<Meters>{};
+
+    // UnitWrapper<Meters>{} * meters_pt(1);
+    // UnitWrapper<Meters>{} / meters_pt(1);
+    // meters_pt(1) * UnitWrapper<Meters>{};
+    // meters_pt(1) / UnitWrapper<Meters>{};
+}
+
+}  // namespace
+}  // namespace detail
+}  // namespace au


### PR DESCRIPTION
Constants (#90) and symbols (#43) have a lot of similarities.  For
example:

- Multiplying by a raw number produces a quantity.
- Multiplying by a quantity changes the units of the quantity.
- They can compose with other instances of the same family (e.g., the
  product of two constants is a constant).

Let's use the term "wrapper" to refer to constants and symbols here. To
make each wrapper as easy as possible to implement, I've created some
"mixin" classes, each of which adds the full set of multiplication and
division operations for a single combination of the wrapper and some
other family of types (raw numbers, quantities, other wrappers, etc.).

These wrappers use a "CRTP-ish" syntax.  But instead of the _type
itself_ being the first template parameter (e.g., `Wrapper<Unit>`), we
provide the _wrapper_ and _unit_ as two separate parameters (i.e.,
`Wrapper` and `Unit`).  The reason is that we need to know the `Unit`,
and providing it explicitly makes it easy to get.  These first two
parameters are the same for all mixins, which makes the list-of-mixins
at the class definition easier to read.

The unit tests are based on an example, `UnitWrapper`, which aggregates
a variety of properties.  The forthcoming "true" classes, `Constant` and
`SymbolFor`, will be defined very similarly to this.

Finally, a word about the plan for "numeric" inputs.  For now, we are
restricting to `std::is_arithmetic`.  This doesn't mean we don't support
other reps; it just means we won't be able to create quantities from
them via constants or symbols for a while.  The evolution plan is to
create a well-defined concept that defines what is a valid rep, and then
replace `std::arithmetic` with that concept (see also #52).

Test plan:

- [x] Add extensive new unit tests
- [x] Manually uncomment each individual "uncomment to test" case