### PR TITLE
Add unit symbol for every unit

### DIFF
--- a/au/units/amperes.hh
+++ b/au/units/amperes.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -31,5 +32,9 @@ struct Amperes : UnitImpl<Current>, AmperesLabel<void> {
 };
 constexpr auto ampere = SingularNameFor<Amperes>{};
 constexpr auto amperes = QuantityMaker<Amperes>{};
+
+namespace symbols {
+constexpr auto A = SymbolFor<Amperes>{};
+}
 
 }  // namespace au

--- a/au/units/bars.hh
+++ b/au/units/bars.hh
@@ -16,6 +16,7 @@
 
 #include "au/prefix.hh"
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/pascals.hh"
 
 namespace au {
@@ -34,4 +35,7 @@ struct Bars : decltype(Kilo<Pascals>{} * mag<100>()), BarsLabel<void> {
 constexpr auto bar = SingularNameFor<Bars>{};
 constexpr auto bars = QuantityMaker<Bars>{};
 
+namespace symbols {
+constexpr auto bar = SymbolFor<Bars>{};
+}  // namespace symbols
 }  // namespace au

--- a/au/units/becquerel.hh
+++ b/au/units/becquerel.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/seconds.hh"
 
 namespace au {
@@ -32,4 +33,7 @@ struct Becquerel : UnitInverseT<Seconds>, BecquerelLabel<void> {
 };
 constexpr auto becquerel = QuantityMaker<Becquerel>{};
 
+namespace symbols {
+constexpr auto Bq = SymbolFor<Becquerel>{};
+}
 }  // namespace au

--- a/au/units/bits.hh
+++ b/au/units/bits.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -32,4 +33,7 @@ struct Bits : UnitImpl<Information>, BitsLabel<void> {
 constexpr auto bit = SingularNameFor<Bits>{};
 constexpr auto bits = QuantityMaker<Bits>{};
 
+namespace symbols {
+constexpr auto b = SymbolFor<Bits>{};
+}
 }  // namespace au

--- a/au/units/bytes.hh
+++ b/au/units/bytes.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/bits.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Bytes : decltype(Bits{} * mag<8>()), BytesLabel<void> {
 constexpr auto byte = SingularNameFor<Bytes>{};
 constexpr auto bytes = QuantityMaker<Bytes>{};
 
+namespace symbols {
+constexpr auto B = SymbolFor<Bytes>{};
+}
 }  // namespace au

--- a/au/units/candelas.hh
+++ b/au/units/candelas.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -32,4 +33,7 @@ struct Candelas : UnitImpl<LuminousIntensity>, CandelasLabel<void> {
 constexpr auto candela = SingularNameFor<Candelas>{};
 constexpr auto candelas = QuantityMaker<Candelas>{};
 
+namespace symbols {
+constexpr auto cd = SymbolFor<Candelas>{};
+}
 }  // namespace au

--- a/au/units/celsius.hh
+++ b/au/units/celsius.hh
@@ -17,6 +17,7 @@
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/kelvins.hh"
 
 namespace au {
@@ -40,4 +41,7 @@ constexpr auto celsius_pt = QuantityPointMaker<Celsius>{};
     "`celsius()` is ambiguous.  Use `celsius_pt()` for _points_, or `celsius_qty()` for "
     "_quantities_")]] constexpr auto celsius = QuantityMaker<Celsius>{};
 
+namespace symbols {
+constexpr auto degC_qty = SymbolFor<Celsius>{};
+}
 }  // namespace au

--- a/au/units/coulombs.hh
+++ b/au/units/coulombs.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/amperes.hh"
 #include "au/units/seconds.hh"
 
@@ -34,4 +35,7 @@ struct Coulombs : decltype(Amperes{} * Seconds{}), CoulombsLabel<void> {
 constexpr auto coulomb = SingularNameFor<Coulombs>{};
 constexpr auto coulombs = QuantityMaker<Coulombs>{};
 
+namespace symbols {
+constexpr auto C = SymbolFor<Coulombs>{};
+}
 }  // namespace au

--- a/au/units/days.hh
+++ b/au/units/days.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/hours.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Days : decltype(Hours{} * mag<24>()), DaysLabel<void> {
 constexpr auto day = SingularNameFor<Days>{};
 constexpr auto days = QuantityMaker<Days>{};
 
+namespace symbols {
+constexpr auto d = SymbolFor<Days>{};
+}
 }  // namespace au

--- a/au/units/degrees.hh
+++ b/au/units/degrees.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/radians.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Degrees : decltype(Radians{} * PI / mag<180>()), DegreesLabel<void> {
 constexpr auto degree = SingularNameFor<Degrees>{};
 constexpr auto degrees = QuantityMaker<Degrees>{};
 
+namespace symbols {
+constexpr auto deg = SymbolFor<Degrees>{};
+}
 }  // namespace au

--- a/au/units/fahrenheit.hh
+++ b/au/units/fahrenheit.hh
@@ -17,6 +17,7 @@
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/kelvins.hh"
 
 namespace au {
@@ -42,4 +43,7 @@ constexpr auto fahrenheit_pt = QuantityPointMaker<Fahrenheit>{};
     "`fahrenheit()` is ambiguous.  Use `fahrenheit_pt()` for _points_, or `fahrenheit_qty()` for "
     "_quantities_")]] constexpr auto fahrenheit = QuantityMaker<Fahrenheit>{};
 
+namespace symbols {
+constexpr auto degF_qty = SymbolFor<Fahrenheit>{};
+}
 }  // namespace au

--- a/au/units/farads.hh
+++ b/au/units/farads.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/coulombs.hh"
 #include "au/units/volts.hh"
 
@@ -34,4 +35,7 @@ struct Farads : decltype(Coulombs{} / Volts{}), FaradsLabel<void> {
 constexpr auto farad = SingularNameFor<Farads>{};
 constexpr auto farads = QuantityMaker<Farads>{};
 
+namespace symbols {
+constexpr auto F = SymbolFor<Farads>{};
+}
 }  // namespace au

--- a/au/units/fathoms.hh
+++ b/au/units/fathoms.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/feet.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Fathoms : decltype(Feet{} * mag<6>()), FathomsLabel<void> {
 constexpr auto fathom = SingularNameFor<Fathoms>{};
 constexpr auto fathoms = QuantityMaker<Fathoms>{};
 
+namespace symbols {
+constexpr auto ftm = SymbolFor<Fathoms>{};
+}
 }  // namespace au

--- a/au/units/feet.hh
+++ b/au/units/feet.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/inches.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Feet : decltype(Inches{} * mag<12>()), FeetLabel<void> {
 constexpr auto foot = SingularNameFor<Feet>{};
 constexpr auto feet = QuantityMaker<Feet>{};
 
+namespace symbols {
+constexpr auto ft = SymbolFor<Feet>{};
+}
 }  // namespace au

