### PR TITLE
[ci] Bump viperproject/check-license-header to v2.0.0

### DIFF
--- a/.github/workflows/check-license-headers.yml
+++ b/.github/workflows/check-license-headers.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
-      - uses: viperproject/check-license-header@971caaf7d1641bb2c6a49acd06b018a5ce51ad6e # v1.0.5
+      - uses: viperproject/check-license-header@4e1a788a49859a75319a1c74abe3f63562d74e32 # v2.0.0
         with:
           path: .
           config: .github/license-check/license-config.json


### PR DESCRIPTION
### Summary

See #260 for background.

Update the [`viperproject/check-license-header`](https://github.com/viperproject/check-license-header) action to the most recent version: [v2.0.0](https://github.com/viperproject/check-license-header/releases/tag/v2.0.0).  Note, this is still on Node16, which is still a deprecated version of Node.  I can look into submitting a PR to upstream to update them to Node20.  

### Test Plan
- [X] Verify [new hash](https://github.com/aurora-opensource/au/actions/runs/10254330417/job/28368864447#step:3:1) on this PR
- [X] Checked the [changelog](https://github.com/viperproject/check-license-header/compare/v1.0.5...v2.0.0) and didn't see any backwards incompatible changes