### PR TITLE
Add forward declarations for individual units

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -47,6 +47,23 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+cc_test(
+    name = "fwd_test",
+    size = "small",
+    srcs = [
+        "code/au/fwd_test.cc",
+        "code/au/fwd_test_lib.cc",
+        "code/au/fwd_test_lib.hh",
+    ],
+    deps = [
+        ":fwd",
+        ":io",
+        ":quantity",
+        ":units",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "io",
     hdrs = ["code/au/io.hh"],

--- a/au/code/au/CMakeLists.txt
+++ b/au/code/au/CMakeLists.txt
@@ -48,60 +48,115 @@ header_only_library(
     stdx/type_traits.hh
     stdx/utility.hh
     units/amperes.hh
+    units/amperes_fwd.hh
     units/bars.hh
+    units/bars_fwd.hh
     units/becquerel.hh
+    units/becquerel_fwd.hh
     units/bits.hh
+    units/bits_fwd.hh
     units/bytes.hh
+    units/bytes_fwd.hh
     units/candelas.hh
+    units/candelas_fwd.hh
     units/celsius.hh
+    units/celsius_fwd.hh
     units/coulombs.hh
+    units/coulombs_fwd.hh
     units/days.hh
+    units/days_fwd.hh
     units/degrees.hh
+    units/degrees_fwd.hh
     units/fahrenheit.hh
+    units/fahrenheit_fwd.hh
     units/farads.hh
+    units/farads_fwd.hh
     units/fathoms.hh
+    units/fathoms_fwd.hh
     units/feet.hh
+    units/feet_fwd.hh
     units/furlongs.hh
+    units/furlongs_fwd.hh
     units/grams.hh
+    units/grams_fwd.hh
     units/grays.hh
+    units/grays_fwd.hh
     units/henries.hh
+    units/henries_fwd.hh
     units/hertz.hh
+    units/hertz_fwd.hh
     units/hours.hh
+    units/hours_fwd.hh
     units/inches.hh
+    units/inches_fwd.hh
     units/joules.hh
+    units/joules_fwd.hh
     units/katals.hh
+    units/katals_fwd.hh
     units/kelvins.hh
+    units/kelvins_fwd.hh
     units/knots.hh
+    units/knots_fwd.hh
     units/liters.hh
+    units/liters_fwd.hh
     units/lumens.hh
+    units/lumens_fwd.hh
     units/lux.hh
+    units/lux_fwd.hh
     units/meters.hh
+    units/meters_fwd.hh
     units/miles.hh
+    units/miles_fwd.hh
     units/minutes.hh
+    units/minutes_fwd.hh
     units/moles.hh
+    units/moles_fwd.hh
     units/nautical_miles.hh
+    units/nautical_miles_fwd.hh
     units/newtons.hh
+    units/newtons_fwd.hh
     units/ohms.hh
+    units/ohms_fwd.hh
     units/pascals.hh
+    units/pascals_fwd.hh
     units/percent.hh
+    units/percent_fwd.hh
     units/pounds_force.hh
+    units/pounds_force_fwd.hh
     units/pounds_mass.hh
+    units/pounds_mass_fwd.hh
     units/radians.hh
+    units/radians_fwd.hh
     units/revolutions.hh
+    units/revolutions_fwd.hh
     units/seconds.hh
+    units/seconds_fwd.hh
     units/siemens.hh
+    units/siemens_fwd.hh
     units/slugs.hh
+    units/slugs_fwd.hh
     units/standard_gravity.hh
+    units/standard_gravity_fwd.hh
     units/steradians.hh
+    units/steradians_fwd.hh
     units/tesla.hh
+    units/tesla_fwd.hh
     units/unos.hh
+    units/unos_fwd.hh
     units/us_gallons.hh
+    units/us_gallons_fwd.hh
     units/us_pints.hh
+    units/us_pints_fwd.hh
     units/us_quarts.hh
+    units/us_quarts_fwd.hh
     units/volts.hh
+    units/volts_fwd.hh
     units/watts.hh
+    units/watts_fwd.hh
     units/webers.hh
+    units/webers_fwd.hh
     units/yards.hh
+    units/yards_fwd.hh
     utility/factoring.hh
     utility/string_constant.hh
     utility/type_traits.hh

--- a/au/code/au/fwd_test.cc
+++ b/au/code/au/fwd_test.cc
@@ -1,0 +1,29 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/fwd_test_lib.hh"
+#include "au/quantity.hh"
+#include "au/units/meters.hh"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::StrEq;
+
+namespace au {
+
+TEST(Fwd, CanCallFunctionDeclaredWithOnlyFwdFiles) {
+    EXPECT_THAT(print_to_string(meters(1)), StrEq("1 m"));
+}
+
+}  // namespace au

--- a/au/code/au/fwd_test_lib.cc
+++ b/au/code/au/fwd_test_lib.cc
@@ -1,0 +1,32 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/fwd_test_lib.hh"
+
+#include <sstream>
+#include <string>
+
+#include "au/io.hh"
+#include "au/quantity.hh"
+#include "au/units/meters.hh"
+
+namespace au {
+
+std::string print_to_string(const QuantityI<Meters> &q) {
+    std::ostringstream oss;
+    oss << q;
+    return oss.str();
+}
+
+}  // namespace au

--- a/au/code/au/fwd_test_lib.hh
+++ b/au/code/au/fwd_test_lib.hh
@@ -1,0 +1,26 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "au/fwd.hh"
+#include "au/units/meters_fwd.hh"
+
+namespace au {
+
+std::string print_to_string(const QuantityI<Meters> &q);
+
+}  // namespace au

--- a/au/code/au/units/amperes.hh
+++ b/au/code/au/units/amperes.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/amperes_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 

--- a/au/code/au/units/amperes_fwd.hh
+++ b/au/code/au/units/amperes_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Amperes;
+
+}  // namespace au

--- a/au/code/au/units/bars.hh
+++ b/au/code/au/units/bars.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/bars_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"

--- a/au/code/au/units/bars_fwd.hh
+++ b/au/code/au/units/bars_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Bars;
+
+}  // namespace au

--- a/au/code/au/units/becquerel.hh
+++ b/au/code/au/units/becquerel.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/becquerel_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/seconds.hh"

--- a/au/code/au/units/becquerel_fwd.hh
+++ b/au/code/au/units/becquerel_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Becquerel;
+
+}  // namespace au

