### PR TITLE
Avoid undesired integer promotion

### DIFF
--- a/au/code/au/utility/factoring.hh
+++ b/au/code/au/utility/factoring.hh
@@ -96,7 +96,7 @@ constexpr std::uintmax_t find_prime_factor(std::uintmax_t n) {
     //
     // Note that range-for isn't supported until C++17, so we need to use an index.
     for (auto i = 0u; i < FirstPrimes::values.size(); ++i) {
-        const auto &p = FirstPrimes::values[i];
+        const std::uintmax_t p = FirstPrimes::values[i];
 
         if (n % p == 0u) {
             return p;


### PR DESCRIPTION
Apparently, this has triggered a `-Wsign-compare` violation by an
obscure and indirect pathway on an end user's build system.  We have not
been able to reproduce this (see #395).  However, on examining the code,
it's clear that `p * p` should be promoted to `int`, which we do compare
with the unsigned `n`.

The simplest fix is to just store each prime in a `uintmax_t`, which is
what we would want it to be in to perform the computations anyway.  The
main benefit of `uint16_t` here is to cram a lot of numbers into the
storage space, and this change preserves that property.

Fixes #395.