### PR TITLE
Add CMake option to fully exclude gtest dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ include(CMakeDependentOption)
 
 option(
    AU_EXCLUDE_GTEST_DEPENDENCY
-   "Avoid taking any dependency on googletest (and, implicitly, do not build tests)"
+   "Avoid taking any dependency on googletest. This option implies that tests will be skipped"
    OFF
 )
 cmake_dependent_option(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,20 @@ project(
    LANGUAGES CXX
 )
 
-option(AU_ENABLE_TESTING "Build Unit Tests" ON)
+include(CMakeDependentOption)
+
+option(
+   AU_EXCLUDE_GTEST_DEPENDENCY
+   "Avoid taking any dependency on googletest (and, implicitly, do not build tests)"
+   OFF
+)
+cmake_dependent_option(
+   AU_ENABLE_TESTING
+   "Build Unit Tests"
+   ON
+   "NOT AU_EXCLUDE_GTEST_DEPENDENCY"
+   OFF
+)
 
 # The export set for all of our headers.
 set(AU_EXPORT_SET_NAME AuHeaders)
@@ -46,23 +59,25 @@ endif()
 
 # Bring in GoogleTest so we can build and run the tests.
 include(FetchContent)
-FetchContent_Declare(
-   googletest
-   GIT_REPOSITORY https://github.com/google/googletest.git
-   GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # Release 1.12.1
-   FIND_PACKAGE_ARGS
-      1.12.1
-      NAMES GTest
-)
+if (NOT AU_EXCLUDE_GTEST_DEPENDENCY)
+   FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # Release 1.12.1
+      FIND_PACKAGE_ARGS
+         1.12.1
+         NAMES GTest
+   )
 
-# https://google.github.io/googletest/quickstart-cmake.html
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+   # https://google.github.io/googletest/quickstart-cmake.html
+   # For Windows: Prevent overriding the parent project's compiler/linker settings
+   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-FetchContent_MakeAvailable(googletest)
-include(GoogleTest)
+   FetchContent_MakeAvailable(googletest)
+   include(GoogleTest)
 
-set(AU_CONFIG_FIND_GTEST_LINE "find_dependency(googletest 1.12.1)")
+   set(AU_CONFIG_FIND_GTEST_LINE "find_dependency(googletest 1.12.1)")
+endif()
 
 add_subdirectory(au)
 

--- a/au/code/au/CMakeLists.txt
+++ b/au/code/au/CMakeLists.txt
@@ -106,26 +106,30 @@ header_only_library(
     utility/type_traits.hh
 )
 
-header_only_library(
-  NAME testing
-  HEADERS testing.hh
-  DEPS
-    au
-    GTest::gmock
-)
+if (NOT AU_EXCLUDE_GTEST_DEPENDENCY)
+  header_only_library(
+    NAME testing
+    HEADERS testing.hh
+    DEPS
+      au
+      GTest::gmock
+  )
+endif()
 
 #
 # Private implementation detail targets
 #
 
-header_only_library(
-  NAME chrono_policy_validation
-  INTERNAL_ONLY
-  HEADERS chrono_policy_validation.hh
-  DEPS
-    au
-    GTest::gtest
-)
+if (NOT AU_EXCLUDE_GTEST_DEPENDENCY)
+  header_only_library(
+    NAME chrono_policy_validation
+    INTERNAL_ONLY
+    HEADERS chrono_policy_validation.hh
+    DEPS
+      au
+      GTest::gtest
+  )
+endif()
 
 #
 # Tests


### PR DESCRIPTION
If users activate this new option, `AU_EXCLUDE_GTEST_DEPENDENCY`, then
it will force `AU_ENABLE_TESTING` to `OFF`.  We will not attempt to pull
in the googletest dependency by any means, and we won't define the extra
targets that depend on it.

To test, run:

```sh
rm -Rf cmake/build/ \
&& cmake \
  -S . \
  -B cmake/build \
  -DAU_EXCLUDE_GTEST_DEPENDENCY=TRUE \
  -DCMAKE_VERIFY_INTERFACE_HEADER_SETS=TRUE \
&& cmake --build cmake/build --target all
```

This provides the `-- Unit tests disabled` message (verifying that the
`AU_ENABLE_TESTING` interaction is working), and it finishes very
quickly without building any tests, or any targets that depend on GTest.

Fixes #257.