### PR TITLE
Clarify a few declarations for static analyzers

### DIFF
--- a/au/code/au/prefix.hh
+++ b/au/code/au/prefix.hh
@@ -134,7 +134,7 @@ constexpr auto mega = PrefixApplier<Mega>{};
 
 template <typename U>
 struct Kilo : decltype(U{} * pow<3>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label{detail::corncatenate("k", UnitLabel<U>::value).char_array()};
+    static constexpr detail::ExtendedLabel<1, U> label{detail::concatenate("k", UnitLabel<U>::value).char_array()};
 };
 template <typename U>
 constexpr detail::ExtendedLabel<1, U> Kilo<U>::label;
@@ -158,7 +158,7 @@ constexpr auto deka = PrefixApplier<Deka>{};
 
 template <typename U>
 struct Deci : decltype(U{} * pow<-1>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label{detail::corncatenate("d", UnitLabel<U>::value).char_array()};
+    static constexpr detail::ExtendedLabel<1, U> label{detail::concatenate("d", UnitLabel<U>::value).char_array()};
 };
 template <typename U>
 constexpr detail::ExtendedLabel<1, U> Deci<U>::label;
@@ -166,7 +166,7 @@ constexpr auto deci = PrefixApplier<Deci>{};
 
 template <typename U>
 struct Centi : decltype(U{} * pow<-2>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label{detail::corncatenate("c", UnitLabel<U>::value).char_array()};
+    static constexpr detail::ExtendedLabel<1, U> label{detail::concatenate("c", UnitLabel<U>::value).char_array()};
 };
 template <typename U>
 constexpr detail::ExtendedLabel<1, U> Centi<U>::label;
@@ -182,7 +182,7 @@ constexpr auto milli = PrefixApplier<Milli>{};
 
 template <typename U>
 struct Micro : decltype(U{} * pow<-6>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label{detail::corncatenate("u", UnitLabel<U>::value).char_array()};
+    static constexpr detail::ExtendedLabel<1, U> label{detail::concatenate("u", UnitLabel<U>::value).char_array()};
 };
 template <typename U>
 constexpr detail::ExtendedLabel<1, U> Micro<U>::label;

--- a/au/code/au/prefix.hh
+++ b/au/code/au/prefix.hh
@@ -134,7 +134,7 @@ constexpr auto mega = PrefixApplier<Mega>{};
 
 template <typename U>
 struct Kilo : decltype(U{} * pow<3>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("k", unit_label<U>());
+    static constexpr detail::ExtendedLabel<1, U> label{detail::corncatenate("k", UnitLabel<U>::value).char_array()};
 };
 template <typename U>
 constexpr detail::ExtendedLabel<1, U> Kilo<U>::label;
@@ -158,7 +158,7 @@ constexpr auto deka = PrefixApplier<Deka>{};
 
 template <typename U>
 struct Deci : decltype(U{} * pow<-1>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("d", unit_label<U>());
+    static constexpr detail::ExtendedLabel<1, U> label{detail::corncatenate("d", UnitLabel<U>::value).char_array()};
 };
 template <typename U>
 constexpr detail::ExtendedLabel<1, U> Deci<U>::label;
@@ -166,7 +166,7 @@ constexpr auto deci = PrefixApplier<Deci>{};
 
 template <typename U>
 struct Centi : decltype(U{} * pow<-2>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("c", unit_label<U>());
+    static constexpr detail::ExtendedLabel<1, U> label{detail::corncatenate("c", UnitLabel<U>::value).char_array()};
 };
 template <typename U>
 constexpr detail::ExtendedLabel<1, U> Centi<U>::label;
@@ -182,7 +182,7 @@ constexpr auto milli = PrefixApplier<Milli>{};
 
 template <typename U>
 struct Micro : decltype(U{} * pow<-6>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("u", unit_label<U>());
+    static constexpr detail::ExtendedLabel<1, U> label{detail::corncatenate("u", UnitLabel<U>::value).char_array()};
 };
 template <typename U>
 constexpr detail::ExtendedLabel<1, U> Micro<U>::label;

