### PR TITLE
Migrate to new home for LLVM toolchain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,11 +89,11 @@ http_archive(
     patches = [
         "@//:third_party/aspect_gcc_toolchain/0001-Expose-target_settings-and-set-std-c-14.patch",
     ],
-    sha256 = "e2e12202dd83f67d71101b24554044de25e1625d16b4b56bc453ecaa8f7c6bd0",
-    strip_prefix = "aspect-build-gcc-toolchain-ac745d4",
+    sha256 = "9c075a67d401d1aa8b4935cc520e9926b1926fba72c1ab609400b239c92f5639",
+    strip_prefix = "f0rmiga-gcc-toolchain-ac745d4",
     type = "tar.gz",
     urls = [
-        "https://github.com/aspect-build/gcc-toolchain/tarball/ac745d4685e2095cc4f057862800f3f0a473c201",
+        "https://github.com/f0rmiga/gcc-toolchain/tarball/ac745d4685e2095cc4f057862800f3f0a473c201",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,16 +29,16 @@ bazel_skylib_workspace()
 
 load("//build:copts.bzl", "BASE_CLANG_COPTS", "EXTRA_COPTS")
 
-BAZEL_TOOLCHAIN_REF = "056aeaa01900f5050a9fed9b11e2d365a684831a"
+BAZEL_TOOLCHAIN_RELEASE = "0.10.3"
 
-BAZEL_TOOLCHAIN_SHA = "93aa940bcaa2bfdd8153d4d029bad1ccc6c0601e29ffff3a23e1d89aba5f61fa"
+BAZEL_TOOLCHAIN_SHA = "b7cd301ef7b0ece28d20d3e778697a5e3b81828393150bed04838c0c52963a01"
 
 http_archive(
     name = "com_grail_bazel_toolchain",
-    canonical_id = BAZEL_TOOLCHAIN_REF,
+    canonical_id = BAZEL_TOOLCHAIN_RELEASE,
     sha256 = BAZEL_TOOLCHAIN_SHA,
-    strip_prefix = "bazel-toolchain-{ref}".format(ref = BAZEL_TOOLCHAIN_REF),
-    url = "https://github.com/grailbio/bazel-toolchain/archive/{ref}.tar.gz".format(ref = BAZEL_TOOLCHAIN_REF),
+    strip_prefix = "toolchains_llvm-{ref}".format(ref = BAZEL_TOOLCHAIN_RELEASE),
+    url = "https://github.com/bazel-contrib/toolchains_llvm/releases/download/{ref}/toolchains_llvm-{ref}.tar.gz".format(ref = BAZEL_TOOLCHAIN_RELEASE),
 )
 
 load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")

--- a/build/copts.bzl
+++ b/build/copts.bzl
@@ -21,7 +21,7 @@ EXTRA_COPTS = [
 
 # Since the clang toolchain we're using doesn't let us extract the default flags, we have to
 # manually specify the default flags here. These are copied from:
-# https://github.com/grailbio/bazel-toolchain/blob/069ee4e20ec605a6c76c1798658e17175b2eb35e/toolchain/cc_toolchain_config.bzl#L118
+# https://github.com/bazel-contrib/toolchains_llvm/blob/069ee4e20ec605a6c76c1798658e17175b2eb35e/toolchain/cc_toolchain_config.bzl#L118
 BASE_CLANG_COPTS = [
     "--target=x86_64-unknown-linux-gnu",
     # Security


### PR DESCRIPTION
The LLVM toolchain graduated from `grailbio/bazel-toolchain` to
`bazel-contrib/toolchains_llvm`.  Good for them!  Unfortunately, that
broke everyone's build who was using a `sha256` checksum, because GitHub
does not guarantee SHA stability for automatically generated artifacts.
(Remember when they [broke the world] in January 2023?)

We need to upgrade to the new repo location, which means changing the
SHA.  We would not like to be forced to do this again, so we'll want to
link to a concrete artifact, not an auto-generated one.  This means
moving from a particular commit hash to a named release, because the
`.tar.gz` file is attached to that release.  So we pick the latest one.

I followed and adapted the [0.10.3 instructions], using the "not
`bzlmod`" section.  I also grepped the repo for `grailbio`, and updated
a URL in some comments.  (I verified that the new URL gives the same
contents as the old one.)

But wait, there's more!  The `aspect-build/gcc-toolchain` repo _also_
migrated to a new home!  Now it lives with a particular individual
called `f0rmiga`, instead of the `aspect-build` bazel organization.  We
can't land code until we unbreak _all_ of the builds, so we need to fix
that in the same PR.  Here, I _don't_ want to migrate to a new release,
because (a) we have a patch on top of the specific commit that we had
been using, and (b) they don't even upload archive files for their
releases.

[broke the world]:
https://github.blog/2023-02-21-update-on-the-future-stability-of-source-code-archives-and-hashes/
[0.10.3 instructions]:
https://github.com/bazel-contrib/toolchains_llvm/releases/tag/0.10.3

Fixes #224.