### PR TITLE
Re-enable clang-format-lint action

### DIFF
--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -14,12 +14,11 @@
 
 name: clang-format-lint
 
-# Temporarily disabled. See #292
-# on:
-#   push:
-#     branches:
-#       - main
-#   pull_request:
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint-clang-format:
@@ -27,7 +26,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
-    - uses: DoozyX/clang-format-lint-action@2ec1a72dfb593e52255693c9039e6d94984187dc #v0.14
+    - uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 #v0.18.2
       with:
         source: './au'
         extensions: 'hh,cc'


### PR DESCRIPTION
The latest version has now been approved by an Aurora-internal security
review.

Fixes #292.