--- a/au/units/furlongs.hh
+++ b/au/units/furlongs.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/miles.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Furlongs : decltype(Miles{} / mag<8>()), FurlongsLabel<void> {
 constexpr auto furlong = SingularNameFor<Furlongs>{};
 constexpr auto furlongs = QuantityMaker<Furlongs>{};
 
+namespace symbols {
+constexpr auto fur = SymbolFor<Furlongs>{};
+}
 }  // namespace au

--- a/au/units/grams.hh
+++ b/au/units/grams.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -32,4 +33,7 @@ struct Grams : UnitImpl<Mass>, GramsLabel<void> {
 constexpr auto gram = SingularNameFor<Grams>{};
 constexpr auto grams = QuantityMaker<Grams>{};
 
+namespace symbols {
+constexpr auto g = SymbolFor<Grams>{};
+}
 }  // namespace au

--- a/au/units/grays.hh
+++ b/au/units/grays.hh
@@ -16,6 +16,7 @@
 
 #include "au/prefix.hh"
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/grams.hh"
 #include "au/units/joules.hh"
 
@@ -35,4 +36,7 @@ struct Grays : decltype(Joules{} / Kilo<Grams>{}), GraysLabel<void> {
 constexpr auto gray = SingularNameFor<Grays>{};
 constexpr auto grays = QuantityMaker<Grays>{};
 
+namespace symbols {
+constexpr auto Gy = SymbolFor<Grays>{};
+}
 }  // namespace au

--- a/au/units/henries.hh
+++ b/au/units/henries.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/amperes.hh"
 #include "au/units/webers.hh"
 
@@ -34,4 +35,7 @@ struct Henries : decltype(Webers{} / Amperes{}), HenriesLabel<void> {
 constexpr auto henry = SingularNameFor<Henries>{};
 constexpr auto henries = QuantityMaker<Henries>{};
 
+namespace symbols {
+constexpr auto H = SymbolFor<Henries>{};
+}
 }  // namespace au

--- a/au/units/hertz.hh
+++ b/au/units/hertz.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/seconds.hh"
 
 namespace au {
@@ -32,4 +33,7 @@ struct Hertz : UnitInverseT<Seconds>, HertzLabel<void> {
 };
 constexpr auto hertz = QuantityMaker<Hertz>{};
 
+namespace symbols {
+constexpr auto Hz = SymbolFor<Hertz>{};
+}
 }  // namespace au

--- a/au/units/hours.hh
+++ b/au/units/hours.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/minutes.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Hours : decltype(Minutes{} * mag<60>()), HoursLabel<void> {
 constexpr auto hour = SingularNameFor<Hours>{};
 constexpr auto hours = QuantityMaker<Hours>{};
 
+namespace symbols {
+constexpr auto h = SymbolFor<Hours>{};
+}
 }  // namespace au

--- a/au/units/inches.hh
+++ b/au/units/inches.hh
@@ -16,6 +16,7 @@
 
 #include "au/prefix.hh"
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/meters.hh"
 
 namespace au {
@@ -34,4 +35,7 @@ struct Inches : decltype(Centi<Meters>{} * mag<254>() / mag<100>()), InchesLabel
 constexpr auto inch = SingularNameFor<Inches>{};
 constexpr auto inches = QuantityMaker<Inches>{};
 
+namespace symbols {
+constexpr auto in = SymbolFor<Inches>{};
+}
 }  // namespace au

--- a/au/units/joules.hh
+++ b/au/units/joules.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/meters.hh"
 #include "au/units/newtons.hh"
 
@@ -34,4 +35,7 @@ struct Joules : decltype(Newtons{} * Meters{}), JoulesLabel<void> {
 constexpr auto joule = SingularNameFor<Joules>{};
 constexpr auto joules = QuantityMaker<Joules>{};
 
+namespace symbols {
+constexpr auto J = SymbolFor<Joules>{};
+}
 }  // namespace au

--- a/au/units/katals.hh
+++ b/au/units/katals.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/moles.hh"
 #include "au/units/seconds.hh"
 
@@ -34,4 +35,7 @@ struct Katals : decltype(Moles{} / Seconds{}), KatalsLabel<void> {
 constexpr auto katal = SingularNameFor<Katals>{};
 constexpr auto katals = QuantityMaker<Katals>{};
 
+namespace symbols {
+constexpr auto kat = SymbolFor<Katals>{};
+}
 }  // namespace au

--- a/au/units/kelvins.hh
+++ b/au/units/kelvins.hh
@@ -16,6 +16,7 @@
 
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -34,4 +35,7 @@ constexpr auto kelvin = SingularNameFor<Kelvins>{};
 constexpr auto kelvins = QuantityMaker<Kelvins>{};
 constexpr auto kelvins_pt = QuantityPointMaker<Kelvins>{};
 
+namespace symbols {
+constexpr auto K = SymbolFor<Kelvins>{};
+}
 }  // namespace au

--- a/au/units/knots.hh
+++ b/au/units/knots.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/hours.hh"
 #include "au/units/nautical_miles.hh"
 
@@ -34,4 +35,7 @@ struct Knots : decltype(NauticalMiles{} / Hours{}), KnotsLabel<void> {
 constexpr auto knot = SingularNameFor<Knots>{};
 constexpr auto knots = QuantityMaker<Knots>{};
 
+namespace symbols {
+constexpr auto kn = SymbolFor<Knots>{};
+}
 }  // namespace au

--- a/au/units/liters.hh
+++ b/au/units/liters.hh
@@ -16,6 +16,7 @@
 
 #include "au/prefix.hh"
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/meters.hh"
 
 namespace au {
@@ -34,4 +35,7 @@ struct Liters : decltype(cubed(Deci<Meters>{})), LitersLabel<void> {
 constexpr auto liter = SingularNameFor<Liters>{};
 constexpr auto liters = QuantityMaker<Liters>{};
 
+namespace symbols {
+constexpr auto L = SymbolFor<Liters>{};
+}
 }  // namespace au

--- a/au/units/lumens.hh
+++ b/au/units/lumens.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/candelas.hh"
 #include "au/units/steradians.hh"
 
@@ -34,4 +35,7 @@ struct Lumens : decltype(Candelas{} * Steradians{}), LumensLabel<void> {
 constexpr auto lumen = SingularNameFor<Lumens>{};
 constexpr auto lumens = QuantityMaker<Lumens>{};
 
+namespace symbols {
+constexpr auto lm = SymbolFor<Lumens>{};
+}
 }  // namespace au

--- a/au/units/lux.hh
+++ b/au/units/lux.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/lumens.hh"
 #include "au/units/meters.hh"
 
@@ -33,4 +34,7 @@ struct Lux : decltype(Lumens{} / squared(Meters{})), LuxLabel<void> {
 };
 constexpr auto lux = QuantityMaker<Lux>{};
 
+namespace symbols {
+constexpr auto lx = SymbolFor<Lux>{};
+}
 }  // namespace au

