### PR TITLE
Eliminate redundant units from `CommonUnit<...>`

### DIFF
--- a/au/code/au/utility/test/type_traits_test.cc
+++ b/au/code/au/utility/test/type_traits_test.cc
@@ -22,11 +22,11 @@ namespace au {
 namespace detail {
 
 template <typename... Ts>
-struct TestingPack;
+struct Pack;
 
 TEST(Prepend, PrependsToPack) {
-    StaticAssertTypeEq<PrependT<TestingPack<>, int>, TestingPack<int>>();
-    StaticAssertTypeEq<PrependT<TestingPack<double, char>, int>, TestingPack<int, double, char>>();
+    StaticAssertTypeEq<PrependT<Pack<>, int>, Pack<int>>();
+    StaticAssertTypeEq<PrependT<Pack<double, char>, int>, Pack<int, double, char>>();
 }
 
 TEST(SameTypeIgnoringCvref, IgnoresCvrefQualifiers) {
@@ -49,6 +49,20 @@ TEST(AlwaysFalse, IsAlwaysFalse) {
     EXPECT_FALSE(AlwaysFalse<void>::value);
     EXPECT_FALSE(AlwaysFalse<>::value);
     EXPECT_FALSE((AlwaysFalse<int, char, double>::value));
+}
+
+TEST(DropAll, IdentityWhenTargetAbsent) {
+    StaticAssertTypeEq<DropAll<void, Pack<>>, Pack<>>();
+    StaticAssertTypeEq<DropAll<void, Pack<int>>, Pack<int>>();
+    StaticAssertTypeEq<DropAll<void, Pack<int, char, double>>, Pack<int, char, double>>();
+}
+
+TEST(DropAll, DropsAllInstancesOfTarget) {
+    StaticAssertTypeEq<DropAll<int, Pack<int>>, Pack<>>();
+    StaticAssertTypeEq<DropAll<int, Pack<int, int>>, Pack<>>();
+    StaticAssertTypeEq<DropAll<int, Pack<int, char, int>>, Pack<char>>();
+    StaticAssertTypeEq<DropAll<int, Pack<char, int, char>>, Pack<char, char>>();
+    StaticAssertTypeEq<DropAll<int, Pack<int, char, int, double>>, Pack<char, double>>();
 }
 
 }  // namespace detail


### PR DESCRIPTION
The core here is the addition to `:quantity_test`.  Making this pass is
the goal of this PR.

To get there, we need a new trait/metafunction that can take a pack of
units, and eliminate all the "redundant" ones.  This means we also need
a definition of "redundant", where the canonical example would be that
"feet" is redundant between "feet" and "inches".  Here's what we came up
with:

- If two units are _identical_ (same type), then each is redundant
  w.r.t. the other.
- If two units are _distinct_, but _quantity-equivalent_, then the
  redundant one is whichever comes later in the "standard pack
  ordering".  (We try to give more "recognizable" units higher
  priority.)
- Otherwise, for _quantity-inequivalent_ units, a redundant unit is an
  exact integer multiple of another unit.

All of this assumes that the units have the same dimension.  We simply
wouldn't call this machinery in the first place if that weren't true.

Finally, we need one more piece of machinery: a simple "drop all X"
metafunction.  This is because when an earlier unit makes later units
redundant, we can't easily "reach into" that "tail pack" of units and
remove them directly.  Instead, we need to mark them with a "tombstone"
(`void`), and then remove all the tombstoned units.

Fixes #295.