### PR TITLE
Tie up loose ends in negative mag implementation

### DIFF
--- a/au/code/au/chrono_interop.hh
+++ b/au/code/au/chrono_interop.hh
@@ -76,6 +76,7 @@ template <typename U, typename R>
 constexpr auto as_chrono_duration(Quantity<U, R> dt) {
     constexpr auto ratio = unit_ratio(U{}, seconds);
     static_assert(is_rational(ratio), "Cannot convert to chrono::duration with non-rational ratio");
+    static_assert(is_positive(ratio), "Chrono library does not support negative duration units");
     return std::chrono::duration<R,
                                  std::ratio<get_value<std::intmax_t>(numerator(ratio)),
                                             get_value<std::intmax_t>(denominator(ratio))>>{dt};

--- a/au/code/au/constant_test.cc
+++ b/au/code/au/constant_test.cc
@@ -29,6 +29,7 @@
 #include "gtest/gtest.h"
 
 using ::testing::AnyOf;
+using ::testing::Eq;
 using ::testing::StaticAssertTypeEq;
 using ::testing::StrEq;
 
@@ -36,6 +37,8 @@ namespace au {
 namespace {
 
 constexpr auto PI = Magnitude<Pi>{};
+constexpr auto m = symbol_for(meters);
+constexpr auto s = symbol_for(seconds);
 
 template <typename U, typename R>
 std::string stream_to_string(Quantity<U, R> q) {
@@ -82,8 +85,6 @@ TEST(MakeConstant, MakesAdHocConstantFromQuantityMaker) {
 }
 
 TEST(MakeConstant, MakesConstantFromSymbol) {
-    constexpr auto m = symbol_for(meters);
-    constexpr auto s = symbol_for(seconds);
     constexpr auto ad_hoc_c = mag<299'792'458>() * make_constant(m / s);
     EXPECT_THAT(123 * ad_hoc_c, QuantityEquivalent(123 * c));
 }
@@ -114,6 +115,16 @@ TEST(Constant, CanCoerce) {
     EXPECT_THAT(c.coerce_in<int>(kilo(meters) / second), SameTypeAndValue(299'792));
     EXPECT_THAT(c.coerce_as<int>(kilo(meters) / second),
                 SameTypeAndValue((kilo(meters) / second)(299'792)));
+}
+
+TEST(Constant, CanNegate) {
+    constexpr auto neg_c = -c;
+    EXPECT_THAT(neg_c, Eq(-299'792'458 * m / s));
+    EXPECT_THAT(stream_to_string(0.75 * neg_c), StrEq("0.75 [-c]"));
+
+    constexpr auto double_neg_c = -neg_c;
+    EXPECT_THAT(double_neg_c, Eq(299'792'458 * m / s));
+    EXPECT_THAT(stream_to_string(0.75 * double_neg_c), StrEq("0.75 c"));
 }
 
 TEST(Constant, MakesQuantityWhenPostMultiplyingNumericValue) {

--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -658,8 +658,10 @@ constexpr auto root(QuantityMaker<Unit>) {
 // Check conversion for overflow (no change of rep).
 template <typename U, typename R, typename TargetUnitSlot>
 constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot target_unit) {
-    return detail::ApplyMagnitudeT<R, decltype(unit_ratio(U{}, target_unit))>::would_overflow(
-        q.in(U{}));
+    using Ratio = decltype(unit_ratio(U{}, target_unit));
+    static_assert(IsPositive<Ratio>::value,
+                  "Runtime conversion checkers don't yet support negative units");
+    return detail::ApplyMagnitudeT<R, Ratio>::would_overflow(q.in(U{}));
 }
 
 // Check conversion for overflow (new rep).
@@ -685,8 +687,10 @@ constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot target_
 // Check conversion for truncation (no change of rep).
 template <typename U, typename R, typename TargetUnitSlot>
 constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot target_unit) {
-    return detail::ApplyMagnitudeT<R, decltype(unit_ratio(U{}, target_unit))>::would_truncate(
-        q.in(U{}));
+    using Ratio = decltype(unit_ratio(U{}, target_unit));
+    static_assert(IsPositive<Ratio>::value,
+                  "Runtime conversion checkers don't yet support negative units");
+    return detail::ApplyMagnitudeT<R, Ratio>::would_truncate(q.in(U{}));
 }
 
 // Check conversion for truncation (new rep).

--- a/au/code/au/unit_of_measure.hh
+++ b/au/code/au/unit_of_measure.hh
@@ -943,6 +943,16 @@ struct UnitLabel<ScaledUnit<U, M>> {
 template <typename U, typename M>
 constexpr typename UnitLabel<ScaledUnit<U, M>>::LabelT UnitLabel<ScaledUnit<U, M>>::value;
 
+// Special case for unit scaled by (-1).
+template <typename U>
+struct UnitLabel<ScaledUnit<U, Magnitude<Negative>>> {
+    using LabelT = detail::ExtendedLabel<3u, U>;
+    static constexpr LabelT value = detail::concatenate("[-", UnitLabel<U>::value, "]");
+};
+template <typename U>
+constexpr typename UnitLabel<ScaledUnit<U, Magnitude<Negative>>>::LabelT
+    UnitLabel<ScaledUnit<U, Magnitude<Negative>>>::value;
+
 // Implementation for CommonUnit: give size in terms of each constituent unit.
 template <typename... Us>
 struct UnitLabel<CommonUnit<Us...>>

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -628,6 +628,10 @@ TEST(UnitLabel, ApplyingMultipleScaleFactorsComposesToOneSingleScaleFactor) {
                 StrEq("[(10 / 21) ft]"));
 }
 
+TEST(UnitLabel, NegatedUnitOmitsNumerals) {
+    EXPECT_THAT(unit_label<decltype(Feet{} * (-mag<1>()))>(), StrEq("[-ft]"));
+}
+
 TEST(UnitLabel, OmitsTrivialScaleFactor) {
     EXPECT_THAT(unit_label<decltype(Feet{} * mag<1>())>(), StrEq("ft"));
     EXPECT_THAT(unit_label<decltype((Feet{} * mag<3>()) / mag<3>())>(), StrEq("ft"));

--- a/au/code/au/wrapper_operations.hh
+++ b/au/code/au/wrapper_operations.hh
@@ -215,6 +215,10 @@ struct CanScaleByMagnitude {
     friend constexpr auto operator/(UnitWrapper<Unit>, Magnitude<BPs...> m) {
         return UnitWrapper<decltype(Unit{} / m)>{};
     }
+
+    friend constexpr auto operator-(UnitWrapper<Unit>) {
+        return UnitWrapper<decltype(Unit{} * (-mag<1>()))>{};
+    }
 };
 
 //

--- a/au/code/au/wrapper_operations_test.cc
+++ b/au/code/au/wrapper_operations_test.cc
@@ -163,6 +163,11 @@ TEST(SupportsRationalPowers, UnlocksNamedPowerHelpers) {
     StaticAssertTypeEq<decltype(sqrt(mol)), decltype(root<2>(mol))>();
 }
 
+TEST(CanScaleByMagnitude, SupportsNegation) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    StaticAssertTypeEq<decltype(-mol), UnitWrapper<decltype(Moles{} * (-mag<1>()))>>();
+}
+
 TEST(ForbidsComposingWith, FailsToCompileWhenMultiplyingOrDividingWithForbiddenWrapper) {
     // Uncomment each line below individually to verify.
 


### PR DESCRIPTION
Our interop with the chrono library should not support negative
magnitudes, so we add a `static_assert`.

Constants should be negatable, and double-negatives should completely
cancel out.  We achieve this by adding support for negation at the "unit
wrapper" level, for any wrapper that can be scaled by a magnitude.

If we simply negate a unit (or constant), the scale factor should simply
be a `-` sign: we don't want to print a scale factor of `-1`.

Finally, we punt on the runtime conversion checkers: they are only
supported for positive units.  There's no sense in putting effort into
an implementation that will be obviated by #387 and #349.

Helps #370.