### PR TITLE
Compare negative units correctly

### DIFF
--- a/au/code/au/cpp20_test.cc
+++ b/au/code/au/cpp20_test.cc
@@ -22,6 +22,7 @@
 namespace au {
 
 using symbols::m;
+using ::testing::Eq;
 
 struct Foo {
     auto operator<=>(const Foo &) const = default;
@@ -36,6 +37,13 @@ struct FooPt {
 };
 
 TEST(Quantity, SupportsSpaceship) { EXPECT_LT(Foo{5 * m}, Foo{6 * m}); }
+
+TEST(Quantity, SpaceshipCorrectForMixedSignUnits) {
+    constexpr auto negm = m * (-mag<1>());
+    EXPECT_THAT((1 * m) <=> (0 * negm), Eq((1 * m) <=> (0 * m)));
+    EXPECT_THAT((1 * m) <=> (-1 * negm), Eq((1 * m) <=> (1 * m)));
+    EXPECT_THAT((1 * m) <=> (-2 * negm), Eq((1 * m) <=> (2 * m)));
+}
 
 TEST(QuantityPoint, SupportsSpaceship) { EXPECT_LT(FooPt{meters_pt(5)}, FooPt{meters_pt(6)}); }
 

--- a/au/code/au/operators.hh
+++ b/au/code/au/operators.hh
@@ -84,6 +84,16 @@ struct LessEqual {
 };
 constexpr auto less_equal = LessEqual{};
 
+#if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
+struct ThreeWayCompare {
+    template <typename T>
+    constexpr auto operator()(const T &a, const T &b) const {
+        return a <=> b;
+    }
+};
+constexpr auto three_way_compare = ThreeWayCompare{};
+#endif
+
 //
 // Arithmetic operators.
 //

--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -100,12 +100,26 @@ constexpr auto as_quantity(T &&x) -> CorrespondingQuantityT<T> {
     return make_quantity<typename Q::Unit>(value);
 }
 
+namespace detail {
+template <typename Rep, bool IsUnitPositive>
+struct CompareUnderlyingValues;
+}  // namespace detail
+
 template <typename UnitT, typename RepT>
 class Quantity {
     template <bool ImplicitOk, typename OtherUnit, typename OtherRep>
     using EnableIfImplicitOkIs = std::enable_if_t<
         ImplicitOk ==
         ConstructionPolicy<UnitT, RepT>::template PermitImplicitFrom<OtherUnit, OtherRep>::value>;
+    using Vals = detail::CompareUnderlyingValues<RepT, IsPositive<detail::MagT<UnitT>>::value>;
+
+    // Not strictly necessary, but we want to keep each comparator implementation to one line.
+    using Eq = detail::Equal;
+    using Ne = detail::NotEqual;
+    using Lt = detail::Less;
+    using Le = detail::LessEqual;
+    using Gt = detail::Greater;
+    using Ge = detail::GreaterEqual;
 
  public:
     using Rep = RepT;
@@ -247,12 +261,17 @@ class Quantity {
     friend struct QuantityMaker<UnitT>;
 
     // Comparison operators.
-    friend constexpr bool operator==(Quantity a, Quantity b) { return a.value_ == b.value_; }
-    friend constexpr bool operator!=(Quantity a, Quantity b) { return a.value_ != b.value_; }
-    friend constexpr bool operator<(Quantity a, Quantity b) { return a.value_ < b.value_; }
-    friend constexpr bool operator<=(Quantity a, Quantity b) { return a.value_ <= b.value_; }
-    friend constexpr bool operator>(Quantity a, Quantity b) { return a.value_ > b.value_; }
-    friend constexpr bool operator>=(Quantity a, Quantity b) { return a.value_ >= b.value_; }
+    friend constexpr bool operator==(Quantity a, Quantity b) { return Vals::cmp(a, b, Eq{}); }
+    friend constexpr bool operator!=(Quantity a, Quantity b) { return Vals::cmp(a, b, Ne{}); }
+    friend constexpr bool operator<(Quantity a, Quantity b) { return Vals::cmp(a, b, Lt{}); }
+    friend constexpr bool operator<=(Quantity a, Quantity b) { return Vals::cmp(a, b, Le{}); }
+    friend constexpr bool operator>(Quantity a, Quantity b) { return Vals::cmp(a, b, Gt{}); }
+    friend constexpr bool operator>=(Quantity a, Quantity b) { return Vals::cmp(a, b, Ge{}); }
+
+#if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
+    using Twc = detail::ThreeWayCompare;
+    friend constexpr auto operator<=>(Quantity a, Quantity b) { return Vals::cmp(a, b, Twc{}); }
+#endif
 
     // Addition and subtraction for like quantities.
     friend constexpr Quantity<UnitT, decltype(std::declval<RepT>() + std::declval<RepT>())>
@@ -831,11 +850,28 @@ constexpr auto operator>=(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q
     return as_quantity(q1) >= q2;
 }
 
+namespace detail {
+template <typename Rep>
+struct CompareUnderlyingValues<Rep, true> {
+    template <typename U, typename Comp>
+    static constexpr auto cmp(Quantity<U, Rep> lhs, Quantity<U, Rep> rhs, Comp comp) {
+        return comp(lhs.in(U{}), rhs.in(U{}));
+    }
+};
+
+template <typename Rep>
+struct CompareUnderlyingValues<Rep, false> {
+    template <typename U, typename Comp>
+    static constexpr auto cmp(Quantity<U, Rep> lhs, Quantity<U, Rep> rhs, Comp comp) {
+        return comp(rhs.in(U{}), lhs.in(U{}));
+    }
+};
+}  // namespace detail
+
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 template <typename U1, typename R1, typename U2, typename R2>
 constexpr auto operator<=>(const Quantity<U1, R1> &lhs, const Quantity<U2, R2> &rhs) {
-    using U = CommonUnitT<U1, U2>;
-    return lhs.in(U{}) <=> rhs.in(U{});
+    return detail::using_common_type(lhs, rhs, detail::ThreeWayCompare{});
 }
 #endif
 

--- a/au/code/au/quantity_point_test.cc
+++ b/au/code/au/quantity_point_test.cc
@@ -372,6 +372,18 @@ TEST(QuantityPoint, CanCompareUnitsWithDifferentOrigins) {
     EXPECT_THAT(celsius_pt(0), ConsistentlyLessThan(kelvins_pt(274)));
 }
 
+TEST(QuantityPoint, ComparisonsWithNegativeUnitHaveAppropriatelyReversedResults) {
+    constexpr auto neg_celsius_pt = celsius_pt * (-mag<1>());
+    constexpr auto neg_kelvins_pt = kelvins_pt * (-mag<1>());
+
+    EXPECT_THAT(neg_celsius_pt(1), ConsistentlyLessThan(neg_celsius_pt(0)));
+
+    EXPECT_THAT(celsius_pt(0), ConsistentlyGreaterThan(neg_kelvins_pt(-273)));
+    EXPECT_THAT(celsius_pt(0), ConsistentlyLessThan(neg_kelvins_pt(-274)));
+
+    EXPECT_THAT(neg_celsius_pt(1), ConsistentlyEqualTo(milli(neg_kelvins_pt)(-272'150)));
+}
+
 TEST(QuantityPoint, AddingPosUnitQuantityToNegUnitPointGivesPosUnitPoint) {
     constexpr auto neg_celsius_pt = celsius_pt * (-mag<1>());
     EXPECT_THAT(neg_celsius_pt(40) + celsius_qty(15), PointEquivalent(celsius_pt(-25)));

--- a/au/code/au/quantity_test.cc
+++ b/au/code/au/quantity_test.cc
@@ -24,11 +24,16 @@
 using ::testing::DoubleEq;
 using ::testing::Each;
 using ::testing::Eq;
+using ::testing::Gt;
+using ::testing::Lt;
 using ::testing::StaticAssertTypeEq;
 
 namespace au {
 
-struct Feet : UnitImpl<Length> {};
+struct Feet : UnitImpl<Length> {
+    static constexpr const char label[] = "ft";
+};
+constexpr const char Feet::label[];
 constexpr auto feet = QuantityMaker<Feet>{};
 
 struct Miles : decltype(Feet{} * mag<5'280>()) {
@@ -38,7 +43,10 @@ constexpr const char Miles::label[];
 constexpr auto mile = SingularNameFor<Miles>{};
 constexpr auto miles = QuantityMaker<Miles>{};
 
-struct Inches : decltype(Feet{} / mag<12>()) {};
+struct Inches : decltype(Feet{} / mag<12>()) {
+    static constexpr const char label[] = "in";
+};
+constexpr const char Inches::label[];
 constexpr auto inches = QuantityMaker<Inches>{};
 
 struct Yards : decltype(Feet{} * mag<3>()) {
@@ -491,6 +499,12 @@ TEST(Quantity, ConvertingByNegativeOneCanBeDoneImplicitly) {
     constexpr auto neginches = inches * (-mag<1>());
     constexpr auto q = inches(int8_t{-10});
     EXPECT_THAT(q.as(neginches), SameTypeAndValue(neginches(int8_t{10})));
+}
+
+TEST(Quantity, ComparisonsAreReversedForNegativeUnits) {
+    constexpr auto neginches = inches * (-mag<1>());
+    EXPECT_THAT(neginches(10), Gt(neginches(20)));
+    EXPECT_THAT(neginches(10u), Lt(neginches(5u)));
 }
 
 TEST(Quantity, AddingNegativeAndPositiveUnitsGivesPositiveUnit) {


### PR DESCRIPTION
For a `Quantity` of a negative unit, we compare by passing the arguments
in the reverse order.  This works for all equality and inequality
comparisons.

I kept the `using Twc` line next to the `operator<=>` line, instead of
with the other `using` statements, to reduce the number of instances of
`#if defined(__cpp_impl_three_way_comparison)...` we needed.

Helps #370.