### PR TITLE
Consolidate Au CMake targets

### DIFF
--- a/au/code/au/CMakeLists.txt
+++ b/au/code/au/CMakeLists.txt
@@ -20,7 +20,87 @@ include("${PROJECT_SOURCE_DIR}/cmake/HeaderOnlyLibrary.cmake")
 
 header_only_library(
   NAME au
-  HEADERS apply_magnitude.hh apply_rational_magnitude_to_integral.hh au.hh chrono_interop.hh constant.hh conversion_policy.hh dimension.hh io.hh magnitude.hh math.hh operators.hh packs.hh power_aliases.hh prefix.hh quantity.hh quantity_point.hh rep.hh unit_of_measure.hh unit_symbol.hh wrapper_operations.hh zero.hh stdx/experimental/is_detected.hh stdx/functional.hh stdx/type_traits.hh stdx/utility.hh units/amperes.hh units/bars.hh units/becquerel.hh units/bits.hh units/bytes.hh units/candelas.hh units/celsius.hh units/coulombs.hh units/days.hh units/degrees.hh units/fahrenheit.hh units/farads.hh units/fathoms.hh units/feet.hh units/furlongs.hh units/grams.hh units/grays.hh units/henries.hh units/hertz.hh units/hours.hh units/inches.hh units/joules.hh units/katals.hh units/kelvins.hh units/knots.hh units/liters.hh units/lumens.hh units/lux.hh units/meters.hh units/miles.hh units/minutes.hh units/moles.hh units/nautical_miles.hh units/newtons.hh units/ohms.hh units/pascals.hh units/percent.hh units/pounds_force.hh units/pounds_mass.hh units/radians.hh units/revolutions.hh units/seconds.hh units/siemens.hh units/slugs.hh units/standard_gravity.hh units/steradians.hh units/tesla.hh units/unos.hh units/volts.hh units/watts.hh units/webers.hh units/yards.hh utility/factoring.hh utility/string_constant.hh utility/type_traits.hh
+  HEADERS
+    apply_magnitude.hh
+    apply_rational_magnitude_to_integral.hh
+    au.hh
+    chrono_interop.hh
+    constant.hh
+    conversion_policy.hh
+    dimension.hh
+    io.hh
+    magnitude.hh
+    math.hh
+    operators.hh
+    packs.hh
+    power_aliases.hh
+    prefix.hh
+    quantity.hh
+    quantity_point.hh
+    rep.hh
+    unit_of_measure.hh
+    unit_symbol.hh
+    wrapper_operations.hh
+    zero.hh
+    stdx/experimental/is_detected.hh
+    stdx/functional.hh
+    stdx/type_traits.hh
+    stdx/utility.hh
+    units/amperes.hh
+    units/bars.hh
+    units/becquerel.hh
+    units/bits.hh
+    units/bytes.hh
+    units/candelas.hh
+    units/celsius.hh
+    units/coulombs.hh
+    units/days.hh
+    units/degrees.hh
+    units/fahrenheit.hh
+    units/farads.hh
+    units/fathoms.hh
+    units/feet.hh
+    units/furlongs.hh
+    units/grams.hh
+    units/grays.hh
+    units/henries.hh
+    units/hertz.hh
+    units/hours.hh
+    units/inches.hh
+    units/joules.hh
+    units/katals.hh
+    units/kelvins.hh
+    units/knots.hh
+    units/liters.hh
+    units/lumens.hh
+    units/lux.hh
+    units/meters.hh
+    units/miles.hh
+    units/minutes.hh
+    units/moles.hh
+    units/nautical_miles.hh
+    units/newtons.hh
+    units/ohms.hh
+    units/pascals.hh
+    units/percent.hh
+    units/pounds_force.hh
+    units/pounds_mass.hh
+    units/radians.hh
+    units/revolutions.hh
+    units/seconds.hh
+    units/siemens.hh
+    units/slugs.hh
+    units/standard_gravity.hh
+    units/steradians.hh
+    units/tesla.hh
+    units/unos.hh
+    units/volts.hh
+    units/watts.hh
+    units/webers.hh
+    units/yards.hh
+    utility/factoring.hh
+    utility/string_constant.hh
+    utility/type_traits.hh
 )
 
 header_only_library(
@@ -50,7 +130,7 @@ header_only_library(
 
 gtest_based_test(
   NAME au_test
-  GTEST_SRCS
+  SRCS
     au_test.cc
   DEPS
     au
@@ -59,7 +139,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME chrono_interop_test
-  GTEST_SRCS
+  SRCS
     chrono_interop_test.cc
   DEPS
     au
@@ -68,7 +148,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME constant_test
-  GTEST_SRCS
+  SRCS
     constant_test.cc
   DEPS
     au
@@ -77,7 +157,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME io_test
-  GTEST_SRCS
+  SRCS
     io_test.cc
   DEPS
     au
@@ -85,7 +165,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME math_test
-  GTEST_SRCS
+  SRCS
     math_test.cc
   DEPS
     au
@@ -94,7 +174,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME prefix_test
-  GTEST_SRCS
+  SRCS
     prefix_test.cc
   DEPS
     au
@@ -103,7 +183,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME quantity_test
-  GTEST_SRCS
+  SRCS
     quantity_chrono_policy_correspondence_test.cc
     quantity_test.cc
   DEPS
@@ -114,7 +194,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME quantity_point_test
-  GTEST_SRCS
+  SRCS
     quantity_point_test.cc
   DEPS
     au
@@ -123,7 +203,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME testing_test
-  GTEST_SRCS
+  SRCS
     testing_test.cc
   DEPS
     au
@@ -132,7 +212,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME units_test
-  GTEST_SRCS
+  SRCS
     units/test/amperes_test.cc
     units/test/bars_test.cc
     units/test/becquerel_test.cc
@@ -192,7 +272,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME unit_symbol_test
-  GTEST_SRCS
+  SRCS
     unit_symbol_test.cc
   DEPS
     au
@@ -205,7 +285,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME apply_magnitude_test
-  GTEST_SRCS
+  SRCS
     apply_magnitude_test.cc
   DEPS
     au
@@ -214,7 +294,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME apply_rational_magnitude_to_integral_test
-  GTEST_SRCS
+  SRCS
     apply_rational_magnitude_to_integral_test.cc
   DEPS
     au
@@ -223,7 +303,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME chrono_policy_validation_test
-  GTEST_SRCS
+  SRCS
     chrono_policy_validation_test.cc
   DEPS
     au
@@ -234,7 +314,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME conversion_policy_test
-  GTEST_SRCS
+  SRCS
     conversion_policy_test.cc
   DEPS
     au
@@ -243,7 +323,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME dimension_test
-  GTEST_SRCS
+  SRCS
     dimension_test.cc
   DEPS
     au
@@ -252,7 +332,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME magnitude_test
-  GTEST_SRCS
+  SRCS
     magnitude_test.cc
   DEPS
     au
@@ -261,7 +341,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME operators_test
-  GTEST_SRCS
+  SRCS
     operators_test.cc
   DEPS
     testing
@@ -269,7 +349,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME packs_test
-  GTEST_SRCS
+  SRCS
     packs_test.cc
   DEPS
     au
@@ -277,7 +357,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME power_aliases_test
-  GTEST_SRCS
+  SRCS
     power_aliases_test.cc
   DEPS
     au
@@ -285,7 +365,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME rep_test
-  GTEST_SRCS
+  SRCS
     rep_test.cc
   DEPS
     au
@@ -293,7 +373,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME stdx_test
-  GTEST_SRCS
+  SRCS
     stdx/test/utility_test.cc
   DEPS
     au
@@ -301,7 +381,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME unit_of_measure_test
-  GTEST_SRCS
+  SRCS
     unit_of_measure_test.cc
   DEPS
     au
@@ -310,7 +390,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME utility_test
-  GTEST_SRCS
+  SRCS
     utility/test/factoring_test.cc
     utility/test/string_constant_test.cc
     utility/test/type_traits_test.cc
@@ -321,7 +401,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME wrapper_operations_test
-  GTEST_SRCS
+  SRCS
     wrapper_operations_test.cc
   DEPS
     au
@@ -330,7 +410,7 @@ gtest_based_test(
 
 gtest_based_test(
   NAME zero_test
-  GTEST_SRCS
+  SRCS
     zero_test.cc
   DEPS
     au

--- a/au/code/au/CMakeLists.txt
+++ b/au/code/au/CMakeLists.txt
@@ -20,203 +20,118 @@ include("${PROJECT_SOURCE_DIR}/cmake/HeaderOnlyLibrary.cmake")
 
 header_only_library(
   NAME au
-  HEADERS
-    au.hh
-  DEPS
-    chrono_interop
-    constant
-    math
-  GTEST_SRCS
-    au_test.cc
-  GTEST_EXTRA_DEPS
-    testing
-)
-
-header_only_library(
-  NAME chrono_interop
-  HEADERS
-    chrono_interop.hh
-  DEPS
-    prefix
-    quantity
-    units
-  GTEST_SRCS
-    chrono_interop_test.cc
-  GTEST_EXTRA_DEPS
-    prefix
-    testing
-)
-
-header_only_library(
-  NAME constant
-  HEADERS
-    constant.hh
-  DEPS
-    quantity
-    unit_of_measure
-    wrapper_operations
-  GTEST_SRCS
-    constant_test.cc
-  GTEST_EXTRA_DEPS
-    chrono_interop
-    testing
-    units
-)
-
-header_only_library(
-  NAME io
-  HEADERS
-    io.hh
-  DEPS
-    quantity
-    quantity_point
-    zero
-  GTEST_SRCS
-    io_test.cc
-  GTEST_EXTRA_DEPS
-    prefix
-)
-
-header_only_library(
-  NAME math
-  HEADERS
-    math.hh
-  DEPS
-    constant
-    quantity
-    quantity_point
-    units
-  GTEST_SRCS
-    math_test.cc
-  GTEST_EXTRA_DEPS
-    testing
-)
-
-header_only_library(
-  NAME prefix
-  HEADERS
-    prefix.hh
-  DEPS
-    quantity
-    quantity_point
-    unit_of_measure
-    unit_symbol
-  GTEST_SRCS
-    prefix_test.cc
-  GTEST_EXTRA_DEPS
-    testing
-)
-
-header_only_library(
-  NAME quantity
-  HEADERS
-    quantity.hh
-  DEPS
-    apply_magnitude
-    conversion_policy
-    operators
-    rep
-    unit_of_measure
-    utility
-    zero
-  GTEST_SRCS
-    quantity_chrono_policy_correspondence_test.cc
-    quantity_test.cc
-  GTEST_EXTRA_DEPS
-    chrono_policy_validation
-    prefix
-    testing
-)
-
-header_only_library(
-  NAME quantity_point
-  HEADERS
-    quantity_point.hh
-  DEPS
-    quantity
-    stdx
-    utility
-  GTEST_SRCS
-    quantity_point_test.cc
-  GTEST_EXTRA_DEPS
-    prefix
-    testing
+  HEADERS apply_magnitude.hh apply_rational_magnitude_to_integral.hh au.hh chrono_interop.hh constant.hh conversion_policy.hh dimension.hh io.hh magnitude.hh math.hh operators.hh packs.hh power_aliases.hh prefix.hh quantity.hh quantity_point.hh rep.hh unit_of_measure.hh unit_symbol.hh wrapper_operations.hh zero.hh stdx/experimental/is_detected.hh stdx/functional.hh stdx/type_traits.hh stdx/utility.hh units/amperes.hh units/bars.hh units/becquerel.hh units/bits.hh units/bytes.hh units/candelas.hh units/celsius.hh units/coulombs.hh units/days.hh units/degrees.hh units/fahrenheit.hh units/farads.hh units/fathoms.hh units/feet.hh units/furlongs.hh units/grams.hh units/grays.hh units/henries.hh units/hertz.hh units/hours.hh units/inches.hh units/joules.hh units/katals.hh units/kelvins.hh units/knots.hh units/liters.hh units/lumens.hh units/lux.hh units/meters.hh units/miles.hh units/minutes.hh units/moles.hh units/nautical_miles.hh units/newtons.hh units/ohms.hh units/pascals.hh units/percent.hh units/pounds_force.hh units/pounds_mass.hh units/radians.hh units/revolutions.hh units/seconds.hh units/siemens.hh units/slugs.hh units/standard_gravity.hh units/steradians.hh units/tesla.hh units/unos.hh units/volts.hh units/watts.hh units/webers.hh units/yards.hh utility/factoring.hh utility/string_constant.hh utility/type_traits.hh
 )
 
 header_only_library(
   NAME testing
-  HEADERS
-    testing.hh
+  HEADERS testing.hh
   DEPS
-    io
-    stdx
-    unit_of_measure
+    au
     GTest::gmock
-  GTEST_SRCS
-    testing_test.cc
 )
 
+#
+# Private implementation detail targets
+#
+
 header_only_library(
-  NAME units
-  HEADERS
-    units/amperes.hh
-    units/bars.hh
-    units/becquerel.hh
-    units/bits.hh
-    units/bytes.hh
-    units/candelas.hh
-    units/celsius.hh
-    units/coulombs.hh
-    units/days.hh
-    units/degrees.hh
-    units/fahrenheit.hh
-    units/farads.hh
-    units/fathoms.hh
-    units/feet.hh
-    units/furlongs.hh
-    units/grams.hh
-    units/grays.hh
-    units/henries.hh
-    units/hertz.hh
-    units/hours.hh
-    units/inches.hh
-    units/joules.hh
-    units/katals.hh
-    units/kelvins.hh
-    units/knots.hh
-    units/liters.hh
-    units/lumens.hh
-    units/lux.hh
-    units/meters.hh
-    units/miles.hh
-    units/minutes.hh
-    units/moles.hh
-    units/nautical_miles.hh
-    units/newtons.hh
-    units/ohms.hh
-    units/pascals.hh
-    units/percent.hh
-    units/pounds_force.hh
-    units/pounds_mass.hh
-    units/radians.hh
-    units/revolutions.hh
-    units/seconds.hh
-    units/siemens.hh
-    units/slugs.hh
-    units/standard_gravity.hh
-    units/steradians.hh
-    units/tesla.hh
-    units/unos.hh
-    units/volts.hh
-    units/watts.hh
-    units/webers.hh
-    units/yards.hh
+  NAME chrono_policy_validation
+  INTERNAL_ONLY
+  HEADERS chrono_policy_validation.hh
   DEPS
-    prefix
-    quantity
-    quantity_point
-    unit_of_measure
-    unit_symbol
+    au
+    GTest::gtest
+)
+
+#
+# Tests
+#
+
+gtest_based_test(
+  NAME au_test
+  GTEST_SRCS
+    au_test.cc
+  DEPS
+    au
+    testing
+)
+
+gtest_based_test(
+  NAME chrono_interop_test
+  GTEST_SRCS
+    chrono_interop_test.cc
+  DEPS
+    au
+    testing
+)
+
+gtest_based_test(
+  NAME constant_test
+  GTEST_SRCS
+    constant_test.cc
+  DEPS
+    au
+    testing
+)
+
+gtest_based_test(
+  NAME io_test
+  GTEST_SRCS
+    io_test.cc
+  DEPS
+    au
+)
+
+gtest_based_test(
+  NAME math_test
+  GTEST_SRCS
+    math_test.cc
+  DEPS
+    au
+    testing
+)
+
+gtest_based_test(
+  NAME prefix_test
+  GTEST_SRCS
+    prefix_test.cc
+  DEPS
+    au
+    testing
+)
+
+gtest_based_test(
+  NAME quantity_test
+  GTEST_SRCS
+    quantity_chrono_policy_correspondence_test.cc
+    quantity_test.cc
+  DEPS
+    au
+    chrono_policy_validation
+    testing
+)
+
+gtest_based_test(
+  NAME quantity_point_test
+  GTEST_SRCS
+    quantity_point_test.cc
+  DEPS
+    au
+    testing
+)
+
+gtest_based_test(
+  NAME testing_test
+  GTEST_SRCS
+    testing_test.cc
+  DEPS
+    au
+    testing
+)
+
+gtest_based_test(
+  NAME units_test
   GTEST_SRCS
     units/test/amperes_test.cc
     units/test/bars_test.cc
@@ -270,238 +185,153 @@ header_only_library(
     units/test/watts_test.cc
     units/test/webers_test.cc
     units/test/yards_test.cc
-  GTEST_EXTRA_DEPS
+  DEPS
+    au
     testing
 )
 
-header_only_library(
-  NAME unit_symbol
-  HEADERS
-    unit_symbol.hh
-  DEPS
-    wrapper_operations
+gtest_based_test(
+  NAME unit_symbol_test
   GTEST_SRCS
     unit_symbol_test.cc
-  GTEST_EXTRA_DEPS
+  DEPS
+    au
     testing
-    units
 )
 
 #
 # Private implementation detail targets
 #
 
-header_only_library(
-  NAME apply_magnitude
-  INTERNAL_ONLY
-  HEADERS
-    apply_magnitude.hh
-  DEPS
-    apply_rational_magnitude_to_integral
+gtest_based_test(
+  NAME apply_magnitude_test
   GTEST_SRCS
     apply_magnitude_test.cc
-  GTEST_EXTRA_DEPS
+  DEPS
+    au
     testing
 )
 
-header_only_library(
-  NAME apply_rational_magnitude_to_integral
-  INTERNAL_ONLY
-  HEADERS
-    apply_rational_magnitude_to_integral.hh
-  DEPS
-    magnitude
+gtest_based_test(
+  NAME apply_rational_magnitude_to_integral_test
   GTEST_SRCS
     apply_rational_magnitude_to_integral_test.cc
-  GTEST_EXTRA_DEPS
+  DEPS
+    au
     testing
 )
 
-header_only_library(
-  NAME chrono_policy_validation
-  INTERNAL_ONLY
-  HEADERS
-    chrono_policy_validation.hh
-  DEPS
-    dimension
-    quantity
-    stdx
-    unit_of_measure
-    GTest::gtest
+gtest_based_test(
+  NAME chrono_policy_validation_test
   GTEST_SRCS
     chrono_policy_validation_test.cc
-  GTEST_EXTRA_DEPS
-    prefix
+  DEPS
+    au
+    chrono_policy_validation
     testing
 )
 
 
-header_only_library(
-  NAME conversion_policy
-  INTERNAL_ONLY
-  HEADERS
-    conversion_policy.hh
-  DEPS
-    magnitude
-    stdx
-    unit_of_measure
+gtest_based_test(
+  NAME conversion_policy_test
   GTEST_SRCS
     conversion_policy_test.cc
+  DEPS
+    au
+    testing
 )
 
-header_only_library(
-  NAME dimension
-  INTERNAL_ONLY
-  HEADERS
-    dimension.hh
-  DEPS
-    packs
-    power_aliases
+gtest_based_test(
+  NAME dimension_test
   GTEST_SRCS
     dimension_test.cc
-  GTEST_EXTRA_DEPS
+  DEPS
+    au
     testing
-    units
 )
 
-header_only_library(
-  NAME magnitude
-  INTERNAL_ONLY
-  HEADERS
-    magnitude.hh
-  DEPS
-    packs
-    power_aliases
-    stdx
-    utility
-    zero
+gtest_based_test(
+  NAME magnitude_test
   GTEST_SRCS
     magnitude_test.cc
-  GTEST_EXTRA_DEPS
+  DEPS
+    au
     testing
 )
 
-header_only_library(
-  NAME operators
-  INTERNAL_ONLY
-  HEADERS
-    operators.hh
+gtest_based_test(
+  NAME operators_test
   GTEST_SRCS
     operators_test.cc
-  GTEST_EXTRA_DEPS
+  DEPS
     testing
 )
 
-header_only_library(
-  NAME packs
-  INTERNAL_ONLY
-  HEADERS
-    packs.hh
-  DEPS
-    stdx
-    utility
+gtest_based_test(
+  NAME packs_test
   GTEST_SRCS
     packs_test.cc
+  DEPS
+    au
 )
 
-header_only_library(
-  NAME power_aliases
-  INTERNAL_ONLY
-  HEADERS
-    power_aliases.hh
+gtest_based_test(
+  NAME power_aliases_test
   GTEST_SRCS
     power_aliases_test.cc
-  GTEST_EXTRA_DEPS
-    packs
+  DEPS
+    au
 )
 
-header_only_library(
-  NAME rep
-  INTERNAL_ONLY
-  HEADERS
-    rep.hh
-  DEPS
-    stdx
+gtest_based_test(
+  NAME rep_test
   GTEST_SRCS
     rep_test.cc
-  GTEST_EXTRA_DEPS
-    chrono_interop
-    constant
-    magnitude
-    prefix
-    quantity
-    quantity_point
-    unit_symbol
-    units
+  DEPS
+    au
 )
 
-header_only_library(
-  NAME stdx
-  INTERNAL_ONLY
-  HEADERS
-    stdx/experimental/is_detected.hh
-    stdx/functional.hh
-    stdx/type_traits.hh
-    stdx/utility.hh
+gtest_based_test(
+  NAME stdx_test
   GTEST_SRCS
     stdx/test/utility_test.cc
+  DEPS
+    au
 )
 
-header_only_library(
-  NAME unit_of_measure
-  INTERNAL_ONLY
-  HEADERS
-    unit_of_measure.hh
-  DEPS
-    dimension
-    magnitude
-    power_aliases
-    stdx
-    utility
-    zero
+gtest_based_test(
+  NAME unit_of_measure_test
   GTEST_SRCS
     unit_of_measure_test.cc
-  GTEST_EXTRA_DEPS
-    prefix
+  DEPS
+    au
     testing
-    units
 )
 
-header_only_library(
-  NAME utility
-  INTERNAL_ONLY
-  HEADERS
-    utility/factoring.hh
-    utility/string_constant.hh
-    utility/type_traits.hh
-  DEPS
-    stdx
+gtest_based_test(
+  NAME utility_test
   GTEST_SRCS
     utility/test/factoring_test.cc
     utility/test/string_constant_test.cc
     utility/test/type_traits_test.cc
+  DEPS
+    au
+    testing
 )
 
-header_only_library(
-  NAME wrapper_operations
-  INTERNAL_ONLY
-  HEADERS
-    wrapper_operations.hh
-  DEPS
-    quantity
-    stdx
+gtest_based_test(
+  NAME wrapper_operations_test
   GTEST_SRCS
     wrapper_operations_test.cc
-  GTEST_EXTRA_DEPS
+  DEPS
+    au
     testing
-    units
 )
 
-header_only_library(
-  NAME zero
-  INTERNAL_ONLY
-  HEADERS
-    zero.hh
+gtest_based_test(
+  NAME zero_test
   GTEST_SRCS
     zero_test.cc
+  DEPS
+    au
 )

--- a/cmake/HeaderOnlyLibrary.cmake
+++ b/cmake/HeaderOnlyLibrary.cmake
@@ -81,7 +81,7 @@ function(gtest_based_test)
   set(prefix ARG)
   set(singleValueVars NAME)
   set(multiValueVars
-    GTEST_SRCS
+    SRCS
     DEPS
   )
 

--- a/cmake/HeaderOnlyLibrary.cmake
+++ b/cmake/HeaderOnlyLibrary.cmake
@@ -23,8 +23,6 @@ function(header_only_library)
   set(multiValueVars
     HEADERS
     DEPS
-    GTEST_SRCS
-    GTEST_EXTRA_DEPS
   )
 
   cmake_parse_arguments(
@@ -73,18 +71,40 @@ function(header_only_library)
     FILE_SET HEADERS
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   )
+endfunction()
 
-  # Add the test, if requested.
-  if (DEFINED ARG_GTEST_SRCS)
-    add_executable("${ARG_NAME}_test")
-    target_sources("${ARG_NAME}_test" PRIVATE ${ARG_GTEST_SRCS})
-    target_link_libraries(
-      "${ARG_NAME}_test"
-      PRIVATE
-      ${ARG_NAME}
-      ${ARG_GTEST_EXTRA_DEPS}
-      GTest::gmock_main
-    )
-    gtest_discover_tests("${ARG_NAME}_test")
-  endif()
+function(gtest_based_test)
+  #
+  # Handle argument parsing
+  #
+
+  set(prefix ARG)
+  set(singleValueVars NAME)
+  set(multiValueVars
+    GTEST_SRCS
+    DEPS
+  )
+
+  cmake_parse_arguments(
+    PARSE_ARGV 0
+    "${prefix}"
+    "${noValueVars}"
+    "${singleValueVars}"
+    "${multiValueVars}"
+  )
+
+  #
+  # Function body
+  #
+
+  # Add the test.
+  add_executable(${ARG_NAME})
+  target_sources(${ARG_NAME} PRIVATE ${ARG_GTEST_SRCS})
+  target_link_libraries(
+    ${ARG_NAME}
+    PRIVATE
+    ${ARG_DEPS}
+    GTest::gmock_main
+  )
+  gtest_discover_tests(${ARG_NAME})
 endfunction()

--- a/cmake/HeaderOnlyLibrary.cmake
+++ b/cmake/HeaderOnlyLibrary.cmake
@@ -99,7 +99,7 @@ function(gtest_based_test)
 
   # Add the test.
   add_executable(${ARG_NAME})
-  target_sources(${ARG_NAME} PRIVATE ${ARG_GTEST_SRCS})
+  target_sources(${ARG_NAME} PRIVATE ${ARG_SRCS})
   target_link_libraries(
     ${ARG_NAME}
     PRIVATE

--- a/docs/install.md
+++ b/docs/install.md
@@ -267,8 +267,7 @@ In either case, here are the main targets and include files provided by the Au l
 
 | Target | Headers provided | Notes |
 |--------|------------------|-------|
-| `Au::au` | `"au/au.hh"`<br>`"au/units/*.hh"` | Core library functionality.  See [all available units](https://github.com/aurora-opensource/au/tree/main/au/units) |
-| `Au::io` | `"au/io.hh"` | `operator<<` support |
+| `Au::au` | `"au/au.hh"`<br>`"au/io.hh"`<br>`"au/units/*.hh"` | Core library functionality.  See [all available units](https://github.com/aurora-opensource/au/tree/main/au/units) |
 | `Au::testing` | `"au/testing.hh"` | Utilities for writing googletest tests |
 
 !!! note
@@ -293,8 +292,8 @@ In either case, here are the main targets and include files provided by the Au l
     FetchContent_MakeAvailable(Au)
     ```
 
-    You should now be able to depend on Au targets, such as `Au::au` or `Au::io`, and include their
-    corresponding headers, such as `#include "au/au.hh"` or `#include "au/io.hh"`.
+    You should now be able to depend on Au targets, such as `Au::au` or `Au::testing`, and include
+    headers from them, such as `#include "au/au.hh"` or `#include "au/testing.hh"`.
 
 === "Using `find_package`"
     Before you can use `find_package`, you need to install the library to your system.  This means


### PR DESCRIPTION
This breaks the 1:1 correspondence between target and test, so we split
up our helper accordingly into two.

We make `au` the single mega-target that holds everything that doesn't
depend on GTest.  It turns out that there are two targets that do.
`testing` is for external users, and contains custom GMock matchers.
`chrono_policy_validation` is an internal-only library that makes it
easy to test that Au is like chrono where we want to be, and unlike
chrono otherwise.  Each of these targets also depends on the `au`
mega-target.

Helps #257.