### PR TITLE
Support `QuantityPoint` in rounding functions

### DIFF
--- a/au/math.hh
+++ b/au/math.hh
@@ -110,6 +110,9 @@ struct RoundingRep<Quantity<U, R>, RoundingUnits> {
     static_assert(std::is_same<decltype(std::floor(type{})), decltype(std::floor(R{}))>::value, "");
     static_assert(std::is_same<decltype(std::ceil(type{})), decltype(std::ceil(R{}))>::value, "");
 };
+template <typename U, typename R, typename RoundingUnits>
+struct RoundingRep<QuantityPoint<U, R>, RoundingUnits>
+    : RoundingRep<Quantity<U, R>, RoundingUnits> {};
 }  // namespace detail
 
 // The absolute value of a Quantity.
@@ -408,44 +411,73 @@ auto remainder(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
 }
 
 //
-// Round the value of this Quantity to the nearest integer in the given units.
+// Round the value of this Quantity or QuantityPoint to the nearest integer in the given units.
 //
 // This is the "Unit-only" format (i.e., `round_in(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
 auto round_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     using OurRoundingRep = detail::RoundingRepT<Quantity<U, R>, RoundingUnits>;
     return std::round(q.template in<OurRoundingRep>(rounding_units));
 }
+// b) Version for QuantityPoint.
+template <typename RoundingUnits, typename U, typename R>
+auto round_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    using OurRoundingRep = detail::RoundingRepT<QuantityPoint<U, R>, RoundingUnits>;
+    return std::round(p.template in<OurRoundingRep>(rounding_units));
+}
 
 //
-// Round the value of this Quantity to the nearest integer in the given units, returning OutputRep.
+// Round the value of this Quantity or QuantityPoint to the nearest integer in the given units,
+// returning OutputRep.
 //
 // This is the "Explicit-Rep" format (e.g., `round_in<int>(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto round_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     return static_cast<OutputRep>(round_in(rounding_units, q));
 }
+// b) Version for QuantityPoint.
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto round_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    return static_cast<OutputRep>(round_in(rounding_units, p));
+}
 
 //
-// The integral-valued Quantity, in this unit, nearest to the input.
+// The integral-valued Quantity or QuantityPoint, in this unit, nearest to the input.
 //
 // This is the "Unit-only" format (i.e., `round_as(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
 auto round_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return make_quantity<AssociatedUnitT<RoundingUnits>>(round_in(rounding_units, q));
 }
+// b) Version for QuantityPoint.
+template <typename RoundingUnits, typename U, typename R>
+auto round_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    return make_quantity_point<AssociatedUnitForPointsT<RoundingUnits>>(
+        round_in(rounding_units, p));
+}
 
 //
-// The integral-valued Quantity, in this unit, nearest to the input, using the specified OutputRep.
+// The integral-valued Quantity or QuantityPoint, in this unit, nearest to the input, using the
+// specified OutputRep.
 //
 // This is the "Explicit-Rep" format (e.g., `round_as<float>(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto round_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return make_quantity<AssociatedUnitT<RoundingUnits>>(round_in<OutputRep>(rounding_units, q));
+}
+// b) Version for QuantityPoint.
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto round_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    return make_quantity_point<AssociatedUnitForPointsT<RoundingUnits>>(
+        round_in<OutputRep>(rounding_units, p));
 }
 
 //
@@ -453,10 +485,17 @@ auto round_as(RoundingUnits rounding_units, Quantity<U, R> q) {
 //
 // This is the "Unit-only" format (i.e., `floor_in(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
 auto floor_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     using OurRoundingRep = detail::RoundingRepT<Quantity<U, R>, RoundingUnits>;
     return std::floor(q.template in<OurRoundingRep>(rounding_units));
+}
+// b) Version for QuantityPoint.
+template <typename RoundingUnits, typename U, typename R>
+auto floor_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    using OurRoundingRep = detail::RoundingRepT<QuantityPoint<U, R>, RoundingUnits>;
+    return std::floor(p.template in<OurRoundingRep>(rounding_units));
 }
 
 //
@@ -464,30 +503,50 @@ auto floor_in(RoundingUnits rounding_units, Quantity<U, R> q) {
 //
 // This is the "Explicit-Rep" format (e.g., `floor_in<int>(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto floor_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     return static_cast<OutputRep>(floor_in(rounding_units, q));
 }
+// b) Version for QuantityPoint.
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto floor_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    return static_cast<OutputRep>(floor_in(rounding_units, p));
+}
 
 //
-// The largest integral-valued Quantity, in this unit, not greater than the input.
+// The largest integral-valued Quantity or QuantityPoint, in this unit, not greater than the input.
 //
 // This is the "Unit-only" format (i.e., `floor_as(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
 auto floor_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return make_quantity<AssociatedUnitT<RoundingUnits>>(floor_in(rounding_units, q));
 }
