### PR TITLE
Use Baillie-PSW for prime factorization

### DIFF
--- a/au/code/au/utility/probable_primes.hh
+++ b/au/code/au/utility/probable_primes.hh
@@ -179,7 +179,7 @@ constexpr int jacobi_symbol(int64_t raw_a, uint64_t n) {
     // Starting conditions: transform `a` to strictly non-negative values, setting `result` to the
     // sign we pick up from this operation (if any).
     int result = bool_sign((raw_a >= 0) || (n % 4u == 1u));
-    auto a = static_cast<uint64_t>(std::abs(raw_a)) % n;
+    auto a = static_cast<uint64_t>(raw_a * bool_sign(raw_a >= 0)) % n;
 
     // Delegate to an implementation which can only handle positive numbers.
     return jacobi_symbol_positive_numerator(a, n, result);

--- a/au/code/au/utility/test/factoring_test.cc
+++ b/au/code/au/utility/test/factoring_test.cc
@@ -22,6 +22,20 @@ namespace {
 std::uintmax_t cube(std::uintmax_t n) { return n * n * n; }
 }  // namespace
 
+TEST(FirstPrimes, HasOnlyPrimesInOrderAndDoesntSkipAny) {
+    const auto &first_primes = FirstPrimes::values;
+    const auto &n_primes = FirstPrimes::N;
+    auto i_prime = 0u;
+    for (auto i = 2u; i_prime < n_primes; ++i) {
+        if (i == first_primes[i_prime]) {
+            EXPECT_TRUE(is_prime(i)) << i;
+            ++i_prime;
+        } else {
+            EXPECT_FALSE(is_prime(i)) << i;
+        }
+    }
+}
+
 TEST(FindFirstFactor, ReturnsInputForPrimes) {
     EXPECT_EQ(find_first_factor(2u), 2u);
     EXPECT_EQ(find_first_factor(3u), 3u);
@@ -58,6 +72,17 @@ TEST(IsPrime, FindsPrimes) {
     EXPECT_FALSE(is_prime(196960u));
     EXPECT_TRUE(is_prime(196961u));
     EXPECT_FALSE(is_prime(196962u));
+}
+
+TEST(IsPrime, CanHandleVeryLargePrimes) {
+    for (const auto &p : {
+             225'653'407'801ull,
+             334'524'384'739ull,
+             9'007'199'254'740'881ull,
+             18'446'744'073'709'551'557ull,
+         }) {
+        EXPECT_TRUE(is_prime(p)) << p;
+    }
 }
 
 TEST(Multiplicity, CountsFactors) {

--- a/au/code/au/utility/test/factoring_test.cc
+++ b/au/code/au/utility/test/factoring_test.cc
@@ -26,7 +26,7 @@ TEST(FirstPrimes, HasOnlyPrimesInOrderAndDoesntSkipAny) {
     const auto &first_primes = FirstPrimes::values;
     const auto &n_primes = FirstPrimes::N;
     auto i_prime = 0u;
-    for (auto i = 2u; i_prime < n_primes; ++i) {
+    for (auto i = 2u; i <= first_primes[n_primes - 1u]; ++i) {
         if (i == first_primes[i_prime]) {
             EXPECT_TRUE(is_prime(i)) << i;
             ++i_prime;

--- a/au/code/au/utility/test/factoring_test.cc
+++ b/au/code/au/utility/test/factoring_test.cc
@@ -14,7 +14,11 @@
 
 #include "au/utility/factoring.hh"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+using ::testing::Gt;
+using ::testing::Le;
 
 namespace au {
 namespace detail {
@@ -51,6 +55,22 @@ TEST(FindFirstFactor, FindsFirstFactor) {
     EXPECT_EQ(find_first_factor(cube(196961u)), 196961u);
 }
 
+TEST(FindFirstFactor, CanFactorNumbersWithLargePrimeFactor) {
+    // Small prime factors.
+    EXPECT_EQ(find_first_factor(2u * 9'007'199'254'740'881u), 2u);
+    EXPECT_EQ(find_first_factor(3u * 9'007'199'254'740'881u), 3u);
+
+    constexpr auto LAST_TRIAL_PRIME = FirstPrimes::values[FirstPrimes::N - 1u];
+
+    // Large prime factor from trial division.
+    ASSERT_THAT(541u, Le(LAST_TRIAL_PRIME));
+    EXPECT_EQ(find_first_factor(541u * 9'007'199'254'740'881u), 541u);
+
+    // Large prime factor higher than what we use for trial division.
+    ASSERT_THAT(1999u, Gt(LAST_TRIAL_PRIME));
+    EXPECT_EQ(find_first_factor(1999u * 9'007'199'254'740'881u), 1999u);
+}
+
 TEST(IsPrime, FalseForLessThan2) {
     EXPECT_FALSE(is_prime(0u));
     EXPECT_FALSE(is_prime(1u));
@@ -76,10 +96,10 @@ TEST(IsPrime, FindsPrimes) {
 
 TEST(IsPrime, CanHandleVeryLargePrimes) {
     for (const auto &p : {
-             225'653'407'801ull,
-             334'524'384'739ull,
-             9'007'199'254'740'881ull,
-             18'446'744'073'709'551'557ull,
+             uint64_t{225'653'407'801u},
+             uint64_t{334'524'384'739u},
+             uint64_t{9'007'199'254'740'881u},
+             uint64_t{18'446'744'073'709'551'557u},
          }) {
         EXPECT_TRUE(is_prime(p)) << p;
     }


### PR DESCRIPTION
Formerly, `is_prime` depended on `find_first_factor`.  Now, we reverse
that dependency!  This is good, because while factoring is generally
hard enough that we've built the foundations of global banking on that
difficulty, `is_prime` can be done in polynomial time --- and now is,
because we're using `baillie_psw`.  We have a `static_assert` to make
sure it's restricted to 64 bits, but even this could probably be
removed, because there aren't any known counterexamples of _any_ size.

For efficiency reasons, when factoring a number, it's common to do trial
division before moving on to the "fast" primality checkers.  We hardcode
a list of the "first N primes", taking N=100 for now.  (We could also
compute them at compile time, but this turned out to have a very large
impact on compilation times.)  It should be easy to adjust the size of
this list if we decide later: there are tests to make sure that it
contains only primes, has them in order, and doesn't skip any.

The new `is_prime` is indeed very fast and accurate.  It now correctly
handles all of the "problem numbers" mentioned in #217, as well as the
(much much larger) largest 64-bit prime.

One more tiny fix: we had switched to use `std::abs` in #322, but this
doesn't actually work: `std::abs` won't be `constexpr` compatible until
C++23!  So as part of this change, we switch back to something that will
work.

Fixes #217.