### PR TITLE
Delete old-style `.in` and `.as` APIs

### DIFF
--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -190,34 +190,6 @@ class Quantity {
         }
     }
 
-    // "Old-style" overloads with <U, R> template parameters, and no function parameters.
-    //
-    // Matches the syntax from the CppCon 2021 talk, and legacy Aurora usage.
-    template <typename U>
-    [[deprecated(
-        "Do not write `.as<YourUnits>()`; write `.as(your_units)` instead.")]] constexpr auto
-    as() const -> decltype(as(U{})) {
-        return as(U{});
-    }
-    template <typename U, typename R, typename = std::enable_if_t<IsUnit<U>::value>>
-    [[deprecated(
-        "Do not write `.as<YourUnits, T>()`; write `.as<T>(your_units)` instead.")]] constexpr auto
-    as() const {
-        return as<R>(U{});
-    }
-    template <typename U>
-    [[deprecated(
-        "Do not write `.in<YourUnits>()`; write `.in(your_units)` instead.")]] constexpr auto
-    in() const -> decltype(in(U{})) {
-        return in(U{});
-    }
-    template <typename U, typename R, typename = std::enable_if_t<IsUnit<U>::value>>
-    [[deprecated(
-        "Do not write `.in<YourUnits, T>()`; write `.in<T>(your_units)` instead.")]] constexpr auto
-    in() const {
-        return in<R>(U{});
-    }
-
     // "Forcing" conversions, which explicitly ignore safety checks for overflow and truncation.
     template <typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {

--- a/au/code/au/quantity_point.hh
+++ b/au/code/au/quantity_point.hh
@@ -154,34 +154,6 @@ class QuantityPoint {
             .in(associated_unit_for_points(u));
     }
 
-    // "Old-style" overloads with <U, R> template parameters, and no function parameters.
-    //
-    // Matches the syntax from the CppCon 2021 talk, and legacy Aurora usage.
-    template <typename U>
-    [[deprecated(
-        "Do not write `.as<YourUnits>()`; write `.as(your_units)` instead.")]] constexpr auto
-    as() const -> decltype(as(U{})) {
-        return as(U{});
-    }
-    template <typename U, typename R, typename = std::enable_if_t<IsUnit<U>::value>>
-    [[deprecated(
-        "Do not write `.as<YourUnits, T>()`; write `.as<T>(your_units)` instead.")]] constexpr auto
-    as() const {
-        return as<R>(U{});
-    }
-    template <typename U>
-    [[deprecated(
-        "Do not write `.in<YourUnits>()`; write `.in(your_units)` instead.")]] constexpr auto
-    in() const -> decltype(in(U{})) {
-        return in(U{});
-    }
-    template <typename U, typename R, typename = std::enable_if_t<IsUnit<U>::value>>
-    [[deprecated(
-        "Do not write `.in<YourUnits, T>()`; write `.in<T>(your_units)` instead.")]] constexpr auto
-    in() const {
-        return in<R>(U{});
-    }
-
     // "Forcing" conversions, which explicitly ignore safety checks for overflow and truncation.
     template <typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {


### PR DESCRIPTION
These have been deprecated for the entire 0.3.x release cycle.  We can
remove them now that we're ready to release 0.4.0.

Fixes #139.