### PR TITLE
Add test client package

### DIFF
--- a/.github/workflows/cmake-client-build-and-test.yml
+++ b/.github/workflows/cmake-client-build-and-test.yml
@@ -1,0 +1,46 @@
+# Copyright 2024 Aurora Operations, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: cmake-client-build-and-test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  cmake-build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be #v2.0.2
+        with:
+          cmake-version: '3.29.x'
+      - name: Generate build files for Au
+        run: cmake -S . -B cmake/build -DAU_EXCLUDE_GTEST_DEPENDENCY=TRUE -DCMAKE_VERIFY_INTERFACE_HEADER_SETS=TRUE
+      - name: Build Au
+        run: cmake --build cmake/build --target all all_verify_interface_header_sets
+      - name: Install Au
+        run: cmake --install cmake/build --prefix "$PWD/cmake/install"
+      - name: Change to folder for client package
+        run: cd test_package
+      - name: Generate build files for client
+        run: cmake -S . -B build -DCMAKE_PREFIX_PATH="$PWD/../cmake/install"
+      - name: Build client
+        run: cmake --build build --target all
+      - name: Run executable
+        run: ./build/test_au_client

--- a/.github/workflows/cmake-client-build-and-test.yml
+++ b/.github/workflows/cmake-client-build-and-test.yml
@@ -36,11 +36,12 @@ jobs:
         run: cmake --build cmake/build --target all all_verify_interface_header_sets
       - name: Install Au
         run: cmake --install cmake/build --prefix "$PWD/cmake/install"
-      - name: Change to folder for client package
-        run: cd test_package
       - name: Generate build files for client
         run: cmake -S . -B build -DCMAKE_PREFIX_PATH="$PWD/../cmake/install"
+        working-directory: test_package
       - name: Build client
         run: cmake --build build --target all
+        working-directory: test_package
       - name: Run executable
         run: ./build/test_au_client
+        working-directory: test_package

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /bazel-*
 cmake/build*
+cmake/install*
+test_package/build*
 Testing

--- a/au/code/au/CMakeLists.txt
+++ b/au/code/au/CMakeLists.txt
@@ -39,6 +39,7 @@ header_only_library(
     quantity.hh
     quantity_point.hh
     rep.hh
+    static_cast_checkers.hh
     unit_of_measure.hh
     unit_symbol.hh
     wrapper_operations.hh
@@ -461,6 +462,14 @@ gtest_based_test(
   NAME rep_test
   SRCS
     rep_test.cc
+  DEPS
+    au
+)
+
+gtest_based_test(
+  NAME static_cast_checkers_test
+  SRCS
+    static_cast_checkers_test.cc
   DEPS
     au
 )

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright 2024 Aurora Operations, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.29)
+
+project(test_au_client LANGUAGES CXX)
+
+find_package(Au REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_au_client.cc)
+target_link_libraries(${PROJECT_NAME} PRIVATE Au::au)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/test_package/test_au_client.cc
+++ b/test_package/test_au_client.cc
@@ -1,0 +1,33 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include "au/io.hh"
+#include "au/prefix.hh"
+#include "au/units/hours.hh"
+#include "au/units/meters.hh"
+#include "au/units/seconds.hh"
+
+using ::au::symbols::h;
+using ::au::symbols::m;
+using ::au::symbols::s;
+constexpr auto km = ::au::kilo(m);
+
+int main(int argc, char **argv) {
+    constexpr auto v1 = 1 * m / s;
+    constexpr auto v2 = 1 * km / h;
+    std::cout << "(" << v1 << ") + (" << v2 << ") = " << (v1 + v2) << std::endl;
+    return 0;
+}


### PR DESCRIPTION
This makes sure that clients can use a version of Au that is installed
by CMake.

First, we add the new workflow, to make sure that it [breaks] in exactly
the way that reveals #359.  Then, in a new commit in this same PR, we
will fix the bug.

[breaks]: https://github.com/aurora-opensource/au/actions/runs/12341997471/job/34441316121?pr=360

Fixes #359.