### PR TITLE
Tighten NTTP creation: require `to_nttp(...)`

### DIFF
--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -376,16 +376,11 @@ class Quantity {
                       "NTTP functionality only works when rep is built-in integral type");
     }
 
-    constexpr operator NTTP() const {
+    friend constexpr NTTP to_nttp(const Quantity &q) {
         static_assert(std::is_integral<Rep>::value,
                       "NTTP functionality only works when rep is built-in integral type");
-        return static_cast<NTTP>(value_);
+        return static_cast<NTTP>(q.value_);
     }
-
-    template <typename C, C x = C::ENUM_VALUES_ARE_UNUSED>
-    constexpr operator C() const = delete;
-    // If you got here ^^^, then you need to do your unit conversion **manually**.  Check the type
-    // of the template parameter, and convert it to that same unit and rep.
 
     friend constexpr Quantity from_nttp(NTTP val) { return val; }
 

--- a/au/code/au/quantity_test.cc
+++ b/au/code/au/quantity_test.cc
@@ -766,12 +766,12 @@ struct TemplateOnLength {
 };
 
 TEST(QuantityNTTP, SupportsPreCpp20NttpTypes) {
-    constexpr auto length = TemplateOnLength<meters(18)>{}.value;
+    constexpr auto length = TemplateOnLength<to_nttp(meters(18))>{}.value;
     EXPECT_THAT(length, SameTypeAndValue(meters(18)));
 }
 
 TEST(QuantityNTTP, CanConvertFromNttpToAnyCompatibleQuantityType) {
-    constexpr QuantityI<Meters>::NTTP LengthNTTP = meters(18);
+    constexpr QuantityI<Meters>::NTTP LengthNTTP = to_nttp(meters(18));
     constexpr QuantityI<Milli<Meters>> length = from_nttp(LengthNTTP);
     EXPECT_THAT(length, SameTypeAndValue(milli(meters)(18'000)));
 }

--- a/docs/howto/quantity-template-parameters.md
+++ b/docs/howto/quantity-template-parameters.md
@@ -13,10 +13,11 @@ a [workaround](../reference/quantity.md#nttp).  This page explains how to use it
     The way it works is that every `Quantity<U, R>` type defines its own custom enumeration type,
     which is associated only with that `Quantity` type: we call it `Quantity<U, R>::NTTP`. The type
     system preserves the association between the two, so we don't get mixed up with the `NTTP` type
-    for any other `Quantity`. This lets us safely provide implicit conversion back and forth between
-    the `Quantity` type and its `NTTP` type. What's more, it's legal C++ to `static_cast` between an
-    enumeration and its underlying type, even for values that aren't part of the enumeration ---
-    therefore, we're able to hold any value that the `Quantity` type can.
+    for any other `Quantity`. This lets us safely convert back and forth between the `Quantity` type
+    and its `NTTP` type, using the `to_nttp(Quantity)` and `from_nttp(Quantity::NTTP)` utilities.
+    What's more, it's legal C++ to `static_cast` between an enumeration and its underlying type,
+    even for values that aren't part of the enumeration --- therefore, we're able to hold any value
+    that the `Quantity` type can.
 
     So, even though we can't _exactly_ use a `Quantity` _value_ as a template parameter, what we
     _can_ do is use a special type that has _low-friction conversion_ to and from that `Quantity`,
@@ -30,14 +31,13 @@ feature.)  Here's how to use this type as a template parameter:
 
 1. Use `Quantity<U, R>::NTTP` as the _type_ of the template parameter.
 
-2. When instantiating the template, pass any instance of `Quantity<U, R>`.
+2. When instantiating the template, pass any instance of `Quantity<U, R>` after calling
+   `to_nttp(...)` on it.
 
-    - Note that you can pass the quantity itself, not `Quantity<U, R>::NTTP`!  Implicit conversion
-      makes this possible.
-    - Note also that the value (call it `q`) must be **exactly** an instance of `Quantity<U, R>`,
-      and not any other `Quantity` type.  If it's not, you'll get a compiler error.  You can fix
-      this by converting to `Quantity<U, R>` via the usual library mechanisms --- namely, something
-      like `q.as<R>(U{})`.
+    - Note that the value (call it `q`) must be **exactly** an instance of `Quantity<U, R>`, and not
+      any other `Quantity` type.  If it's not, you'll get a compiler error.  You can fix this by
+      converting to `Quantity<U, R>` via the usual library mechanisms --- namely, something like
+      `q.as<R>(U{})`.
 
 3. To use the value of the template parameter _as a `Quantity`_ in your code, you have two options.
 
@@ -77,8 +77,8 @@ class Processor {
 And here's how we'd use it.
 
 ```cpp
-// Step (2): when instantiating, convert to the exact right `Quantity` type.
-using Proc = Processor<mega(hertz)(1'200).as<uint64_t>(hertz)>;
+// Step (2): when instantiating, convert to the exact right `Quantity` type, using `to_nttp`.
+using Proc = Processor<to_nttp(mega(hertz)(1'200).as<uint64_t>(hertz))>;
 
 std::cout << Proc::clock_freq() << std::endl;
 ```

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -542,10 +542,15 @@ _pointer_ types, and _enumerations_.
 
 Au provides a workaround for pre-C++20 users that lets you _effectively_ encode any `Quantity<U, R>`
 as an NTTP, _as long as_ its rep `R` is an **integral** type.  To do this, use the
-`Quantity<U, R>::NTTP` type as the template parameter.  You will be able to assign between
-`Quantity<U, R>` and `Quantity<U, R>::NTTP`, _in either direction_, but only in the case of exact
-match of both `U` and `R`.  For all other cases, you'll need to perform a conversion (using the
-usual mechanisms for `Quantity` described elsewhere on this page).
+`Quantity<U, R>::NTTP` type as the template parameter.  Here are the available conversions:
+
+- Quantity-to-NTTP:
+    - Call `to_nttp(Quantity<U, R>)`.  (Note that this requires **exact match** for both `U` and
+      `R`; use the usual `Quantity` conversion methods if this is not the case.)
+- NTTP-to-Quantity:
+    - call `from_nttp(Quantity<U, R>::NTTP)`.
+    - Assign `Quantity<U, R>::NTTP` directly to `Quantity<U, R>`.  In this case, we support implicit
+      conversion (again, only if there is an exact match for both `U` and `R`).
 
 !!! warning
     It is undefined behavior to invoke `Quantity<U, R>::NTTP` whenever `std::is_integral<R>::value`
@@ -561,11 +566,18 @@ usual mechanisms for `Quantity` described elsewhere on this page).
     ```cpp
     template <QuantityI<Hertz>::NTTP Frequency>
     struct TemplatedOnFrequency {
-        QuantityI<Hertz> value = Frequency;      // Assigning `Quantity` from NTTP
+        // Assigning `Quantity` from NTTP:
+        QuantityI<Hertz> value = Frequency;
     };
 
-    using T = TemplatedOnFrequency<hertz(440)>;  // Setting template parameter from `Quantity`
+    // Setting template parameter from `Quantity`:
+    using T = TemplatedOnFrequency<to_nttp(hertz(440))>;
     ```
+
+### `to_nttp(Quantity<U, R>)`
+
+Calling `to_nttp` on a `Quantity<U, R>` will convert it to an instance of the corresponding
+`Quantity<U, R>::NTTP` type, effectively "encoding" it for use as a template parameter.
 
 ### `from_nttp(Quantity<U, R>::NTTP)`
 


### PR DESCRIPTION
This backpedals on the very low friction pathway to pass `Quantity` instances as template parameters.  This causes problems with C++20's spaceship operator `<=>`.  We could fix this with a special C++20 compatibility layer, and we might still do exactly that.  However, this is just one instance of a broader class of vulnerability.

It turns out that giving the very safe `Quantity` an **implicit** conversion to a raw numeric type may simply be inviting trouble.  This gives the compiler a pathway to generate all kinds of operations that we probably don't want to generate.

We _could_ just make the conversion _explicit_... but then, how would we trigger it?  I can't think of a way that would be at all comparably concise to `to_nttp`.

So let's just use `to_nttp` for now.  It will be a lot easier to loosen this later if we're confident that's correct, than to tighten it after we've cut an official release.

Helps #353: it gives a more sensible error.