### PR TITLE
Add `common_unit` and `make_common` utilities

### DIFF
--- a/au/code/au/unit_of_measure.hh
+++ b/au/code/au/unit_of_measure.hh
@@ -260,6 +260,26 @@ constexpr auto associated_unit_for_points(U) {
     return AssociatedUnitForPointsT<U>{};
 }
 
+template <typename... Us>
+constexpr auto common_unit(Us...) {
+    return CommonUnitT<AssociatedUnitT<Us>...>{};
+}
+
+template <typename... Us>
+constexpr auto common_point_unit(Us...) {
+    return CommonPointUnitT<AssociatedUnitForPointsT<Us>...>{};
+}
+
+template <template <class> class Utility, typename... Us>
+constexpr auto make_common(Utility<Us>...) {
+    return Utility<CommonUnitT<AssociatedUnitT<Us>...>>{};
+}
+
+template <template <class> class Utility, typename... Us>
+constexpr auto make_common_point(Utility<Us>...) {
+    return Utility<CommonPointUnitT<AssociatedUnitForPointsT<Us>...>>{};
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Unit arithmetic traits: products, powers, and derived operations.
 

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -561,9 +561,9 @@ TEST(CommonPointUnit, SupportsUnitSlots) {
 
 TEST(MakeCommon, PreservesCategory) {
     constexpr auto feeters = make_common(feet, meters);
-    EXPECT_EQ(feet(1u) % feeters(1u), ZERO);
-    EXPECT_EQ(meters(1u) % feeters(1u), ZERO);
-    EXPECT_EQ(detail::gcd(feet(1u).in(feeters), meters(1u).in(feeters)), 1u);
+    EXPECT_THAT(feet(1u) % feeters(1u), Eq(ZERO));
+    EXPECT_THAT(meters(1u) % feeters(1u), Eq(ZERO));
+    EXPECT_THAT(detail::gcd(feet(1u).in(feeters), meters(1u).in(feeters)), Eq(1u));
 
     using symbols::ft;
     using symbols::m;

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -678,8 +678,14 @@ concept of [common units](../discussion/concepts/common_unit.md).)
 
 ??? example "Examples"
     ```cpp
+    // `meters` and `feet` are quantity makers: pass them a number, they make a quantity.
+    //
+    // `make_common(meters, feet)` is also a quantity maker, so we can pass it `18`.
     constexpr auto x = make_common(meters, feet)(18);
 
+    // `m` and `ft` are unit symbols: multiply a number by them to make a quantity.
+    //
+    // `make_common(meters, feet)` is also a unit symbol, so we can multiply `9.5f` by it.
     using symbols::m;
     using symbols::ft;
     constexpr auto y = 9.5f * make_common(m, ft);
@@ -687,9 +693,11 @@ concept of [common units](../discussion/concepts/common_unit.md).)
 
 ### Making common point units {#make-common-point}
 
-**Result:** A new unit: the largest-magnitude, highest-origin unit which is "common" to the input
-units.  (Read more about the concept of [common units for
-`QuantityPoint`](../discussion/concepts/common_unit.md#common-quantity-point).)
+**Result:** A new unit, which is "common for points" (see [background
+info](../discussion/concepts/common_unit.md#common-quantity-point)) with respect to all input units.
+This means that its magnitude will be the largest-magnitude unit which evenly divides _both_ the
+input units _and_ the units for any differences-of-origin.  And its origin will be the lowest of all
+input origins.
 
 **Syntax:**
 
@@ -697,6 +705,9 @@ units.  (Read more about the concept of [common units for
 
 ??? example "Example"
     ```cpp
+    // `meters_pt` and `feet_pt` are quantity point makers: pass them a number, they make a quantity point.
+    //
+    // `make_common_point(meters_pt, feet_pt)` is also a quantity point maker, so we can pass it `10`.
     constexpr auto temp = make_common_point(celsius_pt, fahrenheit_pt)(10);
     ```
 

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -324,7 +324,7 @@ _instance_ `u` and magnitude instance `m`, this operation:
 
 - `u * m`
 
-## Traits
+## Traits {#traits}
 
 Because units are [monovalue types](./detail/monovalue_types.md), each trait has two forms: one for
 _types_, and another for _instances_.
@@ -575,10 +575,26 @@ no uniquely defined answer, but the program should still produce _some_ answer. 
 the result is associative, and symmetric under any reordering of the input units.  The specific
 implementation choice will be driven by convenience and simplicity.
 
+??? note "A note on inputs vs. outputs for the `common_unit(us...)` form"
+    The return value of the instance version is a _unit_, while the input parameters are
+    [unit _slots_](../discussion/idioms/unit-slots.md).  This means that the return value will often
+    be a different _category of thing_ (i.e., always consistently a unit) than the inputs (which may
+    be quantity makers, unit symbols, or so on).
+
+    For example, consider `common_unit(meters, feet)`.  Recall that the type of `meters` is
+    `QuantityMaker<Meters>`, and that of `feet` is `QuantityMaker<Feet>`.  In this case, the return
+    value is an instance of `CommonUnitT<Meters, Feet>`, _not_
+    `QuantityMaker<CommonUnitT<Meters, Feet>>`.
+
+    If you want something that still computes the common unit, but preserves the _category_ of the
+    inputs, see [`make_common(us...)`](#make-common).
+
 **Syntax:**
 
 - For _types_ `Us...`:
     - `CommonUnitT<Us...>`
+- For _instances_ `us...`:
+    - `common_unit(us...)`
 
 ### Common point unit
 
@@ -603,9 +619,85 @@ A specialization will only exist if the inputs are all units, and will exist but
 error if any two input units have different Dimensions.  We also strive to keep the result
 associative, and symmetric under interchange of any inputs.
 
+??? note "A note on inputs vs. outputs for the `common_point_unit(us...)` form"
+    The return value of the instance version is a _unit_, while the input parameters are
+    [unit _slots_](../discussion/idioms/unit-slots.md).  This means that the return value will often
+    be a different _category of thing_ (i.e., always consistently a unit) than the inputs (which may
+    be quantity point makers, unit symbols, or so on).
+
+    For example, consider `common_unit(meters, feet)`.  Recall that the type of `meters` is
+    `QuantityMaker<Meters>`, and that of `feet` is `QuantityMaker<Feet>`.  In this case, the return
+    value is an instance of `CommonUnitT<Meters, Feet>`, _not_
+    `QuantityMaker<CommonUnitT<Meters, Feet>>`.
+
+    If you want something that still computes the common unit, but preserves the _category_ of the
+    inputs, see [`make_common_point(us...)`](#make-common-point).
+
 **Syntax:**
 
 - For _types_ `Us...`:
     - `CommonPointUnitT<Us...>`
+- For _instances_ `us...`:
+    - `common_point_unit(us...)`
+
+## Category-preserving unit slot operations
+
+A [unit slot](../discussion/idioms/unit-slots.md) API can take a variety of "categories" of input.
+Prominent examples include:
+
+- Simple unit types (`Meters{}`, ...)
+- Quantity makers (`meters`, ...)
+- Unit symbols (`symbols::m`, ...)
+- Constants (`SPEED_OF_LIGHT`, ...)
+
+The [previous section](#traits) demonstrated various traits that can be applied to units.  Some of
+these traits (such as `common_unit(...)`) produce a new unit as their output type.  This will always
+be a _simple_ unit, even though the inputs are unit _slots_: that is, these traits change the
+_category_ of the output.
+
+This section describes a few special operations that _preserve_ that category.  So for example,
+suppose we had an operation `op` of this type.  Let's call the result of `op(Meters{}, Seconds{})`
+as `U{}`.  Then we have:
+
+- `op(meters, seconds)` produces `QuantityMaker<U>`, because its inputs are `QuantityMaker<Meters>`
+  and `QuantityMaker<Seconds>`.
+- `op(m, s)` produces `UnitSymbol<U>`, because its inputs are `UnitSymbol<Meters>` and
+  `UnitSymbol<Seconds>`.
+- ... and so on.
+
+Here are the category-preserving operations we provide.
+
+### Making common units {#make-common}
+
+**Result:** A new unit: the largest unit that evenly divides its input units.  (Read more about the
+concept of [common units](../discussion/concepts/common_unit.md).)
+
+**Syntax:**
+
+- `make_common(us...)`
+
+??? example "Examples"
+    ```cpp
+    constexpr auto x = make_common(meters, feet)(18);
+
+    using symbols::m;
+    using symbols::ft;
+    constexpr auto y = 9.5f * make_common(m, ft);
+    ```
+
+### Making common point units {#make-common-point}
+
+**Result:** A new unit: the largest-magnitude, highest-origin unit which is "common" to the input
+units.  (Read more about the concept of [common units for
+`QuantityPoint`](../discussion/concepts/common_unit.md#common-quantity-point).)
+
+**Syntax:**
+
+- `make_common_point(us...)`
+
+??? example "Example"
+    ```cpp
+    constexpr auto temp = make_common_point(celsius_pt, fahrenheit_pt)(10);
+    ```
 
 <script src="../assets/hrh4.js" async=false defer=false></script>


### PR DESCRIPTION
We also add the "common point" versions of these.

The absence of `common_unit` and `common_point_unit` was mostly just an
oversight.  I recently tried to call one in Godbolt, and got surprised
when I couldn't.  And it turned out that I had already written this
function anyway, except that it was hidden away inside of a test file.

As I thought about these functions more, I thought it was interesting
that the inputs are unit slots, so we could have a wide variety of
things (simple units, quantity makers, unit symbols, etc.), but the
output would always be a simple unit.  Wouldn't it be nice if we could
also combine `meters` and `feet`, or `m` and `ft`, and have the output
act like its inputs?  This idea became the `make_common` and
`make_common_point` utilities.

Docs included (and rendered and tested).