### PR TITLE
Avoid colliding with macro names `B1` and `PI`

### DIFF
--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -131,7 +131,16 @@ using CommonMagnitudeT = typename CommonMagnitude<Ms...>::type;
 // Value based interface for Magnitude.
 
 static constexpr auto ONE = Magnitude<>{};
+
+#ifndef PI
+// Some users must work with frameworks that define `PI` as a macro.  Having a macro with this
+// easily collidable name is exceedingly unwise.  Nevertheless, that's not the users' fault, so we
+// accommodate those frameworks by omitting the definition of `PI` in this case.
+//
+// If you are stuck with such a framework, you can choose a different name that does not collide,
+// and reproduce the following line in your own system.
 static constexpr auto PI = Magnitude<Pi>{};
+#endif
 
 template <typename... BP1s, typename... BP2s>
 constexpr auto operator*(Magnitude<BP1s...>, Magnitude<BP2s...>) {

--- a/au/stdx/type_traits.hh
+++ b/au/stdx/type_traits.hh
@@ -32,18 +32,18 @@ using bool_constant = std::integral_constant<bool, B>;
 // Source: adapted from (https://en.cppreference.com/w/cpp/types/conjunction).
 template <class...>
 struct conjunction : std::true_type {};
-template <class B1>
-struct conjunction<B1> : B1 {};
-template <class B1, class... Bn>
-struct conjunction<B1, Bn...> : std::conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
+template <class B>
+struct conjunction<B> : B {};
+template <class B, class... Bn>
+struct conjunction<B, Bn...> : std::conditional_t<bool(B::value), conjunction<Bn...>, B> {};
 
 // Source: adapted from (https://en.cppreference.com/w/cpp/types/disjunction).
 template <class...>
 struct disjunction : std::false_type {};
-template <class B1>
-struct disjunction<B1> : B1 {};
-template <class B1, class... Bn>
-struct disjunction<B1, Bn...> : std::conditional_t<bool(B1::value), B1, disjunction<Bn...>> {};
+template <class B>
+struct disjunction<B> : B {};
+template <class B, class... Bn>
+struct disjunction<B, Bn...> : std::conditional_t<bool(B::value), B, disjunction<Bn...>> {};
 
 // Source: adapted from (https://en.cppreference.com/w/cpp/types/negation).
 template <class B>

--- a/au/units/degrees.hh
+++ b/au/units/degrees.hh
@@ -28,7 +28,7 @@ struct DegreesLabel {
 };
 template <typename T>
 constexpr const char DegreesLabel<T>::label[];
-struct Degrees : decltype(Radians{} * PI / mag<180>()), DegreesLabel<void> {
+struct Degrees : decltype(Radians{} * Magnitude<Pi>{} / mag<180>()), DegreesLabel<void> {
     using DegreesLabel<void>::label;
 };
 constexpr auto degree = SingularNameFor<Degrees>{};


### PR DESCRIPTION
This helps Arduino compatibility.

Of course, this whole situation is an excellent case in point to
illustrate why, if you _must_ use macros, _never_ to give them such
easily collidable names.  But that is not the users' fault, so since we
can work around the problem, we do so.

The `B1` template parameter can be renamed to `B` without loss of
readability.

`PI` is a little more challenging.  We do use it in one place in our
code, in defining `Degrees`, so we must replace that with its definition
of `Magnitude<Pi>{}`.  We provide workaround instructions in the
comments.  We leave alone the many instances of `PI` in test files,
since that shouldn't affect these users.

Helps #246.