### PR TITLE
Resolve all `-Wsign-conversion` errors

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -665,6 +665,7 @@ cc_test(
     size = "small",
     srcs = glob(["code/au/utility/test/*.cc"]),
     deps = [
+        ":testing",
         ":utility",
         "@com_google_googletest//:gtest_main",
     ],

--- a/au/code/au/magnitude.hh
+++ b/au/code/au/magnitude.hh
@@ -249,7 +249,8 @@ struct PrimeFactorization {
     static constexpr std::uintmax_t power = multiplicity(base, N);
     static constexpr std::uintmax_t remainder = N / int_pow(base, power);
 
-    using type = MagProductT<Magnitude<Pow<Prime<base>, power>>, PrimeFactorizationT<remainder>>;
+    using type = MagProductT<Magnitude<Pow<Prime<base>, static_cast<std::intmax_t>(power)>>,
+                             PrimeFactorizationT<remainder>>;
 };
 
 }  // namespace detail

--- a/au/code/au/unit_of_measure.hh
+++ b/au/code/au/unit_of_measure.hh
@@ -398,7 +398,7 @@ constexpr UnitPowerT<U, Exp> pow(U) {
 }
 
 // Take the Root (of some integral degree) of a Unit.
-template <std::uintmax_t Deg, typename U, typename = std::enable_if_t<IsUnit<U>::value>>
+template <std::intmax_t Deg, typename U, typename = std::enable_if_t<IsUnit<U>::value>>
 constexpr UnitPowerT<U, 1, Deg> root(U) {
     return {};
 }

