### PR TITLE
Perform QuantityPoint subtraction in target rep

### DIFF
--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -132,7 +132,8 @@ class QuantityPoint {
               typename NewUnit,
               typename = std::enable_if_t<IsUnit<NewUnit>::value>>
     constexpr NewRep in(NewUnit u) const {
-        return (x_ - OriginDisplacement<Unit, NewUnit>::value()).template in<NewRep>(u);
+        return (rep_cast<NewRep>(x_) - rep_cast<NewRep>(OriginDisplacement<Unit, NewUnit>::value()))
+            .template in<NewRep>(u);
     }
 
     template <typename NewUnit, typename = std::enable_if_t<IsUnit<NewUnit>::value>>

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -98,6 +98,11 @@ TEST(QuantityPoint, CanGetValueInDifferentUnits) {
     EXPECT_THAT(p.in(centi(meters_pt)), SameTypeAndValue(300));
 }
 
+TEST(QuantityPoint, IntermediateTypeIsSignedIfExplicitRepIsSigned) {
+    EXPECT_THAT(milli(kelvins_pt)(0u).coerce_as<int>(celsius_pt),
+                SameTypeAndValue(celsius_pt(-273)));
+}
+
 TEST(QuantityPoint, SupportsDirectAccessWithSameUnit) {
     auto p = celsius_pt(3);
     ++(p.data_in(Celsius{}));


### PR DESCRIPTION
If we don't do this, then converting from unsigned to signed of the same
size will perform the subtraction in the unsigned type.

Included a unit test that failed before the change, but passes with it.

Fixes #222.