### PR TITLE
Document `cbrt`

### DIFF
--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -214,54 +214,32 @@ constexpr auto int_pow(Quantity<U, R> q);
 **Returns:**  A `Quantity` whose unit is the input unit raised to the given power, and whose value
 is the input value raised to the given power.
 
-#### `sqrt`
+#### `sqrt`, `cbrt`
 
-A unit-aware adaptation of [`std::sqrt`](https://en.cppreference.com/w/cpp/numeric/math/sqrt).  Both
-the input and output are `Quantity` types.  Since `sqrt` is an [arbitrary-unit
-operation](../discussion/concepts/arithmetic.md#arbitrary-unit), the square root applies
+A unit-aware adaptation of [`std::sqrt`](https://en.cppreference.com/w/cpp/numeric/math/sqrt) and
+[`std::cbrt`](https://en.cppreference.com/w/cpp/numeric/math/cbrt).  Both the input and output are
+`Quantity` types.  Since `sqrt` and `cbrt` are [arbitrary-unit
+operations](../discussion/concepts/arithmetic.md#arbitrary-unit), the root applies
 _independently_ to the unit and to the value.
 
-We mirror `std::sqrt` in selecting our output rep.  That is to say: the output rep will be the
-return type of `std::sqrt` when called with a value of our input rep.
+We mirror `std::sqrt` and `std::cbrt` in selecting our output rep.  That is to say: the output rep
+for `sqrt` and `cbrt` will be the return type of `std::sqrt` or `std::cbrt`, respectively, when
+called with a value of our input rep.  For example, if the input quantity has `int` rep, then the
+output will be `double`.
 
 **Signature:**
 
 ```cpp
 template <typename U, typename R>
 auto sqrt(Quantity<U, R> q);
+
+template <typename U, typename R>
+auto cbrt(Quantity<U, R> q);
 ```
 
-**Returns:** A `Quantity` whose unit is the square root of the input quantity's unit, and whose
-value is the square root of the input quantity's value.
-
-??? warning "Warning: not all unit conversions are currently supported"
-    There is one edge case to be aware of with `sqrt`: we don't yet support any **conversion** which
-    picks up a radical factor.  This is because all conversion factors get computed at compile time,
-    and we don't have a way to compute rational powers at compile time.  To fix this, we would need
-    a `constexpr`-compatible implementation of `std::powl`.
-
-    Let's clarify what you can and can't do in today's library, with an example.
-
-    ```cpp
-    // Taking the square root of "weird" units: this works.
-    const auto geo_mean_length = sqrt(inches(1) * meters(1));
-
-    // Now let's look at retrieving the value in different units.
-
-    // Using a Quantity-equivalent Unit just retrieves the stored value.
-    // This _always_ works.  (In this case, it gives `1.0`.)
-    const auto retrieved_value = geo_mean_length.in(sqrt(inch * meters));
-
-    // This conversion is non-trivial, but it's also OK.
-    // The reason is that the conversion factor doesn't have any rational powers.
-    // (In this case, it gives `10.0`.)
-    const auto rationally_converted_value = geo_mean_length.in(sqrt(inch * centi(meters)));
-
-    // This test case doesn't currently work.
-    // Later, if we can compute radical conversion factors at compile time, it will.
-    // (It should give roughly 6.274558...)
-    // const auto radically_converted_value = geo_mean_length.in(inches);
-    ```
+**Returns:** A `Quantity` whose unit is the square root (for `sqrt`) or cube root (for `cbrt`) of
+the input quantity's unit, and whose value is the square root (for `sqrt`) or cube root (for `cbrt`)
+of the input quantity's value.
 
 ### Trigonometric functions
 


### PR DESCRIPTION
Along the way, I found some obsolete documentation about operations that
we "don't support", although we have supported these since at least
0.4.0, possibly earlier (I forget).

Tested with `au-docs-serve`, and doing A/B comparison with the released
docs.

Fixes #388.