### PR TITLE
Add Miller-Rabin probable prime algorithm

### DIFF
--- a/au/code/au/CMakeLists.txt
+++ b/au/code/au/CMakeLists.txt
@@ -159,6 +159,7 @@ header_only_library(
     units/yards_fwd.hh
     utility/factoring.hh
     utility/mod.hh
+    utility/probable_primes.hh
     utility/string_constant.hh
     utility/type_traits.hh
 )
@@ -460,6 +461,7 @@ gtest_based_test(
   SRCS
     utility/test/factoring_test.cc
     utility/test/mod_test.cc
+    utility/test/probable_primes_test.cc
     utility/test/string_constant_test.cc
     utility/test/type_traits_test.cc
   DEPS

--- a/au/code/au/utility/probable_primes.hh
+++ b/au/code/au/utility/probable_primes.hh
@@ -37,8 +37,9 @@ struct NumberDecomposition {
 };
 
 //
-// Express any odd `n` as `(2^s + d) + 1`, where `d` is odd.
+// Express any positive `n` as `(2^s * d)`, where `d` is odd.
 //
+// Preconditions: `n` is positive.
 constexpr NumberDecomposition decompose(uint64_t n) {
     NumberDecomposition result{0u, n};
     while (result.odd_remainder % 2u == 0u) {

--- a/au/code/au/utility/probable_primes.hh
+++ b/au/code/au/utility/probable_primes.hh
@@ -1,0 +1,85 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/utility/mod.hh"
+
+namespace au {
+namespace detail {
+
+//
+// The possible results of a probable prime test.
+//
+enum class PrimeResult {
+    COMPOSITE,
+    PROBABLY_PRIME,
+    BAD_INPUT,
+};
+
+//
+// Decompose a number by factoring out all powers of 2: `n = 2^power_of_two * odd_remainder`.
+//
+struct NumberDecomposition {
+    uint64_t power_of_two;
+    uint64_t odd_remainder;
+};
+
+//
+// Express any odd `n` as `(2^s + d) + 1`, where `d` is odd.
+//
+constexpr NumberDecomposition decompose(uint64_t n) {
+    NumberDecomposition result{0u, n};
+    while (result.odd_remainder % 2u == 0u) {
+        result.odd_remainder /= 2u;
+        ++result.power_of_two;
+    }
+    return result;
+}
+
+//
+// Perform a Miller-Rabin primality test on `n` using base `a`.
+//
+// Preconditions: `n` is odd, and at least as big as `a + 2`.  Also, `2` is the smallest allowable
+// value for `a`.  We will return `BAD_INPUT` if these preconditions are violated.  Otherwise, we
+// will return `PROBABLY_PRIME` for all prime inputs, and also all composite inputs which are
+// pseudoprime to base `a`, returning `COMPOSITE` for all other inputs (which are definitely known
+// to be composite).
+//
+constexpr PrimeResult miller_rabin(std::size_t a, uint64_t n) {
+    if (a < 2u || n < a + 2u || n % 2u == 0u) {
+        return PrimeResult::BAD_INPUT;
+    }
+
+    const auto params = decompose(n - 1u);
+    const auto &s = params.power_of_two;
+    const auto &d = params.odd_remainder;
+
+    uint64_t x = pow_mod(a, d, n);
+    if (x == 1u) {
+        return PrimeResult::PROBABLY_PRIME;
+    }
+
+    const auto minus_one = n - 1u;
+    for (auto r = 0u; r < s; ++r) {
+        if (x == minus_one) {
+            return PrimeResult::PROBABLY_PRIME;
+        }
+        x = mul_mod(x, x, n);
+    }
+    return PrimeResult::COMPOSITE;
+}
+
+}  // namespace detail
+}  // namespace au

--- a/au/code/au/utility/test/probable_primes_test.cc
+++ b/au/code/au/utility/test/probable_primes_test.cc
@@ -1,0 +1,205 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/utility/probable_primes.hh"
+
+#include <array>
+#include <string>
+#include <type_traits>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::Gt;
+using ::testing::Lt;
+
+namespace au {
+namespace detail {
+// Make test output for `PrimeResult` easier to read.
+std::ostream &operator<<(std::ostream &out, const PrimeResult &m) {
+    switch (m) {
+        case PrimeResult::COMPOSITE:
+            return (out << "COMPOSITE");
+        case PrimeResult::PROBABLY_PRIME:
+            return (out << "PROBABLY_PRIME");
+        case PrimeResult::BAD_INPUT:
+            return (out << "BAD_INPUT");
+    }
+    return out;
+}
+
+// We don't need this equality operator in our "real" code, but it's useful for tests.
+constexpr bool operator==(const NumberDecomposition &a, const NumberDecomposition &b) {
+    return (a.power_of_two == b.power_of_two) && (a.odd_remainder == b.odd_remainder);
+}
+
+namespace {
+
+//
+// Compute a compile-time array of the first N prime numbers.
+//
+template <std::size_t N>
+std::array<uint64_t, N> first_n_primes() {
+    static std::array<uint64_t, N> result;
+    result[0u] = 2u;
+
+    uint64_t candidate = 3u;
+    for (auto i = 1u; i < N; ++i) {
+        for (auto j = 0u; j < i; ++j) {
+            const auto &prime = result[j];
+
+            // If we find the candidate is composite, start over with the next candidate.
+            if (candidate % prime == 0u) {
+                candidate += 2u;
+                j = 0u;
+                continue;
+            }
+
+            // If we've checked all of the primes and found no divisors, then this is the next prime
+            // we were looking for.
+            if (prime * prime > candidate) {
+                result[i] = candidate;
+                candidate += 2u;
+                break;
+            }
+        }
+    }
+
+    return result;
+}
+
+TEST(FirstNPrimes, For1ReturnsSingleSizedArrayContainingTwo) {
+    EXPECT_THAT(first_n_primes<1u>(), ElementsAre(2u));
+}
+
+TEST(FirstNPrimes, For10ReturnsFirst10Primes) {
+    EXPECT_THAT(first_n_primes<10u>(), ElementsAre(2u, 3u, 5u, 7u, 11u, 13u, 17u, 19u, 23u, 29u));
+}
+
+TEST(Decompose, ReturnsCorrectValues) {
+    EXPECT_THAT(decompose(126u), Eq(NumberDecomposition{1u, 63u}));
+    EXPECT_THAT(decompose(127u), Eq(NumberDecomposition{0u, 127u}));
+    EXPECT_THAT(decompose(128u), Eq(NumberDecomposition{7u, 1u}));
+}
+
+std::vector<uint64_t> miller_rabin_pseudoprimes_to_base_2() {
+    // https://oeis.org/A001262
+    return {2047u,   3277u,   4033u,   4681u,   8321u,   15841u,  29341u,  42799u,
+            49141u,  52633u,  65281u,  74665u,  80581u,  85489u,  88357u,  90751u,
+            104653u, 130561u, 196093u, 220729u, 233017u, 252601u, 253241u, 256999u,
+            271951u, 280601u, 314821u, 357761u, 390937u, 458989u, 476971u, 486737u};
+}
+
+std::vector<uint64_t> miller_rabin_pseudoprimes_to_base_3() {
+    // https://oeis.org/A020229
+    return {121u,    703u,    1891u,   3281u,   8401u,   8911u,   10585u,  12403u,  16531u,
+            18721u,  19345u,  23521u,  31621u,  44287u,  47197u,  55969u,  63139u,  74593u,
+            79003u,  82513u,  87913u,  88573u,  97567u,  105163u, 111361u, 112141u, 148417u,
+            152551u, 182527u, 188191u, 211411u, 218791u, 221761u, 226801u};
+}
+
+TEST(MillerRabin, EvenNumbersAreBadInput) {
+    EXPECT_THAT(miller_rabin(2u, 0u), Eq(PrimeResult::BAD_INPUT));
+    EXPECT_THAT(miller_rabin(2u, 2u), Eq(PrimeResult::BAD_INPUT));
+    EXPECT_THAT(miller_rabin(2u, 4u), Eq(PrimeResult::BAD_INPUT));
+    EXPECT_THAT(miller_rabin(2u, 6u), Eq(PrimeResult::BAD_INPUT));
+    EXPECT_THAT(miller_rabin(2u, 8u), Eq(PrimeResult::BAD_INPUT));
+
+    EXPECT_THAT(miller_rabin(2u, 123456u), Eq(PrimeResult::BAD_INPUT));
+}
+
+TEST(MillerRabin, NumbersLessThanAPlusTwoAreBadInput) {
+    ASSERT_THAT(miller_rabin(9u, 11u), Eq(PrimeResult::PROBABLY_PRIME));
+
+    EXPECT_THAT(miller_rabin(10u, 11u), Eq(PrimeResult::BAD_INPUT));
+    EXPECT_THAT(miller_rabin(11u, 11u), Eq(PrimeResult::BAD_INPUT));
+}
+
+TEST(MillerRabin, MarksEveryPrimeAsProbablyPrime) {
+    auto expect_miller_rabin_probably_prime = [](std::size_t a, uint64_t n) {
+        const auto result = miller_rabin(a, n);
+        const auto expected =
+            (n < a + 2u || n % 2u == 0u) ? PrimeResult::BAD_INPUT : PrimeResult::PROBABLY_PRIME;
+
+        EXPECT_THAT(result, Eq(expected)) << "a = " << a << ", n = " << n;
+    };
+
+    const auto primes = first_n_primes<3'000u>();
+    for (const auto &p : primes) {
+        expect_miller_rabin_probably_prime(2u, p);
+        expect_miller_rabin_probably_prime(3u, p);
+        expect_miller_rabin_probably_prime(4u, p);
+        expect_miller_rabin_probably_prime(5u, p);
+
+        expect_miller_rabin_probably_prime(88u, p);
+    }
+}
+
+TEST(MillerRabin, OddNumberIsProbablyPrimeIffPrimeOrPseudoprime) {
+    const auto primes = first_n_primes<3'000u>();
+    const auto pseudoprimes = miller_rabin_pseudoprimes_to_base_2();
+
+    // Make sure that we are both _into the regime_ of the pseudoprimes, and that we aren't off the
+    // end of it.
+    ASSERT_THAT(primes.back(), AllOf(Gt(pseudoprimes.front()), Lt(pseudoprimes.back())));
+
+    std::size_t i_prime = 2u;  // Skip 2 and 3; they're too small for Miller-Rabin.
+    std::size_t i_pseudoprime = 0u;
+    for (uint64_t n = primes[i_prime]; i_prime < primes.size(); n += 2u) {
+        const auto is_prime = (n == primes[i_prime]);
+        if (is_prime) {
+            ++i_prime;
+        }
+
+        const auto is_pseudoprime = (n == pseudoprimes[i_pseudoprime]);
+        if (is_pseudoprime) {
+            ++i_pseudoprime;
+        }
+
+        const auto expected =
+            (is_prime || is_pseudoprime) ? PrimeResult::PROBABLY_PRIME : PrimeResult::COMPOSITE;
+        EXPECT_THAT(miller_rabin(2u, n), Eq(expected)) << "n = " << n;
+    }
+}
+
+TEST(MillerRabin, HasExpectedBase2Pseudoprimes) {
+    for (const auto &n : miller_rabin_pseudoprimes_to_base_2()) {
+        EXPECT_THAT(miller_rabin(2u, n), Eq(PrimeResult::PROBABLY_PRIME)) << n;
+    }
+}
+
+TEST(MillerRabin, HasExpectedBase3Pseudoprimes) {
+    for (const auto &n : miller_rabin_pseudoprimes_to_base_3()) {
+        EXPECT_THAT(miller_rabin(3u, n), Eq(PrimeResult::PROBABLY_PRIME)) << n;
+    }
+}
+
+TEST(MillerRabin, HandlesExtremelyLargePrimes) {
+    for (const auto &base : {2ull, 3ull, 4ull, 5ull, 99ull, 12345ull, 9876543210123456789ull}) {
+        EXPECT_THAT(miller_rabin(base, 18'446'744'073'709'551'557u),
+                    Eq(PrimeResult::PROBABLY_PRIME));
+    }
+}
+
+TEST(MillerRabin, SupportsConstexpr) {
+    constexpr auto result = miller_rabin(2u, 997u);
+    static_assert(result == PrimeResult::PROBABLY_PRIME, "997 is prime");
+}
+
+}  // namespace
+}  // namespace detail
+}  // namespace au

--- a/au/code/au/utility/test/probable_primes_test.cc
+++ b/au/code/au/utility/test/probable_primes_test.cc
@@ -159,7 +159,7 @@ TEST(MillerRabin, OddNumberIsProbablyPrimeIffPrimeOrPseudoprime) {
 
     std::size_t i_prime = 2u;  // Skip 2 and 3; they're too small for Miller-Rabin.
     std::size_t i_pseudoprime = 0u;
-    for (uint64_t n = primes[i_prime]; i_prime < primes.size(); n += 2u) {
+    for (uint64_t n = primes[i_prime]; n <= primes.back(); n += 2u) {
         const auto is_prime = (n == primes[i_prime]);
         if (is_prime) {
             ++i_prime;


### PR DESCRIPTION
We put this in a new file, `probable_primes.hh`.  Algorithms in this
class can return one of three outcomes:

- "composite" for numbers that are definitely composite
- "probably prime" for _all_ primes, and possibly _some_ composite
  numbers
- "bad input" for numbers that aren't composite or prime (0 or 1), or
  simply aren't appropriate inputs for that particular algorithm.

The wikipedia page[1] gives a good overview of the algorithm.

How do we know that the implementation is correct?  By these main
strategies:

- [x] Miller-Rabin should mark _every_ prime number as "probably prime",
  so test a large number of known primes, each with a variety of bases.

- [x] Test all (odd) inputs up to a certain maximum, making sure that it
  marks every prime as "probably prime", _every pseudoprime to that
  base_ as "probably prime", and every other number as "composite".

- [x] Test a list of known pseudoprimes for a few given bases, and make
  sure that these are all marked as "probably prime" for that base.
  (Making sure that we make the "right mistakes" is a good way to build
  confidence that we implemented the algorithm correctly.)

- [x] Test an extremely large prime (close to the `uint64_t` limit), to
  check that overflow hasn't crept into any of our calculations.

Given that the implementation passes all of these tests, it seems very
likely that our implementation is correct.

Helps #217.

[1] https://en.wikipedia.org/wiki/Miller%E2%80%93Rabin_primality_test