### PR TITLE
Add `as_raw_number(...)` utility

### DIFF
--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -534,6 +534,20 @@ constexpr auto operator%(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return make_quantity<U>(q1.in(U{}) % q2.in(U{}));
 }
 
+// Callsite-readable way to convert a `Quantity` to a raw number.
+//
+// Only works for dimensionless `Quantities`; will return a compile-time error otherwise.
+//
+// Identity for non-`Quantity` types.
+template <typename U, typename R>
+constexpr R as_raw_number(Quantity<U, R> q) {
+    return q.as(UnitProductT<>{});
+}
+template <typename T>
+constexpr T as_raw_number(T x) {
+    return x;
+}
+
 // Type trait to detect whether two Quantity types are equivalent.
 //
 // In this library, Quantity types are "equivalent" exactly when they use the same Rep, and are


### PR DESCRIPTION
This lets us pave the way to change the behavior of quantity arithmetic
when all units cancel out (#185).  If we make this change all at once,
it'll generally be too big and hard to handle.  But if we provide this
utility now, then people can migrate individual callsites gradually over
time.  Then, at the end (probably 0.5.0?), making the switch to the new
behavior won't be such a big change.

Helps #185.