### PR TITLE
Support negative magnitudes

### DIFF
--- a/au/code/au/fwd.hh
+++ b/au/code/au/fwd.hh
@@ -32,6 +32,8 @@ struct Dimension;
 template <typename... BPs>
 struct Magnitude;
 
+struct Negative;
+
 template <typename UnitT>
 struct QuantityMaker;
 

--- a/au/code/au/magnitude.hh
+++ b/au/code/au/magnitude.hh
@@ -763,7 +763,7 @@ template <typename BP, typename... Ts>
 struct PrependIfExpNegative<BP, Magnitude<Ts...>>
     : std::conditional<(ExpT<BP>::num < 0), Magnitude<BP, Ts...>, Magnitude<Ts...>> {};
 
-// If M is (N/D), DenominatorPartT<M> is D; we want 1/D.
+// Remove all positive powers from M.
 template <typename M>
 using NegativePowers = MagQuotientT<M, NumeratorPartT<M>>;
 }  // namespace detail

--- a/au/code/au/magnitude.hh
+++ b/au/code/au/magnitude.hh
@@ -61,6 +61,38 @@ using MagQuotientT = PackQuotientT<Magnitude, T, U>;
 template <typename T>
 using MagInverseT = PackInverseT<Magnitude, T>;
 
+// Enable negative magnitudes with a type representing (-1) that appears/disappears under powers.
+struct Negative {};
+template <typename... BPs, std::intmax_t ExpNum, std::intmax_t ExpDen>
+struct PackPower<Magnitude, Magnitude<Negative, BPs...>, std::ratio<ExpNum, ExpDen>>
+    : std::conditional<
+          (std::ratio<ExpNum, ExpDen>::num % 2 == 0),
+
+          // Even powers of (-1) are 1 for any root.
+          PackPowerT<Magnitude, Magnitude<BPs...>, ExpNum, ExpDen>,
+
+          // At this point, we know we're taking the D'th root of (-1), which is (-1)
+          // if D is odd, and a hard compiler error if D is even.
+          MagProductT<Magnitude<Negative>, MagPowerT<Magnitude<BPs...>, ExpNum, ExpDen>>>
+// Implement the hard error for raising to (odd / even) power:
+{
+    static_assert(std::ratio<ExpNum, ExpDen>::den % 2 == 1,
+                  "Cannot take even root of negative magnitude");
+};
+template <typename... LeftBPs, typename... RightBPs>
+struct PackProduct<Magnitude, Magnitude<Negative, LeftBPs...>, Magnitude<Negative, RightBPs...>>
+    : stdx::type_identity<MagProductT<Magnitude<LeftBPs...>, Magnitude<RightBPs...>>> {};
+
+// Define negation.
+template <typename... BPs>
+constexpr auto operator-(Magnitude<Negative, BPs...>) {
+    return Magnitude<BPs...>{};
+}
+template <typename... BPs>
+constexpr auto operator-(Magnitude<BPs...>) {
+    return Magnitude<Negative, BPs...>{};
+}
+
 // A printable label to indicate the Magnitude for human readers.
 template <typename MagT>
 struct MagnitudeLabel;
