### PR TITLE
Use official vcpkg link

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -232,7 +232,7 @@ methods have "community support", which means:
 Each package manager contains setup instructions on its page for Au.  Here are the packages:
 
 - **Conan:** [au](https://conan.io/center/recipes/au)
-- **vcpkg:** [aurora-au](https://vcpkg.link/ports/aurora-au)
+- **vcpkg:** [aurora-au](https://vcpkg.io/en/package/aurora-au)
 
 ### Single file {#single-file}
 


### PR DESCRIPTION
[Evidently], `vcpkg.link` is an unofficial third party URL.  We now use
the official URL instead.

[Evidently]: https://github.com/aurora-opensource/au/commit/06b074cd972234fca5b9abe429a7299e9c95af93#r148182262