+// b) Version for QuantityPoint.
+template <typename RoundingUnits, typename U, typename R>
+auto floor_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    return make_quantity_point<AssociatedUnitForPointsT<RoundingUnits>>(
+        floor_in(rounding_units, p));
+}
 
 //
-// The largest integral-valued Quantity, in this unit, not greater than the input, using the
-// specified `OutputRep`.
+// The largest integral-valued Quantity or QuantityPoint, in this unit, not greater than the input,
+// using the specified `OutputRep`.
 //
 // This is the "Explicit-Rep" format (e.g., `floor_as<float>(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto floor_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return make_quantity<AssociatedUnitT<RoundingUnits>>(floor_in<OutputRep>(rounding_units, q));
+}
+// b) Version for QuantityPoint.
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto floor_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    return make_quantity_point<AssociatedUnitForPointsT<RoundingUnits>>(
+        floor_in<OutputRep>(rounding_units, p));
 }
 
 //
@@ -495,10 +554,17 @@ auto floor_as(RoundingUnits rounding_units, Quantity<U, R> q) {
 //
 // This is the "Unit-only" format (i.e., `ceil_in(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
 auto ceil_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     using OurRoundingRep = detail::RoundingRepT<Quantity<U, R>, RoundingUnits>;
     return std::ceil(q.template in<OurRoundingRep>(rounding_units));
+}
+// b) Version for QuantityPoint.
+template <typename RoundingUnits, typename U, typename R>
+auto ceil_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    using OurRoundingRep = detail::RoundingRepT<QuantityPoint<U, R>, RoundingUnits>;
+    return std::ceil(p.template in<OurRoundingRep>(rounding_units));
 }
 
 //
@@ -506,30 +572,49 @@ auto ceil_in(RoundingUnits rounding_units, Quantity<U, R> q) {
 //
 // This is the "Explicit-Rep" format (e.g., `ceil_in<int>(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto ceil_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     return static_cast<OutputRep>(ceil_in(rounding_units, q));
 }
+// b) Version for QuantityPoint.
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto ceil_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    return static_cast<OutputRep>(ceil_in(rounding_units, p));
+}
 
 //
-// The smallest integral-valued Quantity, in this unit, not less than the input.
+// The smallest integral-valued Quantity or QuantityPoint, in this unit, not less than the input.
 //
 // This is the "Unit-only" format (i.e., `ceil_as(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
 auto ceil_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return make_quantity<AssociatedUnitT<RoundingUnits>>(ceil_in(rounding_units, q));
 }
+// b) Version for QuantityPoint.
+template <typename RoundingUnits, typename U, typename R>
+auto ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    return make_quantity_point<AssociatedUnitForPointsT<RoundingUnits>>(ceil_in(rounding_units, p));
+}
 
 //
-// The smallest integral-valued Quantity, in this unit, not less than the input, using the specified
-// `OutputRep`.
+// The smallest integral-valued Quantity or QuantityPoint, in this unit, not less than the input,
+// using the specified `OutputRep`.
 //
 // This is the "Explicit-Rep" format (e.g., `ceil_as<float>(rounding_units, q)`).
 //
