### PR TITLE
Add `/W4` to Windows CI builds

### DIFF
--- a/.github/workflows/single-file-build-and-test.yml
+++ b/.github/workflows/single-file-build-and-test.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Build and run test
         shell: cmd
         run: |
-          cl.exe /std:c++14 single-file-test.cc
+          cl.exe /std:c++14 /W4 single-file-test.cc
           single-file-test.exe


### PR DESCRIPTION
This should help catch a wider variety of warnings.