### PR TITLE
Add overflow helpers for applying rational to int

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -113,7 +113,10 @@ cc_test(
 cc_library(
     name = "apply_magnitude",
     hdrs = ["apply_magnitude.hh"],
-    deps = [":magnitude"],
+    deps = [
+        ":apply_rational_magnitude_to_integral",
+        ":magnitude",
+    ],
 )
 
 cc_test(
@@ -123,6 +126,23 @@ cc_test(
     copts = ["-Iexternal/gtest/include"],
     deps = [
         ":apply_magnitude",
+        ":testing",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "apply_rational_magnitude_to_integral",
+    hdrs = ["apply_rational_magnitude_to_integral.hh"],
+    deps = [":magnitude"],
+)
+
+cc_test(
+    name = "apply_rational_magnitude_to_integral_test",
+    size = "small",
+    srcs = ["apply_rational_magnitude_to_integral_test.cc"],
+    deps = [
+        ":apply_rational_magnitude_to_integral",
         ":testing",
         "@com_google_googletest//:gtest_main",
     ],

--- a/au/apply_magnitude.hh
+++ b/au/apply_magnitude.hh
@@ -164,7 +164,8 @@ struct ApplyMagnitudeImpl<Mag, ApplyAs::RATIONAL_MULTIPLY, T, true> {
                   "Mismatched instantiation (should never be done manually)");
 
     constexpr T operator()(const T &x) {
-        return x * get_value<T>(numerator(Mag{})) / get_value<T>(denominator(Mag{}));
+        return static_cast<T>(x * get_value<T>(numerator(Mag{})) /
+                              get_value<T>(denominator(Mag{})));
     }
 
     static constexpr bool would_overflow(const T &x) {

--- a/au/apply_magnitude.hh
+++ b/au/apply_magnitude.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "au/apply_rational_magnitude_to_integral.hh"
 #include "au/magnitude.hh"
 
 namespace au {
@@ -132,6 +133,28 @@ struct ApplyMagnitudeImpl<Mag, ApplyAs::INTEGER_DIVIDE, T, is_T_integral> {
     }
 };
 
+template <typename T, typename Mag, bool is_T_signed>
+struct RationalOverflowChecker;
+template <typename T, typename Mag>
+struct RationalOverflowChecker<T, Mag, true> {
+    static constexpr bool would_overflow(const T &x) {
+        static_assert(std::is_signed<T>::value,
+                      "Mismatched instantiation (should never be done manually)");
+        const bool safe = (x <= MaxNonOverflowingValue<T, Mag>::value()) &&
+                          (x >= MinNonOverflowingValue<T, Mag>::value());
+        return !safe;
+    }
+};
+template <typename T, typename Mag>
+struct RationalOverflowChecker<T, Mag, false> {
+    static constexpr bool would_overflow(const T &x) {
+        static_assert(!std::is_signed<T>::value,
+                      "Mismatched instantiation (should never be done manually)");
+        const bool safe = (x <= MaxNonOverflowingValue<T, Mag>::value());
+        return !safe;
+    }
+};
+
 // Applying a (non-integer, non-inverse-integer) rational, for any integral type T.
 template <typename Mag, typename T>
 struct ApplyMagnitudeImpl<Mag, ApplyAs::RATIONAL_MULTIPLY, T, true> {
@@ -145,9 +168,7 @@ struct ApplyMagnitudeImpl<Mag, ApplyAs::RATIONAL_MULTIPLY, T, true> {
     }
 
     static constexpr bool would_overflow(const T &x) {
-        constexpr auto mag_value_result = get_value_result<T>(numerator(Mag{}));
-        return OverflowChecker<T, mag_value_result.outcome == MagRepresentationOutcome::OK>::
-            would_product_overflow(x, mag_value_result.value);
+        return RationalOverflowChecker<T, Mag, std::is_signed<T>::value>::would_overflow(x);
     }
 
     static constexpr bool would_truncate(const T &x) {

--- a/au/apply_magnitude.hh
+++ b/au/apply_magnitude.hh
@@ -164,8 +164,9 @@ struct ApplyMagnitudeImpl<Mag, ApplyAs::RATIONAL_MULTIPLY, T, true> {
                   "Mismatched instantiation (should never be done manually)");
 
     constexpr T operator()(const T &x) {
-        return static_cast<T>(x * get_value<T>(numerator(Mag{})) /
-                              get_value<T>(denominator(Mag{})));
+        using P = PromotedType<T>;
+        return static_cast<T>(x * get_value<P>(numerator(Mag{})) /
+                              get_value<P>(denominator(Mag{})));
     }
 
     static constexpr bool would_overflow(const T &x) {

--- a/au/apply_magnitude_test.cc
+++ b/au/apply_magnitude_test.cc
@@ -196,10 +196,8 @@ TEST(WouldOverflow, AlwaysFalseForIntegerDivide) {
 }
 
 TEST(WouldOverflow, UsesNumeratorWhenApplyingRationalMagnitudeToIntegralType) {
-    auto TWO_THIRDS = mag<2>() / mag<3>();
-
     {
-        using ApplyTwoThirdsToI32 = ApplyMagnitudeT<int32_t, decltype(TWO_THIRDS)>;
+        using ApplyTwoThirdsToI32 = ApplyMagnitudeT<int32_t, decltype(mag<2>() / mag<3>())>;
 
         EXPECT_TRUE(ApplyTwoThirdsToI32::would_overflow(2'147'483'647));
         EXPECT_TRUE(ApplyTwoThirdsToI32::would_overflow(1'073'741'824));
@@ -215,14 +213,18 @@ TEST(WouldOverflow, UsesNumeratorWhenApplyingRationalMagnitudeToIntegralType) {
     }
 
     {
-        using ApplyTwoThirdsToU8 = ApplyMagnitudeT<uint8_t, decltype(TWO_THIRDS)>;
+        using ApplyRoughlyOneThirdToU8 =
+            ApplyMagnitudeT<uint8_t, decltype(mag<100'000'000>() / mag<300'000'001>())>;
 
-        EXPECT_TRUE(ApplyTwoThirdsToU8::would_overflow(255));
-        EXPECT_TRUE(ApplyTwoThirdsToU8::would_overflow(128));
+        ASSERT_TRUE((std::is_same<decltype(uint8_t{} * uint8_t{}), int32_t>::value))
+            << "This test fails on architectures where `uint8_t` doesn't get promoted to `int32_t`";
 
-        EXPECT_FALSE(ApplyTwoThirdsToU8::would_overflow(127));
-        EXPECT_FALSE(ApplyTwoThirdsToU8::would_overflow(1));
-        EXPECT_FALSE(ApplyTwoThirdsToU8::would_overflow(0));
+        EXPECT_TRUE(ApplyRoughlyOneThirdToU8::would_overflow(255));
+        EXPECT_TRUE(ApplyRoughlyOneThirdToU8::would_overflow(22));
+
+        EXPECT_FALSE(ApplyRoughlyOneThirdToU8::would_overflow(21));
+        EXPECT_FALSE(ApplyRoughlyOneThirdToU8::would_overflow(1));
+        EXPECT_FALSE(ApplyRoughlyOneThirdToU8::would_overflow(0));
     }
 }
 

--- a/au/apply_rational_magnitude_to_integral.hh
+++ b/au/apply_rational_magnitude_to_integral.hh
@@ -105,14 +105,13 @@ constexpr bool is_known_to_be_less_than_one(Magnitude<BPs...> m) {
 //
 
 //
-// Branch based on whether the denominator of `MagT` can fit in the promoted type of `T`.
+// Branch based on whether `MagT` is less than 1.
 //
 template <typename T, typename MagT, bool IsMagLessThanOne>
 struct MaxNonOverflowingValueImplWhenNumFits;
 
-// If the denominator of `MagT` is bigger than a known-to-fit numerator --- regardless of whether or
-// not that denominator is representable --- then we only need to check for the limiting value where
-// the _numerator multiplication step alone_ would overflow.
+// If `MagT` is less than 1, then we only need to check for the limiting value where the _numerator
+// multiplication step alone_ would overflow.
 template <typename T, typename MagT>
 struct MaxNonOverflowingValueImplWhenNumFits<T, MagT, true> {
     using P = PromotedType<T>;
@@ -123,9 +122,9 @@ struct MaxNonOverflowingValueImplWhenNumFits<T, MagT, true> {
     }
 };
 
-// If the denominator is smaller than a known-to-fit numerator, then we have two opportunities for
-// overflow: the numerator multiplication step can overflow the promoted type; or, the denominator
-// division step can fail to restore it to the original type's range.
+// If `MagT` is greater than 1, then we have two opportunities for overflow: the numerator
+// multiplication step can overflow the promoted type; or, the denominator division step can fail to
+// restore it to the original type's range.
 template <typename T, typename MagT>
 struct MaxNonOverflowingValueImplWhenNumFits<T, MagT, false> {
     using P = PromotedType<T>;
@@ -185,14 +184,13 @@ struct MaxNonOverflowingValue
 //
 
 //
-// Branch based on whether the denominator of `MagT` can fit in the promoted type of `T`.
+// Branch based on whether `MagT` is less than 1.
 //
 template <typename T, typename MagT, bool IsMagLessThanOne>
 struct MinNonOverflowingValueImplWhenNumFits;
 
-// If the denominator of `MagT` is bigger than a known-to-fit numerator --- regardless of whether or
-// not that denominator is representable --- then we only need to check for the limiting value where
-// the _numerator multiplication step alone_ would overflow.
+// If `MagT` is less than 1, then we only need to check for the limiting value where the _numerator
+// multiplication step alone_ would overflow.
 template <typename T, typename MagT>
 struct MinNonOverflowingValueImplWhenNumFits<T, MagT, true> {
     using P = PromotedType<T>;
@@ -203,9 +201,9 @@ struct MinNonOverflowingValueImplWhenNumFits<T, MagT, true> {
     }
 };
 
-// If the denominator is smaller than a known-to-fit numerator, then we have two opportunities for
-// overflow: the numerator multiplication step can overflow the promoted type; or, the denominator
-// division step can fail to restore it to the original type's range.
+// If `MagT` is greater than 1, then we have two opportunities for overflow: the numerator
+// multiplication step can overflow the promoted type; or, the denominator division step can fail to
+// restore it to the original type's range.
 template <typename T, typename MagT>
 struct MinNonOverflowingValueImplWhenNumFits<T, MagT, false> {
     using P = PromotedType<T>;

--- a/au/apply_rational_magnitude_to_integral.hh
+++ b/au/apply_rational_magnitude_to_integral.hh
@@ -1,0 +1,253 @@
+// Copyright 2023 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+
+#include "au/magnitude.hh"
+#include "au/stdx/utility.hh"
+
+// This file exists to analyze one single calculation: `x * N / D`, where `x` is
+// some integral type, and `N` and `D` are the numerator and denominator of a
+// rational magnitude (and hence, are automatically in lowest terms),
+// represented in that same type.  We want to answer one single question: will
+// this calculation overflow at any stage?
+//
+// Importantly, we need to produce correct answers even when `N` and/or `D`
+// _cannot be represented_ in that type (because they would overflow).  We also
+// need to handle subtleties around integer promotion, where the type of `x * x`
+// can be different from the type of `x` when those types are small.
+//
+// The goal for the final solution we produce is to be as fast and efficient as
+// the best such function that an expert C++ engineer could produce by hand, for
+// every combination of integral type and numerator and denominator magnitudes.
+
+namespace au {
+namespace detail {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// `PromotedType<T>` is the result type for arithmetic operations involving `T`.  Of course, this is
+// normally just `T`, but integer promotion for small integral types can change this.
+//
+template <typename T>
+struct PromotedTypeImpl {
+    using type = decltype(std::declval<T>() * std::declval<T>());
+
+    static_assert(std::is_same<type, typename PromotedTypeImpl<type>::type>::value,
+                  "We explicitly assume that promoted types are not again promotable");
+};
+template <typename T>
+using PromotedType = typename PromotedTypeImpl<T>::type;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// `clamp_to_range_of<T>(x)` returns `x` if it is in the range of `T`, and otherwise returns the
+// maximum value representable in `T` if `x` is too large, or the minimum value representable in `T`
+// if `x` is too small.
+//
+
+template <typename T, typename U>
+constexpr T clamp_to_range_of(U x) {
+    return stdx::cmp_greater(x, std::numeric_limits<T>::max())
+               ? std::numeric_limits<T>::max()
+               : (stdx::cmp_less(x, std::numeric_limits<T>::lowest())
+                      ? std::numeric_limits<T>::lowest()
+                      : static_cast<T>(x));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// `is_known_to_be_less_than_one(MagT)` is true if the magnitude `MagT` is purely rational; its
+// numerator is representable in `std::uintmax_t`; and, it is less than 1.
+//
+
+template <typename... BPs>
+constexpr bool is_known_to_be_less_than_one(Magnitude<BPs...> m) {
+    using MagT = Magnitude<BPs...>;
+    static_assert(is_rational(m), "Magnitude must be rational");
+
+    constexpr auto num_result = get_value_result<std::uintmax_t>(numerator(MagT{}));
+    static_assert(num_result.outcome == MagRepresentationOutcome::OK,
+                  "Magnitude must be representable in std::uintmax_t");
+
+    constexpr auto den_result = get_value_result<std::uintmax_t>(denominator(MagT{}));
+    static_assert(
+        den_result.outcome == MagRepresentationOutcome::OK ||
+            den_result.outcome == MagRepresentationOutcome::ERR_CANNOT_FIT,
+        "Magnitude must either be representable in std::uintmax_t, or fail due to overflow");
+
+    return den_result.outcome == MagRepresentationOutcome::OK ? num_result.value < den_result.value
+                                                              : true;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// `MaxNonOverflowingValue<T, MagT>` is the maximum value of type `T` that can have `MagT` applied
+// as numerator-and-denominator without overflowing.  We require that `T` is some integral
+// arithmetic type, and that `MagT` is a rational magnitude that is neither purely integral nor
+// purely inverse-integral.
+//
+// If you are trying to understand these helpers, we suggest starting at the bottom with
+// `MaxNonOverflowingValue`, and reading upwards.
+//
+
+//
+// Branch based on whether the denominator of `MagT` can fit in the promoted type of `T`.
+//
+template <typename T, typename MagT, bool IsMagLessThanOne>
+struct MaxNonOverflowingValueImplWhenNumFits;
+
+// If the denominator of `MagT` is bigger than a known-to-fit numerator --- regardless of whether or
+// not that denominator is representable --- then we only need to check for the limiting value where
+// the _numerator multiplication step alone_ would overflow.
+template <typename T, typename MagT>
+struct MaxNonOverflowingValueImplWhenNumFits<T, MagT, true> {
+    using P = PromotedType<T>;
+
+    static constexpr T value() {
+        return clamp_to_range_of<T>(std::numeric_limits<P>::max() /
+                                    get_value<P>(numerator(MagT{})));
+    }
+};
+
+// If the denominator is smaller than a known-to-fit numerator, then we have two opportunities for
+// overflow: the numerator multiplication step can overflow the promoted type; or, the denominator
+// division step can fail to restore it to the original type's range.
+template <typename T, typename MagT>
+struct MaxNonOverflowingValueImplWhenNumFits<T, MagT, false> {
+    using P = PromotedType<T>;
+
+    static constexpr T value() {
+        constexpr auto num = get_value<P>(numerator(MagT{}));
+        constexpr auto den = get_value<P>(denominator(MagT{}));
+        constexpr auto t_max = std::numeric_limits<T>::max();
+        constexpr auto p_max = std::numeric_limits<P>::max();
+        constexpr auto limit_to_avoid = (den > p_max / t_max) ? p_max : t_max * den;
+        return clamp_to_range_of<T>(limit_to_avoid / num);
+    }
+};
+
+//
+// Branch based on whether the numerator of `MagT` can fit in the promoted type of `T`.
+//
+template <typename T, typename MagT, MagRepresentationOutcome NumOutcome>
+struct MaxNonOverflowingValueImpl;
+
+// If the numerator fits in the promoted type of `T`, delegate further based on whether the
+// denominator is bigger.
+template <typename T, typename MagT>
+struct MaxNonOverflowingValueImpl<T, MagT, MagRepresentationOutcome::OK>
+    : MaxNonOverflowingValueImplWhenNumFits<T, MagT, is_known_to_be_less_than_one(MagT{})> {};
+
+// If `MagT` can't be represented in the promoted type of `T`, then the result is 0.
+template <typename T, typename MagT>
+struct MaxNonOverflowingValueImpl<T, MagT, MagRepresentationOutcome::ERR_CANNOT_FIT> {
+    static constexpr T value() { return T{0}; }
+};
+
+template <typename T, typename MagT>
+struct ValidateTypeAndMagnitude {
+    static_assert(std::is_integral<T>::value, "Only designed for integral types");
+    static_assert(is_rational(MagT{}), "Magnitude must be rational");
+    static_assert(!is_integer(MagT{}), "Magnitude must not be purely integral");
+    static_assert(!is_integer(inverse(MagT{})), "Magnitude must not be purely inverse-integral");
+};
+
+template <typename T, typename MagT>
+struct MaxNonOverflowingValue
+    : ValidateTypeAndMagnitude<T, MagT>,
+      MaxNonOverflowingValueImpl<T,
+                                 MagT,
+                                 get_value_result<PromotedType<T>>(numerator(MagT{})).outcome> {};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// `MinNonOverflowingValue<T, MagT>` is the minimum (i.e., most-negative) value of type `T` that can
+// have `MagT` applied as numerator-and-denominator without overflowing (i.e., becoming too-negative
+// to represent).  We require that `T` is some integral arithmetic type, and that `MagT` is a
+// rational magnitude that is neither purely integral nor purely inverse-integral.
+//
+// If you are trying to understand these helpers, we suggest starting at the bottom with
+// `MinNonOverflowingValue`, and reading upwards.
+//
+
+//
+// Branch based on whether the denominator of `MagT` can fit in the promoted type of `T`.
+//
+template <typename T, typename MagT, bool IsMagLessThanOne>
+struct MinNonOverflowingValueImplWhenNumFits;
+
+// If the denominator of `MagT` is bigger than a known-to-fit numerator --- regardless of whether or
+// not that denominator is representable --- then we only need to check for the limiting value where
+// the _numerator multiplication step alone_ would overflow.
+template <typename T, typename MagT>
+struct MinNonOverflowingValueImplWhenNumFits<T, MagT, true> {
+    using P = PromotedType<T>;
+
+    static constexpr T value() {
+        return clamp_to_range_of<T>(std::numeric_limits<P>::lowest() /
+                                    get_value<P>(numerator(MagT{})));
+    }
+};
+
+// If the denominator is smaller than a known-to-fit numerator, then we have two opportunities for
+// overflow: the numerator multiplication step can overflow the promoted type; or, the denominator
+// division step can fail to restore it to the original type's range.
+template <typename T, typename MagT>
+struct MinNonOverflowingValueImplWhenNumFits<T, MagT, false> {
+    using P = PromotedType<T>;
+
+    static constexpr T value() {
+        constexpr auto num = get_value<P>(numerator(MagT{}));
+        constexpr auto den = get_value<P>(denominator(MagT{}));
+        constexpr auto t_min = std::numeric_limits<T>::lowest();
+        constexpr auto p_min = std::numeric_limits<P>::lowest();
+        constexpr auto limit_to_avoid = (den > p_min / t_min) ? p_min : t_min * den;
+        return clamp_to_range_of<T>(limit_to_avoid / num);
+    }
+};
+
+//
+// Branch based on whether the denominator of `MagT` can fit in the promoted type of `T`.
+//
+template <typename T, typename MagT, MagRepresentationOutcome NumOutcome>
+struct MinNonOverflowingValueImpl;
+
+// If the numerator fits in the promoted type of `T`, delegate further based on whether the
+// denominator is bigger.
+template <typename T, typename MagT>
+struct MinNonOverflowingValueImpl<T, MagT, MagRepresentationOutcome::OK>
+    : MinNonOverflowingValueImplWhenNumFits<T, MagT, is_known_to_be_less_than_one(MagT{})> {};
+
+// If the numerator can't be represented in the promoted type of `T`, then the result is 0.
+template <typename T, typename MagT>
+struct MinNonOverflowingValueImpl<T, MagT, MagRepresentationOutcome::ERR_CANNOT_FIT> {
+    static constexpr T value() { return T{0}; }
+};
+
+template <typename T, typename MagT>
+struct MinNonOverflowingValue
+    : ValidateTypeAndMagnitude<T, MagT>,
+      MinNonOverflowingValueImpl<T,
+                                 MagT,
+                                 get_value_result<PromotedType<T>>(numerator(MagT{})).outcome> {
+    static_assert(std::is_signed<T>::value, "Only designed for signed types");
+    static_assert(std::is_signed<PromotedType<T>>::value,
+                  "We assume the promoted type is also signed");
+};
+
+}  // namespace detail
+}  // namespace au

--- a/au/apply_rational_magnitude_to_integral_test.cc
+++ b/au/apply_rational_magnitude_to_integral_test.cc
@@ -1,0 +1,376 @@
+// Copyright 2023 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/apply_rational_magnitude_to_integral.hh"
+
+#include "au/testing.hh"
+#include "gtest/gtest.h"
+
+using ::testing::AllOf;
+using ::testing::Lt;
+using ::testing::StaticAssertTypeEq;
+
+namespace au {
+namespace detail {
+namespace {
+
+template <typename... BPs>
+constexpr void ensure_relevant_kind_of_magnitude(Magnitude<BPs...> m) {
+    static_assert(is_rational(m), "Magnitude must be rational");
+    static_assert(!is_integer(m), "Magnitude must not be purely integer");
+    static_assert(!is_integer(ONE / m), "Magnitude must not be purely inverse-integer");
+}
+
+TEST(PromotedType, IdentityForInt) {
+    // `int` does not undergo type promotion.
+    StaticAssertTypeEq<int, PromotedType<int>>();
+}
+
+TEST(PromotedType, PromotesUint8TIntoLargerType) {
+    using PromotedU8 = PromotedType<uint8_t>;
+
+    // Technically, this need not be true on every conceivable architecture.  However, it is true on
+    // the vast majority that are used in practice.  Moreover, the failure mode if it's not is
+    // simply that a test would fail when run on some obscure architecture, and the failure would
+    // direct the user to this comment.  This doesn't affect the actual library usage one way or
+    // another.
+    ASSERT_FALSE((std::is_same<uint8_t, PromotedU8>::value));
+
+    EXPECT_GT(sizeof(PromotedU8), sizeof(uint8_t));
+}
+
+TEST(IsKnownToBeLessThanOne, ProducesExpectedResultsForMagnitudesThatCanFitInUintmax) {
+    EXPECT_TRUE(is_known_to_be_less_than_one(mag<1>() / mag<2>()));
+    EXPECT_TRUE(is_known_to_be_less_than_one(mag<999'999>() / mag<1'000'000>()));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Test cases for maximum non-overflowing value.
+//
+// What are the canonical representative situations for the overflow boundary of `x * N / D`, where
+// `x` has type `T`, `TM` is the maximum value of type `T`, and `PM` is the maximum value of type
+// `PromotedType<T>`?  We list them here.  Note that they're listed in a kind of "if/else-if" order:
+// each number's condition assumes that all of the previous conditions are false.  (So for a test
+// case to fall into category "3", it can't be in category "1" or "2".)
+//
+// 1. `N` cannot fit inside `PromotedType<T>`.  This means any nonzero value always overflows: the
+//    max is 0.
+//
+// 2. `N < D` (whether or not `D` can fit inside `PromotedType<T>`).  This means that the final
+//    result will be smaller than the input, and therefore will always fit inside `T` --- as long as
+//    the intermediate calculation `(x * N)` doesn't overflow.  So the maximum non-overflowing value
+//    is `min(PM / N, TM)`.
+//
+// 3. `N > D` (all other cases).  The only step that can overflow is the multiplication with `N`.
+//    There are two conditions we must meet to avoid overflow.  First, we must avoid going over the
+//    limit of the promoted type.  Second, we must ensure that the product is within the limits of
+//    the original type after dividing by `D`.  So the maximum non-overflowing value is the smaller
+//    of `PM` and `TM * D`, divided by `N`.  (We'll have to be careful that the `TM * D` itself
+//    doesn't overflow!  We'll cap it at `PM` if it does.)
+
+enum class IsPromotable { NO, YES };
+enum class NumFitsInPromotedType { NO, YES };
+enum class DenFitsInPromotedType { NO, YES };
+struct TestSpec {
+    IsPromotable is_promotable;
+    NumFitsInPromotedType num_fits;
+    DenFitsInPromotedType den_fits;
+};
+
+template <typename T, typename MagT>
+void validate_spec(TestSpec spec) {
+    using PromotedT = PromotedType<T>;
+    const bool is_promotable = !std::is_same<T, PromotedT>::value;
+    const bool is_expected_to_be_promotable = (spec.is_promotable == IsPromotable::YES);
+    ASSERT_EQ(is_promotable, is_expected_to_be_promotable)
+        << "Expected a type that " << (is_expected_to_be_promotable ? "is" : "is not")
+        << " promotable; got a type that " << (is_promotable ? "is" : "is not");
+
+    using Num = decltype(numerator(MagT{}));
+    constexpr auto num_value_result = get_value_result<PromotedT>(Num{});
+    const bool is_num_representable = (num_value_result.outcome == MagRepresentationOutcome::OK);
+    const bool is_num_expected_to_be_representable = (spec.num_fits == NumFitsInPromotedType::YES);
+    ASSERT_EQ(is_num_representable, is_num_expected_to_be_representable)
+        << "Expected numerator " << (is_num_expected_to_be_representable ? "to be" : "not to be")
+        << " representable in promoted type; it " << (is_num_representable ? "is" : "is not");
+
+    using Den = decltype(denominator(MagT{}));
+    constexpr auto den_value_result = get_value_result<PromotedT>(Den{});
+    const bool is_den_representable = (den_value_result.outcome == MagRepresentationOutcome::OK);
+    const bool is_den_expected_to_be_representable = (spec.den_fits == DenFitsInPromotedType::YES);
+    ASSERT_EQ(is_den_representable, is_den_expected_to_be_representable)
+        << "Expected denominator " << (is_den_expected_to_be_representable ? "to be" : "not to be")
+        << " representable in promoted type; it " << (is_den_representable ? "is" : "is not");
+}
+
+template <typename T, typename MagT>
+void populate_max_non_overflowing_value(TestSpec spec, MagT, T &result_out) {
+    validate_spec<T, MagT>(spec);
+    result_out = MaxNonOverflowingValue<T, MagT>::value();
+}
+
+TEST(MaxNonOverflowingValue, AlwaysZeroIfNumCannotFitInPromotedType) {
+    // Case "1" above.
+    constexpr auto huge = pow<400>(mag<10>()) / mag<3>();
+
+    {
+        int max_int = 123;
+        populate_max_non_overflowing_value(
+            {IsPromotable::NO, NumFitsInPromotedType::NO, DenFitsInPromotedType::YES},
+            huge,
+            max_int);
+        EXPECT_EQ(max_int, 0);
+    }
+    {
+        uint16_t max_u16 = 123u;
+        populate_max_non_overflowing_value(
+            {IsPromotable::YES, NumFitsInPromotedType::NO, DenFitsInPromotedType::YES},
+            huge,
+            max_u16);
+        EXPECT_EQ(max_u16, 0);
+    }
+}
+
+TEST(MaxNonOverflowingValue, IsMaxTDividedByNWhenTIsNotPromotableAndDenomOverflows) {
+    // Case "2" above.  a) Overflowing denominator, non-promotable types only.
+    constexpr auto huge_denom = mag<3>() / pow<400>(mag<10>());
+
+    {
+        int max_int = 0;
+        populate_max_non_overflowing_value(
+            {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
+            huge_denom,
+            max_int);
+        EXPECT_EQ(max_int, std::numeric_limits<int>::max() / 3);
+    }
+
+    {
+        uint64_t max_u64 = 0;
+        populate_max_non_overflowing_value(
+            {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
+            huge_denom,
+            max_u64);
+        EXPECT_EQ(max_u64, std::numeric_limits<uint64_t>::max() / 3);
+    }
+}
+
+TEST(MaxNonOverflowingValue,
+     IsSmallerOfMaxPromotedTDividedByNAndMaxTWhenTIsPromotableAndDenomOverflows) {
+    // Case "2" above.  b) Overflowing denominator, promotable types.
+    {
+        int8_t max_i8 = 0;
+        populate_max_non_overflowing_value(
+            {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
+            mag<3>() / pow<400>(mag<10>()),
+            max_i8);
+        EXPECT_EQ(max_i8, 127);
+    }
+
+    {
+        uint16_t max_u16 = 0;
+        populate_max_non_overflowing_value(
+            {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
+            mag<1'000'000>() / pow<400>(mag<11>()),
+            max_u16);
+
+        ASSERT_TRUE((std::is_same<PromotedType<uint16_t>, int32_t>::value))
+            << "This test will fail on architectures where uint16_t is not promoted to `int32_t`";
+        EXPECT_EQ(max_u16, 2'147);
+    }
+}
+
+TEST(MaxNonOverflowingValue,
+     IsSmallerOfMaxPromotedTDividedByNAndMaxTWhenTIsPromotableAndNLessThanD) {
+    // Case "2" above.  c) Non-overflowing denominator.
+
+    {
+        uint8_t max_u8 = 0;
+        populate_max_non_overflowing_value(
+            {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
+            mag<3>() / mag<10>(),
+            max_u8);
+        EXPECT_EQ(max_u8, 255);
+    }
+
+    {
+        uint16_t max_u16 = 0;
+        populate_max_non_overflowing_value(
+            {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
+            mag<1'000'000>() / pow<6>(mag<11>()),
+            max_u16);
+        EXPECT_EQ(max_u16, 2'147);
+    }
+}
+
+TEST(MaxNonOverflowingValue, IsPromotedMaxOverNWhenNIsLargeAndDIsSlightlySmaller) {
+    // Case 3 above (partial).
+    //
+    // When `N / D` is very slightly larger than 1, then (PM / N) can be the most constraining.
+    // We'll use a promoted type just to make this interesting by making PM different from TM.
+    uint16_t max_u16 = 0;
+    populate_max_non_overflowing_value(
+        {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
+        mag<1'000'000>() / mag<999'999>(),
+        max_u16);
+    ASSERT_TRUE((std::is_same<PromotedType<uint16_t>, int32_t>::value))
+        << "This test will fail on architectures where `uint16_t` is not promoted to `int32_t`";
+    EXPECT_EQ(max_u16, 2'147);
+}
+
+TEST(MaxNonOverflowingValue, IsTMaxOverNTimesDWhenMoreConstrainingThanPMaxOverN) {
+    // Case 3 above (partial).
+    //
+    // The goal is to engineer a test case where `(TM * D) / N` is more constraining than `PM / N`.
+    // Obviously, if `TM = PM`, then this can never be; therefore, we need to use a promotable type.
+    int16_t max_int16 = 0;
+    populate_max_non_overflowing_value(
+        {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
+        mag<1'000>() / mag<3>(),
+        max_int16);
+    ASSERT_TRUE((std::is_same<PromotedType<int16_t>, int32_t>::value))
+        << "This test will fail on architectures where `int16_t` is not promoted to `int32_t`";
+    ASSERT_EQ(98, 32'768 * 3 / 1'000);
+    EXPECT_EQ(max_int16, 98);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Test cases for minimum (i.e. most-negative) non-overflowing value.
+//
+// The test cases are the mirror image of the above, except that we only check signed types.
+
+template <typename T, typename MagT>
+void populate_min_non_overflowing_value(TestSpec spec, MagT, T &result_out) {
+    validate_spec<T, MagT>(spec);
+    result_out = MinNonOverflowingValue<T, MagT>::value();
+}
+
+TEST(MinNonOverflowingValue, AlwaysZeroIfNumCannotFitInPromotedType) {
+    constexpr auto huge = pow<400>(mag<10>()) / mag<3>();
+
+    {
+        int min_int = 123;
+        populate_min_non_overflowing_value(
+            {IsPromotable::NO, NumFitsInPromotedType::NO, DenFitsInPromotedType::YES},
+            huge,
+            min_int);
+        EXPECT_EQ(min_int, 0);
+    }
+
+    {
+        int16_t min_i16 = 123;
+        populate_min_non_overflowing_value(
+            {IsPromotable::YES, NumFitsInPromotedType::NO, DenFitsInPromotedType::YES},
+            huge,
+            min_i16);
+        EXPECT_EQ(min_i16, 0);
+    }
+}
+
+TEST(MinNonOverflowingValue, IsMinTDividedByNWhenTIsNotPromotableAndDenomOverflows) {
+    constexpr auto huge_denom = mag<3>() / pow<400>(mag<10>());
+
+    {
+        int min_int = 0;
+        populate_min_non_overflowing_value(
+            {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
+            huge_denom,
+            min_int);
+        EXPECT_EQ(min_int, std::numeric_limits<int>::lowest() / 3);
+    }
+
+    {
+        int64_t min_i64 = 0;
+        populate_min_non_overflowing_value(
+            {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
+            huge_denom,
+            min_i64);
+        EXPECT_EQ(min_i64, std::numeric_limits<int64_t>::lowest() / 3);
+    }
+}
+
+TEST(MinNonOverflowingValue,
+     IsSmallerOfMinPromotedTDividedByNAndMinTWhenTIsPromotableAndDenomOverflows) {
+    {
+        int8_t min_i8 = 0;
+        populate_min_non_overflowing_value(
+            {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
+            mag<3>() / pow<400>(mag<10>()),
+            min_i8);
+        EXPECT_EQ(min_i8, -128);
+    }
+
+    {
+        int16_t min_i16 = 0;
+        populate_min_non_overflowing_value(
+            {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
+            mag<1'000'000>() / pow<400>(mag<11>()),
+            min_i16);
+
+        ASSERT_TRUE((std::is_same<PromotedType<int16_t>, int32_t>::value))
+            << "This test will fail on architectures where `int16_t` is not promoted to `int32_t`";
+        EXPECT_EQ(min_i16, -2'147);
+    }
+}
+
+TEST(MinNonOverflowingValue,
+     IsSmallerOfMinPromotedTDividedByNAndMinTWhenTIsPromotableAndNLessThanD) {
+
+    {
+        int8_t min_i8 = 0;
+        populate_min_non_overflowing_value(
+            {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
+            mag<3>() / mag<10>(),
+            min_i8);
+        EXPECT_EQ(min_i8, -128);
+    }
+
+    {
+        int16_t min_i16 = 0;
+        populate_min_non_overflowing_value(
+            {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
+            mag<1'000'000>() / pow<6>(mag<11>()),
+            min_i16);
+        EXPECT_EQ(min_i16, -2'147);
+    }
+}
+
+TEST(MinNonOverflowingValue, IsPromotedMinOverNWhenNIsLargeAndDIsSlightlySmaller) {
+    // When `N / D` is very slightly larger than 1, then (PM / N) can be the most constraining.
+    // We'll use a promoted type just to make this interesting by making PM different from TM.
+    int16_t min_i16 = 0;
+    populate_min_non_overflowing_value(
+        {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
+        mag<1'000'000>() / mag<999'999>(),
+        min_i16);
+
+    ASSERT_TRUE((std::is_same<PromotedType<int16_t>, int32_t>::value))
+        << "This test will fail on architectures where `int16_t` is not promoted to `int32_t`";
+    EXPECT_EQ(min_i16, -2'147);
+}
+
+TEST(MinNonOverflowingValue, IsTMinOverNTimesDWhenMoreConstrainingThanPMinOverN) {
+    // The goal is to engineer a test case where `(TM * D) / N` is more constraining than `PM / N`.
+    // Obviously, if `TM = PM`, then this can never be; therefore, we need to use a promotable type.
+    int16_t min_int16 = 0;
+    populate_min_non_overflowing_value(
+        {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
+        mag<1'000>() / mag<3>(),
+        min_int16);
+    ASSERT_EQ(-98, -32'768 * 3 / 1'000);
+    EXPECT_EQ(min_int16, -98);
+}
+
+}  // namespace
+}  // namespace detail
+}  // namespace au

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -33,10 +33,16 @@ constexpr auto miles = QuantityMaker<Miles>{};
 struct Inches : decltype(Feet{} / mag<12>()) {};
 constexpr auto inches = QuantityMaker<Inches>{};
 
-struct Yards : decltype(Feet{} * mag<3>()) {};
+struct Yards : decltype(Feet{} * mag<3>()) {
+    static constexpr const char label[] = "yd";
+};
+constexpr const char Yards::label[];
 constexpr auto yards = QuantityMaker<Yards>{};
 
-struct Meters : decltype(Inches{} * mag<100>() / mag<254>() * mag<100>()) {};
+struct Meters : decltype(Inches{} * mag<100>() / mag<254>() * mag<100>()) {
+    static constexpr const char label[] = "m";
+};
+constexpr const char Meters::label[];
 static constexpr QuantityMaker<Meters> meters{};
 static_assert(are_units_quantity_equivalent(Centi<Meters>{} * mag<254>(), Inches{} * mag<100>()),
               "Double-check this ad hoc definition of meters");


### PR DESCRIPTION
C++'s integer promotion rules for small types make this specific use
case --- applying a rational magnitude to an integral type --- really
interesting!  The product type can be bigger than the type of the two
inputs, so the overflow might not happen when you think it should.
_Moreover,_ the fact that we subsequently divide by a denominator means
that we can _re-enter_ the valid range and still produce a correct
result!

The only way I know how to deal with something this complicated is to
make a separate target that does only that one thing.  Happily, it's
still the case that there is some maximum and minimum value for each
type that will not overflow for a particular rational magnitude.  The
new helper target exists to figure out what those limits are.

I exposed this limitation by adding a conversion between meters and
yards in `uint16_t`.  This is a great test case because the unit ratio
between meters and yards is very close to 1 (it's 1143 to 1250), meaning
the denominator division "rescues" the great majority of cases.
Moreover, the multiplicative factor (either 1143 or 1250 depending on
direction) is far less than the ratio between `uint16_t` and its
promoted type, assuming the latter is equivalent to `int32_t`.  So,
despite the fact that we're multiplying by a number which is pretty
large relative to the type, we almost never actually overflow!

I fixed up the test case so that if it _does_ fail (say, we add some new
unit conversion that exposes a new logic error), it will be very easy to
understand why.