### PR TITLE
[ci] Bump ilammy/msvc-dev-cmd to v1.13.0

### DIFF
--- a/.github/workflows/single-file-build-and-test.yml
+++ b/.github/workflows/single-file-build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
 
       - name: Set up developer command prompt
-        uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89 #v1.12.1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 #v1.13.0
 
       - name: Set up python
         uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 #v3.1.4


### PR DESCRIPTION
### Summary

See #260 for background.

Update the [`ilammy/msvc-dev-cmd`](https://github.com/ilammy/msvc-dev-cmd) action to the most recent version: [v1.13.0](https://github.com/ilammy/msvc-dev-cmd/releases/tag/v1.13.0)

### Test Plan
- [X] Verify [new hash](https://github.com/aurora-opensource/au/actions/runs/10254178506/job/28368397714#step:3:1) on this PR
- [X] Checked job summary and saw no deprecation warnings related to `msvc-dev-cmd`
- [X] Checked the [changelog](https://github.com/ilammy/msvc-dev-cmd/compare/v1.12.1...v1.13.0) and didn't see any backwards incompatible changes