### PR TITLE
Update actions/checkout to v4.1.5

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
       - name: Build and test (${{ inputs.config }})
         run: bazel test --copt=-Werror --config=${{ inputs.config }} //...:all
       - name: Build and test with -Wconversion (${{ inputs.config }})

--- a/.github/workflows/buildifier-lint.yml
+++ b/.github/workflows/buildifier-lint.yml
@@ -24,7 +24,7 @@ jobs:
   lint-buildifier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
       - uses: thompsonja/bazel-buildifier@851a03879729721b9bbb4854a1779977c4718f01 # v0.4.0
         with:
           warnings: all

--- a/.github/workflows/check-license-headers.yml
+++ b/.github/workflows/check-license-headers.yml
@@ -24,7 +24,7 @@ jobs:
   lint-check-license-headers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
       - uses: viperproject/check-license-header@971caaf7d1641bb2c6a49acd06b018a5ce51ad6e # v1.0.5
         with:
           path: .

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0
+    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
     - uses: DoozyX/clang-format-lint-action@2ec1a72dfb593e52255693c9039e6d94984187dc #v0.14
       with:
         source: './au'

--- a/.github/workflows/deploy-doc-site.yml
+++ b/.github/workflows/deploy-doc-site.yml
@@ -27,7 +27,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
         with:
           # This will fetch all history for the repo: all branches and tags.  We
           # need this in order for `git describe` to work correctly when

--- a/.github/workflows/ensure-sha-pinned-actions.yml
+++ b/.github/workflows/ensure-sha-pinned-actions.yml
@@ -24,5 +24,5 @@ jobs:
   ensure-sha-pinned-actions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
       - uses: zgosalvez/github-actions-ensure-sha-pinned-actions@af2eb3226618e2494e3d9084f515ad6dcf16e229 #v2.0.1

--- a/.github/workflows/single-file-build-and-test.yml
+++ b/.github/workflows/single-file-build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ inputs.windows_version }}
 
     steps:
-      - uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 #v2.6.0
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
 
       - name: Set up developer command prompt
         uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89 #v1.12.1


### PR DESCRIPTION
Update the [`actions/checkout`](https://github.com/actions/checkout) action to a more modern version.  v4 includes a more modern version of node (v20) which will fix the deprecation warnings described in #260.

### Test Plan
- [x] Verified [new hash](https://github.com/aurora-opensource/au/actions/runs/9877004785/job/27277529638?pr=261#step:2:1) on this PR
- [X] Checked job [summary](https://github.com/aurora-opensource/au/actions/runs/9877004785?pr=261) and saw now deprecation warnings
- [x] Checked the changelog and didn't see any backwards incompatible changes. 