### PR TITLE
Use Pollard's rho instead of more trial division

### DIFF
--- a/au/code/au/utility/factoring.hh
+++ b/au/code/au/utility/factoring.hh
@@ -65,7 +65,7 @@ constexpr std::uintmax_t find_pollard_rho_factor(std::uintmax_t n) {
             ++cycle_length;
             factor = gcd(n, absolute_diff(tortoise, hare));
         }
-        if (factor > 1u && factor < n) {
+        if (factor < n) {
             return factor;
         }
     }
@@ -112,7 +112,11 @@ constexpr std::uintmax_t find_prime_factor(std::uintmax_t n) {
         return n;
     }
 
-    return find_pollard_rho_factor(n);
+    auto factor = find_pollard_rho_factor(n);
+    while (!is_prime(factor)) {
+        factor = find_pollard_rho_factor(factor);
+    }
+    return factor;
 }
 
 // Find the largest power of `factor` which divides `n`.

--- a/au/code/au/utility/test/factoring_test.cc
+++ b/au/code/au/utility/test/factoring_test.cc
@@ -77,6 +77,21 @@ TEST(FindFactor, CanFactorNumbersWithLargePrimeFactor) {
                 AnyOf(Eq(1999u), Eq(9'007'199'254'740'881u)));
 }
 
+TEST(FindFactor, CanFactorChallengingCompositeNumbers) {
+    // For ideas, see numbers in the "best solution" column in the various tables in
+    // <https://miller-rabin.appspot.com/>.
+    {
+        // Also passes for trial division.
+        constexpr auto factor = find_prime_factor(7'999'252'175'582'851u);
+        EXPECT_THAT(factor, AnyOf(Eq(9'227u), Eq(894'923u), Eq(968'731u)));
+    }
+    {
+        // Fails for trial division: requires Pollard's rho.
+        constexpr auto factor = find_prime_factor(55'245'642'489'451u);
+        EXPECT_THAT(factor, AnyOf(Eq(3'716'371u), Eq(14'865'481u)));
+    }
+}
+
 TEST(IsPrime, FalseForLessThan2) {
     EXPECT_FALSE(is_prime(0u));
     EXPECT_FALSE(is_prime(1u));


### PR DESCRIPTION
In our current implementation, we can't handle any number whose factor
is bigger than, roughly, "the thousandth odd number after the hundredth
prime" --- "thousandth" because that's roughly where compiler iteration
limits kick in, and "hundredth prime" because we try the first hundred
primes in our initial trial division step.  This works out to 2,541
(although again, this is only the _approximate_ limit).

Pollard's rho algorithm requires a number of iterations _on average_
that is proportional to the square root of `p`, the smallest prime
factor.  Thus, we expect it to have good success rates for numbers whose
smallest factor is up to roughly one million, which is a lot higher than
2,541.

In practice, I've found some numbers that we can't factor with our
current implementation, but can if we use Pollard's rho.  I've included
one of them in a test case.  However, there are other factors (see #217)
that even the current version of Pollard's rho can't factor.  If we
can't find an approach that works for these, we may just have to live
with it.

Helps #217.