### PR TITLE
Support `SingularNameFor` in unit slots

### DIFF
--- a/au/code/au/unit_of_measure.hh
+++ b/au/code/au/unit_of_measure.hh
@@ -430,6 +430,10 @@ struct SingularNameFor {
     }
 };
 
+// Support `SingularNameFor` in (quantity) unit slots.
+template <typename U>
+struct AssociatedUnit<SingularNameFor<U>> : stdx::type_identity<U> {};
+
 template <int Exp, typename Unit>
 constexpr auto pow(SingularNameFor<Unit>) {
     return SingularNameFor<UnitPowerT<Unit, Exp>>{};

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -142,8 +142,9 @@ TEST(IsUnit, FalseIfDimOrMagHasWrongType) {
 
 TEST(IsUnit, FunctionalFormFalseForQuantityMaker) { EXPECT_FALSE(is_unit(meters)); }
 
-TEST(FitsInUnitSlot, TrueForUnitAndQuantityMaker) {
+TEST(FitsInUnitSlot, TrueForUnitAndQuantityMakerAndSingularNameFor) {
     EXPECT_TRUE(fits_in_unit_slot(meters));
+    EXPECT_TRUE(fits_in_unit_slot(meter));
     EXPECT_TRUE(fits_in_unit_slot(Meters{}));
 
     EXPECT_FALSE(fits_in_unit_slot(1.2));
@@ -240,6 +241,10 @@ TEST(AssociatedUnitT, IsIdentityForTypeWithNoAssociatedUnit) {
 
 TEST(AssociatedUnitT, HandlesWrappersWhichHaveSpecializedAssociatedUnit) {
     StaticAssertTypeEq<AssociatedUnitT<SomeUnitWrapper<Feet>>, Feet>();
+}
+
+TEST(AssociatedUnitT, SupportsSingularNameFor) {
+    StaticAssertTypeEq<AssociatedUnitT<SingularNameFor<Feet>>, Feet>();
 }
 
 TEST(UnitInverseT, CommutesWithProduct) {


### PR DESCRIPTION
I thought it through, and realized this is pretty clearly for "quantity"
type slots only, not "point" type slots.  The reason this exists is to
participate in multiplications, divisions, and powers with quantity
makers.  Quantity points don't have multiplicative semantics.

Fixes #373.