--- a/au/code/au/units/bits.hh
+++ b/au/code/au/units/bits.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/bits_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 

--- a/au/code/au/units/bits_fwd.hh
+++ b/au/code/au/units/bits_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Bits;
+
+}  // namespace au

--- a/au/code/au/units/bytes.hh
+++ b/au/code/au/units/bytes.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/bytes_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/bits.hh"

--- a/au/code/au/units/bytes_fwd.hh
+++ b/au/code/au/units/bytes_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Bytes;
+
+}  // namespace au

--- a/au/code/au/units/candelas.hh
+++ b/au/code/au/units/candelas.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/candelas_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 

--- a/au/code/au/units/candelas_fwd.hh
+++ b/au/code/au/units/candelas_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Candelas;
+
+}  // namespace au

--- a/au/code/au/units/celsius.hh
+++ b/au/code/au/units/celsius.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/celsius_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"

--- a/au/code/au/units/celsius_fwd.hh
+++ b/au/code/au/units/celsius_fwd.hh
@@ -1,0 +1,19 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace au {
+
+struct Celsius;
+
+}  // namespace au

--- a/au/code/au/units/coulombs.hh
+++ b/au/code/au/units/coulombs.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/coulombs_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/amperes.hh"

--- a/au/code/au/units/coulombs_fwd.hh
+++ b/au/code/au/units/coulombs_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Coulombs;
+
+}  // namespace au

--- a/au/code/au/units/days.hh
+++ b/au/code/au/units/days.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/days_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/hours.hh"

