### PR TITLE
Support streaming output for more types

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -109,8 +109,11 @@ cc_library(
     includes = ["code"],
     visibility = ["//visibility:public"],
     deps = [
+        ":constant",
+        ":magnitude",
         ":quantity",
         ":quantity_point",
+        ":unit_symbol",
         ":zero",
     ],
 )
@@ -120,6 +123,7 @@ cc_test(
     size = "small",
     srcs = ["code/au/io_test.cc"],
     deps = [
+        ":constants",
         ":io",
         ":prefix",
         "@com_google_googletest//:gtest_main",

--- a/au/code/au/io.hh
+++ b/au/code/au/io.hh
@@ -16,8 +16,11 @@
 
 #include <ostream>
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
+#include "au/unit_symbol.hh"
 #include "au/zero.hh"
 
 namespace au {
@@ -45,6 +48,24 @@ std::ostream &operator<<(std::ostream &out, const QuantityPoint<U, R> &p) {
 inline std::ostream &operator<<(std::ostream &out, Zero) {
     out << "0";
     return out;
+}
+
+// Streaming support for Magnitude: print the magnitude label.
+template <typename... BPs>
+std::ostream &operator<<(std::ostream &out, Magnitude<BPs...> m) {
+    return (out << mag_label(m));
+}
+
+// Streaming support for Constant: print the unit label.
+template <typename U>
+std::ostream &operator<<(std::ostream &out, Constant<U>) {
+    return (out << unit_label(U{}));
+}
+
+// Streaming support for unit symbols: print the unit label.
+template <typename U>
+std::ostream &operator<<(std::ostream &out, SymbolFor<U>) {
+    return (out << unit_label(U{}));
 }
 
 }  // namespace au

--- a/au/code/au/io_test.cc
+++ b/au/code/au/io_test.cc
@@ -16,9 +16,13 @@
 
 #include <cstdint>
 
+#include "au/constants/speed_of_light.hh"
 #include "au/prefix.hh"
 #include "au/quantity.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+using ::testing::StrEq;
 
 namespace au {
 namespace {
@@ -34,12 +38,6 @@ struct Feet : UnitImpl<Length> {
 };
 constexpr const char Feet::label[];
 constexpr auto feet = QuantityMaker<Feet>{};
-
-struct Seconds : UnitImpl<Time> {
-    static constexpr const char label[] = "s";
-};
-constexpr const char Seconds::label[];
-constexpr auto second = SingularNameFor<Seconds>{};
 
 struct Kelvins : UnitImpl<Temperature> {
     static constexpr const char label[] = "K";
@@ -80,5 +78,23 @@ TEST(StreamingOutput, DistinguishesPointFromQuantityByAtSign) {
 }
 
 TEST(StreamingOutput, PrintsZero) { EXPECT_EQ(stream_to_string(ZERO), "0"); }
+
+TEST(StreamingOutput, PrintsMagnitude) {
+    EXPECT_THAT(stream_to_string(mag<289374>()), StrEq("289374"));
+    EXPECT_THAT(stream_to_string(mag<22>() / mag<7>()), StrEq("22 / 7"));
+}
+
+TEST(StreamingOutput, PrintsDefaultLabelForMagnitudeWeCantLabelYet) {
+    EXPECT_THAT(stream_to_string(cbrt(Magnitude<Pi>{})), StrEq("(UNLABELED SCALE FACTOR)"));
+}
+
+TEST(StreamingOutput, PrintsUnitLabelForConstant) {
+    EXPECT_THAT(stream_to_string(SPEED_OF_LIGHT), StrEq("c"));
+    EXPECT_THAT(stream_to_string(SPEED_OF_LIGHT * mag<3>() / mag<4>()), StrEq("[(3 / 4) c]"));
+}
+
+TEST(StreamingOutput, PrintsUnitLabelForSymbol) {
+    EXPECT_THAT(stream_to_string(symbol_for(feet)), StrEq("ft"));
+}
 
 }  // namespace au


### PR DESCRIPTION
We add support for `Magnitude`, `Constant`, and `SymbolFor`.

In the test, including `speed_of_light.hh` felt easier than defining a
new version of the speed of light constant.  This brought in the
authoritative definition of `Seconds`, so we deleted our ad hoc
definition.  In general, it would be nice to clearly articulate a policy
as to which header files we want to let ourselves use in which test
files: there's a tension between convenience, and keeping dependencies
clean.  But this is fine for now.

Fixes #378.