### PR TITLE
Convert `Constant` to other libraries' types

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -188,6 +188,7 @@ cc_test(
     size = "small",
     srcs = ["constant_test.cc"],
     deps = [
+        ":chrono_interop",
         ":constant",
         ":testing",
         ":units",

--- a/au/constant.hh
+++ b/au/constant.hh
@@ -87,6 +87,16 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     static constexpr bool can_store_value_in(OtherUnit other) {
         return representable_in<T>(unit_ratio(Unit{}, other));
     }
+
+    // Implicitly convert to type with an exactly corresponding quantity that passes safety checks.
+    template <
+        typename T,
+        typename = std::enable_if_t<can_store_value_in<typename CorrespondingQuantity<T>::Rep>(
+            typename CorrespondingQuantity<T>::Unit{})>>
+    constexpr operator T() const {
+        return as<typename CorrespondingQuantity<T>::Rep>(
+            typename CorrespondingQuantity<T>::Unit{});
+    };
 };
 
 // Make a constant from the given unit.


### PR DESCRIPTION
If users have set up an exact equivalence with another library's types,
we'll now be able to convert any appropriate `Constant` directly to
those types.  We even take advantage of our exact conversion policy.