### PR TITLE
Implement `cbrt()`

### DIFF
--- a/au/code/au/math.hh
+++ b/au/code/au/math.hh
@@ -30,6 +30,7 @@ namespace au {
 // Lookup will stop once it hits `::au::sin()`, hiding the `::sin()` overload in the global
 // namespace.  To learn more about Name Lookup, see this article (https://abseil.io/tips/49).
 using std::abs;
+using std::cbrt;
 using std::copysign;
 using std::cos;
 using std::fmod;
@@ -151,6 +152,12 @@ template <typename U1, typename R1, typename U2, typename R2>
 auto arctan2(Quantity<U1, R1> y, Quantity<U2, R2> x) {
     constexpr auto common_unit = CommonUnitT<U1, U2>{};
     return arctan2(y.in(common_unit), x.in(common_unit));
+}
+
+// Wrapper for std::cbrt() which handles Quantity types.
+template <typename U, typename R>
+auto cbrt(Quantity<U, R> q) {
+    return make_quantity<UnitPowerT<U, 1, 3>>(std::cbrt(q.in(U{})));
 }
 
 // Clamp the first quantity to within the range of the second two.

--- a/au/code/au/math_test.cc
+++ b/au/code/au/math_test.cc
@@ -78,14 +78,6 @@ TEST(cbrt, OutputRepDependsOnInputRep) {
     EXPECT_THAT(cbrt(cubed(meters)(8.L)), QuantityEquivalent(meters(2.L)));
 }
 
-TEST(cbrt, MixedUnitsSupportedWithCasting) {
-    constexpr auto x_in = inches(1);
-    constexpr auto y_cm = centi(meters)(2.54);
-    constexpr auto z_mm = milli(meters)(25.4);
-
-    EXPECT_THAT(cbrt(x_in * y_cm.as(inches) * z_mm.as(inches)), IsNear(x_in, nano(meters)(1)));
-}
-
 TEST(cbrt, SameAsStdCbrtForNumericTypes) {
     EXPECT_EQ(cbrt(1), std::cbrt(1));
     EXPECT_EQ(cbrt(1.), std::cbrt(1.));
@@ -104,7 +96,7 @@ TEST(cbrt, CanConvertIfConversionFactorRational) {
     const auto rationally_converted_value = geo_mean_length.in(cbrt(inch * milli(meter) * yards));
     EXPECT_THAT(rationally_converted_value, SameTypeAndValue(10.0));
 
-    // This test case won't work until we can compute radical conversion factors at compile time.
+    // This test case is "hard": we need to compute radical conversion factors at compile time.
     const auto radically_converted_value = geo_mean_length.in(inches);
     EXPECT_NEAR(radically_converted_value, 11.232841, 0.000001);
 }

--- a/au/code/au/math_test.cc
+++ b/au/code/au/math_test.cc
@@ -90,7 +90,7 @@ TEST(cbrt, SameAsStdCbrtForNumericTypes) {
 TEST(cbrt, CanConvertIfConversionFactorRational) {
     const auto geo_mean_length = cbrt(inches(1) * meters(1) * yards(1));
 
-    // Using Quantity-equivalent Unit just retrieves the stored value.
+    // Using Quantity-equivalent Unit just retrieves the value stored in `geo_mean_length`.
     const auto retrieved_value = geo_mean_length.in(cbrt(inch * meter * yards));
     EXPECT_THAT(retrieved_value, SameTypeAndValue(1.0));
 
@@ -579,12 +579,11 @@ TEST(sqrt, SameAsStdSqrtForNumericTypes) {
 TEST(sqrt, CanConvertIfConversionFactorRational) {
     const auto geo_mean_length = sqrt(inches(1) * meters(1));
 
-    // Using Quantity-equivalent Unit just retrieves the stored value.
-    // This _always_ works.
+    // Using Quantity-equivalent Unit just retrieves the value stored in `geo_mean_length`.
     const auto retrieved_value = geo_mean_length.in(sqrt(inch * meters));
     EXPECT_THAT(retrieved_value, SameTypeAndValue(1.0));
 
-    // This conversion is OK, because the conversion factor doesn't have any rational powers.
+    // This conversion is "easy", because the conversion factor doesn't have any rational powers.
     const auto rationally_converted_value = geo_mean_length.in(sqrt(inch * centi(meters)));
     EXPECT_THAT(rationally_converted_value, SameTypeAndValue(10.0));
 

--- a/au/code/au/math_test.cc
+++ b/au/code/au/math_test.cc
@@ -79,10 +79,10 @@ TEST(cbrt, OutputRepDependsOnInputRep) {
 }
 
 TEST(cbrt, SameAsStdCbrtForNumericTypes) {
-    EXPECT_EQ(cbrt(1), std::cbrt(1));
-    EXPECT_EQ(cbrt(1.), std::cbrt(1.));
-    EXPECT_EQ(cbrt(1.f), std::cbrt(1.f));
-    EXPECT_EQ(cbrt(1.L), std::cbrt(1.L));
+    EXPECT_THAT(cbrt(1), Eq(std::cbrt(1)));
+    EXPECT_THAT(cbrt(1.), Eq(std::cbrt(1.)));
+    EXPECT_THAT(cbrt(1.f), Eq(std::cbrt(1.f)));
+    EXPECT_THAT(cbrt(1.L), Eq(std::cbrt(1.L)));
 }
 
 TEST(cbrt, CanConvertIfConversionFactorRational) {
@@ -98,7 +98,7 @@ TEST(cbrt, CanConvertIfConversionFactorRational) {
 
     // This test case is "hard": we need to compute radical conversion factors at compile time.
     const auto radically_converted_value = geo_mean_length.in(inches);
-    EXPECT_NEAR(radically_converted_value, 11.232841, 0.000001);
+    EXPECT_THAT(radically_converted_value, DoubleNear(11.232841, 0.000001));
 }
 
 TEST(clamp, QuantityConsistentWithStdClampWhenTypesAreIdentical) {
@@ -588,7 +588,7 @@ TEST(sqrt, CanConvertIfConversionFactorRational) {
 
     // This test case is "hard": we need to compute radical conversion factors at compile time.
     const auto radically_converted_value = geo_mean_length.in(inches);
-    EXPECT_NEAR(radically_converted_value, 6.274558, 0.000001);
+    EXPECT_THAT(radically_converted_value, DoubleNear(6.274558, 0.000001));
 }
 
 TEST(tan, TypeDependsOnInputType) {

--- a/au/code/au/math_test.cc
+++ b/au/code/au/math_test.cc
@@ -31,6 +31,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using ::testing::DoubleNear;
+using ::testing::Eq;
 using ::testing::StaticAssertTypeEq;
 
 namespace au {


### PR DESCRIPTION
Additionally, I noticed that we had a commented-out "hard" test case for
`sqrt`, which we have now satisfied for some time.  I uncommented that
test case in this same commit so we can start taking credit for it.

Fixes #388.