### PR TITLE
Unit-Safe Implementation of `std::hypot`

### DIFF
--- a/au/code/au/math.hh
+++ b/au/code/au/math.hh
@@ -182,15 +182,6 @@ auto hypot(Quantity<U1, R1> x, Quantity<U2, R2> y)
     return make_quantity<U>(std::hypot(x.in(U{}), y.in(U{})));
 }
 
-template <typename U1, typename R1, typename U2, typename R2>
-auto hypot(QuantityPoint<U1, R1> x, QuantityPoint<U2, R2> y)
-{
-    using U = CommonPointUnitT<U1, U2>;
-    using R = std::common_type_t<R1, R2>;
-    using ResultT = QuantityPoint<U, R>;
-    return make_quantity_point<U>(std::hypot(x.in(U{}), y.in(U{})));
-}
-
 // Copysign where the magnitude has units.
 template <typename U, typename R, typename T>
 constexpr auto copysign(Quantity<U, R> mag, T sgn) {

--- a/au/code/au/math.hh
+++ b/au/code/au/math.hh
@@ -174,8 +174,7 @@ constexpr auto clamp(QuantityPoint<UV, RV> v,
 }
 
 template <typename U1, typename R1, typename U2, typename R2>
-auto hypot(Quantity<U1, R1> x, Quantity<U2, R2> y)
-{
+auto hypot(Quantity<U1, R1> x, Quantity<U2, R2> y) {
     using U = CommonUnitT<U1, U2>;
     return make_quantity<U>(std::hypot(x.in(U{}), y.in(U{})));
 }

--- a/au/code/au/math.hh
+++ b/au/code/au/math.hh
@@ -33,6 +33,7 @@ using std::abs;
 using std::copysign;
 using std::cos;
 using std::fmod;
+using std::hypot;
 using std::isnan;
 using std::max;
 using std::min;
@@ -170,6 +171,24 @@ constexpr auto clamp(QuantityPoint<UV, RV> v,
     using R = std::common_type_t<RV, RLo, RHi>;
     using ResultT = QuantityPoint<U, R>;
     return (v < lo) ? ResultT{lo} : (hi < v) ? ResultT{hi} : ResultT{v};
+}
+
+template <typename U1, typename R1, typename U2, typename R2>
+auto hypot(Quantity<U1, R1> x, Quantity<U2, R2> y)
+{
+    using U = CommonUnitT<U1, U2>;
+    using R = std::common_type_t<R1, R2>;
+    using ResultT = Quantity<U, R>;
+    return make_quantity<U>(std::hypot(x.in(U{}), y.in(U{})));
+}
+
+template <typename U1, typename R1, typename U2, typename R2>
+auto hypot(QuantityPoint<U1, R1> x, QuantityPoint<U2, R2> y)
+{
+    using U = CommonPointUnitT<U1, U2>;
+    using R = std::common_type_t<R1, R2>;
+    using ResultT = QuantityPoint<U, R>;
+    return make_quantity_point<U>(std::hypot(x.in(U{}), y.in(U{})));
 }
 
 // Copysign where the magnitude has units.

--- a/au/code/au/math.hh
+++ b/au/code/au/math.hh
@@ -177,8 +177,6 @@ template <typename U1, typename R1, typename U2, typename R2>
 auto hypot(Quantity<U1, R1> x, Quantity<U2, R2> y)
 {
     using U = CommonUnitT<U1, U2>;
-    using R = std::common_type_t<R1, R2>;
-    using ResultT = Quantity<U, R>;
     return make_quantity<U>(std::hypot(x.in(U{}), y.in(U{})));
 }
 

--- a/au/code/au/math_test.cc
+++ b/au/code/au/math_test.cc
@@ -188,33 +188,6 @@ TEST(hypot, QuantityProducesResultsInCommonUnitOfInputs) {
     EXPECT_THAT(hypot(inches(5.f), feet(1.f)), SameTypeAndValue(inches(13.f)));
 }
 
-TEST(hypot, QuantityPointConsistentWithStdHypotWhenTypesAreIdentical) {
-    auto expect_consistent_with_std_hypot = [](auto u, auto v) {
-        const auto expected = meters_pt(std::hypot(u, v));
-        const auto actual = hypot(meters_pt(u), meters_pt(v));
-        EXPECT_THAT(actual, SameTypeAndValue(expected));
-    };
-
-    // Rep: `int`.
-    expect_consistent_with_std_hypot(-1, 0);
-    expect_consistent_with_std_hypot(0, 0);
-    expect_consistent_with_std_hypot(1, 0);
-    expect_consistent_with_std_hypot(2, 0);
-    expect_consistent_with_std_hypot(4, 2);
-
-    // Rep: `double`.
-    expect_consistent_with_std_hypot(-1.0, 0.0);
-    expect_consistent_with_std_hypot(0.0, 0.0);
-    expect_consistent_with_std_hypot(1.0, 0.0);
-    expect_consistent_with_std_hypot(2.0, 0.0);
-    expect_consistent_with_std_hypot(4.0, 2.0);
-}
-
-TEST(hypot, QuantityPointProducesResultsInCommonUnitOfInputs) {
-    EXPECT_THAT(hypot(centi(meters_pt)(30), milli(meters_pt)(400)),
-                SameTypeAndValue(milli(meters_pt)(500.0)));
-}
-
 TEST(copysign, ReturnsSameTypesAsStdCopysignForSameUnitInputs) {
     auto expect_consistent_with_std_copysign = [](auto mag, auto raw_sgn) {
         for (const auto test_sgn : {-1, 0, +1}) {

--- a/au/code/au/math_test.cc
+++ b/au/code/au/math_test.cc
@@ -184,6 +184,8 @@ TEST(hypot, QuantityConsistentWithStdHypotWhenTypesAreIdentical) {
 TEST(hypot, QuantityProducesResultsInCommonUnitOfInputs) {
     EXPECT_THAT(hypot(centi(meters)(30), milli(meters)(400)),
                 SameTypeAndValue(milli(meters)(500.0)));
+
+    EXPECT_THAT(hypot(inches(5.f), feet(1.f)), SameTypeAndValue(inches(13.f)));
 }
 
 TEST(hypot, QuantityPointConsistentWithStdHypotWhenTypesAreIdentical) {

--- a/au/code/au/math_test.cc
+++ b/au/code/au/math_test.cc
@@ -159,6 +159,60 @@ TEST(clamp, SupportsZeroForMultipleArguments) {
     EXPECT_THAT(clamp(feet(6), ZERO, ZERO), SameTypeAndValue(feet(0)));
 }
 
+TEST(hypot, QuantityConsistentWithStdHypotWhenTypesAreIdentical) {
+    auto expect_consistent_with_std_hypot = [](auto u, auto v) {
+        const auto expected = ohms(std::hypot(u, v));
+        const auto actual = hypot(ohms(u), ohms(v));
+        EXPECT_THAT(actual, SameTypeAndValue(expected));
+    };
+
+    // Rep: `int`.
+    expect_consistent_with_std_hypot(-1, 0);
+    expect_consistent_with_std_hypot(0, 0);
+    expect_consistent_with_std_hypot(1, 0);
+    expect_consistent_with_std_hypot(2, 0);
+    expect_consistent_with_std_hypot(4, 2);
+
+    // Rep: `double`.
+    expect_consistent_with_std_hypot(-1.0, 0.0);
+    expect_consistent_with_std_hypot(0.0, 0.0);
+    expect_consistent_with_std_hypot(1.0, 0.0);
+    expect_consistent_with_std_hypot(2.0, 0.0);
+    expect_consistent_with_std_hypot(4.0, 2.0);
+}
+
+TEST(hypot, QuantityProducesResultsInCommonUnitOfInputs) {
+    EXPECT_THAT(hypot(centi(meters)(30), milli(meters)(400)),
+                SameTypeAndValue(milli(meters)(500.0)));
+}
+
+TEST(hypot, QuantityPointConsistentWithStdHypotWhenTypesAreIdentical) {
+    auto expect_consistent_with_std_hypot = [](auto u, auto v) {
+        const auto expected = meters_pt(std::hypot(u, v));
+        const auto actual = hypot(meters_pt(u), meters_pt(v));
+        EXPECT_THAT(actual, SameTypeAndValue(expected));
+    };
+
+    // Rep: `int`.
+    expect_consistent_with_std_hypot(-1, 0);
+    expect_consistent_with_std_hypot(0, 0);
+    expect_consistent_with_std_hypot(1, 0);
+    expect_consistent_with_std_hypot(2, 0);
+    expect_consistent_with_std_hypot(4, 2);
+
+    // Rep: `double`.
+    expect_consistent_with_std_hypot(-1.0, 0.0);
+    expect_consistent_with_std_hypot(0.0, 0.0);
+    expect_consistent_with_std_hypot(1.0, 0.0);
+    expect_consistent_with_std_hypot(2.0, 0.0);
+    expect_consistent_with_std_hypot(4.0, 2.0);
+}
+
+TEST(hypot, QuantityPointProducesResultsInCommonUnitOfInputs) {
+    EXPECT_THAT(hypot(centi(meters_pt)(30), milli(meters_pt)(400)),
+                SameTypeAndValue(milli(meters_pt)(500.0)));
+}
+
 TEST(copysign, ReturnsSameTypesAsStdCopysignForSameUnitInputs) {
     auto expect_consistent_with_std_copysign = [](auto mag, auto raw_sgn) {
         for (const auto test_sgn : {-1, 0, +1}) {


### PR DESCRIPTION
## Summary
Implements a unit-safe version of `std::hypot` within the AU library. This implementation ensures dimensional consistency when calculating the hypotenuse/Euclidean norm while preserving the underlying units.

## Implementation Details
- Extends the existing AU library with a unit-safe wrapper around `std::hypot`
- Maintains dimensional analysis correctness throughout calculations
- Returns results in the common unit and underlying representation as the input parameters

Related to #383 