### PR TITLE
Unify `in`/`as` implementations using unit slots

### DIFF
--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -77,8 +77,10 @@ struct PermitAsCarveOutForIntegerPromotion
 template <typename Rep, typename ScaleFactor>
 struct ImplicitRepPermitted : detail::CoreImplicitConversionPolicy<Rep, ScaleFactor, Rep> {};
 
-template <typename Rep, typename SourceUnit, typename TargetUnit>
-constexpr bool implicit_rep_permitted_from_source_to_target(SourceUnit, TargetUnit) {
+template <typename Rep, typename SourceUnitSlot, typename TargetUnitSlot>
+constexpr bool implicit_rep_permitted_from_source_to_target(SourceUnitSlot, TargetUnitSlot) {
+    using SourceUnit = AssociatedUnitT<SourceUnitSlot>;
+    using TargetUnit = AssociatedUnitT<TargetUnitSlot>;
     static_assert(HasSameDimension<SourceUnit, TargetUnit>::value,
                   "Can only convert same-dimension units");
 


### PR DESCRIPTION
With a little more care in our definitions, we no longer need separate
overloads for `QuantityMaker`!  We can just use a unified definition.

Someday, this will also let us replace SFINAE with more readable
`static_assert`, which is good on the assumption that nobody will ever
call `in` or `as` with something that is not compatible with a unit
slot.  Unfortunately, this is blocked on #139, because sometimes
function calls can get resolved to the deprecated legacy APIs... and
this manifests in really weird ways, like the compiler thinking we want
"units" of `int` or `double`.

This paves the way for #43, because `SymbolFor` will also be compatible
with unit slots.  So, not only are we removing one set of overloads;
we're also avoiding the need to add _another_ set in the very near
future.

Test plan:

- [x] All Au tests pass
- [x] Make sure this would enable upcoming `.in(m)` test to pass
- [x] Test AV repo
- [x] Measure compile time impact