### PR TITLE
Correctly stream out quantities with a char Rep

### DIFF
--- a/au/io.hh
+++ b/au/io.hh
@@ -25,7 +25,7 @@ namespace au {
 // Streaming output support for Quantity types.
 template <typename U, typename R>
 std::ostream &operator<<(std::ostream &out, const Quantity<U, R> &q) {
-    out << q.in(U{}) << " " << unit_label(U{});
+    out << +q.in(U{}) << " " << unit_label(U{});
     return out;
 }
 

--- a/au/io_test.cc
+++ b/au/io_test.cc
@@ -61,6 +61,8 @@ TEST(StreamingOutput, PrintsValueAndUnitLabel) {
     EXPECT_EQ(stream_to_string((feet / milli(second))(1.25)), "1.25 ft / ms");
 }
 
+TEST(StreamingOutput, PrintValueRepChar) { EXPECT_EQ(stream_to_string(feet(char{3})), "3 ft"); }
+
 TEST(StreamingOutput, DistinguishesPointFromQuantityByAtSign) {
     EXPECT_EQ(stream_to_string(celsius_qty(20)), "20 deg C");
     EXPECT_EQ(stream_to_string(celsius_pt(20)), "@(20 deg C)");


### PR DESCRIPTION
Quantities that have a `char` `Rep` will have the resulting raw number
streamed as a `char`.  Given that a Quantity is a number, users would
expect that a the value would be streamed as the integral number, not
interpreted as a character code.