### PR TITLE
Temporarily disable clang-format lint

### DIFF
--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -14,11 +14,11 @@
 
 name: clang-format-lint
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+# on:
+#   push:
+#     branches:
+#       - main
+#   pull_request:
 
 jobs:
   lint-clang-format:

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -14,6 +14,7 @@
 
 name: clang-format-lint
 
+# Temporarily disabled. See #292
 # on:
 #   push:
 #     branches:


### PR DESCRIPTION
We'll need to get a known-good release through security review, and then
we can re-enable it.  Meanwhile, #292 will track this issue and remind
us that we'll need to do this.