### PR TITLE
Add `ComputeOriginDisplacementUnit` helper

### DIFF
--- a/au/code/au/unit_of_measure.hh
+++ b/au/code/au/unit_of_measure.hh
@@ -472,6 +472,63 @@ struct ValueDifference {
 };
 }  // namespace detail
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `ValueDisplacementMagnitude` utility.
+namespace detail {
+
+// `ValueDisplacementMagnitude<T1, T2>` is a type that can be instantiated, and is either a
+// `Magnitude` type or else `Zero`.  It represents the magnitude of the unit that takes us from
+// `T1::value()` to `T2::value()` (and is `Zero` if and only if these values are equal).
+//
+// This is fully encapsulated inside of the `detail` namespace because we don't want end users
+// reasoning in terms of "the magnitude" of a unit.  This concept makes no sense generally.
+// However, it's useful to us internally, because it helps us compute the largest possible magnitude
+// of a common point unit.  Being fully encapsulated, we ourselves can be careful not to misuse it.
+enum class AreValuesEqual { YES, NO };
+template <typename U1, typename U2, AreValuesEqual>
+struct ValueDisplacementMagnitudeImpl;
+template <typename U1, typename U2>
+using ValueDisplacementMagnitude = typename ValueDisplacementMagnitudeImpl<
+    U1,
+    U2,
+    (U1::value() == U2::value() ? AreValuesEqual::YES : AreValuesEqual::NO)>::type;
+
+// Equal values case.
+template <typename U1, typename U2>
+struct ValueDisplacementMagnitudeImpl<U1, U2, AreValuesEqual::YES> : stdx::type_identity<Zero> {
+    static_assert(U1::value() == U2::value(), "Mismatched instantiation (should never happen)");
+};
+
+// Prep for handling unequal values: it's useful to be able to turn a signed integer into a
+// Magnitude.
+//
+// The `bool` template parameter in the `MagSign` interface has poor callsite readability, but it
+// doesn't matter because we're only using it right here.
+template <bool IsNeg>
+struct MagSign : stdx::type_identity<Magnitude<>> {};
+template <>
+struct MagSign<true> : stdx::type_identity<Magnitude<Negative>> {};
+template <std::intmax_t N>
+constexpr auto signed_mag() {
+    constexpr auto sign = typename MagSign<(N < 0)>::type{};
+    return sign * mag<(N < 0 ? (-N) : N)>();
+}
+
+// Unequal values case implementation: scale up the magnitude of the diff's _unit_ by the diff's
+// _value in_ that unit.
+template <typename U1, typename U2>
+struct ValueDisplacementMagnitudeImpl<U1, U2, AreValuesEqual::NO> {
+    static_assert(U1::value() != U2::value(), "Mismatched instantiation (should never happen)");
+    static constexpr auto mag() {
+        constexpr auto diff = U2::value() - U1::value();
+        using D = typename decltype(diff)::Unit;
+        return MagT<D>{} * signed_mag<diff.in(D{})>();
+    }
+    using type = decltype(mag());
+};
+
+}  // namespace detail
+
 // Why this conditional, instead of just using `ValueDifference` unconditionally?  The use case is
 // somewhat subtle.  Without it, we would still deduce a displacement _numerically_ equal to 0, but
 // it would be stored in specific _units_.  For example, for Celsius, the displacement would be "0
@@ -761,6 +818,30 @@ struct CommonOrigin<Head, Tail...> :
                                OriginOf<Head>,
                                CommonOrigin<Tail...>>>> {};
 