--- a/au/units/meters.hh
+++ b/au/units/meters.hh
@@ -16,6 +16,7 @@
 
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -34,4 +35,7 @@ constexpr auto meter = SingularNameFor<Meters>{};
 constexpr auto meters = QuantityMaker<Meters>{};
 constexpr auto meters_pt = QuantityPointMaker<Meters>{};
 
+namespace symbols {
+constexpr auto m = SymbolFor<Meters>{};
+}
 }  // namespace au

--- a/au/units/miles.hh
+++ b/au/units/miles.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/feet.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Miles : decltype(Feet{} * mag<5'280>()), MilesLabel<void> {
 constexpr auto mile = SingularNameFor<Miles>{};
 constexpr auto miles = QuantityMaker<Miles>{};
 
+namespace symbols {
+constexpr auto mi = SymbolFor<Miles>{};
+}
 }  // namespace au

--- a/au/units/minutes.hh
+++ b/au/units/minutes.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/seconds.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Minutes : decltype(Seconds{} * mag<60>()), MinutesLabel<void> {
 constexpr auto minute = SingularNameFor<Minutes>{};
 constexpr auto minutes = QuantityMaker<Minutes>{};
 
+namespace symbols {
+constexpr auto min = SymbolFor<Minutes>{};
+}
 }  // namespace au

--- a/au/units/moles.hh
+++ b/au/units/moles.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -32,4 +33,7 @@ struct Moles : UnitImpl<AmountOfSubstance>, MolesLabel<void> {
 constexpr auto mole = SingularNameFor<Moles>{};
 constexpr auto moles = QuantityMaker<Moles>{};
 
+namespace symbols {
+constexpr auto mol = SymbolFor<Moles>{};
+}
 }  // namespace au

--- a/au/units/nautical_miles.hh
+++ b/au/units/nautical_miles.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/meters.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct NauticalMiles : decltype(Meters{} * mag<1'852>()), NauticalMilesLabel<voi
 constexpr auto nautical_mile = SingularNameFor<NauticalMiles>{};
 constexpr auto nautical_miles = QuantityMaker<NauticalMiles>{};
 
+namespace symbols {
+constexpr auto nmi = SymbolFor<NauticalMiles>{};
+}
 }  // namespace au

--- a/au/units/newtons.hh
+++ b/au/units/newtons.hh
@@ -16,6 +16,7 @@
 
 #include "au/prefix.hh"
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/grams.hh"
 #include "au/units/meters.hh"
 #include "au/units/seconds.hh"
@@ -36,4 +37,7 @@ struct Newtons : decltype(Kilo<Grams>{} * Meters{} / squared(Seconds{})), Newton
 constexpr auto newton = SingularNameFor<Newtons>{};
 constexpr auto newtons = QuantityMaker<Newtons>{};
 
+namespace symbols {
+constexpr auto N = SymbolFor<Newtons>{};
+}
 }  // namespace au

--- a/au/units/ohms.hh
+++ b/au/units/ohms.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/amperes.hh"
 #include "au/units/volts.hh"
 
@@ -34,4 +35,7 @@ struct Ohms : decltype(Volts{} / Amperes{}), OhmsLabel<void> {
 constexpr auto ohm = SingularNameFor<Ohms>{};
 constexpr auto ohms = QuantityMaker<Ohms>{};
 
+namespace symbols {
+constexpr auto ohm = SymbolFor<Ohms>{};
+}
 }  // namespace au

--- a/au/units/pascals.hh
+++ b/au/units/pascals.hh
@@ -16,6 +16,7 @@
 
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/meters.hh"
 #include "au/units/newtons.hh"
 
@@ -36,4 +37,7 @@ constexpr auto pascal = SingularNameFor<Pascals>{};
 constexpr auto pascals = QuantityMaker<Pascals>{};
 constexpr QuantityPointMaker<Pascals> pascals_pt{};
 
+namespace symbols {
+constexpr auto Pa = SymbolFor<Pascals>{};
+}
 }  // namespace au

--- a/au/units/percent.hh
+++ b/au/units/percent.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/unos.hh"
 
 namespace au {
@@ -32,4 +33,7 @@ struct Percent : decltype(Unos{} / mag<100>()), PercentLabel<void> {
 };
 constexpr auto percent = QuantityMaker<Percent>{};
 
+namespace symbols {
+constexpr auto pct = SymbolFor<Percent>{};
+}
 }  // namespace au

--- a/au/units/pounds_force.hh
+++ b/au/units/pounds_force.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/pounds_mass.hh"
 #include "au/units/standard_gravity.hh"
 
@@ -34,4 +35,7 @@ struct PoundsForce : decltype(PoundsMass{} * StandardGravity{}), PoundsForceLabe
 constexpr auto pound_force = SingularNameFor<PoundsForce>{};
 constexpr auto pounds_force = QuantityMaker<PoundsForce>{};
 
+namespace symbols {
+constexpr auto lbf = SymbolFor<PoundsForce>{};
+}
 }  // namespace au

--- a/au/units/pounds_mass.hh
+++ b/au/units/pounds_mass.hh
@@ -16,6 +16,7 @@
 
 #include "au/prefix.hh"
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/grams.hh"
 
 namespace au {
@@ -34,4 +35,7 @@ struct PoundsMass : decltype(Micro<Grams>{} * mag<453'592'370>()), PoundsMassLab
 constexpr auto pound_mass = SingularNameFor<PoundsMass>{};
 constexpr auto pounds_mass = QuantityMaker<PoundsMass>{};
 
+namespace symbols {
+constexpr auto lb = SymbolFor<PoundsMass>{};
+}
 }  // namespace au

--- a/au/units/radians.hh
+++ b/au/units/radians.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -32,4 +33,7 @@ struct Radians : UnitImpl<Angle>, RadiansLabel<void> {
 constexpr auto radian = SingularNameFor<Radians>{};
 constexpr auto radians = QuantityMaker<Radians>{};
 
+namespace symbols {
+constexpr auto rad = SymbolFor<Radians>{};
+}
 }  // namespace au

--- a/au/units/revolutions.hh
+++ b/au/units/revolutions.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/degrees.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Revolutions : decltype(Degrees{} * mag<360>()), RevolutionsLabel<void> {
 constexpr auto revolution = SingularNameFor<Revolutions>{};
 constexpr auto revolutions = QuantityMaker<Revolutions>{};
 
+namespace symbols {
+constexpr auto rev = SymbolFor<Revolutions>{};
+}
 }  // namespace au

--- a/au/units/seconds.hh
+++ b/au/units/seconds.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -32,4 +33,7 @@ struct Seconds : UnitImpl<Time>, SecondsLabel<void> {
 constexpr auto second = SingularNameFor<Seconds>{};
 constexpr auto seconds = QuantityMaker<Seconds>{};
 
+namespace symbols {
+constexpr auto s = SymbolFor<Seconds>{};
+}
 }  // namespace au