+// a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto ceil_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return make_quantity<AssociatedUnitT<RoundingUnits>>(ceil_in<OutputRep>(rounding_units, q));
+}
+// b) Version for QuantityPoint.
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+    return make_quantity_point<AssociatedUnitForPointsT<RoundingUnits>>(
+        ceil_in<OutputRep>(rounding_units, p));
 }
 
 // Wrapper for std::sin() which accepts a strongly typed angle quantity.

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -761,8 +761,19 @@ TEST(RoundAs, SameAsStdRoundForSameUnits) {
     EXPECT_THAT(round_as(meters, meters(3.14f)), SameTypeAndValue(meters(std::round(3.14f))));
     EXPECT_THAT(round_as(meters, meters(3.14L)), SameTypeAndValue(meters(std::round(3.14L))));
 
+    EXPECT_THAT(round_as(meters_pt, meters_pt(3)), SameTypeAndValue(meters_pt(std::round(3))));
+    EXPECT_THAT(round_as(meters_pt, meters_pt(3.14)),
+                SameTypeAndValue(meters_pt(std::round(3.14))));
+    EXPECT_THAT(round_as(meters_pt, meters_pt(3.14f)),
+                SameTypeAndValue(meters_pt(std::round(3.14f))));
+    EXPECT_THAT(round_as(meters_pt, meters_pt(3.14L)),
+                SameTypeAndValue(meters_pt(std::round(3.14L))));
+
     EXPECT_THAT(round_as(meters, meters(INTEGER_TOO_BIG_FOR_DOUBLE)),
                 SameTypeAndValue(meters(std::round(INTEGER_TOO_BIG_FOR_DOUBLE))));
+
+    EXPECT_THAT(round_as(meters_pt, meters_pt(INTEGER_TOO_BIG_FOR_DOUBLE)),
+                SameTypeAndValue(meters_pt(std::round(INTEGER_TOO_BIG_FOR_DOUBLE))));
 }
 
 TEST(RoundAs, RoundsAsExpectedForDifferentUnits) {
@@ -770,6 +781,14 @@ TEST(RoundAs, RoundsAsExpectedForDifferentUnits) {
     EXPECT_THAT(round_as(kilo(meters), meters(999.9)), SameTypeAndValue(kilo(meters)(1.0)));
     EXPECT_THAT(round_as(kilo(meters), meters(999.9f)), SameTypeAndValue(kilo(meters)(1.0f)));
     EXPECT_THAT(round_as(kilo(meters), meters(999.9L)), SameTypeAndValue(kilo(meters)(1.0L)));
+
+    EXPECT_THAT(round_as(kilo(meters_pt), meters_pt(999)), SameTypeAndValue(kilo(meters_pt)(1.0)));
+    EXPECT_THAT(round_as(kilo(meters_pt), meters_pt(999.9)),
+                SameTypeAndValue(kilo(meters_pt)(1.0)));
+    EXPECT_THAT(round_as(kilo(meters_pt), meters_pt(999.9f)),
+                SameTypeAndValue(kilo(meters_pt)(1.0f)));
+    EXPECT_THAT(round_as(kilo(meters_pt), meters_pt(999.9L)),
+                SameTypeAndValue(kilo(meters_pt)(1.0L)));
 }
 
 TEST(RoundAs, SupportsDifferentOutputTypes) {
@@ -780,6 +799,30 @@ TEST(RoundAs, SupportsDifferentOutputTypes) {
 
     EXPECT_THAT(round_as<double>(kilo(meters), meters(999.9f)),
                 SameTypeAndValue(kilo(meters)(1.0)));
+
+    EXPECT_THAT(round_as<int>(meters_pt, meters_pt(3)),
+                SameTypeAndValue(meters_pt(static_cast<int>(std::round(3)))));
+    EXPECT_THAT(round_as<int>(meters_pt, meters_pt(3.9)),
+                SameTypeAndValue(meters_pt(static_cast<int>(std::round(3.9)))));
+
+    EXPECT_THAT(round_as<double>(kilo(meters_pt), meters_pt(999.9f)),
+                SameTypeAndValue(kilo(meters_pt)(1.0)));
+}
+
+TEST(RoundAs, SupportsQuantityPointWithNontrivialOffset) {
+    EXPECT_THAT(round_as(kelvins_pt, celsius_pt(20.0f)), SameTypeAndValue(kelvins_pt(293.0f)));
+    EXPECT_THAT(round_as(kelvins_pt, celsius_pt(20.5f)), SameTypeAndValue(kelvins_pt(294.0f)));
+
+    // Each degree Fahrenheit is 5/9 of a degree Celsius.  Thus, moving away from an exact
+    // correspondence by one degree Fahrenheit will be enough to move to the next integer Celsius
+    // when we round, but moving by half a degree will not.
+    EXPECT_THAT(round_as<int>(celsius_pt, fahrenheit_pt(31.0)), SameTypeAndValue(celsius_pt(-1)));
+    EXPECT_THAT(round_as<int>(celsius_pt, fahrenheit_pt(31.5)), SameTypeAndValue(celsius_pt(0)));
+
+    EXPECT_THAT(round_as<int>(celsius_pt, fahrenheit_pt(32.0)), SameTypeAndValue(celsius_pt(0)));
+
+    EXPECT_THAT(round_as<int>(celsius_pt, fahrenheit_pt(32.5)), SameTypeAndValue(celsius_pt(0)));
+    EXPECT_THAT(round_as<int>(celsius_pt, fahrenheit_pt(33.0)), SameTypeAndValue(celsius_pt(1)));
 }
 
 TEST(RoundIn, SameAsRoundAs) {
@@ -787,10 +830,16 @@ TEST(RoundIn, SameAsRoundAs) {
     EXPECT_THAT(round_in(kilo(meters), meters(754.28)), SameTypeAndValue(1.0));
     EXPECT_THAT(round_in(kilo(meters), meters(754.28f)), SameTypeAndValue(1.0f));
     EXPECT_THAT(round_in(kilo(meters), meters(754.28L)), SameTypeAndValue(1.0L));
+
+    EXPECT_THAT(round_in(kilo(meters_pt), meters_pt(754)), SameTypeAndValue(1.0));
+    EXPECT_THAT(round_in(kilo(meters_pt), meters_pt(754.28)), SameTypeAndValue(1.0));
+    EXPECT_THAT(round_in(kilo(meters_pt), meters_pt(754.28f)), SameTypeAndValue(1.0f));
+    EXPECT_THAT(round_in(kilo(meters_pt), meters_pt(754.28L)), SameTypeAndValue(1.0L));
 }
 
 TEST(RoundIn, SupportsDifferentOutputTypes) {
     EXPECT_THAT(round_in<long double>(kilo(meters), meters(754.28f)), SameTypeAndValue(1.0L));
+    EXPECT_THAT(round_in<long double>(kilo(meters_pt), meters_pt(754.28f)), SameTypeAndValue(1.0L));
 }
 
 TEST(FloorAs, SameAsStdFloorForSameUnits) {
@@ -799,8 +848,19 @@ TEST(FloorAs, SameAsStdFloorForSameUnits) {
     EXPECT_THAT(floor_as(meters, meters(3.14f)), SameTypeAndValue(meters(std::floor(3.14f))));
     EXPECT_THAT(floor_as(meters, meters(3.14L)), SameTypeAndValue(meters(std::floor(3.14L))));
 
+    EXPECT_THAT(floor_as(meters_pt, meters_pt(3)), SameTypeAndValue(meters_pt(std::floor(3))));
+    EXPECT_THAT(floor_as(meters_pt, meters_pt(3.14)),
+                SameTypeAndValue(meters_pt(std::floor(3.14))));
+    EXPECT_THAT(floor_as(meters_pt, meters_pt(3.14f)),
+                SameTypeAndValue(meters_pt(std::floor(3.14f))));
+    EXPECT_THAT(floor_as(meters_pt, meters_pt(3.14L)),
+                SameTypeAndValue(meters_pt(std::floor(3.14L))));
+
     EXPECT_THAT(floor_as(meters, meters(INTEGER_TOO_BIG_FOR_DOUBLE)),
                 SameTypeAndValue(meters(std::floor(INTEGER_TOO_BIG_FOR_DOUBLE))));
+
+    EXPECT_THAT(floor_as(meters_pt, meters_pt(INTEGER_TOO_BIG_FOR_DOUBLE)),
+                SameTypeAndValue(meters_pt(std::floor(INTEGER_TOO_BIG_FOR_DOUBLE))));
 }
 
 TEST(FloorAs, RoundsDownAsExpectedForDifferentUnits) {
@@ -809,10 +869,26 @@ TEST(FloorAs, RoundsDownAsExpectedForDifferentUnits) {
     EXPECT_THAT(floor_as(kilo(meters), meters(999.9f)), SameTypeAndValue(kilo(meters)(0.0f)));
     EXPECT_THAT(floor_as(kilo(meters), meters(999.9L)), SameTypeAndValue(kilo(meters)(0.0L)));
 
+    EXPECT_THAT(floor_as(kilo(meters_pt), meters_pt(999)), SameTypeAndValue(kilo(meters_pt)(0.0)));
+    EXPECT_THAT(floor_as(kilo(meters_pt), meters_pt(999.9)),
+                SameTypeAndValue(kilo(meters_pt)(0.0)));
+    EXPECT_THAT(floor_as(kilo(meters_pt), meters_pt(999.9f)),
+                SameTypeAndValue(kilo(meters_pt)(0.0f)));
+    EXPECT_THAT(floor_as(kilo(meters_pt), meters_pt(999.9L)),
+                SameTypeAndValue(kilo(meters_pt)(0.0L)));
+
     EXPECT_THAT(floor_as(kilo(meters), meters(1001)), SameTypeAndValue(kilo(meters)(1.0)));
     EXPECT_THAT(floor_as(kilo(meters), meters(1000.1)), SameTypeAndValue(kilo(meters)(1.0)));
     EXPECT_THAT(floor_as(kilo(meters), meters(1000.1f)), SameTypeAndValue(kilo(meters)(1.0f)));
     EXPECT_THAT(floor_as(kilo(meters), meters(1000.1L)), SameTypeAndValue(kilo(meters)(1.0L)));
+
+    EXPECT_THAT(floor_as(kilo(meters_pt), meters_pt(1001)), SameTypeAndValue(kilo(meters_pt)(1.0)));
+    EXPECT_THAT(floor_as(kilo(meters_pt), meters_pt(1000.1)),
+                SameTypeAndValue(kilo(meters_pt)(1.0)));
+    EXPECT_THAT(floor_as(kilo(meters_pt), meters_pt(1000.1f)),
+                SameTypeAndValue(kilo(meters_pt)(1.0f)));
+    EXPECT_THAT(floor_as(kilo(meters_pt), meters_pt(1000.1L)),
+                SameTypeAndValue(kilo(meters_pt)(1.0L)));
 }
 
 TEST(FloorAs, SupportsDifferentOutputTypes) {
@@ -821,8 +897,32 @@ TEST(FloorAs, SupportsDifferentOutputTypes) {
     EXPECT_THAT(floor_as<int>(meters, meters(3.9)),
                 SameTypeAndValue(meters(static_cast<int>(std::floor(3.9)))));
 
+    EXPECT_THAT(floor_as<int>(meters_pt, meters_pt(3)),
+                SameTypeAndValue(meters_pt(static_cast<int>(std::floor(3)))));
+    EXPECT_THAT(floor_as<int>(meters_pt, meters_pt(3.9)),
+                SameTypeAndValue(meters_pt(static_cast<int>(std::floor(3.9)))));
+
     EXPECT_THAT(floor_as<double>(kilo(meters), meters(1000.1f)),
                 SameTypeAndValue(kilo(meters)(1.0)));
+
+    EXPECT_THAT(floor_as<double>(kilo(meters_pt), meters_pt(1000.1f)),
+                SameTypeAndValue(kilo(meters_pt)(1.0)));
+}
+
+TEST(FloorAs, SupportsQuantityPointWithNontrivialOffset) {
+    EXPECT_THAT(floor_as(kelvins_pt, celsius_pt(20.0f)), SameTypeAndValue(kelvins_pt(293.0f)));
+    EXPECT_THAT(floor_as(kelvins_pt, celsius_pt(20.8f)), SameTypeAndValue(kelvins_pt(293.0f)));
+    EXPECT_THAT(floor_as(kelvins_pt, celsius_pt(20.9f)), SameTypeAndValue(kelvins_pt(294.0f)));
+
+    EXPECT_THAT(floor_as<int>(celsius_pt, fahrenheit_pt(31.0)), SameTypeAndValue(celsius_pt(-1)));
+    EXPECT_THAT(floor_as<int>(celsius_pt, fahrenheit_pt(31.5)), SameTypeAndValue(celsius_pt(-1)));
+
+    EXPECT_THAT(floor_as<int>(celsius_pt, fahrenheit_pt(32.0)), SameTypeAndValue(celsius_pt(0)));
+
+    EXPECT_THAT(floor_as<int>(celsius_pt, fahrenheit_pt(32.5)), SameTypeAndValue(celsius_pt(0)));
+    EXPECT_THAT(floor_as<int>(celsius_pt, fahrenheit_pt(33.0)), SameTypeAndValue(celsius_pt(0)));
+    EXPECT_THAT(floor_as<int>(celsius_pt, fahrenheit_pt(33.5)), SameTypeAndValue(celsius_pt(0)));
+    EXPECT_THAT(floor_as<int>(celsius_pt, fahrenheit_pt(34.0)), SameTypeAndValue(celsius_pt(1)));
 }
 
 TEST(FloorIn, SameAsFloorAs) {
@@ -830,10 +930,17 @@ TEST(FloorIn, SameAsFloorAs) {
     EXPECT_THAT(floor_in(kilo(meters), meters(1154.28)), SameTypeAndValue(1.0));
     EXPECT_THAT(floor_in(kilo(meters), meters(1154.28f)), SameTypeAndValue(1.0f));
     EXPECT_THAT(floor_in(kilo(meters), meters(1154.28L)), SameTypeAndValue(1.0L));
+
+    EXPECT_THAT(floor_in(kilo(meters_pt), meters_pt(1154)), SameTypeAndValue(1.0));
+    EXPECT_THAT(floor_in(kilo(meters_pt), meters_pt(1154.28)), SameTypeAndValue(1.0));
+    EXPECT_THAT(floor_in(kilo(meters_pt), meters_pt(1154.28f)), SameTypeAndValue(1.0f));
+    EXPECT_THAT(floor_in(kilo(meters_pt), meters_pt(1154.28L)), SameTypeAndValue(1.0L));
 }
 
 TEST(FloorIn, SupportsDifferentOutputTypes) {
     EXPECT_THAT(floor_in<long double>(kilo(meters), meters(1154.28f)), SameTypeAndValue(1.0L));
+    EXPECT_THAT(floor_in<long double>(kilo(meters_pt), meters_pt(1154.28f)),
+                SameTypeAndValue(1.0L));
 }
 
 TEST(CeilAs, SameAsStdCeilForSameUnits) {
@@ -842,8 +949,18 @@ TEST(CeilAs, SameAsStdCeilForSameUnits) {
     EXPECT_THAT(ceil_as(meters, meters(3.14f)), SameTypeAndValue(meters(std::ceil(3.14f))));
     EXPECT_THAT(ceil_as(meters, meters(3.14L)), SameTypeAndValue(meters(std::ceil(3.14L))));
 
+    EXPECT_THAT(ceil_as(meters_pt, meters_pt(3)), SameTypeAndValue(meters_pt(std::ceil(3))));
+    EXPECT_THAT(ceil_as(meters_pt, meters_pt(3.14)), SameTypeAndValue(meters_pt(std::ceil(3.14))));
+    EXPECT_THAT(ceil_as(meters_pt, meters_pt(3.14f)),
+                SameTypeAndValue(meters_pt(std::ceil(3.14f))));
+    EXPECT_THAT(ceil_as(meters_pt, meters_pt(3.14L)),
+                SameTypeAndValue(meters_pt(std::ceil(3.14L))));
+
     EXPECT_THAT(ceil_as(meters, meters(INTEGER_TOO_BIG_FOR_DOUBLE)),
                 SameTypeAndValue(meters(std::ceil(INTEGER_TOO_BIG_FOR_DOUBLE))));
+
+    EXPECT_THAT(ceil_as(meters_pt, meters_pt(INTEGER_TOO_BIG_FOR_DOUBLE)),
+                SameTypeAndValue(meters_pt(std::ceil(INTEGER_TOO_BIG_FOR_DOUBLE))));
 }
 
 TEST(CeilAs, RoundsUpAsExpectedForDifferentUnits) {
@@ -852,10 +969,25 @@ TEST(CeilAs, RoundsUpAsExpectedForDifferentUnits) {
     EXPECT_THAT(ceil_as(kilo(meters), meters(999.9f)), SameTypeAndValue(kilo(meters)(1.0f)));
     EXPECT_THAT(ceil_as(kilo(meters), meters(999.9L)), SameTypeAndValue(kilo(meters)(1.0L)));
 
+    EXPECT_THAT(ceil_as(kilo(meters_pt), meters_pt(999)), SameTypeAndValue(kilo(meters_pt)(1.0)));
+    EXPECT_THAT(ceil_as(kilo(meters_pt), meters_pt(999.9)), SameTypeAndValue(kilo(meters_pt)(1.0)));
+    EXPECT_THAT(ceil_as(kilo(meters_pt), meters_pt(999.9f)),
+                SameTypeAndValue(kilo(meters_pt)(1.0f)));
+    EXPECT_THAT(ceil_as(kilo(meters_pt), meters_pt(999.9L)),
+                SameTypeAndValue(kilo(meters_pt)(1.0L)));
+
     EXPECT_THAT(ceil_as(kilo(meters), meters(1001)), SameTypeAndValue(kilo(meters)(2.0)));
     EXPECT_THAT(ceil_as(kilo(meters), meters(1000.1)), SameTypeAndValue(kilo(meters)(2.0)));
     EXPECT_THAT(ceil_as(kilo(meters), meters(1000.1f)), SameTypeAndValue(kilo(meters)(2.0f)));
     EXPECT_THAT(ceil_as(kilo(meters), meters(1000.1L)), SameTypeAndValue(kilo(meters)(2.0L)));
+
+    EXPECT_THAT(ceil_as(kilo(meters_pt), meters_pt(1001)), SameTypeAndValue(kilo(meters_pt)(2.0)));
+    EXPECT_THAT(ceil_as(kilo(meters_pt), meters_pt(1000.1)),
+                SameTypeAndValue(kilo(meters_pt)(2.0)));
+    EXPECT_THAT(ceil_as(kilo(meters_pt), meters_pt(1000.1f)),
+                SameTypeAndValue(kilo(meters_pt)(2.0f)));
+    EXPECT_THAT(ceil_as(kilo(meters_pt), meters_pt(1000.1L)),
+                SameTypeAndValue(kilo(meters_pt)(2.0L)));
 }
 
 TEST(CeilAs, SupportsDifferentOutputTypes) {
@@ -864,8 +996,32 @@ TEST(CeilAs, SupportsDifferentOutputTypes) {
     EXPECT_THAT(ceil_as<int>(meters, meters(3.9)),
                 SameTypeAndValue(meters(static_cast<int>(std::ceil(3.9)))));
 
+    EXPECT_THAT(ceil_as<int>(meters_pt, meters_pt(3)),
+                SameTypeAndValue(meters_pt(static_cast<int>(std::ceil(3)))));
+    EXPECT_THAT(ceil_as<int>(meters_pt, meters_pt(3.9)),
+                SameTypeAndValue(meters_pt(static_cast<int>(std::ceil(3.9)))));
+
     EXPECT_THAT(ceil_as<double>(kilo(meters), meters(1000.1f)),
                 SameTypeAndValue(kilo(meters)(2.0)));
+
+    EXPECT_THAT(ceil_as<double>(kilo(meters_pt), meters_pt(1000.1f)),
+                SameTypeAndValue(kilo(meters_pt)(2.0)));
+}
+
+TEST(CeilAs, SupportsQuantityPointWithNontrivialOffset) {
+    EXPECT_THAT(ceil_as(kelvins_pt, celsius_pt(20.0f)), SameTypeAndValue(kelvins_pt(294.0f)));
+    EXPECT_THAT(ceil_as(kelvins_pt, celsius_pt(20.8f)), SameTypeAndValue(kelvins_pt(294.0f)));
+    EXPECT_THAT(ceil_as(kelvins_pt, celsius_pt(20.9f)), SameTypeAndValue(kelvins_pt(295.0f)));
+
+    EXPECT_THAT(ceil_as<int>(celsius_pt, fahrenheit_pt(30.0)), SameTypeAndValue(celsius_pt(-1)));
+    EXPECT_THAT(ceil_as<int>(celsius_pt, fahrenheit_pt(30.5)), SameTypeAndValue(celsius_pt(0)));
+    EXPECT_THAT(ceil_as<int>(celsius_pt, fahrenheit_pt(31.0)), SameTypeAndValue(celsius_pt(0)));
+    EXPECT_THAT(ceil_as<int>(celsius_pt, fahrenheit_pt(31.5)), SameTypeAndValue(celsius_pt(0)));
+
+    EXPECT_THAT(ceil_as<int>(celsius_pt, fahrenheit_pt(32.0)), SameTypeAndValue(celsius_pt(0)));
+
+    EXPECT_THAT(ceil_as<int>(celsius_pt, fahrenheit_pt(32.5)), SameTypeAndValue(celsius_pt(1)));
+    EXPECT_THAT(ceil_as<int>(celsius_pt, fahrenheit_pt(33.0)), SameTypeAndValue(celsius_pt(1)));
 }
 
 TEST(CeilIn, SameAsCeilAs) {
@@ -873,10 +1029,16 @@ TEST(CeilIn, SameAsCeilAs) {
     EXPECT_THAT(ceil_in(kilo(meters), meters(354.28)), SameTypeAndValue(1.0));
     EXPECT_THAT(ceil_in(kilo(meters), meters(354.28f)), SameTypeAndValue(1.0f));
     EXPECT_THAT(ceil_in(kilo(meters), meters(354.28L)), SameTypeAndValue(1.0L));
+
+    EXPECT_THAT(ceil_in(kilo(meters_pt), meters_pt(354)), SameTypeAndValue(1.0));
+    EXPECT_THAT(ceil_in(kilo(meters_pt), meters_pt(354.28)), SameTypeAndValue(1.0));
+    EXPECT_THAT(ceil_in(kilo(meters_pt), meters_pt(354.28f)), SameTypeAndValue(1.0f));
+    EXPECT_THAT(ceil_in(kilo(meters_pt), meters_pt(354.28L)), SameTypeAndValue(1.0L));
 }
 
 TEST(CeilIn, SupportsDifferentOutputTypes) {
     EXPECT_THAT(ceil_in<long double>(kilo(meters), meters(354.28f)), SameTypeAndValue(1.0L));
+    EXPECT_THAT(ceil_in<long double>(kilo(meters_pt), meters_pt(354.28f)), SameTypeAndValue(1.0L));
 }
 
 TEST(InverseAs, HandlesIntegerRepCorrectly) {

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -400,18 +400,30 @@ As with everything else in the library, `"as"` is a word that means "return a `Q
 
 ```cpp
 //
-// round_as(): return a Quantity
+// round_as(): return a Quantity or QuantityPoint (depending on the input type)
 //
 
 // 1. Unit-only version (including safety checks).  Typical callsites look like:
 //    `round_as(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename RoundingUnits, typename U, typename R>
 auto round_as(RoundingUnits rounding_units, Quantity<U, R> q);
 
+// b) For `QuantityPoint` inputs
+template <typename RoundingUnits, typename U, typename R>
+auto round_as(RoundingUnits rounding_units, QuantityPoint<U, R> q);
+
 // 2. Explicit-rep version (overriding; ignores safety checks).  Typical callsites look like:
 //    `round_as<Type>(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto round_as(RoundingUnits rounding_units, Quantity<U, R> q);
+
+// b) For `QuantityPoint` inputs
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto round_as(RoundingUnits rounding_units, QuantityPoint<U, R> q);
 
 
 //
@@ -420,17 +432,30 @@ auto round_as(RoundingUnits rounding_units, Quantity<U, R> q);
 
 // 1. Unit-only version (including safety checks).  Typical callsites look like:
 //    `round_in(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename RoundingUnits, typename U, typename R>
 auto round_in(RoundingUnits rounding_units, Quantity<U, R> q);
 
+// b) For `QuantityPoint` inputs
+template <typename RoundingUnits, typename U, typename R>
+auto round_in(RoundingUnits rounding_units, QuantityPoint<U, R> q);
+
 // 2. Explicit-rep version (overriding; ignores safety checks).  Typical callsites look like:
 //    `round_in<Type>(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto round_in(RoundingUnits rounding_units, Quantity<U, R> q);
+
+// b) For `QuantityPoint` inputs
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto round_in(RoundingUnits rounding_units, QuantityPoint<U, R> q);
 ```
 
-**Returns:** A `Quantity`, expressed in the requested units, which has an integer value in those
-units.  We return the nearest such quantity to the original input quantity.
+**Returns:** A `Quantity` or `QuantityPoint` (depending on the input type), expressed in the
+requested units, which has an integer value in those units. We return the nearest such quantity to
+the original input quantity.
 
 The policy for the rep is consistent with
 [`std::round`](https://en.cppreference.com/w/cpp/numeric/math/round).  The output rep is the same as
@@ -454,18 +479,30 @@ As with everything else in the library, `"as"` is a word that means "return a `Q
 
 ```cpp
 //
-// ceil_as(): return a Quantity
+// ceil_as(): return a Quantity or QuantityPoint (depending on the input type)
 //
 
 // 1. Unit-only version (including safety checks).  Typical callsites look like:
 //    `ceil_as(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename RoundingUnits, typename U, typename R>
 auto ceil_as(RoundingUnits rounding_units, Quantity<U, R> q);
 
+// b) For `QuantityPoint` inputs
+template <typename RoundingUnits, typename U, typename R>
+auto ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> q);
+
 // 2. Explicit-rep version (overriding; ignores safety checks).  Typical callsites look like:
 //    `ceil_as<Type>(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto ceil_as(RoundingUnits rounding_units, Quantity<U, R> q);
+
+// b) For `QuantityPoint` inputs
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> q);
 
 
 //
@@ -474,13 +511,25 @@ auto ceil_as(RoundingUnits rounding_units, Quantity<U, R> q);
 
 // 1. Unit-only version (including safety checks).  Typical callsites look like:
 //    `ceil_in(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename RoundingUnits, typename U, typename R>
 auto ceil_in(RoundingUnits rounding_units, Quantity<U, R> q);
 
+// b) For `QuantityPoint` inputs
+template <typename RoundingUnits, typename U, typename R>
+auto ceil_in(RoundingUnits rounding_units, QuantityPoint<U, R> q);
+
 // 2. Explicit-rep version (overriding; ignores safety checks).  Typical callsites look like:
 //    `ceil_in<Type>(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto ceil_in(RoundingUnits rounding_units, Quantity<U, R> q);
+
+// b) For `QuantityPoint` inputs
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto ceil_in(RoundingUnits rounding_units, QuantityPoint<U, R> q);
 ```
 
 **Returns:** A `Quantity`, expressed in the requested units, which has an integer value in those
@@ -508,18 +557,30 @@ As with everything else in the library, `"as"` is a word that means "return a `Q
 
 ```cpp
 //
-// floor_as(): return a Quantity
+// floor_as(): return a Quantity or QuantityPoint (depending on the input type)
 //
 
 // 1. Unit-only version (including safety checks).  Typical callsites look like:
 //    `floor_as(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename RoundingUnits, typename U, typename R>
 auto floor_as(RoundingUnits rounding_units, Quantity<U, R> q);
 
+// b) For `QuantityPoint` inputs
+template <typename RoundingUnits, typename U, typename R>
+auto floor_as(RoundingUnits rounding_units, QuantityPoint<U, R> q);
+
 // 2. Explicit-rep version (overriding; ignores safety checks).  Typical callsites look like:
 //    `floor_as<Type>(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto floor_as(RoundingUnits rounding_units, Quantity<U, R> q);
+
+// b) For `QuantityPoint` inputs
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto floor_as(RoundingUnits rounding_units, QuantityPoint<U, R> q);
 
 
 //
@@ -528,13 +589,25 @@ auto floor_as(RoundingUnits rounding_units, Quantity<U, R> q);
 
 // 1. Unit-only version (including safety checks).  Typical callsites look like:
 //    `floor_in(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename RoundingUnits, typename U, typename R>
 auto floor_in(RoundingUnits rounding_units, Quantity<U, R> q);
 
+// b) For `QuantityPoint` inputs
+template <typename RoundingUnits, typename U, typename R>
+auto floor_in(RoundingUnits rounding_units, QuantityPoint<U, R> q);
+
 // 2. Explicit-rep version (overriding; ignores safety checks).  Typical callsites look like:
 //    `floor_in<Type>(units, quantity)`
+
+// a) For `Quantity` inputs
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
 auto floor_in(RoundingUnits rounding_units, Quantity<U, R> q);
+
+// b) For `QuantityPoint` inputs
+template <typename OutputRep, typename RoundingUnits, typename U, typename R>
+auto floor_in(RoundingUnits rounding_units, QuantityPoint<U, R> q);
 ```
 
 **Returns:** A `Quantity`, expressed in the requested units, which has an integer value in those
@@ -640,8 +713,13 @@ Indicates whether the underlying value of a `Quantity` is a NaN ("not-a-number")
 **Signature:**
 
 ```cpp
+// 1. `Quantity` inputs
 template <typename U, typename R>
 constexpr bool isnan(Quantity<U, R> q);
+
+// 2. `QuantityPoint` inputs
+template <typename U, typename R>
+constexpr bool isnan(QuantityPoint<U, R> q);
 ```
 
 **Returns:** `true` if `q` is NaN; `false` otherwise.
@@ -715,4 +793,3 @@ auto remainder(Quantity<U1, R1> q1, Quantity<U2, R2> q2);
 
 **Returns:** The remainder of `q1 / q2`, in the type `Quantity<U, R>`, where `U` is the common unit
 of `U1` and `U2`, and `R` is the common type of `R1` and `R2`.
-


### PR DESCRIPTION
Includes the `round`, `floor`, and `ceil` families.

There's more subtlety here than for `Quantity`, because we can have
additive offsets.  However, since these functions all aim to behave like
the standard library, and the standard library always uses floating
point, then it's actually quite simple.  The way we handle rounding a
quantity point in different units than it's stored is to first perform
the conversion, then do the rounding.  As with quantities, we use
`RoundingRep` to make sure we're using a sane floating point type to
perform the conversion.

Includes a bunch of new test cases, and doc updates.

Fixes #221.