### PR TITLE
Permit integer-dividing quantity-equivalent units

### DIFF
--- a/au/code/au/quantity_test.cc
+++ b/au/code/au/quantity_test.cc
@@ -852,6 +852,11 @@ TEST(integer_quotient, EnablesIntegerDivision) {
     EXPECT_THAT(freq, SameTypeAndValue(inverse(minutes)(3)));
 }
 
+TEST(Quantity, CanIntegerDivideQuantitiesOfQuantityEquivalentUnits) {
+    constexpr auto ratio = meters(60) / meters(25);
+    EXPECT_EQ(ratio, 2);
+}
+
 TEST(mod, ComputesRemainderForSameUnits) {
     constexpr auto remainder = inches(50) % inches(12);
     EXPECT_THAT(remainder, QuantityEquivalent(inches(2)));


### PR DESCRIPTION
This means we need to know the unit inside of
`warn_if_integer_division()`, which seems OK.  For the raw number cases,
we synthesize a unitless unit.

One weird thing is that sometimes the template parameters for
`warn_if_integer_division()` are for the numerator, and sometimes for
the denominator.  But it still gives the correct answer in all cases. If
both are `Quantity` types, then it doesn't matter which is which,
because "both integers and quantity-inequivalent units" is symmetric.
And if one is a raw number, then `warn_if_integer_division()` is _not_
symmetric, but that's fine because we simply don't _call it_ from the
`Q/ N` variant (which is always fine); we only call it from the `N / Q`
variant (which might not be fine).

Fixes #249.