### PR TITLE
Rename `pip_deps` to `au_pip_deps`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@pip_deps//:requirements.bzl", "requirement")
+load("@au_pip_deps//:requirements.bzl", "requirement")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -144,12 +144,12 @@ load("@python3_10//:defs.bzl", "interpreter")
 load("@rules_python//python:pip.bzl", "pip_parse")
 
 pip_parse(
-    name = "pip_deps",
+    name = "au_pip_deps",
     python_interpreter_target = interpreter,
     requirements_lock = "@//:requirements_lock.txt",
 )
 
-load("@pip_deps//:requirements.bzl", "install_deps")
+load("@au_pip_deps//:requirements.bzl", "install_deps")
 
 install_deps()
 


### PR DESCRIPTION
I was experimenting with importing au, but ran into a conflict with
rules_docker's `pip_deps` repository. This patch fixes the conflict by
switching to a more unique name.

Another solution is to switch to bzlmod completely, but that's more
work.