### PR TITLE
Use perfect conversion policy in inverse functions

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -240,6 +240,7 @@ cc_library(
     name = "math",
     hdrs = ["math.hh"],
     deps = [
+        ":constant",
         ":quantity",
         ":quantity_point",
         ":units",

--- a/au/math.hh
+++ b/au/math.hh
@@ -19,6 +19,7 @@
 #include <limits>
 #include <type_traits>
 
+#include "au/constant.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/units/radians.hh"
@@ -237,8 +238,8 @@ constexpr auto int_pow(Quantity<U, R> q) {
 template <typename TargetRep, typename TargetUnits, typename U, typename R>
 constexpr auto inverse_in(TargetUnits target_units, Quantity<U, R> q) {
     using Rep = std::common_type_t<TargetRep, R>;
-    return static_cast<TargetRep>(
-        make_quantity<UnitProductT<>>(Rep{1}).in(associated_unit(target_units) * U{}) / q.in(U{}));
+    constexpr auto ONE = make_constant(UnitProductT<>{});
+    return static_cast<TargetRep>(ONE.in<Rep>(associated_unit(target_units) * U{}) / q.in(U{}));
 }
 
 //
@@ -269,8 +270,10 @@ constexpr auto inverse_in(TargetUnits target_units, Quantity<U, R> q) {
     // This will fail at compile time for types that can't hold 1'000'000.
     constexpr R threshold = 1'000'000;
 
+    constexpr auto ONE = make_constant(UnitProductT<>{});
+
     static_assert(
-        make_quantity<UnitProductT<>>(R{1}).in(associated_unit(target_units) * U{}) >= threshold ||
+        ONE.in<R>(associated_unit(target_units) * U{}) >= threshold ||
             std::is_floating_point<R>::value,
         "Dangerous inversion risking truncation to 0; must supply explicit Rep if truly desired");
 

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -910,4 +910,12 @@ TEST(InverseAs, ProducesCorrectRep) {
     EXPECT_THAT(inverse_as<int64_t>(nano(seconds), hertz(50.0)),
                 SameTypeAndValue(rep_cast<int64_t>(nano(seconds)(20'000'000))));
 }
+
+TEST(InverseAs, HandlesConversionsBetweenOverflowSafetySurfaceAndRepresentableLimits) {
+    EXPECT_THAT(inverse_as(nano(seconds), hertz(10)), SameTypeAndValue(nano(seconds)(100'000'000)));
+
+    // Must not compile.  (Error should likely mention "Cannot represent constant in this unit/rep"
+    // and/or "Value outside range of destination type".)  Uncomment to check:
+    // inverse_as(pico(seconds), hertz(10))
+}
 }  // namespace au


### PR DESCRIPTION
Now that we have constants, we can replace the overflow safety surface
heuristic with exact checks.  This PR uses constants to do this.  It
adds a new unit test that would have failed before these implementation
changes.  It also includes an uncomment-to-check test case which still
would fail, as it must.

Fixes #190.