--- a/au/units/siemens.hh
+++ b/au/units/siemens.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/ohms.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Siemens : UnitInverseT<Ohms>, SiemensLabel<void> {
 constexpr auto siemen = SingularNameFor<Siemens>{};
 constexpr auto siemens = QuantityMaker<Siemens>{};
 
+namespace symbols {
+constexpr auto S = SymbolFor<Siemens>{};
+}
 }  // namespace au

--- a/au/units/slugs.hh
+++ b/au/units/slugs.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/feet.hh"
 #include "au/units/pounds_force.hh"
 #include "au/units/seconds.hh"
@@ -35,4 +36,7 @@ struct Slugs : decltype(PoundsForce{} * squared(Seconds{}) / Feet{}), SlugsLabel
 constexpr auto slug = SingularNameFor<Slugs>{};
 constexpr auto slugs = QuantityMaker<Slugs>{};
 
+namespace symbols {
+constexpr auto slug = SymbolFor<Slugs>{};
+}
 }  // namespace au

--- a/au/units/standard_gravity.hh
+++ b/au/units/standard_gravity.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/meters.hh"
 #include "au/units/seconds.hh"
 
@@ -35,4 +36,7 @@ struct StandardGravity
 };
 constexpr auto standard_gravity = QuantityMaker<StandardGravity>{};
 
+namespace symbols {
+constexpr auto g_0 = SymbolFor<StandardGravity>{};
+}
 }  // namespace au

--- a/au/units/steradians.hh
+++ b/au/units/steradians.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/radians.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Steradians : decltype(squared(Radians{})), SteradiansLabel<void> {
 constexpr auto steradian = SingularNameFor<Steradians>{};
 constexpr auto steradians = QuantityMaker<Steradians>{};
 
+namespace symbols {
+constexpr auto sr = SymbolFor<Steradians>{};
+}
 }  // namespace au

--- a/au/units/tesla.hh
+++ b/au/units/tesla.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/meters.hh"
 #include "au/units/webers.hh"
 
@@ -33,4 +34,7 @@ struct Tesla : decltype(Webers{} / squared(Meters{})), TeslaLabel<void> {
 };
 constexpr auto tesla = QuantityMaker<Tesla>{};
 
+namespace symbols {
+constexpr auto T = SymbolFor<Tesla>{};
+}
 }  // namespace au

--- a/au/units/test/amperes_test.cc
+++ b/au/units/test/amperes_test.cc
@@ -32,4 +32,9 @@ TEST(Amperes, ProductWithVoltsGivesPower) {
     EXPECT_THAT(amperes(2.0), QuantityEquivalent(watts(8.0) / volts(4.0)));
 }
 
+TEST(Amperes, HasExpectedSymbol) {
+    using symbols::A;
+    EXPECT_THAT(5 * A, SameTypeAndValue(amperes(5)));
+}
+
 }  // namespace au

--- a/au/units/test/bars_test.cc
+++ b/au/units/test/bars_test.cc
@@ -24,4 +24,9 @@ TEST(Bars, HasExpectedLabel) { expect_label<Bars>("bar"); }
 
 TEST(Bars, HasCorrectRelationshipWithPascals) { EXPECT_EQ(bars(1), kilo(pascals)(100)); }
 
+TEST(Bars, HasExpectedSymbol) {
+    using symbols::bar;
+    EXPECT_THAT(5 * bar, SameTypeAndValue(bars(5)));
+}
+
 }  // namespace au

--- a/au/units/test/becquerel_test.cc
+++ b/au/units/test/becquerel_test.cc
@@ -26,4 +26,9 @@ TEST(Becquerel, EquivalentToInverseSeconds) {
     EXPECT_THAT(becquerel(4.0), QuantityEquivalent(inverse(seconds)(4.0)));
 }
 
+TEST(Becquerel, HasExpectedSymbol) {
+    using symbols::Bq;
+    EXPECT_THAT(5 * Bq, SameTypeAndValue(becquerel(5)));
+}
+
 }  // namespace au

--- a/au/units/test/bits_test.cc
+++ b/au/units/test/bits_test.cc
@@ -24,4 +24,9 @@ TEST(Bits, HasExpectedLabel) { expect_label<Bits>("b"); }
 
 TEST(Bits, OneEighthOfAByte) { EXPECT_EQ(bits(1.0), bytes(1.0 / 8.0)); }
 
+TEST(Bits, HasExpectedSymbol) {
+    using symbols::b;
+    EXPECT_THAT(5 * b, SameTypeAndValue(bits(5)));
+}
+
 }  // namespace au

--- a/au/units/test/bytes_test.cc
+++ b/au/units/test/bytes_test.cc
@@ -24,4 +24,9 @@ TEST(Bytes, HasExpectedLabel) { expect_label<Bytes>("B"); }
 
 TEST(Bytes, EquivalentTo8Bits) { EXPECT_EQ(bytes(1), bits(8)); }
 
+TEST(Bytes, HasExpectedSymbol) {
+    using symbols::B;
+    EXPECT_THAT(5 * B, SameTypeAndValue(bytes(5)));
+}
+
 }  // namespace au

--- a/au/units/test/candelas_test.cc
+++ b/au/units/test/candelas_test.cc
@@ -27,4 +27,9 @@ TEST(Candelas, EquivalentToLumensPerSteradian) {
     EXPECT_THAT(candelas(2.0), QuantityEquivalent(lumens(6.0) / steradians(3.0)));
 }
 
+TEST(Candelas, HasExpectedSymbol) {
+    using symbols::cd;
+    EXPECT_THAT(5 * cd, SameTypeAndValue(candelas(5)));
+}
+
 }  // namespace au

--- a/au/units/test/celsius_test.cc
+++ b/au/units/test/celsius_test.cc
@@ -37,4 +37,9 @@ TEST(Celsius, QuantityPointMatchesUpCorrectlyWithFahrenheit) {
     EXPECT_EQ(celsius_pt(100), fahrenheit_pt(212));
 }
 
+TEST(Celsius, HasExpectedSymbol) {
+    using symbols::degC_qty;
+    EXPECT_THAT(5 * degC_qty, SameTypeAndValue(celsius_qty(5)));
+}
+
 }  // namespace au

--- a/au/units/test/coulombs_test.cc
+++ b/au/units/test/coulombs_test.cc
@@ -27,4 +27,9 @@ TEST(Coulombs, EquivalentToAmpereSeconds) {
     EXPECT_THAT(coulombs(10), QuantityEquivalent(amperes(2) * seconds(5)));
 }
 
+TEST(Coulombs, HasExpectedSymbol) {
+    using symbols::C;
+    EXPECT_THAT(5 * C, SameTypeAndValue(coulombs(5)));
+}
+
 }  // namespace au