--- a/au/code/au/units/days_fwd.hh
+++ b/au/code/au/units/days_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Days;
+
+}  // namespace au

--- a/au/code/au/units/degrees.hh
+++ b/au/code/au/units/degrees.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/degrees_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/radians.hh"

--- a/au/code/au/units/degrees_fwd.hh
+++ b/au/code/au/units/degrees_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Degrees;
+
+}  // namespace au

--- a/au/code/au/units/fahrenheit.hh
+++ b/au/code/au/units/fahrenheit.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/fahrenheit_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"

--- a/au/code/au/units/fahrenheit_fwd.hh
+++ b/au/code/au/units/fahrenheit_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2022 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Fahrenheit;
+
+}  // namespace au

--- a/au/code/au/units/farads.hh
+++ b/au/code/au/units/farads.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/farads_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/coulombs.hh"

--- a/au/code/au/units/farads_fwd.hh
+++ b/au/code/au/units/farads_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Farads;
+
+}  // namespace au

--- a/au/code/au/units/fathoms.hh
+++ b/au/code/au/units/fathoms.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/fathoms_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/feet.hh"

--- a/au/code/au/units/fathoms_fwd.hh
+++ b/au/code/au/units/fathoms_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Fathoms;
+
+}  // namespace au

--- a/au/code/au/units/feet.hh
+++ b/au/code/au/units/feet.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/feet_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/inches.hh"

--- a/au/code/au/units/feet_fwd.hh
+++ b/au/code/au/units/feet_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Feet;
+
+}  // namespace au

--- a/au/code/au/units/furlongs.hh
+++ b/au/code/au/units/furlongs.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/furlongs_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/miles.hh"

--- a/au/code/au/units/furlongs_fwd.hh
+++ b/au/code/au/units/furlongs_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Furlongs;
+
+}  // namespace au

--- a/au/code/au/units/grams.hh
+++ b/au/code/au/units/grams.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/grams_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 

--- a/au/code/au/units/grams_fwd.hh
+++ b/au/code/au/units/grams_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Grams;
+
+}  // namespace au

--- a/au/code/au/units/grays.hh
+++ b/au/code/au/units/grays.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/grays_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"

--- a/au/code/au/units/grays_fwd.hh
+++ b/au/code/au/units/grays_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Grays;
+
+}  // namespace au

--- a/au/code/au/units/henries.hh
+++ b/au/code/au/units/henries.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/henries_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/amperes.hh"

--- a/au/code/au/units/henries_fwd.hh
+++ b/au/code/au/units/henries_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Henries;
+
+}  // namespace au

--- a/au/code/au/units/hertz.hh
+++ b/au/code/au/units/hertz.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/hertz_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/seconds.hh"

--- a/au/code/au/units/hertz_fwd.hh
+++ b/au/code/au/units/hertz_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Hertz;
+
+}  // namespace au

--- a/au/code/au/units/hours.hh
+++ b/au/code/au/units/hours.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/hours_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/minutes.hh"

--- a/au/code/au/units/hours_fwd.hh
+++ b/au/code/au/units/hours_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Hours;
+
+}  // namespace au

--- a/au/code/au/units/inches.hh
+++ b/au/code/au/units/inches.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/inches_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"

--- a/au/code/au/units/inches_fwd.hh
+++ b/au/code/au/units/inches_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Inches;
+
+}  // namespace au

--- a/au/code/au/units/joules.hh
+++ b/au/code/au/units/joules.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/joules_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/meters.hh"

--- a/au/code/au/units/joules_fwd.hh
+++ b/au/code/au/units/joules_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Joules;
+
+}  // namespace au

--- a/au/code/au/units/katals.hh
+++ b/au/code/au/units/katals.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/katals_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/moles.hh"

--- a/au/code/au/units/katals_fwd.hh
+++ b/au/code/au/units/katals_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Katals;
+
+}  // namespace au

--- a/au/code/au/units/kelvins.hh
+++ b/au/code/au/units/kelvins.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/kelvins_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/unit_symbol.hh"

