### PR TITLE
Add CI build with `-Wsign-conversion`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,3 +33,5 @@ jobs:
         run: bazel test --copt=-Werror --copt=-Wconversion --config=${{ inputs.config }} --test_tag_filters=-no_wconversion --build_tag_filters=-no_wconversion //au/...:all
       - name: Build and test in C++20 mode (${{ inputs.config }})
         run: bazel test --copt=-Werror --copt=-std=c++20 --config=${{ inputs.config }} //...:all //au:cpp20_test
+      - name: Build and test with -Wsign-conversion
+        run: bazel build --copt=-Werror --copt=-Wsign-conversion --config=${{ inputs.config }} //...:all


### PR DESCRIPTION
We expect this to expose some violations of this warning.  We'll fix
those violations, and then we'll land this CI change to keep them fixed.