### PR TITLE
Test options in CMake CI jobs

### DIFF
--- a/.github/workflows/cmake-build-and-test.yml
+++ b/.github/workflows/cmake-build-and-test.yml
@@ -26,8 +26,8 @@ jobs:
       matrix:
         options: [
           { extra_cmake_args: '', extra_targets: 'test' },
-          { extra_cmake_args: ' -DAU_ENABLE_TESTING=FALSE', extra_targets: 'test' },
-          { extra_cmake_args: ' -DAU_EXCLUDE_GTEST_DEPENDENCY=TRUE', extra_targets: 'test' }
+          { extra_cmake_args: ' -DAU_ENABLE_TESTING=FALSE', extra_targets: '' },
+          { extra_cmake_args: ' -DAU_EXCLUDE_GTEST_DEPENDENCY=TRUE', extra_targets: '' }
         ]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cmake-build-and-test.yml
+++ b/.github/workflows/cmake-build-and-test.yml
@@ -26,8 +26,8 @@ jobs:
       matrix:
         options: [
           { extra_cmake_args: '', extra_targets: 'test' },
-          { extra_cmake_args: ' -DAU_ENABLE_TESTING=FALSE', extra_targets: '' },
-          { extra_cmake_args: ' -DAU_EXCLUDE_GTEST_DEPENDENCY=TRUE', extra_targets: '' }
+          { extra_cmake_args: ' -DAU_ENABLE_TESTING=FALSE', extra_targets: 'test' },
+          { extra_cmake_args: ' -DAU_EXCLUDE_GTEST_DEPENDENCY=TRUE', extra_targets: 'test' }
         ]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cmake-build-and-test.yml
+++ b/.github/workflows/cmake-build-and-test.yml
@@ -22,6 +22,13 @@ on:
 
 jobs:
   cmake-build-and-test:
+    strategy:
+      matrix:
+        options: [
+          { extra_cmake_args: '', extra_targets: 'test' },
+          { extra_cmake_args: ' -DAU_ENABLE_TESTING=FALSE', extra_targets: '' },
+          { extra_cmake_args: ' -DAU_EXCLUDE_GTEST_DEPENDENCY=TRUE', extra_targets: '' }
+        ]
     runs-on: ubuntu-latest
 
     steps:
@@ -31,6 +38,6 @@ jobs:
         with:
           cmake-version: '3.29.x'
       - name: Generate
-        run: cmake -S . -B cmake/build -DCMAKE_VERIFY_INTERFACE_HEADER_SETS=TRUE
+        run: cmake -S . -B cmake/build -DCMAKE_VERIFY_INTERFACE_HEADER_SETS=TRUE ${{ matrix.options.extra_cmake_args }}
       - name: Build and test
-        run: cmake --build cmake/build --target all all_verify_interface_header_sets test
+        run: cmake --build cmake/build --target all all_verify_interface_header_sets ${{ matrix.options.extra_targets }}


### PR DESCRIPTION
Currently, we only run one CMake configuration in CI.  It's the default
one, where we permit the GTest dependency, and we build and run tests.
Now we are adding two more configurations, one for each of the new
options:

- Set `AU_ENABLE_TESTING` to `FALSE`
- Set `AU_EXCLUDE_GTEST_DEPENDENCY` to `TRUE` (implies the former)

In both these instances, the `test` target won't exist, so we exclude it
from running.

We do however retain the `CMAKE_VERIFY_INTERFACE_HEADER_SETS` option,
because that gives us useful testing for our interface targets.

Fixes #304.