### PR TITLE
Authoritatively forward declare core types

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -41,6 +41,13 @@ cc_test(
 )
 
 cc_library(
+    name = "fwd",
+    hdrs = ["code/au/fwd.hh"],
+    includes = ["code"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "io",
     hdrs = ["code/au/io.hh"],
     includes = ["code"],
@@ -208,6 +215,7 @@ cc_library(
     hdrs = ["code/au/constant.hh"],
     includes = ["code"],
     deps = [
+        ":fwd",
         ":quantity",
         ":unit_of_measure",
         ":wrapper_operations",
@@ -254,6 +262,7 @@ cc_library(
     hdrs = ["code/au/dimension.hh"],
     includes = ["code"],
     deps = [
+        ":fwd",
         ":packs",
         ":power_aliases",
     ],
@@ -276,6 +285,7 @@ cc_library(
     hdrs = ["code/au/magnitude.hh"],
     includes = ["code"],
     deps = [
+        ":fwd",
         ":packs",
         ":power_aliases",
         ":stdx",
@@ -389,6 +399,7 @@ cc_library(
     hdrs = ["code/au/prefix.hh"],
     includes = ["code"],
     deps = [
+        ":fwd",
         ":quantity",
         ":quantity_point",
         ":unit_of_measure",
@@ -414,6 +425,7 @@ cc_library(
     deps = [
         ":apply_magnitude",
         ":conversion_policy",
+        ":fwd",
         ":operators",
         ":rep",
         ":unit_of_measure",
@@ -443,6 +455,7 @@ cc_library(
     hdrs = ["code/au/quantity_point.hh"],
     includes = ["code"],
     deps = [
+        ":fwd",
         ":quantity",
         ":stdx",
         ":utility",
@@ -465,7 +478,10 @@ cc_library(
     name = "rep",
     hdrs = ["code/au/rep.hh"],
     includes = ["code"],
-    deps = [":stdx"],
+    deps = [
+        ":fwd",
+        ":stdx",
+    ],
 )
 
 cc_test(
@@ -540,7 +556,10 @@ cc_library(
     name = "unit_symbol",
     hdrs = ["code/au/unit_symbol.hh"],
     includes = ["code"],
-    deps = [":wrapper_operations"],
+    deps = [
+        ":fwd",
+        ":wrapper_operations",
+    ],
 )
 
 cc_test(
@@ -598,6 +617,7 @@ cc_library(
     name = "zero",
     hdrs = ["code/au/zero.hh"],
     includes = ["code"],
+    deps = [":fwd"],
 )
 
 cc_test(

--- a/au/code/au/CMakeLists.txt
+++ b/au/code/au/CMakeLists.txt
@@ -28,6 +28,7 @@ header_only_library(
     constant.hh
     conversion_policy.hh
     dimension.hh
+    fwd.hh
     io.hh
     magnitude.hh
     math.hh

--- a/au/code/au/constant.hh
+++ b/au/code/au/constant.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "au/fwd.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/stdx/type_traits.hh"

--- a/au/code/au/dimension.hh
+++ b/au/code/au/dimension.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "au/fwd.hh"
 #include "au/packs.hh"
 #include "au/power_aliases.hh"
 

--- a/au/code/au/fwd.hh
+++ b/au/code/au/fwd.hh
@@ -1,0 +1,168 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace au {
+
+struct Zero;
+
+template <typename... BPs>
+struct Dimension;
+
+template <typename... BPs>
+struct Magnitude;
+
+template <typename UnitT>
+struct QuantityMaker;
+
+template <typename Unit>
+struct SingularNameFor;
+
+template <typename UnitT>
+struct QuantityPointMaker;
+
+template <typename UnitT, typename RepT>
+class Quantity;
+
+//
+// Quantity aliases to set a particular Rep.
+//
+// This presents a less cumbersome interface for end users.
+//
+template <typename UnitT>
+using QuantityD = Quantity<UnitT, double>;
+template <typename UnitT>
+using QuantityF = Quantity<UnitT, float>;
+template <typename UnitT>
+using QuantityI = Quantity<UnitT, int>;
+template <typename UnitT>
+using QuantityU = Quantity<UnitT, unsigned int>;
+template <typename UnitT>
+using QuantityI32 = Quantity<UnitT, int32_t>;
+template <typename UnitT>
+using QuantityU32 = Quantity<UnitT, uint32_t>;
+template <typename UnitT>
+using QuantityI64 = Quantity<UnitT, int64_t>;
+template <typename UnitT>
+using QuantityU64 = Quantity<UnitT, uint64_t>;
+
+template <typename T>
+struct CorrespondingQuantity;
+
+template <typename UnitT, typename RepT>
+class QuantityPoint;
+
+//
+// QuantityPoint aliases to set a particular Rep.
+//
+// This presents a less cumbersome interface for end users.
+//
+template <typename UnitT>
+using QuantityPointD = QuantityPoint<UnitT, double>;
+template <typename UnitT>
+using QuantityPointF = QuantityPoint<UnitT, float>;
+template <typename UnitT>
+using QuantityPointI = QuantityPoint<UnitT, int>;
+template <typename UnitT>
+using QuantityPointU = QuantityPoint<UnitT, unsigned int>;
+template <typename UnitT>
+using QuantityPointI32 = QuantityPoint<UnitT, int32_t>;
+template <typename UnitT>
+using QuantityPointU32 = QuantityPoint<UnitT, uint32_t>;
+template <typename UnitT>
+using QuantityPointI64 = QuantityPoint<UnitT, int64_t>;
+template <typename UnitT>
+using QuantityPointU64 = QuantityPoint<UnitT, uint64_t>;
+
+template <typename Unit>
+struct Constant;
+
+template <typename Unit>
+struct SymbolFor;
+
+template <template <class U> class Prefix>
+struct PrefixApplier;
+
+// SI Prefixes.
+template <typename U>
+struct Quetta;
+template <typename U>
+struct Ronna;
+template <typename U>
+struct Yotta;
+template <typename U>
+struct Zetta;
+template <typename U>
+struct Exa;
+template <typename U>
+struct Peta;
+template <typename U>
+struct Tera;
+template <typename U>
+struct Giga;
+template <typename U>
+struct Mega;
+template <typename U>
+struct Kilo;
+template <typename U>
+struct Hecto;
+template <typename U>
+struct Deka;
+template <typename U>
+struct Deci;
+template <typename U>
+struct Centi;
+template <typename U>
+struct Milli;
+template <typename U>
+struct Micro;
+template <typename U>
+struct Nano;
+template <typename U>
+struct Pico;
+template <typename U>
+struct Femto;
+template <typename U>
+struct Atto;
+template <typename U>
+struct Zepto;
+template <typename U>
+struct Yocto;
+template <typename U>
+struct Ronto;
+template <typename U>
+struct Quecto;
+
+// Binary Prefixes.
+template <typename U>
+struct Yobi;
+template <typename U>
+struct Zebi;
+template <typename U>
+struct Exbi;
+template <typename U>
+struct Pebi;
+template <typename U>
+struct Tebi;
+template <typename U>
+struct Gibi;
+template <typename U>
+struct Mebi;
+template <typename U>
+struct Kibi;
+
+}  // namespace au

--- a/au/code/au/magnitude.hh
+++ b/au/code/au/magnitude.hh
@@ -17,6 +17,7 @@
 #include <limits>
 #include <utility>
 
+#include "au/fwd.hh"
 #include "au/packs.hh"
 #include "au/power_aliases.hh"
 #include "au/stdx/utility.hh"

--- a/au/code/au/prefix.hh
+++ b/au/code/au/prefix.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "au/fwd.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/unit_of_measure.hh"

--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -18,6 +18,7 @@
 
 #include "au/apply_magnitude.hh"
 #include "au/conversion_policy.hh"
+#include "au/fwd.hh"
 #include "au/operators.hh"
 #include "au/rep.hh"
 #include "au/stdx/functional.hh"
@@ -26,12 +27,6 @@
 #include "au/zero.hh"
 
 namespace au {
-
-template <typename UnitT>
-struct QuantityMaker;
-
-template <typename UnitT, typename RepT>
-class Quantity;
 
 //
 // Make a Quantity of the given Unit, which has this value as measured in the Unit.
@@ -461,33 +456,6 @@ template <typename NewRep>
 constexpr auto rep_cast(Zero z) {
     return z;
 }
-
-//
-// Quantity aliases to set a particular Rep.
-//
-// This presents a less cumbersome interface for end users.
-//
-template <typename UnitT>
-using QuantityD = Quantity<UnitT, double>;
-template <typename UnitT>
-using QuantityF = Quantity<UnitT, float>;
-template <typename UnitT>
-using QuantityI = Quantity<UnitT, int>;
-template <typename UnitT>
-using QuantityU = Quantity<UnitT, unsigned int>;
-template <typename UnitT>
-using QuantityI32 = Quantity<UnitT, int32_t>;
-template <typename UnitT>
-using QuantityU32 = Quantity<UnitT, uint32_t>;
-template <typename UnitT>
-using QuantityI64 = Quantity<UnitT, int64_t>;
-template <typename UnitT>
-using QuantityU64 = Quantity<UnitT, uint64_t>;
-
-// Forward declare `QuantityPoint` here, so that we can give better error messages when users try to
-// make it into a quantity.
-template <typename U, typename R>
-class QuantityPoint;
 
 template <typename UnitT>
 struct QuantityMaker {

--- a/au/code/au/quantity_point.hh
+++ b/au/code/au/quantity_point.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "au/fwd.hh"
 #include "au/quantity.hh"
 #include "au/stdx/type_traits.hh"
 #include "au/utility/type_traits.hh"
@@ -33,11 +34,6 @@ namespace au {
 // _absolute temperature measurements_ (e.g., `QuantityPoint<Celsius, T>`).  This type is also
 // analogous to `std::chrono::time_point`, in the same way that `Quantity` is analogous to
 // `std::chrono::duration`.
-template <typename UnitT, typename RepT>
-class QuantityPoint;
-
-template <typename UnitT>
-struct QuantityPointMaker;
 
 // Make a Quantity of the given Unit, which has this value as measured in the Unit.
 template <typename UnitT, typename T>
@@ -327,28 +323,6 @@ template <typename NewRep, typename Unit, typename Rep>
 constexpr auto rep_cast(QuantityPoint<Unit, Rep> q) {
     return q.template as<NewRep>(Unit{});
 }
-
-//
-// QuantityPoint aliases to set a particular Rep.
-//
-// This presents a less cumbersome interface for end users.
-//
-template <typename UnitT>
-using QuantityPointD = QuantityPoint<UnitT, double>;
-template <typename UnitT>
-using QuantityPointF = QuantityPoint<UnitT, float>;
-template <typename UnitT>
-using QuantityPointI = QuantityPoint<UnitT, int>;
-template <typename UnitT>
-using QuantityPointU = QuantityPoint<UnitT, unsigned int>;
-template <typename UnitT>
-using QuantityPointI32 = QuantityPoint<UnitT, int32_t>;
-template <typename UnitT>
-using QuantityPointU32 = QuantityPoint<UnitT, uint32_t>;
-template <typename UnitT>
-using QuantityPointI64 = QuantityPoint<UnitT, int64_t>;
-template <typename UnitT>
-using QuantityPointU64 = QuantityPoint<UnitT, uint64_t>;
 
 namespace detail {
 template <typename X, typename Y, typename Func>

--- a/au/code/au/rep.hh
+++ b/au/code/au/rep.hh
@@ -16,6 +16,7 @@
 
 #include <type_traits>
 
+#include "au/fwd.hh"
 #include "au/stdx/experimental/is_detected.hh"
 #include "au/stdx/type_traits.hh"
 
@@ -47,14 +48,6 @@ struct IsQuotientValidRep;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Implementation details below.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Forward declarations for main Au container types.
-template <typename U, typename R>
-class Quantity;
-template <typename U, typename R>
-class QuantityPoint;
-template <typename T>
-struct CorrespondingQuantity;
 
 namespace detail {
 template <typename T>

--- a/au/code/au/unit_symbol.hh
+++ b/au/code/au/unit_symbol.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "au/fwd.hh"
 #include "au/wrapper_operations.hh"
 
 namespace au {

--- a/au/code/au/zero.hh
+++ b/au/code/au/zero.hh
@@ -17,6 +17,8 @@
 #include <chrono>
 #include <type_traits>
 
+#include "au/fwd.hh"
+
 namespace au {
 
 // A type representing a quantity of "zero" in any units.


### PR DESCRIPTION
From now on, anyone can just include `"au/fwd.hh"`, and get
authoritatively correct forward declarations.  These will be implicitly
tested automatically by adding an `#include` of this new file at the top
of every file that has a definition for which we now provide a forward
declaration: if we get a forward declaration wrong, we'll get a compiler
warning.

We also include `fwd.hh` in a few places where it lets us get rid of
some manual forward declarations.

The rep-named aliases move upstream into `fwd.hh`, because they'll be
directly useful for forward declaration use cases, and because you can't
"forward declare" an alias: you just have to move the definition
upstream.

Helps #232.  To resolve it completely, we will need to provide a forward
declaration file for each individual unit file.