### PR TITLE
Add `-pedantic` to `EXTRA_COPTS`

### DIFF
--- a/au/constant.hh
+++ b/au/constant.hh
@@ -96,7 +96,7 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     constexpr operator T() const {
         return as<typename CorrespondingQuantity<T>::Rep>(
             typename CorrespondingQuantity<T>::Unit{});
-    };
+    }
 };
 
 // Make a constant from the given unit.

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -227,7 +227,7 @@ struct ExpectConsistentWith {
 };
 template <typename AuFunc, typename StdFunc>
 auto expect_consistent_with(AuFunc au_func, StdFunc std_func) {
-    return ExpectConsistentWith<AuFunc, StdFunc>{.au_func = au_func, .std_func = std_func};
+    return ExpectConsistentWith<AuFunc, StdFunc>{au_func, std_func};
 }
 
 TEST(fmod, SameAsStdFmodForNumericTypes) {

--- a/au/quantity_chrono_policy_correspondence_test.cc
+++ b/au/quantity_chrono_policy_correspondence_test.cc
@@ -44,14 +44,14 @@ bool operator==(const AllComparisons &a, const AllComparisons &b) {
 
 template <typename T, typename U>
 AllComparisons compare(const T &t, const U &u) {
-    return {
-        .eq = (t == u),
-        .ne = (t != u),
-        .lt = (t < u),
-        .le = (t <= u),
-        .gt = (t > u),
-        .ge = (t >= u),
-    };
+    AllComparisons result;
+    result.eq = (t == u);
+    result.ne = (t != u);
+    result.lt = (t < u);
+    result.le = (t <= u);
+    result.gt = (t > u);
+    result.ge = (t >= u);
+    return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -286,21 +286,21 @@ struct CorrespondingQuantity<MyHours> {
     static constexpr Rep extract_value(MyHours x) { return x.value; }
 
     // Support Quantity conversion to Hours.
-    static constexpr MyHours construct_from_value(Rep x) { return {.value = x}; }
+    static constexpr MyHours construct_from_value(Rep x) { return {x}; }
 };
 
 TEST(Quantity, ImplicitConstructionFromCorrespondingQuantity) {
-    constexpr Quantity<Hours, int> x = MyHours{.value = 3};
+    constexpr Quantity<Hours, int> x = MyHours{3};
     EXPECT_EQ(x, hours(3));
 }
 
 TEST(Quantity, ImplicitConstructionFromTwoHopCorrespondingQuantity) {
-    constexpr Quantity<Minutes, int> x = MyHours{.value = 3};
+    constexpr Quantity<Minutes, int> x = MyHours{3};
     EXPECT_THAT(x, SameTypeAndValue(minutes(180)));
 }
 
 TEST(Quantity, ImplicitConstructionFromLvalueCorrespondingQuantity) {
-    MyHours original{.value = 10};
+    MyHours original{10};
     const Quantity<Hours, int> converted = original;
     EXPECT_EQ(converted, hours(10));
 }
@@ -322,7 +322,7 @@ TEST(Quantity, ImplicitConversionToLvalueCorrespondingQuantity) {
 }
 
 TEST(AsQuantity, DeducesCorrespondingQuantity) {
-    constexpr auto q = as_quantity(MyHours{.value = 8});
+    constexpr auto q = as_quantity(MyHours{8});
     EXPECT_THAT(q, QuantityEquivalent(hours(8)));
 }
 

--- a/au/utility/string_constant.hh
+++ b/au/utility/string_constant.hh
@@ -105,9 +105,9 @@ constexpr std::size_t string_size(int64_t x) {
 template <std::size_t... Ns>
 constexpr std::size_t sum() {
     std::size_t result{0};
-    std::size_t values[] = {Ns...};
+    std::size_t values[] = {0u, Ns...};  // Dummy `0u` avoids empty array.
     for (std::size_t i = 0; i < sizeof...(Ns); ++i) {
-        result += values[i];
+        result += values[i + 1u];  // "+ 1u" to skip the dummy value.
     }
     return result;
 }

--- a/build/copts.bzl
+++ b/build/copts.bzl
@@ -16,6 +16,7 @@
 # -Wall is already set by aspect_gcc_toolchain.
 EXTRA_COPTS = [
     "-Wextra",
+    "-pedantic",
 ]
 
 # Since the clang toolchain we're using doesn't let us extract the default flags, we have to


### PR DESCRIPTION
Our godbolt link is broken!  https://godbolt.org/z/KrvfhP4M3

To fix this robustly, we add the `-pedantic` option to our builds.  We
put it in `EXTRA_COPTS` instead of `BASE_CLANG_COPTS` because otherwise,
the warning doesn't show up when we run this repro command:

```sh
bazel clean && bazel build --config=gcc //au:constant_test
```

This PR fixes all of the other warnings that started showing up when I
added this compiler option, too.  Interestingly, the godbolt-breaking
problem (extra `;`) seems like it shows up only for gcc's `-pedantic`
implementation, not clang's.