### PR TITLE
Explicitly specify `QuantityPoint` calc type

### DIFF
--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -195,6 +195,11 @@ TEST(QuantityPoint, CanCastToUnitWithDifferentOrigin) {
     EXPECT_THAT(celsius_pt(10).coerce_as(Kelvins{}), SameTypeAndValue(kelvins_pt(283)));
 }
 
+TEST(QuantityPoint, HandlesConversionWithSignedSourceAndUnsignedDestination) {
+    EXPECT_THAT(celsius_pt(int16_t{-5}).coerce_as<uint16_t>(kelvins_pt),
+                SameTypeAndValue(kelvins_pt(uint16_t{268})));
+}
+
 TEST(QuantityPoint, CoerceAsWillForceLossyConversion) {
     // Truncation.
     EXPECT_THAT(inches_pt(30).coerce_as(feet_pt), SameTypeAndValue(feet_pt(2)));
@@ -238,6 +243,12 @@ TEST(QuantityPoint, CoerceInExplicitRepSetsOutputType) {
     // Coerced unsigned overflow.
     ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
     EXPECT_THAT(feet_pt(30).coerce_in<uint8_t>(inches_pt), SameTypeAndValue(uint8_t{104}));
+}
+
+TEST(QuantityPoint, CoerceAsPerformsConversionInWidestType) {
+    constexpr QuantityPointU32<Milli<Kelvins>> temp = milli(kelvins_pt)(313'150u);
+    EXPECT_THAT(temp.coerce_as<uint16_t>(deci(kelvins_pt)),
+                SameTypeAndValue(deci(kelvins_pt)(uint16_t{3131})));
 }
 
 TEST(QuantityPoint, ComparisonsWorkAsExpected) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -253,6 +253,12 @@ TEST(Quantity, CoerceInExplicitRepSetsOutputType) {
     EXPECT_THAT(feet(30).coerce_in<uint8_t>(inches), SameTypeAndValue(uint8_t{104}));
 }
 
+TEST(Quantity, CoerceAsPerformsConversionInWidestType) {
+    constexpr QuantityU32<Milli<Meters>> length = milli(meters)(313'150u);
+    EXPECT_THAT(length.coerce_as<uint16_t>(deci(meters)),
+                SameTypeAndValue(deci(meters)(uint16_t{3131})));
+}
+
 TEST(Quantity, CanImplicitlyConvertToDifferentUnitOfSameDimension) {
     constexpr QuantityI32<Inches> x = yards(2);
     EXPECT_EQ(x.in(inches), 72);


### PR DESCRIPTION
We want to carry out our intermediate computations in the common type of
the old and new rep, generally.  However, we already know from #222 that
if the new rep is a signed integer, and the old rep is unsigned, we need
to be careful to use a signed type for intermediate computations.

To preserve this behaviour but restore correct behavoiur for other cases
(namely, #233), we add a new type trait for this intermediate type.  It
basically boils down to the common type, but with an explicit carve-out
to keep #222 fixed.  We explicitly cast both participants to this new
type-for-intermediate-computations, and then cast to the destination rep
at the end.

Compile time tests showed no discernible impact at all.  This change has
also passed all Aurora-internal builds.

Fixes #233.