--- a/au/code/au/utility/test/string_constant_test.cc
+++ b/au/code/au/utility/test/string_constant_test.cc
@@ -21,6 +21,8 @@
 namespace au {
 namespace detail {
 
+using ::testing::StrEq;
+
 TEST(StringConstant, CanCreateFromStringLiteral) {
     constexpr StringConstant<5> x{"hello"};
     EXPECT_STREQ(x.c_str(), "hello");
@@ -54,16 +56,16 @@ TEST(AbsAsUnsigned, NegatesNegativeNumbers) {
 }
 
 TEST(IToA, ValueHoldsStringVersionOfTemplateParameter) {
-    EXPECT_STREQ(IToA<0>::value.c_str(), "0");
+    EXPECT_THAT(IToA<0>::value.c_str(), StrEq("0"));
 
-    EXPECT_STREQ(IToA<1>::value.c_str(), "1");
-    EXPECT_STREQ(IToA<9>::value.c_str(), "9");
-    EXPECT_STREQ(IToA<10>::value.c_str(), "10");
-    EXPECT_STREQ(IToA<91>::value.c_str(), "91");
-    EXPECT_STREQ(IToA<312839>::value.c_str(), "312839");
+    EXPECT_THAT(IToA<1>::value.c_str(), StrEq("1"));
+    EXPECT_THAT(IToA<9>::value.c_str(), StrEq("9"));
+    EXPECT_THAT(IToA<10>::value.c_str(), StrEq("10"));
+    EXPECT_THAT(IToA<91>::value.c_str(), StrEq("91"));
+    EXPECT_THAT(IToA<312839>::value.c_str(), StrEq("312839"));
 
-    EXPECT_STREQ(IToA<-1>::value.c_str(), "-1");
-    EXPECT_STREQ(IToA<-83294>::value.c_str(), "-83294");
+    EXPECT_THAT(IToA<-1>::value.c_str(), StrEq("-1"));
+    EXPECT_THAT(IToA<-83294>::value.c_str(), StrEq("-83294"));
 
     // This funny way of writing it is because `-9'223'372'036'854'775'808` isn't a literal.  The
     // actual literal is `9'223'372'036'854'775'808`, which is too big (by one) to fit into

--- a/au/code/au/utility/test/string_constant_test.cc
+++ b/au/code/au/utility/test/string_constant_test.cc
@@ -70,7 +70,7 @@ TEST(IToA, ValueHoldsStringVersionOfTemplateParameter) {
     // `int64_t` --- even though `-9'223'372'036'854'775'808` can!  So instead, we negate the
     // largest literal, and then subtract one to get the lowest literal.
     constexpr int64_t min = -9'223'372'036'854'775'807 - 1;
-    EXPECT_STREQ(IToA<min>::value.c_str(), "-9223372036854775808");
+    EXPECT_THAT(IToA<min>::value, StrEq("-9223372036854775808"));
 }
 
 TEST(IToA, HasLengthMember) {

--- a/au/code/au/utility/test/string_constant_test.cc
+++ b/au/code/au/utility/test/string_constant_test.cc
@@ -14,6 +14,8 @@
 
 #include "au/utility/string_constant.hh"
 
+#include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -39,6 +41,18 @@ TEST(AsStringConstant, PassingStringConstantIsIdentity) {
     EXPECT_STREQ(x.c_str(), "goodbye");
 }
 
+TEST(AbsAsUnsigned, IdentityForPositiveNumbers) {
+    EXPECT_THAT(abs_as_unsigned(int8_t{0}), SameTypeAndValue(uint8_t{0}));
+    EXPECT_THAT(abs_as_unsigned(int8_t{1}), SameTypeAndValue(uint8_t{1}));
+    EXPECT_THAT(abs_as_unsigned(int8_t{127}), SameTypeAndValue(uint8_t{127}));
+}
+
+TEST(AbsAsUnsigned, NegatesNegativeNumbers) {
+    EXPECT_THAT(abs_as_unsigned(int8_t{-1}), SameTypeAndValue(uint8_t{1}));
+    EXPECT_THAT(abs_as_unsigned(int8_t{-127}), SameTypeAndValue(uint8_t{127}));
+    EXPECT_THAT(abs_as_unsigned(int8_t{-128}), SameTypeAndValue(uint8_t{128}));
+}
+
 TEST(IToA, ValueHoldsStringVersionOfTemplateParameter) {
     EXPECT_STREQ(IToA<0>::value.c_str(), "0");
 
@@ -50,6 +64,13 @@ TEST(IToA, ValueHoldsStringVersionOfTemplateParameter) {
 
     EXPECT_STREQ(IToA<-1>::value.c_str(), "-1");
     EXPECT_STREQ(IToA<-83294>::value.c_str(), "-83294");
+
+    // This funny way of writing it is because `-9'223'372'036'854'775'808` isn't a literal.  The
+    // actual literal is `9'223'372'036'854'775'808`, which is too big (by one) to fit into
+    // `int64_t` --- even though `-9'223'372'036'854'775'808` can!  So instead, we negate the
+    // largest literal, and then subtract one to get the lowest literal.
+    constexpr int64_t min = -9'223'372'036'854'775'807 - 1;
+    EXPECT_STREQ(IToA<min>::value.c_str(), "-9223372036854775808");
 }
 
 TEST(IToA, HasLengthMember) {


### PR DESCRIPTION
The goal was to get this command to pass cleanly:

```sh
bazel build \
  --copt="-Werror" \
  --copt="-Wsign-conversion" \
  --config=gcc10 \
  //release/...:all \
  //au/...:all
```

The biggest change was to `string_constant`: we needed to fix up our
strategy for taking the absolute value of a number.  It was cleanest to
write a new helper, `abs_as_unsigned(T)`, which carefully and
efficiently handles all values (even the troublesome minimum
representable value, _whose negative can't be represented in `T`_). So
we're not just becoming warning-clean here; we're also handling values
that we couldn't handle before.  I found this cleaned up the
implementation a bit, too (no more `x = -x;`; no more ternary).

All of these new utilities got unit tests, to build confidence.

For the `unit_of_measure.hh` change, the right move was to change the
interface to accept `std::intmax` directly.  After all, literally the
only thing we do with `Deg` is to pass it to `UnitPowerT`, which takes
`std::intmax_t`.

For `magnitude.hh`, we simply insert an explicit static cast.  This is
very safe in this case, because `power` is the _log_ of a representable
number: it simply can't be very big at all.

Helps #392.  After this PR lands, #393 should become landable.