--- a/au/code/au/units/kelvins_fwd.hh
+++ b/au/code/au/units/kelvins_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Kelvins;
+
+}  // namespace au

--- a/au/code/au/units/knots.hh
+++ b/au/code/au/units/knots.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/knots_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/hours.hh"

--- a/au/code/au/units/knots_fwd.hh
+++ b/au/code/au/units/knots_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Knots;
+
+}  // namespace au

--- a/au/code/au/units/liters.hh
+++ b/au/code/au/units/liters.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/liters_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"

--- a/au/code/au/units/liters_fwd.hh
+++ b/au/code/au/units/liters_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Liters;
+
+}  // namespace au

--- a/au/code/au/units/lumens.hh
+++ b/au/code/au/units/lumens.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/lumens_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/candelas.hh"

--- a/au/code/au/units/lumens_fwd.hh
+++ b/au/code/au/units/lumens_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Lumens;
+
+}  // namespace au

--- a/au/code/au/units/lux.hh
+++ b/au/code/au/units/lux.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/lux_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/lumens.hh"

--- a/au/code/au/units/lux_fwd.hh
+++ b/au/code/au/units/lux_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Lux;
+
+}  // namespace au

--- a/au/code/au/units/meters.hh
+++ b/au/code/au/units/meters.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/meters_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/unit_symbol.hh"

--- a/au/code/au/units/meters_fwd.hh
+++ b/au/code/au/units/meters_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Meters;
+
+}  // namespace au

--- a/au/code/au/units/miles.hh
+++ b/au/code/au/units/miles.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/miles_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/feet.hh"

--- a/au/code/au/units/miles_fwd.hh
+++ b/au/code/au/units/miles_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Miles;
+
+}  // namespace au

--- a/au/code/au/units/minutes.hh
+++ b/au/code/au/units/minutes.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/minutes_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/seconds.hh"

--- a/au/code/au/units/minutes_fwd.hh
+++ b/au/code/au/units/minutes_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Minutes;
+
+}  // namespace au

--- a/au/code/au/units/moles.hh
+++ b/au/code/au/units/moles.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/moles_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 

--- a/au/code/au/units/moles_fwd.hh
+++ b/au/code/au/units/moles_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Moles;
+
+}  // namespace au

--- a/au/code/au/units/nautical_miles.hh
+++ b/au/code/au/units/nautical_miles.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/nautical_miles_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/meters.hh"

--- a/au/code/au/units/nautical_miles_fwd.hh
+++ b/au/code/au/units/nautical_miles_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct NauticalMiles;
+
+}  // namespace au

--- a/au/code/au/units/newtons.hh
+++ b/au/code/au/units/newtons.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/newtons_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"

--- a/au/code/au/units/newtons_fwd.hh
+++ b/au/code/au/units/newtons_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Newtons;
+
+}  // namespace au

--- a/au/code/au/units/ohms.hh
+++ b/au/code/au/units/ohms.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/ohms_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/amperes.hh"

--- a/au/code/au/units/ohms_fwd.hh
+++ b/au/code/au/units/ohms_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Ohms;
+
+}  // namespace au

--- a/au/code/au/units/pascals.hh
+++ b/au/code/au/units/pascals.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/pascals_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/unit_symbol.hh"

--- a/au/code/au/units/pascals_fwd.hh
+++ b/au/code/au/units/pascals_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Pascals;
+
+}  // namespace au

--- a/au/code/au/units/percent.hh
+++ b/au/code/au/units/percent.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/percent_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/unos.hh"

--- a/au/code/au/units/percent_fwd.hh
+++ b/au/code/au/units/percent_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Percent;
+
+}  // namespace au

--- a/au/code/au/units/pounds_force.hh
+++ b/au/code/au/units/pounds_force.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/pounds_force_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/pounds_mass.hh"

--- a/au/code/au/units/pounds_force_fwd.hh
+++ b/au/code/au/units/pounds_force_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct PoundsForce;
+
+}  // namespace au

