### PR TITLE
Deprecate `pascal`

### DIFF
--- a/au/code/au/units/pascals.hh
+++ b/au/code/au/units/pascals.hh
@@ -33,7 +33,13 @@ constexpr const char PascalsLabel<T>::label[];
 struct Pascals : decltype(Newtons{} / squared(Meters{})), PascalsLabel<void> {
     using PascalsLabel<void>::label;
 };
-constexpr auto pascal = SingularNameFor<Pascals>{};
+
+#ifndef pascal
+[[deprecated(
+    "Conflicts with the `pascal` macro from <Windows.h>; declare manually "
+    "instead.")]] constexpr auto pascal = SingularNameFor<Pascals>{};
+#endif
+
 constexpr auto pascals = QuantityMaker<Pascals>{};
 constexpr QuantityPointMaker<Pascals> pascals_pt{};
 


### PR DESCRIPTION
It conflicts with the `pascal` macro in `<Windows.h>`.  Yes, they really
did define a lowercase-named macro in `<Windows.h>`.

As with `PI` (#247), the `#ifndef` should immediately unblock most
users, but it's not a long-term solution, because it depends on
order-of-includes.  Therefore, we also deprecate `pascal` (as with `PI`
in #250).  I think a good rule of thumb is that deprecated constructs
should be deprecated for at least one full minor release cycle, so we'll
plan to delete it (along with `PI`) as part of 0.5.0.

Fixes #284.