--- a/au/units/test/days_test.cc
+++ b/au/units/test/days_test.cc
@@ -19,6 +19,13 @@
 
 namespace au {
 
+TEST(Days, HasExpectedLabel) { expect_label<Days>("d"); }
+
 TEST(Days, EquivalentTo24Hours) { EXPECT_EQ(days(1), hours(24)); }
+
+TEST(Days, HasExpectedSymbol) {
+    using symbols::d;
+    EXPECT_THAT(5 * d, SameTypeAndValue(days(5)));
+}
 
 }  // namespace au

--- a/au/units/test/degrees_test.cc
+++ b/au/units/test/degrees_test.cc
@@ -28,4 +28,9 @@ TEST(Degrees, RoughlyEquivalentToPiOver180Radians) {
 
 TEST(Degrees, One360thOfARevolution) { EXPECT_EQ(degrees(360), revolutions(1)); }
 
+TEST(Degrees, HasExpectedSymbol) {
+    using symbols::deg;
+    EXPECT_THAT(5 * deg, SameTypeAndValue(degrees(5)));
+}
+
 }  // namespace au

--- a/au/units/test/fahrenheit_test.cc
+++ b/au/units/test/fahrenheit_test.cc
@@ -31,4 +31,9 @@ TEST(Fahrenheit, HasCorrectRelationshipsWithCelsius) {
     EXPECT_THAT(fahrenheit_pt(212.0).as(celsius_pt), SameTypeAndValue(celsius_pt(100.0)));
 }
 
+TEST(Fahrenheit, HasExpectedSymbol) {
+    using symbols::degF_qty;
+    EXPECT_THAT(5 * degF_qty, SameTypeAndValue(fahrenheit_qty(5)));
+}
+
 }  // namespace au

--- a/au/units/test/farads_test.cc
+++ b/au/units/test/farads_test.cc
@@ -27,4 +27,9 @@ TEST(Farads, EquivalentToCoulombsPerVolt) {
     EXPECT_THAT(farads(4.0), QuantityEquivalent(coulombs(8.0) / volts(2.0)));
 }
 
+TEST(Farads, HasExpectedSymbol) {
+    using symbols::F;
+    EXPECT_THAT(5 * F, SameTypeAndValue(farads(5)));
+}
+
 }  // namespace au

--- a/au/units/test/fathoms_test.cc
+++ b/au/units/test/fathoms_test.cc
@@ -24,4 +24,9 @@ TEST(Fathoms, HasExpectedLabel) { expect_label<Fathoms>("ftm"); }
 
 TEST(Fathoms, EquivalentTo6Feet) { EXPECT_EQ(fathoms(1), feet(6)); }
 
+TEST(Fathoms, HasExpectedSymbol) {
+    using symbols::ftm;
+    EXPECT_THAT(5 * ftm, SameTypeAndValue(fathoms(5)));
+}
+
 }  // namespace au

--- a/au/units/test/feet_test.cc
+++ b/au/units/test/feet_test.cc
@@ -23,4 +23,9 @@ TEST(Feet, HasExpectedLabel) { expect_label<Feet>("ft"); }
 
 TEST(Feet, EquivalentTo12Inches) { EXPECT_EQ(feet(1), inches(12)); }
 
+TEST(Feet, HasExpectedSymbol) {
+    using symbols::ft;
+    EXPECT_THAT(5 * ft, SameTypeAndValue(feet(5)));
+}
+
 }  // namespace au

--- a/au/units/test/furlongs_test.cc
+++ b/au/units/test/furlongs_test.cc
@@ -24,4 +24,9 @@ TEST(Furlongs, HasExpectedLabel) { expect_label<Furlongs>("fur"); }
 
 TEST(Furlongs, EquivalentToOneEighthMile) { EXPECT_EQ(furlongs(8), miles(1)); }
 
+TEST(Furlongs, HasExpectedSymbol) {
+    using symbols::fur;
+    EXPECT_THAT(5 * fur, SameTypeAndValue(furlongs(5)));
+}
+
 }  // namespace au

--- a/au/units/test/grams_test.cc
+++ b/au/units/test/grams_test.cc
@@ -26,4 +26,9 @@ TEST(Grams, HasCorrectRelationshipWithPoundsMass) {
     EXPECT_EQ(micro(grams)(453'592'370L), pounds_mass(1L));
 }
 
+TEST(Grams, HasExpectedSymbol) {
+    using symbols::g;
+    EXPECT_THAT(5 * g, SameTypeAndValue(grams(5)));
+}
+
 }  // namespace au

--- a/au/units/test/grays_test.cc
+++ b/au/units/test/grays_test.cc
@@ -27,4 +27,9 @@ TEST(Grays, EquivalentToJoulesPerKilogram) {
     EXPECT_THAT(grays(4.0), QuantityEquivalent(joules(8.0) / kilo(grams)(2.0)));
 }
 
+TEST(Grays, HasExpectedSymbol) {
+    using symbols::Gy;
+    EXPECT_THAT(5 * Gy, SameTypeAndValue(grays(5)));
+}
+
 }  // namespace au

--- a/au/units/test/henries_test.cc
+++ b/au/units/test/henries_test.cc
@@ -27,4 +27,9 @@ TEST(Henries, EquivalentToWebersPerAmpere) {
     EXPECT_THAT(henries(4.0), QuantityEquivalent(webers(8.0) / amperes(2.0)));
 }
 
+TEST(Henries, HasExpectedSymbol) {
+    using symbols::H;
+    EXPECT_THAT(5 * H, SameTypeAndValue(henries(5)));
+}
+
 }  // namespace au

--- a/au/units/test/hertz_test.cc
+++ b/au/units/test/hertz_test.cc
@@ -25,4 +25,9 @@ TEST(Hertz, EquivalentToInverseSeconds) {
     EXPECT_THAT(hertz(5.5), QuantityEquivalent(inverse(seconds)(5.5)));
 }
 
+TEST(Hertz, HasExpectedSymbol) {
+    using symbols::Hz;
+    EXPECT_THAT(5 * Hz, SameTypeAndValue(hertz(5)));
+}
+
 }  // namespace au

--- a/au/units/test/hours_test.cc
+++ b/au/units/test/hours_test.cc
@@ -23,4 +23,9 @@ TEST(Hours, HasExpectedLabel) { expect_label<Hours>("h"); }
 
 TEST(Hours, EquivalentTo60Minutes) { EXPECT_EQ(hours(3), minutes(180)); }
 
+TEST(Hours, HasExpectedSymbol) {
+    using symbols::h;
+    EXPECT_THAT(5 * h, SameTypeAndValue(hours(5)));
+}
+
 }  // namespace au