--- a/au/code/au/units/pounds_mass.hh
+++ b/au/code/au/units/pounds_mass.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/pounds_mass_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"

--- a/au/code/au/units/pounds_mass_fwd.hh
+++ b/au/code/au/units/pounds_mass_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct PoundsMass;
+
+}  // namespace au

--- a/au/code/au/units/radians.hh
+++ b/au/code/au/units/radians.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/radians_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 

--- a/au/code/au/units/radians_fwd.hh
+++ b/au/code/au/units/radians_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Radians;
+
+}  // namespace au

--- a/au/code/au/units/revolutions.hh
+++ b/au/code/au/units/revolutions.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/revolutions_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/degrees.hh"

--- a/au/code/au/units/revolutions_fwd.hh
+++ b/au/code/au/units/revolutions_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Revolutions;
+
+}  // namespace au

--- a/au/code/au/units/seconds.hh
+++ b/au/code/au/units/seconds.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/seconds_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 

--- a/au/code/au/units/seconds_fwd.hh
+++ b/au/code/au/units/seconds_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Seconds;
+
+}  // namespace au

--- a/au/code/au/units/siemens.hh
+++ b/au/code/au/units/siemens.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/siemens_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/ohms.hh"

--- a/au/code/au/units/siemens_fwd.hh
+++ b/au/code/au/units/siemens_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Siemens;
+
+}  // namespace au

--- a/au/code/au/units/slugs.hh
+++ b/au/code/au/units/slugs.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/slugs_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/feet.hh"

--- a/au/code/au/units/slugs_fwd.hh
+++ b/au/code/au/units/slugs_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Slugs;
+
+}  // namespace au

--- a/au/code/au/units/standard_gravity.hh
+++ b/au/code/au/units/standard_gravity.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/standard_gravity_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/meters.hh"

--- a/au/code/au/units/standard_gravity_fwd.hh
+++ b/au/code/au/units/standard_gravity_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct StandardGravity;
+
+}  // namespace au

--- a/au/code/au/units/steradians.hh
+++ b/au/code/au/units/steradians.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/steradians_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/radians.hh"

--- a/au/code/au/units/steradians_fwd.hh
+++ b/au/code/au/units/steradians_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Steradians;
+
+}  // namespace au

--- a/au/code/au/units/tesla.hh
+++ b/au/code/au/units/tesla.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/tesla_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/meters.hh"

--- a/au/code/au/units/tesla_fwd.hh
+++ b/au/code/au/units/tesla_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Tesla;
+
+}  // namespace au

--- a/au/code/au/units/unos.hh
+++ b/au/code/au/units/unos.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/unos_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 
 namespace au {

--- a/au/code/au/units/unos_fwd.hh
+++ b/au/code/au/units/unos_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Unos;
+
+}  // namespace au

--- a/au/code/au/units/us_gallons.hh
+++ b/au/code/au/units/us_gallons.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/us_gallons_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/units/inches.hh"
 
 namespace au {

--- a/au/code/au/units/us_gallons_fwd.hh
+++ b/au/code/au/units/us_gallons_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct USGallons;
+
+}  // namespace au

--- a/au/code/au/units/us_pints.hh
+++ b/au/code/au/units/us_pints.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/us_pints_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/units/inches.hh"
 
 namespace au {

--- a/au/code/au/units/us_pints_fwd.hh
+++ b/au/code/au/units/us_pints_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct USPints;
+
+}  // namespace au

--- a/au/code/au/units/us_quarts.hh
+++ b/au/code/au/units/us_quarts.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/us_quarts_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/units/inches.hh"
 
 namespace au {

--- a/au/code/au/units/us_quarts_fwd.hh
+++ b/au/code/au/units/us_quarts_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct USQuarts;
+
+}  // namespace au

--- a/au/code/au/units/volts.hh
+++ b/au/code/au/units/volts.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/volts_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/amperes.hh"

--- a/au/code/au/units/volts_fwd.hh
+++ b/au/code/au/units/volts_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Volts;
+
+}  // namespace au

