### PR TITLE
Add quantity template params to alternatives doc

### DIFF
--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -936,6 +936,34 @@ features.
     <tr>
         <td>
             <details class="criterion">
+                <summary>Quantity template parameters</summary>
+                <p>
+                    The ability to use quantity <i>values</i> as template parameters.
+                </p>
+            </details>
+        </td>
+        <td class="poor"></td>
+        <td class="poor"></td>
+        <td class="poor"></td>
+        <td class="best">
+            <ul>
+                <li class="check">Supports all quantities</li>
+                <li class="check">Supports automatic conversions</li>
+                <li class="check">Supports quantity families via concepts</li>
+            </ul>
+        </td>
+        <td class="good">
+            <ul>
+                <li class="check">Supports integral rep</li>
+                <li class="check">Only library with pre-C++20 support</li>
+                <li class="x">User must provide exact unit and rep</li>
+                <li class="x">No floating point support</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <details class="criterion">
                 <summary>"Kind" Types</summary>
                 <p>
                     Any feature which supports robustly distinguishing between units that have the


### PR DESCRIPTION
Only mp-units and Au have this feature.  The mp-units support takes very
impressive advantage of C++20 features.  See these godbolt links:

- <https://godbolt.org/z/K9Y5aMvGK>: automatic unit conversion
- <https://godbolt.org/z/7dKKG5nrs>: generic parameter via concepts

Tested with `au-docs-serve`.

Follow-on to #316.