### PR TITLE
Default construct rep inside quantity

### DIFF
--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -403,7 +403,7 @@ class Quantity {
 
     constexpr Quantity(Rep value) : value_{value} {}
 
-    Rep value_{0};
+    Rep value_{};
 };
 
 // Force integer division beteween two integer Quantities, in a callsite-obvious way.

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -133,11 +133,17 @@ class Quantity {
 };
 ```
 
-A default-constructed `Quantity` is initialized to some value, which helps avoid certain kinds of
-memory safety bugs.  However, **the value is contractually unspecified**.  You can of course look up
-that value by reading the source code, but we may change it in the future, and **we would not
-consider this to be a breaking change**.  The only valid operation on a default-constructed
-`Quantity` is to assign to it later on.
+A default-constructed `Quantity` is always initialized (which helps avoid certain kinds of memory
+safety bugs).  It will contain a default-constructed instance of the rep type.
+
+!!! warning
+    Avoid relying on the _specific value_ of a default-constructed `Quantity`, because it poorly
+    communicates intent.  The only logically valid operation on a default-constructed `Quantity` is
+    to assign to it later on.
+
+    The default value for many rep types, including all fundamental arithmetic types, is `0`.
+    Instead of relying on this behaviour, initialize your `Quantity` with [`au::ZERO`](./zero.md) to
+    better communicate your intent.
 
 ### Constructing from corresponding quantity
 


### PR DESCRIPTION
This won't change any actual values when the rep is a fundamental
arithmetic type, but it is more stylistically consistent with the idea
of a "default constructor".

We also update our contract to officially promise that we do this.  This
lets us get rid of the scary/threatening language that "we might change
this out from under you!", even though we never had any intention to
actually do so.  We retain the encouragement to use `au::ZERO`, and to
avoid using a default-constructed `Quantity` for anything other than
future assignment.

Fixes #273.