--- a/au/code/au/units/watts.hh
+++ b/au/code/au/units/watts.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/watts_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/joules.hh"

--- a/au/code/au/units/watts_fwd.hh
+++ b/au/code/au/units/watts_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Watts;
+
+}  // namespace au

--- a/au/code/au/units/webers.hh
+++ b/au/code/au/units/webers.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/webers_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/seconds.hh"

--- a/au/code/au/units/webers_fwd.hh
+++ b/au/code/au/units/webers_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Webers;
+
+}  // namespace au

--- a/au/code/au/units/yards.hh
+++ b/au/code/au/units/yards.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/units/yards_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 #include "au/units/feet.hh"

--- a/au/code/au/units/yards_fwd.hh
+++ b/au/code/au/units/yards_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct Yards;
+
+}  // namespace au

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -201,7 +201,12 @@ These costs can bring significant benefits, but we still want them to be as smal
         <td class="poor">Very slow, but can be <i>greatly</i> improved by removing I/O support and most units</td>
         <td class="na"></td>
         <td class="na"></td>
-        <td class="good">Possibly "best", but will need to assess all libraries on the same code</td>
+        <td class="good">
+            <ul>
+                <li class="check">Includes `fwd.hh` headers</li>
+                <li>Possibly "best" overall, but will need to assess all libraries on the same code</li>
+            </ul>
+        </td>
     </tr>
     <tr>
         <td>

--- a/docs/install.md
+++ b/docs/install.md
@@ -120,7 +120,7 @@ to your `deps` attribute, and include the appropriate files.
 
 | Dependency | Headers provided | Notes |
 |------------|------------------|-------|
-| `@au//au` | `"au/au.hh"`<br>`"au/units/*.hh"` | Core library functionality.  See [all available units](https://github.com/aurora-opensource/au/tree/main/au/units) |
+| `@au//au` | `"au/au.hh"`<br>`"au/fwd.hh"`<br>`"au/units/*.hh"`<br>`"au/units/*_fwd.hh"` | Core library functionality.  See [all available units](https://github.com/aurora-opensource/au/tree/main/au/units) |
 | `@au//au:io` | `"au/io.hh"` | `operator<<` support |
 | `@au//au:testing` | `"au/testing.hh"` | Utilities for writing googletest tests<br>_Note:_ `testonly = True` |
 
@@ -141,7 +141,7 @@ In either case, here are the main targets and include files provided by the Au l
 
 | Target | Headers provided | Notes |
 |--------|------------------|-------|
-| `Au::au` | `"au/au.hh"`<br>`"au/io.hh"`<br>`"au/units/*.hh"` | Core library functionality.  See [all available units](https://github.com/aurora-opensource/au/tree/main/au/units) |
+| `Au::au` | `"au/au.hh"`<br>`"au/fwd.hh"`<br>`"au/io.hh"`<br>`"au/units/*.hh"`<br>`"au/units/*_fwd.hh"` | Core library functionality.  See [all available units](https://github.com/aurora-opensource/au/tree/main/au/units) |
 | `Au::testing` | `"au/testing.hh"` | Utilities for writing googletest tests |
 
 !!! note


### PR DESCRIPTION
Individual `"au/units/*.hh"` files still pull in some decently heavy
machinery.  The sensible, scalable solution is to provide a
`"au/units/*_fwd.hh"` file corresponding to each of them.  Each
"regular" units header will include its `_fwd.hh` header as the first
include (and we add a comment to that effect to prevent clang-format
from reordering them).

Happily, this enables us to write a somewhat meaningful test for the
forward declaraction machinery.  We can now make a header file that
provides an interface with only the forward declarations.  Then we call
that API inside of a test file.

Finally, this is worth updating the docs for:

- **Installation:** mention the `fwd.hh` files.
- **Alternatives:** mention this feature, as we're the first units
  library I know of that provides it.

All of these changes are in separate commits for the convenience of the
reviewer: I recommend starting at the first, and using `n` and `p` to
navigate them.

Fixes #232.