### PR TITLE
Add MSVC coverage for `Constant` and `UnitSymbol`

### DIFF
--- a/.github/workflows/single-file-build-and-test.yml
+++ b/.github/workflows/single-file-build-and-test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build single-file package
         shell: cmd
-        run: python tools/bin/make-single-file --units meters seconds --version-id NA > au.hh
+        run: python tools/bin/make-single-file --units meters seconds --constants speed_of_light --version-id NA > au.hh
 
       - name: Build and run test
         shell: cmd

--- a/au/code/au/constant.hh
+++ b/au/code/au/constant.hh
@@ -56,7 +56,8 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     // Convert this constant to a Quantity of the given unit and rep.
     template <typename T, typename OtherUnit>
     constexpr auto as(OtherUnit u) const {
-        static_assert(can_store_value_in<T>(u), "Cannot represent constant in this unit/rep");
+        static_assert(can_store_value_in<T>(OtherUnit{}),
+                      "Cannot represent constant in this unit/rep");
         return coerce_as<T>(u);
     }
 
@@ -69,7 +70,8 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     // Get the value of this constant in the given unit and rep.
     template <typename T, typename OtherUnit>
     constexpr auto in(OtherUnit u) const {
-        static_assert(can_store_value_in<T>(u), "Cannot represent constant in this unit/rep");
+        static_assert(can_store_value_in<T>(OtherUnit{}),
+                      "Cannot represent constant in this unit/rep");
         return coerce_in<T>(u);
     }
 

--- a/single-file-test.cc
+++ b/single-file-test.cc
@@ -26,6 +26,8 @@
 // dependencies outside of the C++14 standard library, and the single-file package of Au itself.
 
 using namespace au;
+using ::au::symbols::m;
+using ::au::symbols::s;
 
 // This ad hoc utility is a stand-in for GTEST, which we can't use here.
 template <typename ExpectedT, typename ActualT>
@@ -42,6 +44,7 @@ int main(int argc, char **argv) {
     const std::vector<bool> results{
         {
             expect_equal((meters / second)(5) * seconds(6), meters(30)),
+            expect_equal(SPEED_OF_LIGHT.as<int>(m / s), 299'792'458 * m / s),
         },
     };
     return std::all_of(std::begin(results), std::end(results), [](auto x) { return x; }) ? 0 : 1;


### PR DESCRIPTION
Some comments on the vcpkg PR to upgrade Au to 0.4.0 made me suspicious
that we lacked coverage here.  I added a test case, and sure enough, it
[broke].

What's happening here is that MSVC is being _extremely persnickety_
about what we pass to a `static_assert`.  We are passing a function
parameter, which _in the general case_ might be a **runtime** value;
hence, inappropriate for `static_assert`.

What MSVC doesn't know is that `OtherUnit` is a [monovalue type], so it
can only ever have one possible value, and therefore that value _is_
knowable at compile time.  That said, since it _is_ a monovalue type,
that means that it's safe to replace the instance `u` with an ad hoc
construction of the type name, `OtherUnit{}`.  This appeases MSVC.

Helps #364: we'll go over every other `static_assert` before closing.

[broke]: https://github.com/aurora-opensource/au/actions/runs/12395185495/job/34600303870
[monovalue type]: https://aurora-opensource.github.io/au/main/reference/detail/monovalue_types