### PR TITLE
[ci] Bump actions/setup-python to v5.1.1

### DIFF
--- a/.github/workflows/single-file-build-and-test.yml
+++ b/.github/workflows/single-file-build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89 #v1.12.1
 
       - name: Set up python
-        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 #v3.1.4
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f #v5.1.1
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
### Summary

See #260 for background.

Update the [`actions/setup-python`](https://github.com/actions/setup-python) action to the most recent version: [v5.1.1](https://github.com/actions/setup-python/releases/tag/v5.1.1).  Quick summary of major versions:
* [v4](https://github.com/actions/setup-python/releases/tag/v4.0.0): there is no longer a default `python-version`, and we already specify one, so we should be ok
* [v5](https://github.com/actions/setup-python/releases/tag/v5.0.0) contained the Node20 upgrade

### Test Plan
- [ ] Verify new hash on this PR
- [ ] Checked job summary and saw no deprecation warnings related to `actions/setup-python`
- [X] Checked the changelog and didn't see any backwards incompatible changes