### PR TITLE
Let `u` in `unit_label(u)` be a unit slot

### DIFF
--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -793,7 +793,7 @@ constexpr
 
 template <typename Unit>
 constexpr const auto &unit_label(Unit) {
-    return detail::as_char_array(UnitLabel<Unit>::value);
+    return detail::as_char_array(UnitLabel<AssociatedUnitT<Unit>>::value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/au/unit_of_measure_test.cc
+++ b/au/unit_of_measure_test.cc
@@ -77,6 +77,12 @@ struct InvalidWrongMagType {
     using Mag = char;
 };
 
+// Useful for testing "unit slot" compatibility in APIs.
+template <typename UnitT>
+struct SomeUnitWrapper {};
+template <typename UnitT>
+struct AssociatedUnit<SomeUnitWrapper<UnitT>> : stdx::type_identity<UnitT> {};
+
 struct UnlabeledUnit : decltype(Feet{} * mag<9>()) {};
 
 MATCHER_P(QuantityEquivalentToUnit, target, "") {
@@ -216,6 +222,10 @@ TEST(AssociatedUnitT, IsIdentityForTypeWithNoAssociatedUnit) {
     // down `AssociatedUnitT` because it's used so widely.  It's simpler to think of it as a trait
     // which "redirects" a type only when there is a definite, positive reason to do so.
     StaticAssertTypeEq<AssociatedUnitT<double>, double>();
+}
+
+TEST(AssociatedUnitT, HandlesWrappersWhichHaveSpecializedAssociatedUnit) {
+    StaticAssertTypeEq<AssociatedUnitT<SomeUnitWrapper<Feet>>, Feet>();
 }
 
 TEST(UnitInverseT, CommutesWithProduct) {
@@ -597,6 +607,8 @@ TEST(UnitLabel, CommonPointUnitLabelWorksWithUnitProduct) {
     EXPECT_THAT(unit_label(U{}),
                 AnyOf(StrEq("COM_PT[m / min, in / min]"), StrEq("COM_PT[in / min, m / min]")));
 }
+
+TEST(UnitLabel, APICompatibleWithUnitSlots) { EXPECT_THAT(unit_label(feet), StrEq("ft")); }
 
 namespace detail {
 

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -58,6 +58,10 @@ For a unit type `U`, or instance `u`, we can access the label as follows:
 - `unit_label<U>()`
 - `unit_label(u)`
 
+Note that the `u` in `unit_label(u)` is a [unit slot](../discussion/idioms/unit-slots.md), so you
+can pass anything that "acts like a unit" to it.  For instance, you can say `unit_label(meters)`;
+you don't need to write `unit_label(Meters{})`.
+
 This function returns a reference to the array, which again is a compile time constant.
 
 Note especially that the type is an _array_ (`[]`).  A pointer (`*`) is _not_ acceptable.  This is


### PR DESCRIPTION
I just noticed this wasn't already the case, and this seemed silly and"
annoying.

I also added a missing test case for the mechanism that makes unit slots
work, namely, `AssociatedUnitT`.

And I updated the docs.