### PR TITLE
Add "football fields" unit of measure

### DIFF
--- a/au/code/au/CMakeLists.txt
+++ b/au/code/au/CMakeLists.txt
@@ -89,6 +89,8 @@ header_only_library(
     units/fathoms_fwd.hh
     units/feet.hh
     units/feet_fwd.hh
+    units/football_fields.hh
+    units/football_fields_fwd.hh
     units/furlongs.hh
     units/furlongs_fwd.hh
     units/grams.hh
@@ -325,6 +327,7 @@ gtest_based_test(
     units/test/farads_test.cc
     units/test/fathoms_test.cc
     units/test/feet_test.cc
+    units/test/football_fields_test.cc
     units/test/furlongs_test.cc
     units/test/grams_test.cc
     units/test/grays_test.cc

--- a/au/code/au/units/football_fields.hh
+++ b/au/code/au/units/football_fields.hh
@@ -1,0 +1,43 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/units/football_fields_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
+#include "au/quantity.hh"
+#include "au/unit_symbol.hh"
+#include "au/units/yards.hh"
+
+namespace au {
+
+// DO NOT follow this pattern to define your own units.  This is for library-defined units.
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
+template <typename T>
+struct FootballFieldsLabel {
+    static constexpr const char label[] = "ftbl_fld";
+};
+template <typename T>
+constexpr const char FootballFieldsLabel<T>::label[];
+struct FootballFields : decltype(Yards{} * mag<100>()), FootballFieldsLabel<void> {
+    using FootballFieldsLabel<void>::label;
+};
+constexpr auto football_field = SingularNameFor<FootballFields>{};
+constexpr auto football_fields = QuantityMaker<FootballFields>{};
+
+namespace symbols {
+constexpr auto ftbl_fld = SymbolFor<FootballFields>{};
+}
+}  // namespace au

--- a/au/code/au/units/football_fields_fwd.hh
+++ b/au/code/au/units/football_fields_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2024 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct FootballFields;
+
+}  // namespace au

--- a/au/code/au/units/test/football_fields_test.cc
+++ b/au/code/au/units/test/football_fields_test.cc
@@ -1,0 +1,46 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/units/football_fields.hh"
+
+#include "au/testing.hh"
+#include "au/units/meters.hh"
+#include "au/units/yards.hh"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace au {
+
+using ::testing::Eq;
+using ::testing::Lt;
+
+TEST(FootballFields, HasExpectedLabel) { expect_label<FootballFields>("ftbl_fld"); }
+
+TEST(FootballFields, HasCorrectQuantityRelationshipWithYards) {
+    EXPECT_THAT(football_fields(1), Eq(yards(100)));
+}
+
+TEST(FootballFields, FourFootballFieldsIsLessThanKnownFirstlightLidarRange) {
+    // Sources:
+    // https://blog.aurora.tech/progress/firstlight-lidar-on-a-chip
+    // https://ir.aurora.tech/news-events/press-releases/detail/119/aurora-begins-commercial-driverless-trucking-in-texas
+    EXPECT_THAT(football_fields(4), Lt(meters(400)));
+}
+
+TEST(FootballFields, HasExpectedSymbol) {
+    using symbols::ftbl_fld;
+    EXPECT_THAT(5 * ftbl_fld, SameTypeAndValue(football_fields(5)));
+}
+
+}  // namespace au


### PR DESCRIPTION
At the time of Aurora's successful Commercial Launch, delivering the
first NVO trucks regularly hauling loads on public roads, several press
releases and public news articles referred to the forward lidar sensor
range as "over four football fields".  It is clearly important to be
able to verify this measurement in C++ code.  Therefore, we add support
for this classic American unit of measure to Au.

To make sure we got it right, we compare not just against the
[authoritative] definition, but also against an Aurora [blog] which
gives "over 400 meters" as a reference point.

[authoritative]: https://en.wikipedia.org/wiki/American_football_field
[blog]: https://blog.aurora.tech/progress/firstlight-lidar-on-a-chip