### PR TITLE
Add `UIToA<uint64_t>`

### DIFF
--- a/au/code/au/magnitude.hh
+++ b/au/code/au/magnitude.hh
@@ -604,7 +604,7 @@ constexpr const bool MagnitudeLabelImplementation<MagT, Category>::has_exposed_s
 
 template <typename MagT>
 struct MagnitudeLabelImplementation<MagT, MagLabelCategory::INTEGER>
-    : detail::IToA<get_value<std::uintmax_t>(MagT{})> {
+    : detail::UIToA<get_value<std::uintmax_t>(MagT{})> {
     static constexpr const bool has_exposed_slash = false;
 };
 template <typename MagT>

--- a/au/code/au/utility/test/string_constant_test.cc
+++ b/au/code/au/utility/test/string_constant_test.cc
@@ -66,6 +66,10 @@ TEST(IToA, HasLengthMember) {
     EXPECT_EQ(IToA<-12345>::length, 6);
 }
 
+TEST(UIToA, CanHandleNumbersBiggerThanIntmaxButWithinUintmax) {
+    EXPECT_STREQ(UIToA<10000000000000000000u>::value.c_str(), "10000000000000000000");
+}
+
 TEST(join, EmptyStringForNoArguments) {
     constexpr auto x = as_string_constant("sep").join();
     EXPECT_STREQ(x.c_str(), "");


### PR DESCRIPTION
Turns out, using `IToA` for magnitudes was a little bit sloppy.
Magnitude values are always unsigned, which means there are meaningful
values that won't fit inside of an `int64_t`.  Fortunately, adding all
those constants (#336) was a great stress test to expose this.

I think the most natural fix would be to add a `UIToA`, which can't
handle signed values, but which _can_ handle the "upper half" of
`uint64_t` values.  This way, we can have `IToA` delegate to `UIToA` for
the "integer magnitude" parts of the logic.

Why not just get rid of `IToA` altogether?  Well, we do need it for
printing exponents, which can be negative.

Helps #90: this gets the test to pass on #336.