+template <typename U1, typename U2>
+struct OriginDisplacementUnit {
+    static_assert(OriginOf<U1>::value() != OriginOf<U2>::value(),
+                  "OriginDisplacementUnit must be an actual unit, so it must be nonzero.");
+
+    using Dim = CommonDimensionT<DimT<U1>, DimT<U2>>;
+    using Mag = ValueDisplacementMagnitude<OriginOf<U1>, OriginOf<U2>>;
+};
+
+// `ComputeOriginDisplacementUnit<U1, U2>` produces an ad hoc unit equal to the displacement from
+// the origin of `U1` to the origin of `U2`.  If `U1` and `U2` have equal origins, then it is
+// `Zero`.  Otherwise, it will be `OriginDisplacementUnit<U1, U2>`.
+template <typename U1, typename U2>
+using ComputeOriginDisplacementUnit =
+    std::conditional_t<(OriginOf<U1>::value() == OriginOf<U2>::value()),
+                       Zero,
+                       OriginDisplacementUnit<U1, U2>>;
+
+template <typename U1, typename U2>
+constexpr auto origin_displacement_unit(U1, U2) {
+    return ComputeOriginDisplacementUnit<AssociatedUnitForPointsT<U1>,
+                                         AssociatedUnitForPointsT<U2>>{};
+}
+
 // MagTypeT<T> gives some measure of the size of the unit for this "quantity-alike" type.
 //
 // Zero acts like a quantity in this context, and we treat it as if its unit's Magnitude is Zero.
@@ -773,6 +854,16 @@ template <>
 struct MagType<Zero> : stdx::type_identity<Zero> {};
 
 }  // namespace detail
+
+template <typename U1, typename U2>
+struct UnitLabel<detail::OriginDisplacementUnit<U1, U2>> {
+    using LabelT = detail::ExtendedLabel<15u, U1, U2>;
+    static constexpr LabelT value =
+        detail::concatenate("(@(0 ", UnitLabel<U2>::value, ") - @(0 ", UnitLabel<U1>::value, "))");
+};
+template <typename U1, typename U2>
+constexpr typename UnitLabel<detail::OriginDisplacementUnit<U1, U2>>::LabelT
+    UnitLabel<detail::OriginDisplacementUnit<U1, U2>>::value;
 
 // This exists to be the "named type" for the common unit of a bunch of input units.
 //

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -780,6 +780,25 @@ TEST(CommonOrigin, SymmetricUnderReordering) {
     EXPECT_THAT(common_origin_value, Not(SameTypeAndValue(AlternateCelsius::origin())));
 }
 
+TEST(ComputeOriginDisplacementUnit, ZeroForSameOrigin) {
+    StaticAssertTypeEq<ComputeOriginDisplacementUnit<Celsius, Milli<Celsius>>, Zero>();
+}
+
+TEST(ComputeOriginDisplacementUnit, HasExpectedMagnitudeAndSign) {
+    constexpr auto disp_k0_to_c0 = make_constant(ComputeOriginDisplacementUnit<Kelvins, Celsius>{});
+    EXPECT_THAT(disp_k0_to_c0, Eq(centi(kelvins)(273'15)));
+
+    constexpr auto disp_c0_to_k0 = make_constant(ComputeOriginDisplacementUnit<Celsius, Kelvins>{});
+    EXPECT_THAT(disp_c0_to_k0, Eq(centi(kelvins)(-273'15)));
+}
+
+TEST(ComputeOriginDisplacementUnit, HasExpectedLabel) {
+    EXPECT_THAT(unit_label(origin_displacement_unit(kelvins_pt, celsius_pt)),
+                StrEq("(@(0 deg_C) - @(0 K))"));
+    EXPECT_THAT(unit_label(origin_displacement_unit(celsius_pt, kelvins_pt)),
+                StrEq("(@(0 K) - @(0 deg_C))"));
+}
+
 TEST(EliminateRedundantUnits, IdentityForEmptySet) {
     StaticAssertTypeEq<EliminateRedundantUnits<SomePack<>>, SomePack<>>();
 }


### PR DESCRIPTION
This will produce an actual unit whenever possible --- that is, whenever
the input units have the same dimension, but different origins.
Otherwise, it will produce `Zero`.  Of course, in the latter case, this
isn't an actual "unit", but it will participate correctly in the common
unit machinery.

We automatically generate a label, which is consistent with our
(somewhat quirky and dubious) `@(...)` syntax for printing
`QuantityPoint`.

Helps #369.