### PR TITLE
Add `as_chrono_duration()` utility

### DIFF
--- a/au/au.hh
+++ b/au/au.hh
@@ -34,4 +34,14 @@ struct CorrespondingQuantity<std::chrono::duration<RepT, Period>> {
     static constexpr ChronoDuration construct_from_value(Rep x) { return ChronoDuration{x}; }
 };
 
+// Convert any Au duration quantity to an equivalent `std::chrono::duration`.
+template <typename U, typename R>
+constexpr auto as_chrono_duration(Quantity<U, R> dt) {
+    constexpr auto ratio = unit_ratio(U{}, seconds);
+    static_assert(is_rational(ratio), "Cannot convert to chrono::duration with non-rational ratio");
+    return std::chrono::duration<R,
+                                 std::ratio<get_value<std::intmax_t>(numerator(ratio)),
+                                            get_value<std::intmax_t>(denominator(ratio))>>{dt};
+}
+
 }  // namespace au

--- a/au/au_test.cc
+++ b/au/au_test.cc
@@ -49,6 +49,13 @@ TEST(DurationQuantity, InterconvertsWithIndirectlyEquivalentChronoDuration) {
     EXPECT_THAT(from_chrono, SameTypeAndValue(seconds(1.234)));
 }
 
+TEST(AsChronoDuration, ProducesExpectedResults) {
+    constexpr auto original = milli(seconds)(12.3f);
+    constexpr auto result = as_chrono_duration(original);
+    EXPECT_THAT(result.count(), SameTypeAndValue(12.3f));
+    EXPECT_THAT(as_quantity(result), QuantityEquivalent(original));
+}
+
 TEST(Conversions, SupportIntMHzToU32Hz) {
     constexpr QuantityU32<Hertz> freq = mega(hertz)(40);
     EXPECT_THAT(freq, SameTypeAndValue(hertz(40'000'000u)));


### PR DESCRIPTION
This makes it easy to convert any Au duration quantity to an
exactly-equivalent `std::chrono::duration`.

Fixes #187.