@@ -98,6 +130,15 @@ struct Pi {
 namespace detail {
 template <typename T, typename U>
 struct OrderByValue : stdx::bool_constant<(T::value() < U::value())> {};
+
+template <typename T>
+struct OrderByValue<Negative, T> : std::true_type {};
+
+template <typename T>
+struct OrderByValue<T, Negative> : std::false_type {};
+
+template <>
+struct OrderByValue<Negative, Negative> : std::false_type {};
 }  // namespace detail
 
 template <typename A, typename B>
@@ -112,12 +153,22 @@ template <typename MagT>
 using IntegerPartT = typename IntegerPartImpl<MagT>::type;
 
 template <typename MagT>
+struct AbsImpl;
+template <typename MagT>
+using Abs = typename AbsImpl<MagT>::type;
+
+template <typename MagT>
 struct NumeratorImpl;
 template <typename MagT>
 using NumeratorT = typename NumeratorImpl<MagT>::type;
 
 template <typename MagT>
-using DenominatorT = NumeratorT<MagInverseT<MagT>>;
+using DenominatorT = NumeratorT<MagInverseT<Abs<MagT>>>;
+
+template <typename MagT>
+struct IsPositive : std::true_type {};
+template <typename... BPs>
+struct IsPositive<Magnitude<Negative, BPs...>> : std::false_type {};
 
 template <typename MagT>
 struct IsRational
@@ -191,6 +242,12 @@ constexpr auto integer_part(Magnitude<BPs...>) {
 }
 
 template <typename... BPs>
+constexpr auto abs(Magnitude<BPs...>) {
+    return Abs<Magnitude<BPs...>>{};
+}
+constexpr auto abs(Zero z) { return z; }
+
+template <typename... BPs>
 constexpr auto numerator(Magnitude<BPs...>) {
     return NumeratorT<Magnitude<BPs...>>{};
 }
@@ -198,6 +255,11 @@ constexpr auto numerator(Magnitude<BPs...>) {
 template <typename... BPs>
 constexpr auto denominator(Magnitude<BPs...>) {
     return DenominatorT<Magnitude<BPs...>>{};
+}
+
+template <typename... BPs>
+constexpr bool is_positive(Magnitude<BPs...>) {
+    return IsPositive<Magnitude<BPs...>>::value;
 }
 
 template <typename... BPs>
@@ -276,6 +338,22 @@ struct IntegerPartImpl<Magnitude<BPs...>>
     : stdx::type_identity<
           MagProductT<typename IntegerPartOfBasePower<BaseT<BPs>, ExpT<BPs>>::type...>> {};
 
+template <typename... BPs>
+struct IntegerPartImpl<Magnitude<Negative, BPs...>>
+    : stdx::type_identity<MagProductT<Magnitude<Negative>, IntegerPartT<Magnitude<BPs...>>>> {};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `abs()` implementation.
+
+template <typename... BPs>
+struct AbsImpl<Magnitude<Negative, BPs...>> : stdx::type_identity<Magnitude<BPs...>> {};
+
+template <typename... BPs>
+struct AbsImpl<Magnitude<BPs...>> : stdx::type_identity<Magnitude<BPs...>> {};
+
+template <>
+struct AbsImpl<Zero> : stdx::type_identity<Zero> {};
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `numerator()` implementation.
 
@@ -292,6 +370,7 @@ namespace detail {
 enum class MagRepresentationOutcome {
     OK,
     ERR_NON_INTEGER_IN_INTEGER_TYPE,
+    ERR_NEGATIVE_NUMBER_IN_UNSIGNED_TYPE,
     ERR_INVALID_ROOT,
     ERR_CANNOT_FIT,
 };
@@ -543,6 +622,19 @@ template <typename T>
 constexpr MagRepresentationOrError<T> get_value_result(Magnitude<>) {
     return {MagRepresentationOutcome::OK, static_cast<T>(1)};
 }
+
+template <typename T, typename... BPs>
+constexpr MagRepresentationOrError<T> get_value_result(Magnitude<Negative, BPs...>) {
+    if (std::is_unsigned<T>::value) {
+        return {MagRepresentationOutcome::ERR_NEGATIVE_NUMBER_IN_UNSIGNED_TYPE};
+    }
+
+    const auto result = get_value_result<T>(Magnitude<BPs...>{});
+    if (result.outcome != MagRepresentationOutcome::OK) {
+        return result;
+    }
+    return {MagRepresentationOutcome::OK, static_cast<T>(-result.value)};
+}
 }  // namespace detail
 
 template <typename T, typename... BPs>
@@ -641,6 +733,18 @@ struct MagnitudeLabel<Magnitude<BPs...>>
     : detail::MagnitudeLabelImplementation<Magnitude<BPs...>,
                                            detail::categorize_mag_label(Magnitude<BPs...>{})> {};
 
+template <typename... BPs>
+struct MagnitudeLabel<Magnitude<Negative, BPs...>> :
+    // Inherit for "has exposed slash".
+    MagnitudeLabel<Magnitude<BPs...>> {
+    using LabelT = detail::ExtendedMagLabel<1u, Magnitude<BPs...>>;
+    static constexpr LabelT value =
+        detail::concatenate("-", MagnitudeLabel<Magnitude<BPs...>>::value);
+};
+template <typename... BPs>
+constexpr typename MagnitudeLabel<Magnitude<Negative, BPs...>>::LabelT
+    MagnitudeLabel<Magnitude<Negative, BPs...>>::value;
+
 template <typename MagT>
 constexpr const auto &mag_label(MagT) {
     return detail::as_char_array(MagnitudeLabel<MagT>::value);
@@ -661,7 +765,7 @@ struct PrependIfExpNegative<BP, Magnitude<Ts...>>
 
 // If M is (N/D), DenominatorPartT<M> is D; we want 1/D.
 template <typename M>
-using NegativePowers = MagInverseT<DenominatorPartT<M>>;
+using NegativePowers = MagQuotientT<M, NumeratorPartT<M>>;
 }  // namespace detail
 
 // 1-ary case: identity.

--- a/au/code/au/magnitude_test.cc
+++ b/au/code/au/magnitude_test.cc
@@ -148,8 +148,8 @@ TEST(IntegerPart, PicksOutIntegersFromNumerator) {
 }
 
 TEST(IntegerPart, PreservesSign) {
-    EXPECT_EQ(integer_part(-mag<1>()), -mag<1>());
-    EXPECT_EQ(integer_part(-mag<8765>()), -mag<8765>());
+    EXPECT_THAT(integer_part(-mag<1>()), Eq(-mag<1>()));
+    EXPECT_THAT(integer_part(-mag<8765>()), Eq(-mag<8765>()));
 }
 
 TEST(Numerator, IsIdentityForInteger) {

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -605,7 +605,9 @@ TEST(UnitLabel, PicksUpLabelForLabeledUnit) {
 
 TEST(UnitLabel, PrependsScaleFactorToLabelForScaledUnit) {
     EXPECT_THAT(unit_label<decltype(Feet{} * mag<3>())>(), StrEq("[3 ft]"));
+    EXPECT_THAT(unit_label<decltype(Feet{} * (-mag<3>()))>(), StrEq("[-3 ft]"));
     EXPECT_THAT(unit_label<decltype(Feet{} / mag<12>())>(), StrEq("[(1 / 12) ft]"));
+    EXPECT_THAT(unit_label<decltype(Feet{} / (-mag<12>()))>(), StrEq("[(-1 / 12) ft]"));
 }
 
 TEST(UnitLabel, ApplyingMultipleScaleFactorsComposesToOneSingleScaleFactor) {


### PR DESCRIPTION
We add a new base, `au::Negative`.  This always goes at the beginning of
the pack.  We define rational powers such that `Negative` disappears
when the numerator (expressed in lowest terms) is even; otherwise, it
remains if the denominator is odd, and we produce a hard compiler error
if the denominator is even.  For products, the usual machinery works in
most cases, but if both inputs have `Negative`, then we remove them
both, and delegate to the product of what remains.

This brings new magnitude traits: `Abs` for the absolute value, and
`IsPositive` to tell whether a magnitude is positive: formerly, these
would have been the identity, and trivially true, respectively.

For obtaining magnitude representations, we add a new error state
outcome, `ERR_NEGATIVE_NUMBER_IN_UNSIGNED_TYPE`.  If this doesn't
happen, we simply delegate to computing the magnitude of the absolute
value, and negate the result.  This does mean we won't produce an answer
for the minimum value of signed integral types, but we can complete that
later.

Finally, we support magnitude labels by prepending a `-` sign.  We
always prepend this sign, even for unlabeled magnitudes, because it's
important to convey sign information.

**Note that this change enables users to create broken units and
quantities.**  If they use negative magnitudes _with units_, it will not
produce correct results.  But given that (a) nobody has ever been able
to form these magnitudes before, (b) the functionality is undocumented,
and (c) we will follow up very soon with changes that restore this
functionality, this does not seem like a serious concern.

Helps #370.