### PR TITLE
Add most basic runtime conversion checkers

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -532,6 +532,29 @@ constexpr auto root(QuantityMaker<Unit>) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+// Runtime conversion checkers
+
+// Check conversion for overflow (no change of rep).
+template <typename U, typename R, typename TargetUnitSlot>
+constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot target_unit) {
+    return detail::ApplyMagnitudeT<R, decltype(unit_ratio(U{}, target_unit))>::would_overflow(
+        q.in(U{}));
+}
+
+// Check conversion for truncation (no change of rep).
+template <typename U, typename R, typename TargetUnitSlot>
+constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot target_unit) {
+    return detail::ApplyMagnitudeT<R, decltype(unit_ratio(U{}, target_unit))>::would_truncate(
+        q.in(U{}));
+}
+
+// Check for any lossiness in conversion (no change of rep).
+template <typename U, typename R, typename TargetUnitSlot>
+constexpr bool is_conversion_lossy(Quantity<U, R> q, TargetUnitSlot target_unit) {
+    return will_conversion_truncate(q, target_unit) || will_conversion_overflow(q, target_unit);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 // Comparing and/or combining Quantities of different types.
 
 namespace detail {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -725,8 +725,10 @@ TEST(WillConversionTruncate, UsesModForIntegerTypes) {
 TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions) {
     // We will check literally every representable value in the type, and make sure that the result
     // of `is_conversion_lossy()` matches perfectly with the inability to recover the initial value.
-    auto test_round_trip_for_every_uint8_value = [](auto source_units, auto target_units) {
-        for (int i = 0; i <= 65535; ++i) {
+    auto test_round_trip_for_every_uint16_value = [](auto source_units, auto target_units) {
+        for (int i = std::numeric_limits<uint16_t>::lowest();
+             i <= std::numeric_limits<uint16_t>::max();
+             ++i) {
             const auto original = source_units(static_cast<uint16_t>(i));
             const auto converted = original.coerce_as(target_units);
             const auto round_trip = converted.coerce_as(source_units);
@@ -753,10 +755,10 @@ TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions
     };
 
     // Inches-to-feet tests truncation.
-    test_round_trip_for_every_uint8_value(inches, feet);
+    test_round_trip_for_every_uint16_value(inches, feet);
 
     // Feet-to-inches tests overflow.
-    test_round_trip_for_every_uint8_value(feet, inches);
+    test_round_trip_for_every_uint16_value(feet, inches);
 }
 
 TEST(AreQuantityTypesEquivalent, RequiresSameRepAndEquivalentUnits) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -748,8 +748,7 @@ TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions
             // (The reason for all of the `rep_cast` is that `uint8_t` tends to print as a `char` on
             // at least some platforms, which means a lot of the small numbers correspond to control
             // characters, and that can be confusing otherwise.)
-            ASSERT_FALSE((!is_conversion_lossy(source(before), target)) &&
-                         is_conversion_lossy(source(before).coerce_as(target), source));
+            ASSERT_TRUE(!is_conversion_lossy(source(before).coerce_as(target), source) || is_lossy);
 
             EXPECT_EQ(is_lossy, did_value_change) << "before: " << before << ", after: " << after;
         }

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -726,8 +726,8 @@ TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions
     // We will check literally every representable value in the type, and make sure that the result
     // of `is_conversion_lossy()` matches perfectly with the inability to recover the initial value.
     auto test_round_trip_for_every_uint8_value = [](auto source_units, auto target_units) {
-        for (int i = 0; i <= 255; ++i) {
-            const auto original = source_units(static_cast<uint8_t>(i));
+        for (int i = 0; i <= 65535; ++i) {
+            const auto original = source_units(static_cast<uint16_t>(i));
             const auto converted = original.coerce_as(target_units);
             const auto round_trip = converted.coerce_as(source_units);
 


### PR DESCRIPTION
To start out with, this is only for `Quantity` (not `QuantityPoint`),
and only for same-rep conversions (so no explicit-rep variants).  The
plan is to start getting some experience with these, check them out on
godbolt, make some runtime-checking converters that use them, etc.  We
can follow up later with a more complete set of APIs.  Oh, and docs, too
--- this is starting out as an undocumented feature.

Every utility's signature looks something like:

```cpp
constexpr bool is_foo(Quantity q, TargetUnit target);
```

The instances of `is_foo` that we provide are specifically:

- `will_conversion_overflow`
- `will_conversion_truncate`
- `is_conversion_lossy`

The third is the disjunction of the first two.  So we would use them
something like this:

```cpp
constexpr bool ok = is_conversion_lossy(inches(36), feet);
```

The above would return `false`, but would return `true` if we replace
`inches(36)` with `inches(37)`.

On the implementation side, each magnitude-applying type gets its own
dedicated utility.  This is nice, because then the function that checks
each condition appears directly next to the function that applies the
magnitude, so it's easy to check that they're consistent!  (For example,
when applying a rational magnitude to an integral type, we check whether
the _numerator alone_ would cause overflow, because we know we'd be
multiplying by that numerator _before_ dividing by the denominator.)

Along the way, we also make a new type trait to make it easy to get the
appropriate type of magnitude applicator.  This made it a lot easier to
write the tests.

And speaking of tests, we concentrate the vast majority of them in the
`detail`-namespaced helpers, which separately check for overflow and
truncation.  For the `:quantity_test` tests, we just pick one
representative test case that is just complicated enough to give us
confidence that we're correctly using the utilities.

The most exciting test case is the one for `is_conversion_lossy()`.  We
take one type (`uint8_t`), and check for **every representable value**
that a round-trip unit coversion is the identity, _if and only if_ we
have identified that conversion as "not lossy".  We got 100% correct
results for both inches-to-feet (truncation), and feet-to-inches
(overflow).  Nice!