--- a/au/code/au/unit_of_measure.hh
+++ b/au/code/au/unit_of_measure.hh
@@ -80,8 +80,20 @@ namespace detail {
 // While clunky, this approach is at least robust against errors.  If the user supplies the wrong
 // prefix length, it will fail to compile, because there is no assignment operator between
 // `StringConstant` instances of different lengths.
+template <typename Unit>
+struct UnitLabelSize
+    : std::integral_constant<std::size_t, as_string_constant(UnitLabel<Unit>::value).size()> {};
+template <typename... Us>
+constexpr std::size_t total_label_size(Us...) {
+    std::size_t vals[] = {UnitLabelSize<Us>::value...};
+    std::size_t total = 0;
+    for (auto i = 0u; i < sizeof...(Us); ++i) {
+        total += vals[i];
+    }
+    return total;
+}
 template <std::size_t ExtensionStrlen, typename... Us>
-using ExtendedLabel = StringConstant<concatenate(unit_label<Us>()...).size() + ExtensionStrlen>;
+using ExtendedLabel = StringConstant<(ExtensionStrlen + total_label_size(Us{}...))>;
 }  // namespace detail
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/au/code/au/units/celsius.hh
+++ b/au/code/au/units/celsius.hh
@@ -35,7 +35,7 @@ template <typename T>
 constexpr const char CelsiusLabel<T>::label[];
 struct Celsius : Kelvins, CelsiusLabel<void> {
     using CelsiusLabel<void>::label;
-    static constexpr auto origin() { return centi(kelvins)(273'15); }
+    static constexpr auto origin() { return 273'15 * SymbolFor<Centi<Kelvins>>{}; }
 };
 constexpr auto celsius_qty = QuantityMaker<Celsius>{};
 constexpr auto celsius_pt = QuantityPointMaker<Celsius>{};

--- a/au/code/au/utility/string_constant.hh
+++ b/au/code/au/utility/string_constant.hh
@@ -191,6 +191,17 @@ class StringConstant {
 template <std::size_t Strlen>
 constexpr std::size_t StringConstant<Strlen>::length;
 
+template <typename T>
+struct StringLength;
+template <std::size_t N>
+struct StringLength<StringConstant<N>> : std::integral_constant<std::size_t, N> {};
+template <std::size_t N>
+struct StringLength<const char (&)[N]> : std::integral_constant<std::size_t, N - 1u> {};
+template <std::size_t N>
+struct StringLength<char[N]> : std::integral_constant<std::size_t, N - 1u> {};
+template <typename... Ts>
+struct TotalStrLen : std::integral_constant<std::size_t, sum<StringLength<Ts>::value...>()> {};
+
 template <typename... Ts>
 constexpr auto concatenate(const Ts &...ts) {
     return join_by("", ts...);
@@ -199,6 +210,11 @@ constexpr auto concatenate(const Ts &...ts) {
 template <typename SepT, typename... StringTs>
 constexpr auto join_by(const SepT &sep, const StringTs &...ts) {
     return as_string_constant(sep).join(as_string_constant(ts)...);
+}
+
+template <typename... Ts>
+constexpr StringConstant<TotalStrLen<Ts...>::value> corncatenate(const Ts &...ts) {
+    return join_by("", ts...);
 }
 
 template <int64_t N>

--- a/au/code/au/utility/string_constant.hh
+++ b/au/code/au/utility/string_constant.hh
@@ -212,11 +212,6 @@ constexpr auto join_by(const SepT &sep, const StringTs &...ts) {
     return as_string_constant(sep).join(as_string_constant(ts)...);
 }
 
-template <typename... Ts>
-constexpr StringConstant<TotalStrLen<Ts...>::value> corncatenate(const Ts &...ts) {
-    return join_by("", ts...);
-}
-
 template <int64_t N>
 struct IToA {
  private:


### PR DESCRIPTION
Some static analyzers can have trouble with some of these templates; this PR separates them to help parsers that might have difficulty.