--- a/au/units/test/inches_test.cc
+++ b/au/units/test/inches_test.cc
@@ -23,4 +23,9 @@ TEST(Inches, HasExpectedLabel) { expect_label<Inches>("in"); }
 
 TEST(Inches, EquivalentTo2Point54CentiMeters) { EXPECT_EQ(centi(meters)(254), inches(100)); }
 
+TEST(Inches, HasExpectedSymbol) {
+    using symbols::in;
+    EXPECT_THAT(5 * in, SameTypeAndValue(inches(5)));
+}
+
 }  // namespace au

--- a/au/units/test/joules_test.cc
+++ b/au/units/test/joules_test.cc
@@ -25,4 +25,9 @@ TEST(Joules, HasExpectedLabel) { expect_label<Joules>("J"); }
 
 TEST(Joules, EquivalentToNewtonMeters) { EXPECT_EQ(joules(18), (newton * meters)(18)); }
 
+TEST(Joules, HasExpectedSymbol) {
+    using symbols::J;
+    EXPECT_THAT(5 * J, SameTypeAndValue(joules(5)));
+}
+
 }  // namespace au

--- a/au/units/test/katals_test.cc
+++ b/au/units/test/katals_test.cc
@@ -27,4 +27,9 @@ TEST(Katals, EquivalentToMolesPerSecond) {
     EXPECT_THAT(katals(2.0), QuantityEquivalent(moles(6.0) / seconds(3.0)));
 }
 
+TEST(Katals, HasExpectedSymbol) {
+    using symbols::kat;
+    EXPECT_THAT(5 * kat, SameTypeAndValue(katals(5)));
+}
+
 }  // namespace au

--- a/au/units/test/kelvins_test.cc
+++ b/au/units/test/kelvins_test.cc
@@ -26,4 +26,9 @@ TEST(Kelvins, QuantityEquivalentToCelsius) {
     EXPECT_THAT(kelvins(10), QuantityEquivalent(celsius_qty(10)));
 }
 
+TEST(Kelvins, HasExpectedSymbol) {
+    using symbols::K;
+    EXPECT_THAT(5 * K, SameTypeAndValue(kelvins(5)));
+}
+
 }  // namespace au

--- a/au/units/test/knots_test.cc
+++ b/au/units/test/knots_test.cc
@@ -26,4 +26,9 @@ TEST(Knots, HasExpectedLabel) { expect_label<Knots>("kn"); }
 
 TEST(Knots, EquivalentToNauticalMilesPerHour) { EXPECT_EQ(knots(1), (nautical_miles / hour)(1)); }
 
+TEST(Knots, HasExpectedSymbol) {
+    using symbols::kn;
+    EXPECT_THAT(5 * kn, SameTypeAndValue(knots(5)));
+}
+
 }  // namespace au

--- a/au/units/test/liters_test.cc
+++ b/au/units/test/liters_test.cc
@@ -28,4 +28,9 @@ TEST(Liters, HasExpectedRelationshipsWithLinearUnits) {
     EXPECT_EQ(milli(liters)(1), cubed(centi(meters))(1));
 }
 
+TEST(Liters, HasExpectedSymbol) {
+    using symbols::L;
+    EXPECT_THAT(5 * L, SameTypeAndValue(liters(5)));
+}
+
 }  // namespace au

--- a/au/units/test/lumens_test.cc
+++ b/au/units/test/lumens_test.cc
@@ -27,4 +27,9 @@ TEST(Lumens, EquivalentToCandelaSteradians) {
     EXPECT_THAT(lumens(6), QuantityEquivalent(candelas(2) * steradians(3)));
 }
 
+TEST(Lumens, HasExpectedSymbol) {
+    using symbols::lm;
+    EXPECT_THAT(5 * lm, SameTypeAndValue(lumens(5)));
+}
+
 }  // namespace au

--- a/au/units/test/lux_test.cc
+++ b/au/units/test/lux_test.cc
@@ -27,4 +27,9 @@ TEST(Lux, ProductWithAreaGivesLumens) {
     EXPECT_THAT(lux(2.0), QuantityEquivalent(lumens(8.0) / squared(meters)(4.0)));
 }
 
+TEST(Lux, HasExpectedSymbol) {
+    using symbols::lx;
+    EXPECT_THAT(5 * lx, SameTypeAndValue(lux(5)));
+}
+
 }  // namespace au

--- a/au/units/test/meters_test.cc
+++ b/au/units/test/meters_test.cc
@@ -25,4 +25,9 @@ TEST(Meters, HasExpectedLabel) { expect_label<Meters>("m"); }
 
 TEST(Meters, HasExpectedRelationshipsWithInches) { EXPECT_EQ(centi(meters)(254), inches(100)); }
 
+TEST(Meters, HasExpectedSymbol) {
+    using symbols::m;
+    EXPECT_THAT(5 * m, SameTypeAndValue(meters(5)));
+}
+
 }  // namespace au

--- a/au/units/test/miles_test.cc
+++ b/au/units/test/miles_test.cc
@@ -23,4 +23,9 @@ TEST(Miles, HasExpectedLabel) { expect_label<Miles>("mi"); }
 
 TEST(Miles, EquivalentTo5280Feet) { EXPECT_EQ(miles(1), feet(5280)); }
 
+TEST(Miles, HasExpectedSymbol) {
+    using symbols::mi;
+    EXPECT_THAT(5 * mi, SameTypeAndValue(miles(5)));
+}
+
 }  // namespace au

--- a/au/units/test/minutes_test.cc
+++ b/au/units/test/minutes_test.cc
@@ -23,4 +23,9 @@ TEST(Minutes, HasExpectedLabel) { expect_label<Minutes>("min"); }
 
 TEST(Minutes, EquivalentTo60Seconds) { EXPECT_EQ(minutes(3), seconds(180)); }
 
+TEST(Minutes, HasExpectedSymbol) {
+    using symbols::min;
+    EXPECT_THAT(5 * min, SameTypeAndValue(minutes(5)));
+}
+
 }  // namespace au

--- a/au/units/test/moles_test.cc
+++ b/au/units/test/moles_test.cc
@@ -27,4 +27,9 @@ TEST(Moles, EquivalentToKatalSeconds) {
     EXPECT_THAT(moles(6), QuantityEquivalent(katals(2) * seconds(3)));
 }
 
+TEST(Moles, HasExpectedSymbol) {
+    using symbols::mol;
+    EXPECT_THAT(5 * mol, SameTypeAndValue(moles(5)));
+}
+
 }  // namespace au

