### PR TITLE
[ci] Bump zgosalvez/github-actions-ensure-sha-pinned-actions to v3.0.10

### DIFF
--- a/.github/workflows/ensure-sha-pinned-actions.yml
+++ b/.github/workflows/ensure-sha-pinned-actions.yml
@@ -25,4 +25,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
-      - uses: zgosalvez/github-actions-ensure-sha-pinned-actions@af2eb3226618e2494e3d9084f515ad6dcf16e229 #v2.0.1
+      - uses: zgosalvez/github-actions-ensure-sha-pinned-actions@b88cd0aad2c36a63e42c71f81cb1958fed95ac87 #v3.0.10


### PR DESCRIPTION
### Summary

See #260 for background.

Update the [`zgosalvez/github-actions-ensure-sha-pinned-actions`](https://github.com/zgosalvez/github-actions-ensure-sha-pinned-actions) action to the most recent version: [v3.0.10](https://github.com/zgosalvez/github-actions-ensure-sha-pinned-actions/releases/tag/v3.0.10). This contained a lot of commits, but mostly dependency bumps.

### Test Plan
- [X] Verify [new hash](https://github.com/aurora-opensource/au/actions/runs/10254451999/job/28369271409#step:3:1) on this PR
- [X] Checked job summary and saw no deprecation warnings
- [X] Checked the [changelog](https://github.com/zgosalvez/github-actions-ensure-sha-pinned-actions/compare/v2.0.1...v3.0.10) and didn't see any backwards incompatible changes