### PR TITLE
Include constants in godbolt links

### DIFF
--- a/au/au.hh
+++ b/au/au.hh
@@ -16,6 +16,7 @@
 
 #include <chrono>
 
+#include "au/constant.hh"
 #include "au/math.hh"
 #include "au/prefix.hh"
 #include "au/units/seconds.hh"


### PR DESCRIPTION
Currently, the godbolt link doesn't have constants, because we forgot to
include them in `au.hh`.

To test this, run `au-docs-serve`, and open this URL:
http://127.0.0.1:8000/au/au_all_units.hh

Before this PR, `Ctrl-F` for `make_constant` gives no results, but after
this PR we can see that it's there.