--- a/au/units/test/nautical_miles_test.cc
+++ b/au/units/test/nautical_miles_test.cc
@@ -28,4 +28,9 @@ TEST(NauticalMiles, EquivalentTo1852Meters) { EXPECT_EQ(nautical_miles(1), meter
 
 TEST(NauticalMiles, EquivalentToKnotHours) { EXPECT_EQ(nautical_miles(1), (knot * hours)(1)); }
 
+TEST(NauticalMiles, HasExpectedSymbol) {
+    using symbols::nmi;
+    EXPECT_THAT(5 * nmi, SameTypeAndValue(nautical_miles(5)));
+}
+
 }  // namespace au

--- a/au/units/test/newtons_test.cc
+++ b/au/units/test/newtons_test.cc
@@ -25,4 +25,9 @@ TEST(Newtons, EquivalentToKilogramMetersPerSquaredSecond) {
     EXPECT_THAT(newtons(8), QuantityEquivalent((kilo(gram) * meters / squared(second))(8)));
 }
 
+TEST(Newtons, HasExpectedSymbol) {
+    using symbols::N;
+    EXPECT_THAT(5 * N, SameTypeAndValue(newtons(5)));
+}
+
 }  // namespace au

--- a/au/units/test/ohms_test.cc
+++ b/au/units/test/ohms_test.cc
@@ -36,4 +36,9 @@ TEST(Ohms, SatisfiesOhmicHeatingEquation) {
     EXPECT_EQ(ohms(10.0), (volts(50.0) * volts(50.0)) / watts(250.0));
 }
 
+TEST(Ohms, HasExpectedSymbol) {
+    using symbols::ohm;
+    EXPECT_THAT(5 * ohm, SameTypeAndValue(ohms(5)));
+}
+
 }  // namespace au

--- a/au/units/test/pascals_test.cc
+++ b/au/units/test/pascals_test.cc
@@ -25,4 +25,9 @@ TEST(Pascals, EquivalentToForcePerArea) {
     EXPECT_THAT(pascals(12), QuantityEquivalent((newtons / squared(meter))(12)));
 }
 
+TEST(Pascals, HasExpectedSymbol) {
+    using symbols::Pa;
+    EXPECT_THAT(5 * Pa, SameTypeAndValue(pascals(5)));
+}
+
 }  // namespace au

--- a/au/units/test/percent_test.cc
+++ b/au/units/test/percent_test.cc
@@ -25,4 +25,9 @@ TEST(Percent, HasExpectedLabel) { expect_label<Percent>("%"); }
 
 TEST(Percent, OneHundredthOfUnos) { EXPECT_EQ(percent(75.0), unos(0.75)); }
 
+TEST(Percent, HasExpectedSymbol) {
+    using symbols::pct;
+    EXPECT_THAT(5 * pct, SameTypeAndValue(percent(5)));
+}
+
 }  // namespace au

--- a/au/units/test/pounds_force_test.cc
+++ b/au/units/test/pounds_force_test.cc
@@ -25,4 +25,9 @@ TEST(PoundsForce, EquivalentToStandardGravityActingOnPoundMass) {
     EXPECT_THAT(pounds_force(123), QuantityEquivalent((pound_mass * standard_gravity)(123)));
 }
 
+TEST(PoundsForce, HasExpectedSymbol) {
+    using symbols::lbf;
+    EXPECT_THAT(5 * lbf, SameTypeAndValue(pounds_force(5)));
+}
+
 }  // namespace au

--- a/au/units/test/pounds_mass_test.cc
+++ b/au/units/test/pounds_mass_test.cc
@@ -25,4 +25,9 @@ TEST(PoundsMass, EquivalentToAppropriateQuantityOfKilograms) {
     EXPECT_EQ(pounds_mass(100'000'000L), (kilo(grams)(45'359'237L)));
 }
 
+TEST(PoundsMass, HasExpectedSymbol) {
+    using symbols::lb;
+    EXPECT_THAT(5 * lb, SameTypeAndValue(pounds_mass(5)));
+}
+
 }  // namespace au

--- a/au/units/test/radians_test.cc
+++ b/au/units/test/radians_test.cc
@@ -26,4 +26,9 @@ TEST(Radians, TwoPiPerRevolution) {
     EXPECT_DOUBLE_EQ(radians(get_value<double>(mag<2>() * PI)).in(revolutions), 1.0);
 }
 
+TEST(Radians, HasExpectedSymbol) {
+    using symbols::rad;
+    EXPECT_THAT(5 * rad, SameTypeAndValue(radians(5)));
+}
+
 }  // namespace au

--- a/au/units/test/revolutions_test.cc
+++ b/au/units/test/revolutions_test.cc
@@ -23,4 +23,9 @@ TEST(Revolutions, HasExpectedLabel) { expect_label<Revolutions>("rev"); }
 
 TEST(Revolutions, ExactlyEquivalentTo360Degrees) { EXPECT_EQ(revolutions(1), degrees(360)); }
 
+TEST(Revolutions, HasExpectedSymbol) {
+    using symbols::rev;
+    EXPECT_THAT(5 * rev, SameTypeAndValue(revolutions(5)));
+}
+
 }  // namespace au

--- a/au/units/test/seconds_test.cc
+++ b/au/units/test/seconds_test.cc
@@ -24,4 +24,9 @@ TEST(Seconds, HasExpectedLabel) { expect_label<Seconds>("s"); }
 
 TEST(Seconds, SixtyPerMinute) { EXPECT_EQ(seconds(60), minutes(1)); }
 
+TEST(Seconds, HasExpectedSymbol) {
+    using symbols::s;
+    EXPECT_THAT(5 * s, SameTypeAndValue(seconds(5)));
+}
+
 }  // namespace au

--- a/au/units/test/siemens_test.cc
+++ b/au/units/test/siemens_test.cc
@@ -26,4 +26,9 @@ TEST(Siemens, EquivalentToInverseOhms) {
     EXPECT_THAT(siemens(4.0), QuantityEquivalent(1.0 / ohms(0.25)));
 }
 
+TEST(Siemens, HasExpectedSymbol) {
+    using symbols::S;
+    EXPECT_THAT(5 * S, SameTypeAndValue(siemens(5)));
+}
+
 }  // namespace au

--- a/au/units/test/slugs_test.cc
+++ b/au/units/test/slugs_test.cc
@@ -36,4 +36,9 @@ TEST(Slugs, ExactDefinitionIsCorrect) {
     EXPECT_THAT(slugs(1.0), IsNear(pounds_mass(32.174), milli(pounds_mass)(1)));
 }
 
+TEST(Slugs, HasExpectedSymbol) {
+    using symbols::slug;
+    EXPECT_THAT(5 * slug, SameTypeAndValue(slugs(5)));
+}
+
 }  // namespace au

--- a/au/units/test/standard_gravity_test.cc
+++ b/au/units/test/standard_gravity_test.cc
@@ -28,4 +28,9 @@ TEST(StandardGravity, HasExpectedValue) {
     EXPECT_EQ(standard_gravity(1L), (micro(meters) / squared(second))(9'806'650L));
 }
 
+TEST(StandardGravity, HasExpectedSymbol) {
+    using symbols::g_0;
+    EXPECT_THAT(5 * g_0, SameTypeAndValue(standard_gravity(5)));
+}
+
 }  // namespace au

