### PR TITLE
Add type-based aliases for power helpers

### DIFF
--- a/au/code/au/power_aliases.hh
+++ b/au/code/au/power_aliases.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+#include <utility>
 
 namespace au {
 
@@ -45,29 +46,39 @@ template <typename T>
 constexpr auto inverse(T x) -> decltype(pow<-1>(x)) {
     return pow<-1>(x);
 }
+template <typename T>
+using Inverse = decltype(inverse(std::declval<T>()));
 
 // Make "squared" an alias for "pow<2>" when the latter exists (for anything).
 template <typename T>
 constexpr auto squared(T x) -> decltype(pow<2>(x)) {
     return pow<2>(x);
 }
+template <typename T>
+using Squared = decltype(squared(std::declval<T>()));
 
 // Make "cubed" an alias for "pow<3>" when the latter exists (for anything).
 template <typename T>
 constexpr auto cubed(T x) -> decltype(pow<3>(x)) {
     return pow<3>(x);
 }
+template <typename T>
+using Cubed = decltype(cubed(std::declval<T>()));
 
 // Make "sqrt" an alias for "root<2>" when the latter exists (for anything).
 template <typename T>
 constexpr auto sqrt(T x) -> decltype(root<2>(x)) {
     return root<2>(x);
 }
+template <typename T>
+using Sqrt = decltype(sqrt(std::declval<T>()));
 
 // Make "cbrt" an alias for "root<3>" when the latter exists (for anything).
 template <typename T>
 constexpr auto cbrt(T x) -> decltype(root<3>(x)) {
     return root<3>(x);
 }
+template <typename T>
+using Cbrt = decltype(cbrt(std::declval<T>()));
 
 }  // namespace au

--- a/au/code/au/power_aliases_test.cc
+++ b/au/code/au/power_aliases_test.cc
@@ -56,10 +56,24 @@ TEST(Inverse, RaisesToPowerNegativeOne) {
                        Vector<Pow<B<2>, -1>, Pow<B<3>, -8>, RatioPow<B<5>, -1, 2>>>();
 }
 
+TEST(Inverse, TypeBasedFormGivesExpectedResult) {
+    StaticAssertTypeEq<Inverse<Vector<>>, Vector<>>();
+
+    StaticAssertTypeEq<Inverse<Vector<B<2>, Pow<B<3>, 8>, RatioPow<B<5>, 1, 2>>>,
+                       Vector<Pow<B<2>, -1>, Pow<B<3>, -8>, RatioPow<B<5>, -1, 2>>>();
+}
+
 TEST(Squared, RaisesToPowerTwo) {
     StaticAssertTypeEq<decltype(squared(Vector<>{})), Vector<>>();
 
     StaticAssertTypeEq<decltype(squared(Vector<B<2>, Pow<B<3>, 8>, RatioPow<B<5>, 1, 2>>{})),
+                       Vector<Pow<B<2>, 2>, Pow<B<3>, 16>, B<5>>>();
+}
+
+TEST(Squared, TypeBasedFormGivesExpectedResult) {
+    StaticAssertTypeEq<Squared<Vector<>>, Vector<>>();
+
+    StaticAssertTypeEq<Squared<Vector<B<2>, Pow<B<3>, 8>, RatioPow<B<5>, 1, 2>>>,
                        Vector<Pow<B<2>, 2>, Pow<B<3>, 16>, B<5>>>();
 }
 
@@ -70,6 +84,13 @@ TEST(Cubed, RaisesToPowerThree) {
                        Vector<Pow<B<2>, 3>, Pow<B<3>, 24>, B<5>>>();
 }
 
+TEST(Cubed, TypeBasedFormGivesExpectedResult) {
+    StaticAssertTypeEq<Cubed<Vector<>>, Vector<>>();
+
+    StaticAssertTypeEq<Cubed<Vector<B<2>, Pow<B<3>, 8>, RatioPow<B<5>, 1, 3>>>,
+                       Vector<Pow<B<2>, 3>, Pow<B<3>, 24>, B<5>>>();
+}
+
 TEST(Sqrt, TakesSecondRoot) {
     StaticAssertTypeEq<decltype(sqrt(Vector<>{})), Vector<>>();
 
@@ -77,10 +98,24 @@ TEST(Sqrt, TakesSecondRoot) {
                        Vector<RatioPow<B<2>, 1, 2>, Pow<B<3>, 4>, B<5>>>();
 }
 
+TEST(Sqrt, TypeBasedFormGivesExpectedResult) {
+    StaticAssertTypeEq<Sqrt<Vector<>>, Vector<>>();
+
+    StaticAssertTypeEq<Sqrt<Vector<B<2>, Pow<B<3>, 8>, Pow<B<5>, 2>>>,
+                       Vector<RatioPow<B<2>, 1, 2>, Pow<B<3>, 4>, B<5>>>();
+}
+
 TEST(Cbrt, TakesThirdRoot) {
     StaticAssertTypeEq<decltype(cbrt(Vector<>{})), Vector<>>();
 
     StaticAssertTypeEq<decltype(cbrt(Vector<B<2>, Pow<B<3>, 9>, Pow<B<5>, 3>>{})),
+                       Vector<RatioPow<B<2>, 1, 3>, Pow<B<3>, 3>, B<5>>>();
+}
+
+TEST(Cbrt, TypeBasedFormGivesExpectedResult) {
+    StaticAssertTypeEq<Cbrt<Vector<>>, Vector<>>();
+
+    StaticAssertTypeEq<Cbrt<Vector<B<2>, Pow<B<3>, 9>, Pow<B<5>, 3>>>,
                        Vector<RatioPow<B<2>, 1, 3>, Pow<B<3>, 3>, B<5>>>();
 }
 

--- a/docs/reference/powers.md
+++ b/docs/reference/powers.md
@@ -59,3 +59,17 @@ compatible monovalue type (a unit, a magnitude, ...):
 | `cubed(x)` | `pow<3>(x)` |
 | `sqrt(x)` | `root<2>(x)` |
 | `cbrt(x)` | `root<3>(x)` |
+
+### Type-based versions (`Inverse`, `Squared`, `Cubed`, `Sqrt`, `Cbrt`) {#type-based}
+
+We provide type-based versions of the above helpers, to make it easier to concisely form readable
+type names.  Here are the following helpers as applied to a unit `U`, and the equivalent result as
+expressed using more general unit power APIs.
+
+| Helper | Result |
+|--------|--------|
+| `Inverse<U>` | `UnitPowerT<U, -1>` |
+| `Squared<U>` | `UnitPowerT<U, 2>` |
+| `Cubed<U>` | `UnitPowerT<U, 3>` |
+| `Sqrt<U>` | `UnitPowerT<U, 1, 2>` |
+| `Cbrt<U>` | `UnitPowerT<U, 1, 3>` |


### PR DESCRIPTION
Consider the following three options for creating a unit of squared
nanoseconds:

```cpp
using NanoSecondsSquared = decltype(squared(Nano<Seconds>{}));
using NanoSecondsSquared = UnitPowerT<Nano<Seconds>, 2>;
using NanoSecondsSquared = Squared<Nano<Seconds>>;
```

The third one is the most appealing, but it doesn't currently exist.
This PR adds it.

Includes docs.

Fixes #397.