### PR TITLE
Support `Zero` as common unit and constant

### DIFF
--- a/au/code/au/constant.hh
+++ b/au/code/au/constant.hh
@@ -109,6 +109,8 @@ constexpr Constant<AssociatedUnitT<UnitSlot>> make_constant(UnitSlot) {
     return {};
 }
 
+constexpr Zero make_constant(Zero) { return {}; }
+
 // Support using `Constant` in a unit slot.
 template <typename Unit>
 struct AssociatedUnit<Constant<Unit>> : stdx::type_identity<Unit> {};

--- a/au/code/au/constant_test.cc
+++ b/au/code/au/constant_test.cc
@@ -316,6 +316,8 @@ TEST(Constant, SupportsModWithQuantity) {
     EXPECT_THAT(degrees(300) % half_rev, SameTypeAndValue(degrees(120)));
 }
 
+TEST(MakeConstant, IdentityForZero) { EXPECT_THAT(make_constant(ZERO), SameTypeAndValue(ZERO)); }
+
 TEST(CanStoreValueIn, ChecksRangeOfTypeForIntegers) {
     EXPECT_TRUE(decltype(c)::can_store_value_in<int32_t>(meters / second));
     EXPECT_FALSE(decltype(c)::can_store_value_in<int16_t>(meters / second));

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -471,6 +471,18 @@ TEST(CommonUnit, DedupesUnitsMadeIdenticalAfterUnscalingSameScaledUnit) {
                        Feet>();
 }
 
+TEST(CommonUnit, HandlesAndNeglectsZero) {
+    StaticAssertTypeEq<CommonUnitT<Yards, Zero, Feet>, Feet>();
+    StaticAssertTypeEq<CommonUnitT<Zero, Feet, Zero>, Feet>();
+}
+
+TEST(CommonUnit, ZeroIfAllInputsAreZero) {
+    StaticAssertTypeEq<CommonUnitT<>, Zero>();
+    StaticAssertTypeEq<CommonUnitT<Zero>, Zero>();
+    StaticAssertTypeEq<CommonUnitT<Zero, Zero>, Zero>();
+    StaticAssertTypeEq<CommonUnitT<Zero, Zero, Zero>, Zero>();
+}
+
 TEST(CommonUnit, DownranksAnonymousScaledUnits) {
     StaticAssertTypeEq<CommonUnitT<Yards, decltype(Feet{} * mag<3>())>, Yards>();
 }

--- a/au/code/au/utility/test/type_traits_test.cc
+++ b/au/code/au/utility/test/type_traits_test.cc
@@ -65,5 +65,11 @@ TEST(DropAll, DropsAllInstancesOfTarget) {
     StaticAssertTypeEq<DropAll<int, Pack<int, char, int, double>>, Pack<char, double>>();
 }
 
+TEST(IncludeInPackIf, MakesPackOfEverythingThatMatches) {
+    StaticAssertTypeEq<
+        IncludeInPackIf<std::is_unsigned, Pack, int32_t, uint8_t, double, char, uint64_t, int16_t>,
+        Pack<uint8_t, uint64_t>>();
+}
+
 }  // namespace detail
 }  // namespace au


### PR DESCRIPTION
The thrust of #369 is to make the origin displacement trait always
produce a shapeshifter type.  Obviously, many unit pairs have an origin
displacement of zero.  Therefore, we want to set ourselves up to have
`Zero` and `Constant<U>` behave more interchangeably in a wider variety
of circumstances.

The most important change here is to let `Zero` participate naturally in
our common unit machinery.  There are two principles.  First, any time
`Zero` is an _input_, it should simply "drop out" of the calculation.
Second, any time _all_ inputs drop out, we should produce `Zero` as an
output.  (These principles play nicely with, for example, the idea that
the "common unit of common units" is always equivalent to what you get
by flattening out all of the nesting.)

Additionally, we add trivial `Zero` support for `make_constant`: it's
just the identity.  This will enable us to write `make_constant` in
generic contexts.

These changes are helped by a new type trait, `IncludeInPackIf`, which
has its own tests.

Helps #369.