### PR TITLE
Clarify why we're not using lambdas

### DIFF
--- a/au/math.hh
+++ b/au/math.hh
@@ -319,7 +319,7 @@ constexpr bool isnan(QuantityPoint<U, R> p) {
 }
 
 namespace detail {
-// Some compilers do not support lambdas in constexpr contexts, so we make a manual function object.
+// We can't use lambdas in `constexpr` contexts until C++17, so we make a manual function object.
 struct StdMaxByValue {
     template <typename T>
     constexpr auto operator()(T a, T b) const {
@@ -374,7 +374,7 @@ constexpr auto max(T x, Zero z) {
 }
 
 namespace detail {
-// Some compilers do not support lambdas in constexpr contexts, so we make a manual function object.
+// We can't use lambdas in `constexpr` contexts until C++17, so we make a manual function object.
 struct StdMinByValue {
     template <typename T>
     constexpr auto operator()(T a, T b) const {


### PR DESCRIPTION
Turns out, they can't be `constexpr` until C++17, but we must support
C++14.