### PR TITLE
Properly declare googletest dependency

### DIFF
--- a/cmake/AuConfig.cmake.in
+++ b/cmake/AuConfig.cmake.in
@@ -14,6 +14,9 @@
 
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(googletest 1.12.1)
+
 include(${CMAKE_CURRENT_LIST_DIR}/AuHeaders.cmake)
 
 check_required_components(Au)


### PR DESCRIPTION
This lets us support installing the library to the system, and then
using it via `find_package()`.

To test this, I ran `sudo cmake --install cmake/build`, observed that it
completed with no errors, and then made a new CMake package that simply
used `find_package(Au)`.  Everything worked!

Helps #215.