--- a/au/units/test/steradians_test.cc
+++ b/au/units/test/steradians_test.cc
@@ -26,4 +26,9 @@ TEST(Steradians, EquivalentToSquaredRadians) {
     EXPECT_THAT(steradians(6), QuantityEquivalent(radians(2) * radians(3)));
 }
 
+TEST(Steradians, HasExpectedSymbol) {
+    using symbols::sr;
+    EXPECT_THAT(5 * sr, SameTypeAndValue(steradians(5)));
+}
+
 }  // namespace au

--- a/au/units/test/tesla_test.cc
+++ b/au/units/test/tesla_test.cc
@@ -27,4 +27,9 @@ TEST(Tesla, EquivalentToWebersPerMeterSquared) {
     EXPECT_THAT(tesla(4.0), QuantityEquivalent(webers(8.0) / squared(meters)(2.0)));
 }
 
+TEST(Tesla, HasExpectedSymbol) {
+    using symbols::T;
+    EXPECT_THAT(5 * T, SameTypeAndValue(tesla(5)));
+}
+
 }  // namespace au

--- a/au/units/test/unos_test.cc
+++ b/au/units/test/unos_test.cc
@@ -29,4 +29,9 @@ TEST(Unos, ImplicitlyConvertToRawNumbers) {
     EXPECT_THAT(x, SameTypeAndValue(1.23));
 }
 
+TEST(Unos, HasExpectedSymbol) {
+    using symbols::U;
+    EXPECT_THAT(5 * U, SameTypeAndValue(unos(5)));
+}
+
 }  // namespace au

--- a/au/units/test/volts_test.cc
+++ b/au/units/test/volts_test.cc
@@ -25,4 +25,9 @@ TEST(Volts, HasExpectedLabel) { expect_label<Volts>("V"); }
 
 TEST(Volts, SatisfiesOhmsLaw) { EXPECT_THAT(volts(8), QuantityEquivalent(amperes(2) * ohms(4))); }
 
+TEST(Volts, HasExpectedSymbol) {
+    using symbols::V;
+    EXPECT_THAT(5 * V, SameTypeAndValue(volts(5)));
+}
+
 }  // namespace au

--- a/au/units/test/watts_test.cc
+++ b/au/units/test/watts_test.cc
@@ -38,4 +38,9 @@ TEST(Watts, EquivalentToOhmicHeating) {
     EXPECT_THAT(i * i * r, QuantityEquivalent(p));
 }
 
+TEST(Watts, HasExpectedSymbol) {
+    using symbols::W;
+    EXPECT_THAT(5 * W, SameTypeAndValue(watts(5)));
+}
+
 }  // namespace au

--- a/au/units/test/webers_test.cc
+++ b/au/units/test/webers_test.cc
@@ -33,4 +33,9 @@ TEST(Webers, EquivalentToHenryAmperes) {
     EXPECT_THAT(webers(8.0), QuantityEquivalent(henries(4.0) * amperes(2.0)));
 }
 
+TEST(Webers, HasExpectedSymbol) {
+    using symbols::Wb;
+    EXPECT_THAT(5 * Wb, SameTypeAndValue(webers(5)));
+}
+
 }  // namespace au

--- a/au/units/test/yards_test.cc
+++ b/au/units/test/yards_test.cc
@@ -23,4 +23,9 @@ TEST(Yards, HasExpectedLabel) { expect_label<Yards>("yd"); }
 
 TEST(Yards, EquivalentTo3Feet) { EXPECT_EQ(yards(1), feet(3)); }
 
+TEST(Yards, HasExpectedSymbol) {
+    using symbols::yd;
+    EXPECT_THAT(5 * yd, SameTypeAndValue(yards(5)));
+}
+
 }  // namespace au

--- a/au/units/unos.hh
+++ b/au/units/unos.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -31,4 +32,7 @@ struct Unos : UnitProductT<>, UnosLabel<void> {
 };
 constexpr auto unos = QuantityMaker<Unos>{};
 
+namespace symbols {
+constexpr auto U = SymbolFor<Unos>{};
+}
 }  // namespace au

--- a/au/units/volts.hh
+++ b/au/units/volts.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/amperes.hh"
 #include "au/units/watts.hh"
 
@@ -34,4 +35,7 @@ struct Volts : decltype(Watts{} / Amperes{}), VoltsLabel<void> {
 constexpr auto volt = SingularNameFor<Volts>{};
 constexpr auto volts = QuantityMaker<Volts>{};
 
+namespace symbols {
+constexpr auto V = SymbolFor<Volts>{};
+}
 }  // namespace au

--- a/au/units/watts.hh
+++ b/au/units/watts.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/joules.hh"
 #include "au/units/seconds.hh"
 
@@ -34,4 +35,7 @@ struct Watts : decltype(Joules{} / Seconds{}), WattsLabel<void> {
 constexpr auto watt = SingularNameFor<Watts>{};
 constexpr auto watts = QuantityMaker<Watts>{};
 
+namespace symbols {
+constexpr auto W = SymbolFor<Watts>{};
+}
 }  // namespace au

--- a/au/units/webers.hh
+++ b/au/units/webers.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/seconds.hh"
 #include "au/units/volts.hh"
 
@@ -34,4 +35,7 @@ struct Webers : decltype(Volts{} * Seconds{}), WebersLabel<void> {
 constexpr auto weber = SingularNameFor<Webers>{};
 constexpr auto webers = QuantityMaker<Webers>{};
 
+namespace symbols {
+constexpr auto Wb = SymbolFor<Webers>{};
+}
 }  // namespace au

--- a/au/units/yards.hh
+++ b/au/units/yards.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 #include "au/units/feet.hh"
 
 namespace au {
@@ -33,4 +34,7 @@ struct Yards : decltype(Feet{} * mag<3>()), YardsLabel<void> {
 constexpr auto yard = SingularNameFor<Yards>{};
 constexpr auto yards = QuantityMaker<Yards>{};
 
+namespace symbols {
+constexpr auto yd = SymbolFor<Yards>{};
+}
 }  // namespace au


### PR DESCRIPTION
Usually, this is just the unit label. Exceptions:

- For Percent, we use `pct` instead of `%` (which would not work).
- For temperatures with "offset zero", we append `_qty` as an extra
  measure to avoid confusion: `degC_qty` and `degF_qty`.  (If users
  don't like this, they can define their own symbols!)

Many symbols would be in danger of colliding with, e.g.,
`SingularNameFor`. For example, `bar` is both the symbol for `Bars` and
its singular name. For this reason --- and, because symbols introduce
many very short names! --- we add an extra namespace, `::au::symbols`.
Users should import symbols one at a time, as needed. For example, in a
`.cc` file:

```cpp
using ::au::symbols::m;
```

This makes it easy for anyone who runs across the `m` symbol to find its
definition.

Fixes #43.