### PR TITLE
Prefer specific feature test macros

### DIFF
--- a/au/code/au/cpp20_test.cc
+++ b/au/code/au/cpp20_test.cc
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if __cplusplus >= 202002L
-
 #include <compare>
 
 #include "au/quantity.hh"
@@ -42,5 +40,3 @@ TEST(Quantity, SupportsSpaceship) { EXPECT_LT(Foo{5 * m}, Foo{6 * m}); }
 TEST(QuantityPoint, SupportsSpaceship) { EXPECT_LT(FooPt{meters_pt(5)}, FooPt{meters_pt(6)}); }
 
 }  // namespace au
-
-#endif

--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -815,8 +815,7 @@ constexpr auto operator>=(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q
     return as_quantity(q1) >= q2;
 }
 
-// Spaceship operator provides C++20 compatibility.
-#if __cplusplus >= 202002L
+#if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 template <typename U1, typename R1, typename U2, typename R2>
 constexpr auto operator<=>(const Quantity<U1, R1> &lhs, const Quantity<U2, R2> &rhs) {
     using U = CommonUnitT<U1, U2>;

--- a/au/code/au/quantity_point.hh
+++ b/au/code/au/quantity_point.hh
@@ -370,8 +370,7 @@ constexpr auto operator-(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     return detail::using_common_point_unit(p1, p2, detail::minus);
 }
 
-// Spaceship operator provides C++20 compatibility.
-#if __cplusplus >= 202002L
+#if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 template <typename U1, typename R1, typename U2, typename R2>
 constexpr auto operator<=>(const QuantityPoint<U1, R1> &lhs, const QuantityPoint<U2, R2> &rhs) {
     using U = CommonPointUnitT<U1, U2>;


### PR DESCRIPTION
Rather than testing for the entire C++ standard revision using
`__cplusplus`, use specific feature test macros for testing the presence
of the particular features being used.

Testing the entire C++ standard revision is insufficient, as toolchains
may implement and enable features incrementally during implementation of
the next revision. A toolchain could feasibly implement three-way
comparisons but have not yet incremented `__cplusplus` as other features
remain unimplemented. [^1]

I also believe this approach to be somewhat more self-describing, which
is appealing even in the face of its verbosity/clunkiness.

[^1]: https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations#explanation-and-rationale-for-the-approach