### PR TITLE
Provide compatibility with `<=>` in C++20 mode

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Build and test (${{ inputs.config }})
         run: bazel test --copt=-Werror --config=${{ inputs.config }} //...:all
       - name: Build and test with -Wconversion (${{ inputs.config }})
-        run: bazel test --copt=-Werror --copt=-Wconversion --config=${{ inputs.config }} `bazel query 'kind(".*_test", //au/...:all except //au:no_wconversion_test)'`
+        run: bazel test --copt=-Werror --copt=-Wconversion --config=${{ inputs.config }} --test_tag_filters=-no_wconversion --build_tag_filters=-no_wconversion //au/...:all
       - name: Build and test in C++20 mode (${{ inputs.config }})
         run: bazel test --copt=-Werror --copt=-std=c++20 --config=${{ inputs.config }} //...:all //au:cpp20_test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,3 +31,5 @@ jobs:
         run: bazel test --copt=-Werror --config=${{ inputs.config }} //...:all
       - name: Build and test with -Wconversion (${{ inputs.config }})
         run: bazel test --copt=-Werror --copt=-Wconversion --config=${{ inputs.config }} `bazel query 'kind(".*_test", //au/...:all except //au:no_wconversion_test)'`
+      - name: Build and test in C++20 mode (${{ inputs.config }})
+        run: bazel test --copt=-Werror --copt=-std=c++20 --config=${{ inputs.config }} //...:all //au:cpp20_test

--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -65,6 +65,19 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "cpp20_test",
+    size = "small",
+    srcs = ["code/au/cpp20_test.cc"],
+    tags = ["manual"],
+    deps = [
+        ":quantity",
+        ":testing",
+        ":units",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "fwd",
     hdrs = ["code/au/fwd.hh"],

--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -72,6 +72,7 @@ cc_test(
     tags = ["manual"],
     deps = [
         ":quantity",
+        ":quantity_point",
         ":testing",
         ":units",
         "@com_google_googletest//:gtest_main",

--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -387,6 +387,7 @@ cc_test(
     name = "no_wconversion_test",
     size = "small",
     srcs = ["code/au/no_wconversion_test.cc"],
+    tags = ["no_wconversion"],
     deps = [
         ":quantity",
         ":testing",

--- a/au/code/au/cpp20_test.cc
+++ b/au/code/au/cpp20_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if __cplusplus >= 202002L
+
 #include <compare>
 
 #include "au/quantity.hh"
@@ -40,3 +42,5 @@ TEST(Quantity, SupportsSpaceship) { EXPECT_LT(Foo{5 * m}, Foo{6 * m}); }
 TEST(QuantityPoint, SupportsSpaceship) { EXPECT_LT(FooPt{meters_pt(5)}, FooPt{meters_pt(6)}); }
 
 }  // namespace au
+
+#endif

--- a/au/code/au/cpp20_test.cc
+++ b/au/code/au/cpp20_test.cc
@@ -1,0 +1,31 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/quantity.hh"
+#include "au/testing.hh"
+#include "au/units/meters.hh"
+
+namespace au {
+
+using symbols::m;
+
+struct Foo {
+    auto operator<=>(const Foo &) const = default;
+
+    QuantityD<Meters> thickness;
+};
+
+TEST(Quantity, SupportsSpaceship) { EXPECT_LT(Foo{5 * m}, Foo{6 * m}); }
+
+}  // namespace au

--- a/au/code/au/cpp20_test.cc
+++ b/au/code/au/cpp20_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <compare>
+
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/testing.hh"

--- a/au/code/au/cpp20_test.cc
+++ b/au/code/au/cpp20_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "au/quantity.hh"
+#include "au/quantity_point.hh"
 #include "au/testing.hh"
 #include "au/units/meters.hh"
 
@@ -26,6 +27,14 @@ struct Foo {
     QuantityD<Meters> thickness;
 };
 
+struct FooPt {
+    auto operator<=>(const FooPt &) const = default;
+
+    QuantityPointD<Meters> position;
+};
+
 TEST(Quantity, SupportsSpaceship) { EXPECT_LT(Foo{5 * m}, Foo{6 * m}); }
+
+TEST(QuantityPoint, SupportsSpaceship) { EXPECT_LT(FooPt{meters_pt(5)}, FooPt{meters_pt(6)}); }
 
 }  // namespace au

--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -815,6 +815,15 @@ constexpr auto operator>=(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q
     return as_quantity(q1) >= q2;
 }
 
+// Spaceship operator provides C++20 compatibility.
+#if __cplusplus >= 202002L
+template <typename U1, typename R1, typename U2, typename R2>
+constexpr auto operator<=>(const Quantity<U1, R1> &lhs, const Quantity<U2, R2> &rhs) {
+    using U = CommonUnitT<U1, U2>;
+    return lhs.in(U{}) <=> rhs.in(U{});
+}
+#endif
+
 // Helper to compute the `std::common_type_t` of two `Quantity` types.
 //
 // `std::common_type` requires its specializations to be SFINAE-friendly, meaning that the `type`

--- a/au/code/au/quantity_point.hh
+++ b/au/code/au/quantity_point.hh
@@ -370,6 +370,15 @@ constexpr auto operator-(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     return detail::using_common_point_unit(p1, p2, detail::minus);
 }
 
+// Spaceship operator provides C++20 compatibility.
+#if __cplusplus >= 202002L
+template <typename U1, typename R1, typename U2, typename R2>
+constexpr auto operator<=>(const QuantityPoint<U1, R1> &lhs, const QuantityPoint<U2, R2> &rhs) {
+    using U = CommonPointUnitT<U1, U2>;
+    return lhs.in(U{}) <=> rhs.in(U{});
+}
+#endif
+
 namespace detail {
 
 template <typename TargetRep, typename U, typename R>

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -1026,6 +1026,6 @@ features.
                 <li>Only one user-facing macro for C++20 backwards compatibility</li>
             </ul>
         </td>
-        <td class="best">No macros</td>
+        <td class="best">Zero user-facing macros; only one internal macro</td>
     </tr>
 </table>

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -1026,6 +1026,6 @@ features.
                 <li>Only one user-facing macro for C++20 backwards compatibility</li>
             </ul>
         </td>
-        <td class="best">Zero user-facing macros; only one internal macro</td>
+        <td class="best">Zero user-facing macros; only two internal macros</td>
     </tr>
 </table>


### PR DESCRIPTION
This is the end of an era: the first Au core library code that uses a
macro.  Still, the use case meets the high bar we would need to justify
this: it keeps the library working out of the box for C++20 users,
without their needing to do anything.

To test this, we add a new C++20 mode to our CI tests.  We'll make sure
that it's working by pushing a first commit that should fail, because
all we have done is to add the test and run it in CI.  After that, we'll
push up the fix, and take the PR out of draft mode.

Fixes #353.  We may or may not also follow up to remove the implicit
conversion to the NTTP type, depending on the outcome of an internal
design discussion.