### PR TITLE
Support powers and roots for unit wrappers

### DIFF
--- a/au/code/au/constant.hh
+++ b/au/code/au/constant.hh
@@ -40,6 +40,7 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
                   detail::ComposesWith<Constant, Unit, Constant, Constant>,
                   detail::ComposesWith<Constant, Unit, QuantityMaker, QuantityMaker>,
                   detail::ComposesWith<Constant, Unit, SingularNameFor, SingularNameFor>,
+                  detail::SupportsRationalPowers<Constant, Unit>,
                   detail::CanScaleByMagnitude<Constant, Unit> {
     // Convert this constant to a Quantity of the given rep.
     template <typename T>

--- a/au/code/au/constant_test.cc
+++ b/au/code/au/constant_test.cc
@@ -228,6 +228,8 @@ TEST(Constant, SupportsMultiplyingConstantByItself) {
     StaticAssertTypeEq<decltype(c * c), Constant<decltype(squared(SpeedOfLight{}))>>();
 }
 
+TEST(Constant, CanTakePowers) { StaticAssertTypeEq<decltype(squared(c)), decltype(c * c)>(); }
+
 TEST(Constant, ComposesViaDivision) {
     StaticAssertTypeEq<decltype(c / h), Constant<decltype(SpeedOfLight{} / PlancksConstant{})>>();
 }

--- a/au/code/au/unit_symbol.hh
+++ b/au/code/au/unit_symbol.hh
@@ -31,6 +31,7 @@ template <typename Unit>
 struct SymbolFor : detail::MakesQuantityFromNumber<SymbolFor, Unit>,
                    detail::ScalesQuantity<SymbolFor, Unit>,
                    detail::ComposesWith<SymbolFor, Unit, SymbolFor, SymbolFor>,
+                   detail::SupportsRationalPowers<SymbolFor, Unit>,
                    detail::CanScaleByMagnitude<SymbolFor, Unit> {};
 
 //

--- a/au/code/au/unit_symbol_test.cc
+++ b/au/code/au/unit_symbol_test.cc
@@ -51,4 +51,8 @@ TEST(SymbolFor, CanScaleByMagnitude) {
     EXPECT_THAT(3.5f / u100_m, SameTypeAndValue(inverse(meters * mag<100>())(3.5f)));
 }
 
+TEST(SymbolFor, CanApplyNamedPowerFunctions) {
+    StaticAssertTypeEq<decltype(squared(m)), decltype(m * m)>();
+}
+
 }  // namespace au

--- a/au/code/au/wrapper_operations.hh
+++ b/au/code/au/wrapper_operations.hh
@@ -217,5 +217,23 @@ struct CanScaleByMagnitude {
     }
 };
 
+//
+// A mixin to enable raising a unit wrapper to a rational power.
+//
+template <template <typename U> class UnitWrapper, typename Unit>
+struct SupportsRationalPowers {
+    // (W^N), for wrapper W and integer N.
+    template <std::intmax_t N>
+    friend constexpr auto pow(UnitWrapper<Unit>) {
+        return UnitWrapper<UnitPowerT<Unit, N>>{};
+    }
+
+    // (W^(1/N)), for wrapper W and integer N.
+    template <std::intmax_t N>
+    friend constexpr auto root(UnitWrapper<Unit>) {
+        return UnitWrapper<UnitPowerT<Unit, 1, N>>{};
+    }
+};
+
 }  // namespace detail
 }  // namespace au

--- a/au/code/au/wrapper_operations_test.cc
+++ b/au/code/au/wrapper_operations_test.cc
@@ -33,6 +33,7 @@ struct UnitWrapper : MakesQuantityFromNumber<UnitWrapper, Unit>,
                      ScalesQuantity<UnitWrapper, Unit>,
                      ComposesWith<UnitWrapper, Unit, UnitWrapper, UnitWrapper>,
                      ComposesWith<UnitWrapper, Unit, QuantityMaker, QuantityMaker>,
+                     SupportsRationalPowers<UnitWrapper, Unit>,
                      CanScaleByMagnitude<UnitWrapper, Unit> {};
 
 TEST(MakesQuantityFromNumber, MakesQuantityWhenPostMultiplyingNumericValue) {
@@ -144,18 +145,22 @@ TEST(CanScaleByMagnitude, MakesScaledWrapperWhenDividingByMagnitude) {
     StaticAssertTypeEq<decltype(mol / PI), UnitWrapper<decltype(Moles{} / PI)>>();
 }
 
-TEST(ForbidsComposingWith, FailsToCompileWhenMultiplyingOrDividingWithForbiddenWrapper) {
-    // Uncomment each line below individually to verify.
+TEST(SupportsRationalPowers, RaisesUnitToGivenPower) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    StaticAssertTypeEq<decltype(pow<3>(mol)), UnitWrapper<decltype(pow<3>(Moles{}))>>();
+}
 
-    // UnitWrapper<Meters>{} * meters_pt;
-    // UnitWrapper<Meters>{} / meters_pt;
-    // meters_pt *UnitWrapper<Meters>{};
-    // meters_pt / UnitWrapper<Meters>{};
+TEST(SupportsRationalPowers, EnablesTakingRoots) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    StaticAssertTypeEq<decltype(root<8>(mol)), UnitWrapper<decltype(root<8>(Moles{}))>>();
+}
 
-    // UnitWrapper<Meters>{} * meters_pt(1);
-    // UnitWrapper<Meters>{} / meters_pt(1);
-    // meters_pt(1) * UnitWrapper<Meters>{};
-    // meters_pt(1) / UnitWrapper<Meters>{};
+TEST(SupportsRationalPowers, UnlocksNamedPowerHelpers) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+
+    StaticAssertTypeEq<decltype(cubed(mol)), decltype(pow<3>(mol))>();
+    StaticAssertTypeEq<decltype(squared(mol)), decltype(pow<2>(mol))>();
+    StaticAssertTypeEq<decltype(sqrt(mol)), decltype(root<2>(mol))>();
 }
 
 }  // namespace

--- a/au/code/au/wrapper_operations_test.cc
+++ b/au/code/au/wrapper_operations_test.cc
@@ -163,6 +163,20 @@ TEST(SupportsRationalPowers, UnlocksNamedPowerHelpers) {
     StaticAssertTypeEq<decltype(sqrt(mol)), decltype(root<2>(mol))>();
 }
 
+TEST(ForbidsComposingWith, FailsToCompileWhenMultiplyingOrDividingWithForbiddenWrapper) {
+    // Uncomment each line below individually to verify.
+
+    // UnitWrapper<Meters>{} * meters_pt;
+    // UnitWrapper<Meters>{} / meters_pt;
+    // meters_pt *UnitWrapper<Meters>{};
+    // meters_pt / UnitWrapper<Meters>{};
+
+    // UnitWrapper<Meters>{} * meters_pt(1);
+    // UnitWrapper<Meters>{} / meters_pt(1);
+    // meters_pt(1) * UnitWrapper<Meters>{};
+    // meters_pt(1) / UnitWrapper<Meters>{};
+}
+
 }  // namespace
 }  // namespace detail
 }  // namespace au


### PR DESCRIPTION
This unlocks some basic missing functionality for `Constant` and
`SymbolFor`: namely, we should be able to pass instances of them to
`squared()`, `sqrt()`, `pow<N>()`, `root<N>()`, and so on.

Fixes #375.