### PR TITLE
Delete `ForbidsComposingWith` mixin

### DIFF
--- a/au/constant.hh
+++ b/au/constant.hh
@@ -40,8 +40,6 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
                   detail::ComposesWith<Constant, Unit, Constant, Constant>,
                   detail::ComposesWith<Constant, Unit, QuantityMaker, QuantityMaker>,
                   detail::ComposesWith<Constant, Unit, SingularNameFor, SingularNameFor>,
-                  detail::ForbidsComposingWith<Constant, Unit, QuantityPointMaker>,
-                  detail::ForbidsComposingWith<Constant, Unit, QuantityPoint>,
                   detail::CanScaleByMagnitude<Constant, Unit> {
     // Convert this constant to a Quantity of the given rep.
     template <typename T>

--- a/au/wrapper_operations.hh
+++ b/au/wrapper_operations.hh
@@ -217,30 +217,5 @@ struct CanScaleByMagnitude {
     }
 };
 
-//
-// A mixin to explicitly delete operations that we want to forbid.
-//
-template <template <typename U> class UnitWrapper,
-          typename Unit,
-          template <typename... Us>
-          class OtherWrapper>
-struct ForbidsComposingWith {
-    // (W * O), for wrapper W and wrapper O.
-    template <typename... Us>
-    friend constexpr void operator*(UnitWrapper<Unit>, OtherWrapper<Us...>) = delete;
-
-    // (W / O), for wrapper W and wrapper O.
-    template <typename... Us>
-    friend constexpr void operator/(UnitWrapper<Unit>, OtherWrapper<Us...>) = delete;
-
-    // (O * W), for wrapper W and wrapper O.
-    template <typename... Us>
-    friend constexpr void operator*(OtherWrapper<Us...>, UnitWrapper<Unit>) = delete;
-
-    // (O / W), for wrapper W and wrapper O.
-    template <typename... Us>
-    friend constexpr void operator/(OtherWrapper<Us...>, UnitWrapper<Unit>) = delete;
-};
-
 }  // namespace detail
 }  // namespace au

--- a/au/wrapper_operations_test.cc
+++ b/au/wrapper_operations_test.cc
@@ -31,8 +31,6 @@ struct UnitWrapper : MakesQuantityFromNumber<UnitWrapper, Unit>,
                      ScalesQuantity<UnitWrapper, Unit>,
                      ComposesWith<UnitWrapper, Unit, UnitWrapper, UnitWrapper>,
                      ComposesWith<UnitWrapper, Unit, QuantityMaker, QuantityMaker>,
-                     ForbidsComposingWith<UnitWrapper, Unit, QuantityPointMaker>,
-                     ForbidsComposingWith<UnitWrapper, Unit, QuantityPoint>,
                      CanScaleByMagnitude<UnitWrapper, Unit> {};
 
 TEST(MakesQuantityFromNumber, MakesQuantityWhenPostMultiplyingNumericValue) {


### PR DESCRIPTION
It causes problems with Apple Clang version 9, apparently.  I think this
compiler technically falls outside of our support window.  However, an
actual user is having issues with it, and I think `ForbidsComposingWith`
is adding only very marginal value anyway.  I tried deleting it and the
error messages became a couple of lines shorter, although perhaps less
direct (no more reference to "explicitly deleted").

Amusingly, I'm keeping the unit test for it around, because it's one of
those unfortunate "uncomment to test" deals, and the tests _will_ still
pass.  (We'll get compiler errors for doing unsupported operations.)

Fixes #226.