### PR TITLE
Make building unit tests optional to simplify packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,28 +32,35 @@ project(
    LANGUAGES CXX
 )
 
+option(ENABLE_TESTING "Build Unit Tests" ON)
+
 # The export set for all of our headers.
 set(AU_EXPORT_SET_NAME AuHeaders)
 
-enable_testing()
+if(ENABLE_TESTING)
+   message(STATUS "Unit tests enabled")
+   enable_testing()
 
-# Bring in GoogleTest so we can build and run the tests.
-include(FetchContent)
-FetchContent_Declare(
-   googletest
-   GIT_REPOSITORY https://github.com/google/googletest.git
-   GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # Release 1.12.1
-   FIND_PACKAGE_ARGS
-      1.12.1
-      NAMES GTest
-)
+   # Bring in GoogleTest so we can build and run the tests.
+   include(FetchContent)
+   FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # Release 1.12.1
+      FIND_PACKAGE_ARGS
+         1.12.1
+         NAMES GTest
+   )
 
-# https://google.github.io/googletest/quickstart-cmake.html
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+   # https://google.github.io/googletest/quickstart-cmake.html
+   # For Windows: Prevent overriding the parent project's compiler/linker settings
+   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-FetchContent_MakeAvailable(googletest)
-include(GoogleTest)
+   FetchContent_MakeAvailable(googletest)
+   include(GoogleTest)
+else()
+   message(STATUS "Unit tests disabled")
+endif()
 
 add_subdirectory(au)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ if(ENABLE_TESTING)
 
    FetchContent_MakeAvailable(googletest)
    include(GoogleTest)
+
+   set(AU_CONFIG_FIND_GTEST_LINE "find_dependency(googletest 1.12.1)")
 else()
    message(STATUS "Unit tests disabled")
 endif()

--- a/cmake/AuConfig.cmake.in
+++ b/cmake/AuConfig.cmake.in
@@ -15,7 +15,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(googletest 1.12.1)
+@AU_CONFIG_FIND_GTEST_LINE@
 
 include(${CMAKE_CURRENT_LIST_DIR}/AuHeaders.cmake)
 

--- a/cmake/HeaderOnlyLibrary.cmake
+++ b/cmake/HeaderOnlyLibrary.cmake
@@ -75,7 +75,7 @@ function(header_only_library)
   )
 
   # Add the test, if requested.
-  if (DEFINED ARG_GTEST_SRCS)
+  if (DEFINED ARG_GTEST_SRCS AND ENABLE_TESTING)
     add_executable("${ARG_NAME}_test")
     target_sources("${ARG_NAME}_test" PRIVATE ${ARG_GTEST_SRCS})
     target_link_libraries(


### PR DESCRIPTION
I intent to package this library with Conan.

I don't want the conan package to depend on GTest, so instead of patching it out on the conan recipe I decided to propose this here instead.

I maintained the tests enabled by default, but a user can opt out of them with `-DENABLE_TESTING:BOOL=OFF`.

I don't think that gtest has any business on the installed targets. I disabled the `find_package()` call on the generated config file if we're building unit tests, but there are other references to gtest on the generated files. That's unusual. I think GTest should be treated as an internal tool, used for testing, and do not get propagated downstream.

-Eric