### PR TITLE
Convert existing boolean checks to matcher syntax

### DIFF
--- a/au/code/au/constant_test.cc
+++ b/au/code/au/constant_test.cc
@@ -28,12 +28,15 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+namespace au {
+
 using ::testing::AnyOf;
 using ::testing::Eq;
+using ::testing::IsFalse;
+using ::testing::IsTrue;
 using ::testing::StaticAssertTypeEq;
 using ::testing::StrEq;
 
-namespace au {
 namespace {
 
 constexpr auto PI = Magnitude<Pi>{};
@@ -277,15 +280,18 @@ TEST(Constant, ImplicitlyConvertsToNonAuTypesWithAppropriateCorrespondingQuantit
     // If we had represented this constant as a quantity, it wouldn't be able to convert to a
     // quantity of seconds backed by `uint32_t`, because of the overflow safety surface.  However,
     // the constant value itself can be safely converted, because we know its exact value.
-    ASSERT_FALSE((
-        std::is_convertible<decltype(dt_as_quantity_u32), std::chrono::duration<uint32_t>>::value));
-    EXPECT_TRUE(
-        (std::is_convertible<decltype(dt_as_constant), std::chrono::duration<uint32_t>>::value));
+    ASSERT_THAT(
+        (std::is_convertible<decltype(dt_as_quantity_u32), std::chrono::duration<uint32_t>>::value),
+        IsFalse());
+    EXPECT_THAT(
+        (std::is_convertible<decltype(dt_as_constant), std::chrono::duration<uint32_t>>::value),
+        IsTrue());
 
     // Here, the constant value itself can't be safely converted, because it's too big for a
     // `uint16_t`.
-    EXPECT_FALSE(
-        (std::is_convertible<decltype(dt_as_constant), std::chrono::duration<uint16_t>>::value));
+    EXPECT_THAT(
+        (std::is_convertible<decltype(dt_as_constant), std::chrono::duration<uint16_t>>::value),
+        IsFalse());
 }
 
 TEST(Constant, SupportsUnitSlotAPIs) {
@@ -319,8 +325,8 @@ TEST(Constant, SupportsModWithQuantity) {
 TEST(MakeConstant, IdentityForZero) { EXPECT_THAT(make_constant(ZERO), SameTypeAndValue(ZERO)); }
 
 TEST(CanStoreValueIn, ChecksRangeOfTypeForIntegers) {
-    EXPECT_TRUE(decltype(c)::can_store_value_in<int32_t>(meters / second));
-    EXPECT_FALSE(decltype(c)::can_store_value_in<int16_t>(meters / second));
+    EXPECT_THAT(decltype(c)::can_store_value_in<int32_t>(meters / second), IsTrue());
+    EXPECT_THAT(decltype(c)::can_store_value_in<int16_t>(meters / second), IsFalse());
 }
 
 }  // namespace

--- a/au/code/au/magnitude_test.cc
+++ b/au/code/au/magnitude_test.cc
@@ -17,16 +17,21 @@
 #include <cmath>
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+namespace au {
 
 using ::testing::DoubleEq;
 using ::testing::Eq;
 using ::testing::FloatEq;
+using ::testing::IsFalse;
+using ::testing::IsTrue;
 using ::testing::StaticAssertTypeEq;
 using ::testing::StrEq;
 
-namespace au {
 namespace {
+
 constexpr auto PI = Magnitude<Pi>{};
 
 template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
@@ -107,9 +112,9 @@ TEST(MagnitudeLabel, DefaultsToUnlabeledForFactorTooBig) {
 }
 
 TEST(MagnitudeLabel, IndicatesPresenceOfExposedSlash) {
-    EXPECT_FALSE(MagnitudeLabel<decltype(mag<287'987>())>::has_exposed_slash);
-    EXPECT_TRUE(MagnitudeLabel<decltype(mag<1>() / mag<2>())>::has_exposed_slash);
-    EXPECT_TRUE(MagnitudeLabel<decltype(-mag<1>() / mag<2>())>::has_exposed_slash);
+    EXPECT_THAT(MagnitudeLabel<decltype(mag<287'987>())>::has_exposed_slash, IsFalse());
+    EXPECT_THAT(MagnitudeLabel<decltype(mag<1>() / mag<2>())>::has_exposed_slash, IsTrue());
+    EXPECT_THAT(MagnitudeLabel<decltype(-mag<1>() / mag<2>())>::has_exposed_slash, IsTrue());
 }
 
 TEST(Pi, HasCorrectValue) {
@@ -199,63 +204,63 @@ TEST(Abs, FlipsSignForNegative) {
 TEST(Abs, IdentityForZero) { EXPECT_EQ(abs(ZERO), ZERO); }
 
 TEST(IsPositive, TrueForPositive) {
-    EXPECT_TRUE(is_positive(mag<1>()));
-    EXPECT_TRUE(is_positive(mag<2>()));
-    EXPECT_TRUE(is_positive(mag<5>() / mag<7>()));
+    EXPECT_THAT(is_positive(mag<1>()), IsTrue());
+    EXPECT_THAT(is_positive(mag<2>()), IsTrue());
+    EXPECT_THAT(is_positive(mag<5>() / mag<7>()), IsTrue());
 }
 
 TEST(IsPositive, FalseForNegative) {
-    EXPECT_FALSE(is_positive(-mag<1>()));
-    EXPECT_FALSE(is_positive(-mag<5>() / mag<7>()));
-    EXPECT_FALSE(is_positive(-mag<2>() / PI));
+    EXPECT_THAT(is_positive(-mag<1>()), IsFalse());
+    EXPECT_THAT(is_positive(-mag<5>() / mag<7>()), IsFalse());
+    EXPECT_THAT(is_positive(-mag<2>() / PI), IsFalse());
 }
 
 TEST(IsRational, TrueForRatios) {
-    EXPECT_TRUE(is_rational(mag<1>()));
-    EXPECT_TRUE(is_rational(mag<9>()));
-    EXPECT_TRUE(is_rational(mag<1>() / mag<10>()));
-    EXPECT_TRUE(is_rational(mag<9>() / mag<10>()));
+    EXPECT_THAT(is_rational(mag<1>()), IsTrue());
+    EXPECT_THAT(is_rational(mag<9>()), IsTrue());
+    EXPECT_THAT(is_rational(mag<1>() / mag<10>()), IsTrue());
+    EXPECT_THAT(is_rational(mag<9>() / mag<10>()), IsTrue());
 }
 
 TEST(IsRational, TrueForNegativeRatios) {
-    EXPECT_TRUE(is_rational(-mag<1>()));
-    EXPECT_TRUE(is_rational(-mag<9>()));
-    EXPECT_TRUE(is_rational(-mag<1>() / mag<10>()));
-    EXPECT_TRUE(is_rational(-mag<9>() / mag<10>()));
+    EXPECT_THAT(is_rational(-mag<1>()), IsTrue());
+    EXPECT_THAT(is_rational(-mag<9>()), IsTrue());
+    EXPECT_THAT(is_rational(-mag<1>() / mag<10>()), IsTrue());
+    EXPECT_THAT(is_rational(-mag<9>() / mag<10>()), IsTrue());
 }
 
 TEST(IsRational, FalseForInexactRoots) {
-    EXPECT_TRUE(is_rational(root<2>(mag<9>())));
-    EXPECT_FALSE(is_rational(root<3>(mag<9>())));
+    EXPECT_THAT(is_rational(root<2>(mag<9>())), IsTrue());
+    EXPECT_THAT(is_rational(root<3>(mag<9>())), IsFalse());
 }
 
 TEST(IsInteger, TrueForIntegers) {
-    EXPECT_TRUE(is_integer(mag<1>()));
-    EXPECT_TRUE(is_integer(mag<1234>()));
-    EXPECT_TRUE(is_integer(mag<142857>()));
+    EXPECT_THAT(is_integer(mag<1>()), IsTrue());
+    EXPECT_THAT(is_integer(mag<1234>()), IsTrue());
+    EXPECT_THAT(is_integer(mag<142857>()), IsTrue());
 }
 
 TEST(IsInteger, FalseForInexactFractions) {
-    EXPECT_TRUE(is_integer(mag<6>() / mag<3>()));
-    EXPECT_FALSE(is_integer(mag<7>() / mag<3>()));
-    EXPECT_FALSE(is_integer(mag<8>() / mag<3>()));
-    EXPECT_TRUE(is_integer(mag<9>() / mag<3>()));
+    EXPECT_THAT(is_integer(mag<6>() / mag<3>()), IsTrue());
+    EXPECT_THAT(is_integer(mag<7>() / mag<3>()), IsFalse());
+    EXPECT_THAT(is_integer(mag<8>() / mag<3>()), IsFalse());
+    EXPECT_THAT(is_integer(mag<9>() / mag<3>()), IsTrue());
 }
 
-TEST(IsInteger, FalseForIrrationalBase) { EXPECT_FALSE(is_integer(PI)); }
+TEST(IsInteger, FalseForIrrationalBase) { EXPECT_THAT(is_integer(PI), IsFalse()); }
 
 TEST(RepresentableIn, DocumentationExamplesAreCorrect) {
-    EXPECT_TRUE(representable_in<int>(mag<1>()));
+    EXPECT_THAT(representable_in<int>(mag<1>()), IsTrue());
 
     // (1 / 2) is not an integer.
-    EXPECT_FALSE(representable_in<int>(mag<1>() / mag<2>()));
+    EXPECT_THAT(representable_in<int>(mag<1>() / mag<2>()), IsFalse());
 
-    EXPECT_TRUE(representable_in<float>(mag<1>() / mag<2>()));
+    EXPECT_THAT(representable_in<float>(mag<1>() / mag<2>()), IsTrue());
 
-    EXPECT_TRUE(representable_in<uint32_t>(mag<4'000'000'000>()));
+    EXPECT_THAT(representable_in<uint32_t>(mag<4'000'000'000>()), IsTrue());
 
     // 4 billion is larger than the max value representable in `int32_t`.
-    EXPECT_FALSE(representable_in<int32_t>(mag<4'000'000'000>()));
+    EXPECT_THAT(representable_in<int32_t>(mag<4'000'000'000>()), IsFalse());
 }
 
 TEST(GetValue, SupportsIntegerOutputForIntegerMagnitude) {
@@ -311,7 +316,7 @@ TEST(GetValue, ImpossibleRequestsArePreventedAtCompileTime) {
     // get_value<double>(pow<3099999>(mag<10>()));
 
     constexpr auto sqrt_2 = root<2>(mag<2>());
-    ASSERT_FALSE(is_integer(sqrt_2));
+    ASSERT_THAT(is_integer(sqrt_2), IsFalse());
     // get_value<int>(sqrt_2);
 }
 
@@ -358,12 +363,12 @@ TEST(CommonMagnitude, DividesBothMagnitudes) {
     constexpr auto a = pow<10>(mag<2>()) * pow<-4>(mag<3>()) * pow<40>(mag<11>());
     constexpr auto b = pow<-1>(mag<2>()) * pow<12>(mag<3>()) * pow<-8>(mag<13>());
 
-    ASSERT_FALSE(is_integer(a / b));
-    ASSERT_FALSE(is_integer(b / a));
+    ASSERT_THAT(is_integer(a / b), IsFalse());
+    ASSERT_THAT(is_integer(b / a), IsFalse());
 
     EXPECT_EQ(common_magnitude(a, b), common_magnitude(b, a));
-    EXPECT_TRUE(is_integer(a / common_magnitude(a, b)));
-    EXPECT_TRUE(is_integer(b / common_magnitude(a, b)));
+    EXPECT_THAT(is_integer(a / common_magnitude(a, b)), IsTrue());
+    EXPECT_THAT(is_integer(b / common_magnitude(a, b)), IsTrue());
 }
 
 TEST(CommonMagnitude, HandlesMultiplePositivePowers) {
@@ -397,6 +402,7 @@ TEST(CommonMagnitude, CommonMagOfNegAndNegIsNeg) {
     EXPECT_EQ(common_magnitude(-mag<12>(), -mag<15>(), -mag<27>()), -mag<3>());
     EXPECT_EQ(common_magnitude(-mag<9>(), -mag<12>(), -mag<15>(), -mag<27>()), -mag<3>());
 }
+
 }  // namespace
 
 namespace detail {

--- a/au/code/au/math_test.cc
+++ b/au/code/au/math_test.cc
@@ -31,12 +31,16 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+namespace au {
+
 using ::testing::DoubleNear;
 using ::testing::Eq;
+using ::testing::IsFalse;
+using ::testing::IsTrue;
 using ::testing::StaticAssertTypeEq;
 
-namespace au {
 namespace {
+
 constexpr auto INTEGER_TOO_BIG_FOR_DOUBLE = 9'007'199'254'740'993LL;
 
 // Backport of std::clamp() from C++17 for testing purposes.
@@ -50,6 +54,7 @@ template <class T>
 constexpr const T &std_clamp(const T &v, const T &lo, const T &hi) {
     return std_clamp(v, lo, hi, std::less<void>{});
 }
+
 }  // namespace
 
 TEST(abs, AlwaysReturnsNonnegativeVersionOfInput) {
@@ -164,7 +169,8 @@ TEST(clamp, QuantityPointTakesOffsetIntoAccount) {
     // into account for this mixed result.  This means whatever unit we return must be at most 1/20
     // Kelvins, and must evenly divide 1/20 Kelvins.
     constexpr auto celsius_origin = clamp(celsius_pt(0), kelvins_pt(200), kelvins_pt(300));
-    ASSERT_TRUE(is_integer(unit_ratio(Kelvins{} / mag<20>(), decltype(celsius_origin)::unit)));
+    ASSERT_THAT(is_integer(unit_ratio(Kelvins{} / mag<20>(), decltype(celsius_origin)::unit)),
+                IsTrue());
     EXPECT_EQ(celsius_origin, centi(kelvins_pt)(273'15));
 }
 
@@ -719,7 +725,7 @@ TEST(isnan, TransparentlyActsOnSameAsValue) {
 TEST(isnan, UnqualifiedCallsGiveStdVersions) {
     // This test exists to make sure we don't break code with unqualified isnan calls.
     const bool b = isnan(5.5);
-    EXPECT_FALSE(b);
+    EXPECT_THAT(b, IsFalse());
 }
 
 TEST(numeric_limits, MemberVariablesSetCorrectlyForQuantitySpecialization) {
@@ -730,18 +736,18 @@ TEST(numeric_limits, MemberVariablesSetCorrectlyForQuantitySpecialization) {
     // Source for rule: https://en.cppreference.com/w/cpp/language/extending_std
     // List of members: https://en.cppreference.com/w/cpp/types/numeric_limits
     using meters_limits_int = std::numeric_limits<Quantity<Meters, int>>;
-    EXPECT_TRUE(meters_limits_int::is_specialized);
-    EXPECT_TRUE(meters_limits_int::is_signed);
-    EXPECT_TRUE(meters_limits_int::is_integer);
-    EXPECT_TRUE(meters_limits_int::is_exact);
-    EXPECT_FALSE(meters_limits_int::has_infinity);
-    EXPECT_FALSE(meters_limits_int::has_quiet_NaN);
-    EXPECT_FALSE(meters_limits_int::has_signaling_NaN);
+    EXPECT_THAT(meters_limits_int::is_specialized, IsTrue());
+    EXPECT_THAT(meters_limits_int::is_signed, IsTrue());
+    EXPECT_THAT(meters_limits_int::is_integer, IsTrue());
+    EXPECT_THAT(meters_limits_int::is_exact, IsTrue());
+    EXPECT_THAT(meters_limits_int::has_infinity, IsFalse());
+    EXPECT_THAT(meters_limits_int::has_quiet_NaN, IsFalse());
+    EXPECT_THAT(meters_limits_int::has_signaling_NaN, IsFalse());
     EXPECT_EQ(meters_limits_int::has_denorm, std::denorm_absent);
-    EXPECT_FALSE(meters_limits_int::has_denorm_loss);
+    EXPECT_THAT(meters_limits_int::has_denorm_loss, IsFalse());
     EXPECT_EQ(meters_limits_int::round_style, std::round_toward_zero);
-    EXPECT_FALSE(meters_limits_int::is_iec559);
-    EXPECT_TRUE(meters_limits_int::is_bounded);
+    EXPECT_THAT(meters_limits_int::is_iec559, IsFalse());
+    EXPECT_THAT(meters_limits_int::is_bounded, IsTrue());
     EXPECT_EQ(meters_limits_int::is_modulo, std::numeric_limits<int>::is_modulo);
     EXPECT_EQ(meters_limits_int::digits, std::numeric_limits<int>::digits);
     EXPECT_EQ(meters_limits_int::digits10, std::numeric_limits<int>::digits10);
@@ -751,23 +757,23 @@ TEST(numeric_limits, MemberVariablesSetCorrectlyForQuantitySpecialization) {
     EXPECT_EQ(meters_limits_int::min_exponent10, 0);
     EXPECT_EQ(meters_limits_int::max_exponent, 0);
     EXPECT_EQ(meters_limits_int::max_exponent10, 0);
-    EXPECT_TRUE(meters_limits_int::traps);
-    EXPECT_FALSE(meters_limits_int::tinyness_before);
+    EXPECT_THAT(meters_limits_int::traps, IsTrue());
+    EXPECT_THAT(meters_limits_int::tinyness_before, IsFalse());
 
     using radians_limits_uint32_t = std::numeric_limits<Quantity<Radians, uint32_t>>;
-    EXPECT_TRUE(radians_limits_uint32_t::is_specialized);
-    EXPECT_FALSE(radians_limits_uint32_t::is_signed);
-    EXPECT_TRUE(radians_limits_uint32_t::is_integer);
-    EXPECT_TRUE(radians_limits_uint32_t::is_exact);
-    EXPECT_FALSE(radians_limits_uint32_t::has_infinity);
-    EXPECT_FALSE(radians_limits_uint32_t::has_quiet_NaN);
-    EXPECT_FALSE(radians_limits_uint32_t::has_signaling_NaN);
+    EXPECT_THAT(radians_limits_uint32_t::is_specialized, IsTrue());
+    EXPECT_THAT(radians_limits_uint32_t::is_signed, IsFalse());
+    EXPECT_THAT(radians_limits_uint32_t::is_integer, IsTrue());
+    EXPECT_THAT(radians_limits_uint32_t::is_exact, IsTrue());
+    EXPECT_THAT(radians_limits_uint32_t::has_infinity, IsFalse());
+    EXPECT_THAT(radians_limits_uint32_t::has_quiet_NaN, IsFalse());
+    EXPECT_THAT(radians_limits_uint32_t::has_signaling_NaN, IsFalse());
     EXPECT_EQ(radians_limits_uint32_t::has_denorm, std::denorm_absent);
-    EXPECT_FALSE(radians_limits_uint32_t::has_denorm_loss);
+    EXPECT_THAT(radians_limits_uint32_t::has_denorm_loss, IsFalse());
     EXPECT_EQ(radians_limits_uint32_t::round_style, std::round_toward_zero);
-    EXPECT_FALSE(radians_limits_uint32_t::is_iec559);
-    EXPECT_TRUE(radians_limits_uint32_t::is_bounded);
-    EXPECT_TRUE(radians_limits_uint32_t::is_modulo);
+    EXPECT_THAT(radians_limits_uint32_t::is_iec559, IsFalse());
+    EXPECT_THAT(radians_limits_uint32_t::is_bounded, IsTrue());
+    EXPECT_THAT(radians_limits_uint32_t::is_modulo, IsTrue());
     EXPECT_EQ(radians_limits_uint32_t::digits, std::numeric_limits<uint32_t>::digits);
     EXPECT_EQ(radians_limits_uint32_t::digits10, std::numeric_limits<uint32_t>::digits10);
     EXPECT_EQ(radians_limits_uint32_t::max_digits10, 0);
@@ -776,23 +782,23 @@ TEST(numeric_limits, MemberVariablesSetCorrectlyForQuantitySpecialization) {
     EXPECT_EQ(radians_limits_uint32_t::min_exponent10, 0);
     EXPECT_EQ(radians_limits_uint32_t::max_exponent, 0);
     EXPECT_EQ(radians_limits_uint32_t::max_exponent10, 0);
-    EXPECT_TRUE(radians_limits_uint32_t::traps);
-    EXPECT_FALSE(radians_limits_uint32_t::tinyness_before);
+    EXPECT_THAT(radians_limits_uint32_t::traps, IsTrue());
+    EXPECT_THAT(radians_limits_uint32_t::tinyness_before, IsFalse());
 
     using celsius_limits_float = std::numeric_limits<Quantity<Celsius, float>>;
-    EXPECT_TRUE(celsius_limits_float::is_specialized);
-    EXPECT_TRUE(celsius_limits_float::is_signed);
-    EXPECT_FALSE(celsius_limits_float::is_integer);
-    EXPECT_FALSE(celsius_limits_float::is_exact);
-    EXPECT_TRUE(celsius_limits_float::has_infinity);
-    EXPECT_TRUE(celsius_limits_float::has_quiet_NaN);
-    EXPECT_TRUE(celsius_limits_float::has_signaling_NaN);
+    EXPECT_THAT(celsius_limits_float::is_specialized, IsTrue());
+    EXPECT_THAT(celsius_limits_float::is_signed, IsTrue());
+    EXPECT_THAT(celsius_limits_float::is_integer, IsFalse());
+    EXPECT_THAT(celsius_limits_float::is_exact, IsFalse());
+    EXPECT_THAT(celsius_limits_float::has_infinity, IsTrue());
+    EXPECT_THAT(celsius_limits_float::has_quiet_NaN, IsTrue());
+    EXPECT_THAT(celsius_limits_float::has_signaling_NaN, IsTrue());
     EXPECT_EQ(celsius_limits_float::has_denorm, std::denorm_present);
     EXPECT_EQ(celsius_limits_float::has_denorm_loss, std::numeric_limits<float>::has_denorm_loss);
     EXPECT_EQ(celsius_limits_float::round_style, std::round_to_nearest);
-    EXPECT_TRUE(celsius_limits_float::is_iec559);
-    EXPECT_TRUE(celsius_limits_float::is_bounded);
-    EXPECT_FALSE(celsius_limits_float::is_modulo);
+    EXPECT_THAT(celsius_limits_float::is_iec559, IsTrue());
+    EXPECT_THAT(celsius_limits_float::is_bounded, IsTrue());
+    EXPECT_THAT(celsius_limits_float::is_modulo, IsFalse());
     EXPECT_EQ(celsius_limits_float::digits, FLT_MANT_DIG);
     EXPECT_EQ(celsius_limits_float::digits10, FLT_DIG);
     EXPECT_EQ(celsius_limits_float::max_digits10, std::numeric_limits<float>::max_digits10);
@@ -801,7 +807,7 @@ TEST(numeric_limits, MemberVariablesSetCorrectlyForQuantitySpecialization) {
     EXPECT_EQ(celsius_limits_float::min_exponent10, FLT_MIN_10_EXP);
     EXPECT_EQ(celsius_limits_float::max_exponent, FLT_MAX_EXP);
     EXPECT_EQ(celsius_limits_float::max_exponent10, FLT_MAX_10_EXP);
-    EXPECT_FALSE(celsius_limits_float::traps);
+    EXPECT_THAT(celsius_limits_float::traps, IsFalse());
     EXPECT_EQ(celsius_limits_float::tinyness_before, std::numeric_limits<float>::tinyness_before);
 }
 

--- a/au/code/au/quantity_point_test.cc
+++ b/au/code/au/quantity_point_test.cc
@@ -19,18 +19,23 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+namespace au {
+
+using ::testing::IsFalse;
+using ::testing::IsTrue;
 using ::testing::Not;
 using ::testing::StaticAssertTypeEq;
 using ::testing::StrEq;
 
-namespace au {
 namespace {
+
 template <typename T>
 std::string stream_to_string(const T &t) {
     std::ostringstream oss;
     oss << t;
     return oss.str();
 }
+
 }  // namespace
 
 struct Meters : UnitImpl<Length> {};
@@ -80,19 +85,23 @@ TEST(QuantityPoint, HasExpectedDiffType) {
 }
 
 TEST(QuantityPoint, CanImplicitlyConstructDoubleFromIntButNotViceVersa) {
-    EXPECT_TRUE((std::is_convertible<QuantityPointI32<Celsius>, QuantityPointD<Celsius>>::value));
-    EXPECT_FALSE((std::is_convertible<QuantityPointD<Celsius>, QuantityPointI32<Celsius>>::value));
+    EXPECT_THAT((std::is_convertible<QuantityPointI32<Celsius>, QuantityPointD<Celsius>>::value),
+                IsTrue());
+    EXPECT_THAT((std::is_convertible<QuantityPointD<Celsius>, QuantityPointI32<Celsius>>::value),
+                IsFalse());
 }
 
 TEST(QuantityPoint, CanImplicitlyConstructWithNonintegerOffsetIffDestinationIsFloatingPoint) {
-    EXPECT_FALSE(
-        (std::is_convertible<QuantityPointI32<Celsius>, QuantityPointI32<Kelvins>>::value));
+    EXPECT_THAT((std::is_convertible<QuantityPointI32<Celsius>, QuantityPointI32<Kelvins>>::value),
+                IsFalse());
 
-    EXPECT_TRUE((std::is_convertible<QuantityPointI32<Celsius>, QuantityPointD<Kelvins>>::value));
+    EXPECT_THAT((std::is_convertible<QuantityPointI32<Celsius>, QuantityPointD<Kelvins>>::value),
+                IsTrue());
 
     // Also works for ints if the destination unit evenly divides both offset and initial diff.
-    EXPECT_TRUE(
-        (std::is_convertible<QuantityPointI32<Celsius>, QuantityPointI32<Milli<Kelvins>>>::value));
+    EXPECT_THAT(
+        (std::is_convertible<QuantityPointI32<Celsius>, QuantityPointI32<Milli<Kelvins>>>::value),
+        IsTrue());
 }
 
 TEST(QuantityPoint, ImplicitConstructionsAreCorrect) {
@@ -405,16 +414,19 @@ TEST(QuantityPoint, InheritsOverflowSafetySurfaceFromUnderlyingQuantityTypes) {
     //   hence, dangerous conversion.
 
     // UNCOMMENT THE FOLLOWING LINE TO TEST:
-    // ASSERT_FALSE(celsius_pt(static_cast<int16_t>(20)) < kelvins_pt(static_cast<int16_t>(293)));
+    // ASSERT_THAT(celsius_pt(static_cast<int16_t>(20)) < kelvins_pt(static_cast<int16_t>(293)),
+    // IsFalse());
 
     // It so happens that moving from `int16_t` to `uint16_t` would give us enough room to make the
     // test compile (and pass).
-    ASSERT_FALSE(celsius_pt(static_cast<uint16_t>(20)) < kelvins_pt(static_cast<uint16_t>(293)));
+    ASSERT_THAT(celsius_pt(static_cast<uint16_t>(20)) < kelvins_pt(static_cast<uint16_t>(293)),
+                IsFalse());
 
     // Note also that the failure is explicitly due to the influence of the origin _difference_.
     // For _quantities_, rather than quantity _points_, this would work just fine, as the following
     // test shows.
-    ASSERT_TRUE(celsius_qty(static_cast<int16_t>(20)) < kelvins(static_cast<int16_t>(293)));
+    ASSERT_THAT(celsius_qty(static_cast<int16_t>(20)) < kelvins(static_cast<int16_t>(293)),
+                IsTrue());
 }
 
 TEST(QuantityPoint, PreservesRep) {
@@ -434,42 +446,44 @@ TEST(QuantityPointMaker, CanScaleByMagnitude) {
 }
 
 namespace detail {
+
 TEST(OriginDisplacementFitsIn, CanRetrieveValueInGivenRep) {
-    EXPECT_TRUE((OriginDisplacementFitsIn<uint64_t, Kelvins, Celsius>::value));
-    EXPECT_TRUE((OriginDisplacementFitsIn<int64_t, Kelvins, Celsius>::value));
+    EXPECT_THAT((OriginDisplacementFitsIn<uint64_t, Kelvins, Celsius>::value), IsTrue());
+    EXPECT_THAT((OriginDisplacementFitsIn<int64_t, Kelvins, Celsius>::value), IsTrue());
 
-    EXPECT_TRUE((OriginDisplacementFitsIn<uint32_t, Kelvins, Celsius>::value));
-    EXPECT_TRUE((OriginDisplacementFitsIn<int32_t, Kelvins, Celsius>::value));
+    EXPECT_THAT((OriginDisplacementFitsIn<uint32_t, Kelvins, Celsius>::value), IsTrue());
+    EXPECT_THAT((OriginDisplacementFitsIn<int32_t, Kelvins, Celsius>::value), IsTrue());
 
-    EXPECT_TRUE((OriginDisplacementFitsIn<uint16_t, Kelvins, Celsius>::value));
-    EXPECT_TRUE((OriginDisplacementFitsIn<int16_t, Kelvins, Celsius>::value));
+    EXPECT_THAT((OriginDisplacementFitsIn<uint16_t, Kelvins, Celsius>::value), IsTrue());
+    EXPECT_THAT((OriginDisplacementFitsIn<int16_t, Kelvins, Celsius>::value), IsTrue());
 
-    EXPECT_FALSE((OriginDisplacementFitsIn<uint8_t, Kelvins, Celsius>::value));
-    EXPECT_FALSE((OriginDisplacementFitsIn<int8_t, Kelvins, Celsius>::value));
+    EXPECT_THAT((OriginDisplacementFitsIn<uint8_t, Kelvins, Celsius>::value), IsFalse());
+    EXPECT_THAT((OriginDisplacementFitsIn<int8_t, Kelvins, Celsius>::value), IsFalse());
 }
 
 TEST(OriginDisplacementFitsIn, AlwaysTrueForZero) {
-    EXPECT_TRUE((OriginDisplacementFitsIn<uint64_t, Celsius, Celsius>::value));
-    EXPECT_TRUE((OriginDisplacementFitsIn<int64_t, Celsius, Celsius>::value));
+    EXPECT_THAT((OriginDisplacementFitsIn<uint64_t, Celsius, Celsius>::value), IsTrue());
+    EXPECT_THAT((OriginDisplacementFitsIn<int64_t, Celsius, Celsius>::value), IsTrue());
 
-    EXPECT_TRUE((OriginDisplacementFitsIn<uint32_t, Celsius, Celsius>::value));
-    EXPECT_TRUE((OriginDisplacementFitsIn<int32_t, Celsius, Celsius>::value));
+    EXPECT_THAT((OriginDisplacementFitsIn<uint32_t, Celsius, Celsius>::value), IsTrue());
+    EXPECT_THAT((OriginDisplacementFitsIn<int32_t, Celsius, Celsius>::value), IsTrue());
 
-    EXPECT_TRUE((OriginDisplacementFitsIn<uint16_t, Celsius, Celsius>::value));
-    EXPECT_TRUE((OriginDisplacementFitsIn<int16_t, Celsius, Celsius>::value));
+    EXPECT_THAT((OriginDisplacementFitsIn<uint16_t, Celsius, Celsius>::value), IsTrue());
+    EXPECT_THAT((OriginDisplacementFitsIn<int16_t, Celsius, Celsius>::value), IsTrue());
 
-    EXPECT_TRUE((OriginDisplacementFitsIn<uint8_t, Celsius, Celsius>::value));
-    EXPECT_TRUE((OriginDisplacementFitsIn<int8_t, Celsius, Celsius>::value));
+    EXPECT_THAT((OriginDisplacementFitsIn<uint8_t, Celsius, Celsius>::value), IsTrue());
+    EXPECT_THAT((OriginDisplacementFitsIn<int8_t, Celsius, Celsius>::value), IsTrue());
 }
 
 TEST(OriginDisplacementFitsIn, FailsNegativeDisplacementForUnsignedRep) {
-    EXPECT_FALSE((OriginDisplacementFitsIn<uint64_t, Celsius, Kelvins>::value));
-    EXPECT_FALSE((OriginDisplacementFitsIn<uint32_t, Celsius, Kelvins>::value));
-    EXPECT_FALSE((OriginDisplacementFitsIn<uint16_t, Celsius, Kelvins>::value));
+    EXPECT_THAT((OriginDisplacementFitsIn<uint64_t, Celsius, Kelvins>::value), IsFalse());
+    EXPECT_THAT((OriginDisplacementFitsIn<uint32_t, Celsius, Kelvins>::value), IsFalse());
+    EXPECT_THAT((OriginDisplacementFitsIn<uint16_t, Celsius, Kelvins>::value), IsFalse());
 
-    EXPECT_TRUE((OriginDisplacementFitsIn<int64_t, Celsius, Kelvins>::value));
-    EXPECT_TRUE((OriginDisplacementFitsIn<int32_t, Celsius, Kelvins>::value));
-    EXPECT_TRUE((OriginDisplacementFitsIn<int16_t, Celsius, Kelvins>::value));
+    EXPECT_THAT((OriginDisplacementFitsIn<int64_t, Celsius, Kelvins>::value), IsTrue());
+    EXPECT_THAT((OriginDisplacementFitsIn<int32_t, Celsius, Kelvins>::value), IsTrue());
+    EXPECT_THAT((OriginDisplacementFitsIn<int16_t, Celsius, Kelvins>::value), IsTrue());
 }
+
 }  // namespace detail
 }  // namespace au

--- a/au/code/au/static_cast_checkers_test.cc
+++ b/au/code/au/static_cast_checkers_test.cc
@@ -14,98 +14,105 @@
 
 #include "au/static_cast_checkers.hh"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
+
+using ::testing::IsFalse;
+using ::testing::IsTrue;
+
 namespace detail {
 
 TEST(WillStaticCastOverflow, DependsOnValueForUnsignedToNonContainingSigned) {
-    EXPECT_FALSE(will_static_cast_overflow<int8_t>(uint8_t{127}));
-    EXPECT_TRUE(will_static_cast_overflow<int8_t>(uint8_t{128}));
+    EXPECT_THAT(will_static_cast_overflow<int8_t>(uint8_t{127}), IsFalse());
+    EXPECT_THAT(will_static_cast_overflow<int8_t>(uint8_t{128}), IsTrue());
 }
 
 TEST(WillStaticCastOverflow, AlwaysFalseForUnsignedToContainingSigned) {
-    EXPECT_FALSE(will_static_cast_overflow<int>(uint8_t{124}));
-    EXPECT_FALSE(will_static_cast_overflow<int>(uint8_t{125}));
+    EXPECT_THAT(will_static_cast_overflow<int>(uint8_t{124}), IsFalse());
+    EXPECT_THAT(will_static_cast_overflow<int>(uint8_t{125}), IsFalse());
 }
 
 TEST(WillStaticCastOverflow, ChecksLimitForNonContainingSameSignedness) {
-    EXPECT_FALSE(will_static_cast_overflow<int8_t>(127));
-    EXPECT_TRUE(will_static_cast_overflow<int8_t>(128));
+    EXPECT_THAT(will_static_cast_overflow<int8_t>(127), IsFalse());
+    EXPECT_THAT(will_static_cast_overflow<int8_t>(128), IsTrue());
 }
 
 TEST(WillStaticCastOverflow, TrueForNegativeInputAndUnsignedDestination) {
-    EXPECT_TRUE(will_static_cast_overflow<uint8_t>(-1));
-    EXPECT_TRUE(will_static_cast_overflow<unsigned int>(int8_t{-1}));
+    EXPECT_THAT(will_static_cast_overflow<uint8_t>(-1), IsTrue());
+    EXPECT_THAT(will_static_cast_overflow<unsigned int>(int8_t{-1}), IsTrue());
 }
 
 TEST(WillStaticCastOverflow, FalseWhenDestBoundsContainsSourceBounds) {
-    EXPECT_FALSE(will_static_cast_overflow<float>(std::numeric_limits<uint64_t>::max()));
+    EXPECT_THAT(will_static_cast_overflow<float>(std::numeric_limits<uint64_t>::max()), IsFalse());
 }
 
 TEST(WillStaticCastOverflow, DependsOnTypeLimitsForFloatToInt) {
-    EXPECT_TRUE(will_static_cast_overflow<uint8_t>(-0.0001));
-    EXPECT_FALSE(will_static_cast_overflow<uint8_t>(0.0000));
-    EXPECT_FALSE(will_static_cast_overflow<uint8_t>(0.0001));
+    EXPECT_THAT(will_static_cast_overflow<uint8_t>(-0.0001), IsTrue());
+    EXPECT_THAT(will_static_cast_overflow<uint8_t>(0.0000), IsFalse());
+    EXPECT_THAT(will_static_cast_overflow<uint8_t>(0.0001), IsFalse());
 
-    EXPECT_FALSE(will_static_cast_overflow<uint8_t>(254.9999));
-    EXPECT_FALSE(will_static_cast_overflow<uint8_t>(255.0000));
-    EXPECT_TRUE(will_static_cast_overflow<uint8_t>(255.0001));
+    EXPECT_THAT(will_static_cast_overflow<uint8_t>(254.9999), IsFalse());
+    EXPECT_THAT(will_static_cast_overflow<uint8_t>(255.0000), IsFalse());
+    EXPECT_THAT(will_static_cast_overflow<uint8_t>(255.0001), IsTrue());
 }
 
 TEST(WillStaticCastOverflow, TrueForReallyBigDoubleGoingToFloat) {
-    EXPECT_TRUE(will_static_cast_overflow<float>(1e200));
+    EXPECT_THAT(will_static_cast_overflow<float>(1e200), IsTrue());
 }
 
 TEST(WillStaticCastTruncate, IntToFloatFalseForIntTypeThatCanFitInFloat) {
-    EXPECT_FALSE(will_static_cast_truncate<float>(uint8_t{124}));
-    EXPECT_FALSE(will_static_cast_truncate<double>(124));
+    EXPECT_THAT(will_static_cast_truncate<float>(uint8_t{124}), IsFalse());
+    EXPECT_THAT(will_static_cast_truncate<double>(124), IsFalse());
 
     static_assert(std::numeric_limits<double>::digits >= std::numeric_limits<int32_t>::digits, "");
-    EXPECT_FALSE(will_static_cast_truncate<double>(std::numeric_limits<int32_t>::max()));
-    EXPECT_FALSE(will_static_cast_truncate<double>(std::numeric_limits<int32_t>::max() - 1));
+    EXPECT_THAT(will_static_cast_truncate<double>(std::numeric_limits<int32_t>::max()), IsFalse());
+    EXPECT_THAT(will_static_cast_truncate<double>(std::numeric_limits<int32_t>::max() - 1),
+                IsFalse());
 
     static_assert(std::numeric_limits<double>::digits >= std::numeric_limits<uint32_t>::digits, "");
-    EXPECT_FALSE(will_static_cast_truncate<double>(std::numeric_limits<uint32_t>::max()));
-    EXPECT_FALSE(will_static_cast_truncate<double>(std::numeric_limits<uint32_t>::max() - 1));
+    EXPECT_THAT(will_static_cast_truncate<double>(std::numeric_limits<uint32_t>::max()), IsFalse());
+    EXPECT_THAT(will_static_cast_truncate<double>(std::numeric_limits<uint32_t>::max() - 1),
+                IsFalse());
 }
 
 TEST(WillStaticCastTruncate, IntToFloatFalseByConvention) {
     static_assert(std::numeric_limits<float>::radix == 2, "Test assumes binary");
 
     constexpr auto first_unrepresentable = (1 << std::numeric_limits<float>::digits) + 1;
-    EXPECT_FALSE(will_static_cast_truncate<float>(first_unrepresentable - 2));
-    EXPECT_FALSE(will_static_cast_truncate<float>(first_unrepresentable - 1));
+    EXPECT_THAT(will_static_cast_truncate<float>(first_unrepresentable - 2), IsFalse());
+    EXPECT_THAT(will_static_cast_truncate<float>(first_unrepresentable - 1), IsFalse());
 
     // This is actually non-representable, but we call it "non-truncating" by convention.
-    EXPECT_FALSE(will_static_cast_truncate<float>(first_unrepresentable + 0));
+    EXPECT_THAT(will_static_cast_truncate<float>(first_unrepresentable + 0), IsFalse());
 
-    EXPECT_FALSE(will_static_cast_truncate<float>(first_unrepresentable + 1));
+    EXPECT_THAT(will_static_cast_truncate<float>(first_unrepresentable + 1), IsFalse());
 
     // This is actually non-representable, but we call it "non-truncating" by convention.
-    EXPECT_FALSE(will_static_cast_truncate<float>(first_unrepresentable + 2));
+    EXPECT_THAT(will_static_cast_truncate<float>(first_unrepresentable + 2), IsFalse());
 }
 
 TEST(WillStaticCastTruncate, AutomaticallyFalseForIntegralToIntegral) {
-    EXPECT_FALSE(will_static_cast_truncate<int8_t>(uint8_t{127}));
-    EXPECT_FALSE(will_static_cast_truncate<int8_t>(uint8_t{128}));
-    EXPECT_FALSE(will_static_cast_truncate<int8_t>(128));
-    EXPECT_FALSE(will_static_cast_truncate<int8_t>(uint64_t{9876543210u}));
+    EXPECT_THAT(will_static_cast_truncate<int8_t>(uint8_t{127}), IsFalse());
+    EXPECT_THAT(will_static_cast_truncate<int8_t>(uint8_t{128}), IsFalse());
+    EXPECT_THAT(will_static_cast_truncate<int8_t>(128), IsFalse());
+    EXPECT_THAT(will_static_cast_truncate<int8_t>(uint64_t{9876543210u}), IsFalse());
 }
 
 TEST(WillStaticCastTruncate, TrueForFloatToIntIffInputHasAFractionalPart) {
-    EXPECT_TRUE(will_static_cast_truncate<uint8_t>(-0.1));
-    EXPECT_FALSE(will_static_cast_truncate<uint8_t>(0.0));
-    EXPECT_TRUE(will_static_cast_truncate<uint8_t>(0.1));
+    EXPECT_THAT(will_static_cast_truncate<uint8_t>(-0.1), IsTrue());
+    EXPECT_THAT(will_static_cast_truncate<uint8_t>(0.0), IsFalse());
+    EXPECT_THAT(will_static_cast_truncate<uint8_t>(0.1), IsTrue());
 
-    EXPECT_TRUE(will_static_cast_truncate<uint8_t>(254.9));
-    EXPECT_FALSE(will_static_cast_truncate<uint8_t>(255.0));
-    EXPECT_TRUE(will_static_cast_truncate<uint8_t>(255.1));
+    EXPECT_THAT(will_static_cast_truncate<uint8_t>(254.9), IsTrue());
+    EXPECT_THAT(will_static_cast_truncate<uint8_t>(255.0), IsFalse());
+    EXPECT_THAT(will_static_cast_truncate<uint8_t>(255.1), IsTrue());
 }
 
 TEST(WillStaticCastTruncate, IgnoresLimitsOfDestinationType) {
     // Yes, this would be lossy, but we would chalk it up to "overflow", not "truncation".
-    EXPECT_FALSE(will_static_cast_truncate<uint8_t>(9999999.0));
+    EXPECT_THAT(will_static_cast_truncate<uint8_t>(9999999.0), IsFalse());
 }
 
 }  // namespace detail

--- a/au/code/au/stdx/test/utility_test.cc
+++ b/au/code/au/stdx/test/utility_test.cc
@@ -14,23 +14,28 @@
 
 #include "au/stdx/utility.hh"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
+
+using ::testing::IsFalse;
+using ::testing::IsTrue;
+
 namespace stdx {
 
 TEST(CmpLess, HandlesMixedSignedUnsigned) {
-    EXPECT_TRUE(cmp_less(-1, 1u));
-    EXPECT_FALSE(cmp_less(1u, -1));
-    EXPECT_FALSE(cmp_less(1u, 1));
-    EXPECT_TRUE(cmp_less(1u, 2));
+    EXPECT_THAT(cmp_less(-1, 1u), IsTrue());
+    EXPECT_THAT(cmp_less(1u, -1), IsFalse());
+    EXPECT_THAT(cmp_less(1u, 1), IsFalse());
+    EXPECT_THAT(cmp_less(1u, 2), IsTrue());
 }
 
 TEST(CmpEqual, HandlesMixedSignedUnsigned) {
-    EXPECT_FALSE(cmp_equal(-1, 1u));
-    EXPECT_FALSE(cmp_equal(1u, -1));
-    EXPECT_TRUE(cmp_equal(1u, 1));
-    EXPECT_FALSE(cmp_equal(1u, 2));
+    EXPECT_THAT(cmp_equal(-1, 1u), IsFalse());
+    EXPECT_THAT(cmp_equal(1u, -1), IsFalse());
+    EXPECT_THAT(cmp_equal(1u, 1), IsTrue());
+    EXPECT_THAT(cmp_equal(1u, 2), IsFalse());
 }
 
 }  // namespace stdx

--- a/au/code/au/utility/test/factoring_test.cc
+++ b/au/code/au/utility/test/factoring_test.cc
@@ -17,15 +17,20 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+namespace au {
+
 using ::testing::AnyOf;
 using ::testing::Eq;
 using ::testing::Gt;
+using ::testing::IsFalse;
+using ::testing::IsTrue;
 using ::testing::Le;
 
-namespace au {
 namespace detail {
 namespace {
+
 std::uintmax_t cube(std::uintmax_t n) { return n * n * n; }
+
 }  // namespace
 
 TEST(FirstPrimes, HasOnlyPrimesInOrderAndDoesntSkipAny) {
@@ -33,10 +38,10 @@ TEST(FirstPrimes, HasOnlyPrimesInOrderAndDoesntSkipAny) {
     auto i_prime = 0u;
     for (auto i = 2u; i <= first_primes.back(); ++i) {
         if (i == first_primes[i_prime]) {
-            EXPECT_TRUE(is_prime(i)) << i;
+            EXPECT_THAT(is_prime(i), IsTrue()) << i;
             ++i_prime;
         } else {
-            EXPECT_FALSE(is_prime(i)) << i;
+            EXPECT_THAT(is_prime(i), IsFalse()) << i;
         }
     }
 }
@@ -92,26 +97,26 @@ TEST(FindFactor, CanFactorChallengingCompositeNumbers) {
 }
 
 TEST(IsPrime, FalseForLessThan2) {
-    EXPECT_FALSE(is_prime(0u));
-    EXPECT_FALSE(is_prime(1u));
+    EXPECT_THAT(is_prime(0u), IsFalse());
+    EXPECT_THAT(is_prime(1u), IsFalse());
 }
 
 TEST(IsPrime, FindsPrimes) {
-    EXPECT_TRUE(is_prime(2u));
-    EXPECT_TRUE(is_prime(3u));
-    EXPECT_FALSE(is_prime(4u));
-    EXPECT_TRUE(is_prime(5u));
-    EXPECT_FALSE(is_prime(6u));
-    EXPECT_TRUE(is_prime(7u));
-    EXPECT_FALSE(is_prime(8u));
-    EXPECT_FALSE(is_prime(9u));
-    EXPECT_FALSE(is_prime(10u));
-    EXPECT_TRUE(is_prime(11u));
+    EXPECT_THAT(is_prime(2u), IsTrue());
+    EXPECT_THAT(is_prime(3u), IsTrue());
+    EXPECT_THAT(is_prime(4u), IsFalse());
+    EXPECT_THAT(is_prime(5u), IsTrue());
+    EXPECT_THAT(is_prime(6u), IsFalse());
+    EXPECT_THAT(is_prime(7u), IsTrue());
+    EXPECT_THAT(is_prime(8u), IsFalse());
+    EXPECT_THAT(is_prime(9u), IsFalse());
+    EXPECT_THAT(is_prime(10u), IsFalse());
+    EXPECT_THAT(is_prime(11u), IsTrue());
 
-    EXPECT_FALSE(is_prime(196959u));
-    EXPECT_FALSE(is_prime(196960u));
-    EXPECT_TRUE(is_prime(196961u));
-    EXPECT_FALSE(is_prime(196962u));
+    EXPECT_THAT(is_prime(196959u), IsFalse());
+    EXPECT_THAT(is_prime(196960u), IsFalse());
+    EXPECT_THAT(is_prime(196961u), IsTrue());
+    EXPECT_THAT(is_prime(196962u), IsFalse());
 }
 
 TEST(IsPrime, CanHandleVeryLargePrimes) {
@@ -121,7 +126,7 @@ TEST(IsPrime, CanHandleVeryLargePrimes) {
              uint64_t{9'007'199'254'740'881u},
              uint64_t{18'446'744'073'709'551'557u},
          }) {
-        EXPECT_TRUE(is_prime(p)) << p;
+        EXPECT_THAT(is_prime(p), IsTrue()) << p;
     }
 }
 

--- a/au/code/au/utility/test/probable_primes_test.cc
+++ b/au/code/au/utility/test/probable_primes_test.cc
@@ -21,14 +21,17 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+namespace au {
+
 using ::testing::AllOf;
 using ::testing::ElementsAre;
 using ::testing::Eq;
 using ::testing::Gt;
+using ::testing::IsFalse;
 using ::testing::Lt;
 
-namespace au {
 namespace detail {
+
 // Make test output for `PrimeResult` easier to read.
 std::ostream &operator<<(std::ostream &out, const PrimeResult &m) {
     switch (m) {
@@ -318,7 +321,7 @@ TEST(Gcd, ResultIsAlwaysAFactorAndGCDFindsNoLargerFactor) {
 
             // Brute force: no larger factors.
             for (auto k = g + 1u; k < j / 2u; ++k) {
-                EXPECT_FALSE((i % k == 0u) && (j % k == 0u));
+                EXPECT_THAT((i % k == 0u) && (j % k == 0u), IsFalse());
             }
         }
     }

--- a/au/code/au/utility/test/type_traits_test.cc
+++ b/au/code/au/utility/test/type_traits_test.cc
@@ -14,11 +14,15 @@
 
 #include "au/utility/type_traits.hh"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+namespace au {
+
+using ::testing::IsFalse;
+using ::testing::IsTrue;
 using ::testing::StaticAssertTypeEq;
 
-namespace au {
 namespace detail {
 
 template <typename... Ts>
@@ -30,25 +34,25 @@ TEST(Prepend, PrependsToPack) {
 }
 
 TEST(SameTypeIgnoringCvref, IgnoresCvrefQualifiers) {
-    EXPECT_TRUE((SameTypeIgnoringCvref<int, int &>::value));
-    EXPECT_TRUE((SameTypeIgnoringCvref<const int &&, volatile int>::value));
+    EXPECT_THAT((SameTypeIgnoringCvref<int, int &>::value), IsTrue());
+    EXPECT_THAT((SameTypeIgnoringCvref<const int &&, volatile int>::value), IsTrue());
 }
 
 TEST(SameTypeIgnoringCvref, FalseForDifferentBases) {
-    EXPECT_FALSE((SameTypeIgnoringCvref<int, char>::value));
-    EXPECT_FALSE((SameTypeIgnoringCvref<const double &, const float &>::value));
+    EXPECT_THAT((SameTypeIgnoringCvref<int, char>::value), IsFalse());
+    EXPECT_THAT((SameTypeIgnoringCvref<const double &, const float &>::value), IsFalse());
 }
 
 TEST(SameTypeIgnoringCvref, CanTakeInstances) {
-    EXPECT_TRUE(same_type_ignoring_cvref(1, 2));
-    EXPECT_FALSE(same_type_ignoring_cvref(1.0, 2.0f));
+    EXPECT_THAT(same_type_ignoring_cvref(1, 2), IsTrue());
+    EXPECT_THAT(same_type_ignoring_cvref(1.0, 2.0f), IsFalse());
 }
 
 TEST(AlwaysFalse, IsAlwaysFalse) {
-    EXPECT_FALSE(AlwaysFalse<int>::value);
-    EXPECT_FALSE(AlwaysFalse<void>::value);
-    EXPECT_FALSE(AlwaysFalse<>::value);
-    EXPECT_FALSE((AlwaysFalse<int, char, double>::value));
+    EXPECT_THAT(AlwaysFalse<int>::value, IsFalse());
+    EXPECT_THAT(AlwaysFalse<void>::value, IsFalse());
+    EXPECT_THAT(AlwaysFalse<>::value, IsFalse());
+    EXPECT_THAT((AlwaysFalse<int, char, double>::value), IsFalse());
 }
 
 TEST(DropAll, IdentityWhenTargetAbsent) {

--- a/au/code/au/zero_test.cc
+++ b/au/code/au/zero_test.cc
@@ -14,11 +14,16 @@
 
 #include "au/zero.hh"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using namespace std::chrono_literals;
 
 namespace au {
+
+using ::testing::IsFalse;
+using ::testing::IsTrue;
+
 // Example for supporting implicit construction from Zero.
 class WrappedInt {
  public:
@@ -34,17 +39,17 @@ class WrappedInt {
 };
 
 TEST(WrappedInt, BasicInterfaceWorksAsExpected) {
-    EXPECT_TRUE(WrappedInt{1} > WrappedInt{0});
-    EXPECT_FALSE(WrappedInt{0} > WrappedInt{1});
-    EXPECT_FALSE(WrappedInt{1} > WrappedInt{1});
+    EXPECT_THAT(WrappedInt{1} > WrappedInt{0}, IsTrue());
+    EXPECT_THAT(WrappedInt{0} > WrappedInt{1}, IsFalse());
+    EXPECT_THAT(WrappedInt{1} > WrappedInt{1}, IsFalse());
 
-    EXPECT_TRUE(WrappedInt{1} < WrappedInt{2});
-    EXPECT_FALSE(WrappedInt{2} < WrappedInt{1});
-    EXPECT_FALSE(WrappedInt{2} < WrappedInt{2});
+    EXPECT_THAT(WrappedInt{1} < WrappedInt{2}, IsTrue());
+    EXPECT_THAT(WrappedInt{2} < WrappedInt{1}, IsFalse());
+    EXPECT_THAT(WrappedInt{2} < WrappedInt{2}, IsFalse());
 
-    EXPECT_TRUE(WrappedInt{1} == WrappedInt{1});
-    EXPECT_FALSE(WrappedInt{2} == WrappedInt{1});
-    EXPECT_FALSE(WrappedInt{1} == WrappedInt{2});
+    EXPECT_THAT(WrappedInt{1} == WrappedInt{1}, IsTrue());
+    EXPECT_THAT(WrappedInt{2} == WrappedInt{1}, IsFalse());
+    EXPECT_THAT(WrappedInt{1} == WrappedInt{2}, IsFalse());
 }
 
 TEST(Zero, MinusZeroIsZero) {
@@ -68,13 +73,13 @@ TEST(Zero, ComparableToArbitraryQuantities) {
 }
 
 TEST(Zero, ComparesEqualToZero) {
-    EXPECT_TRUE(ZERO == ZERO);
-    EXPECT_TRUE(ZERO >= ZERO);
-    EXPECT_TRUE(ZERO <= ZERO);
+    EXPECT_THAT(ZERO == ZERO, IsTrue());
+    EXPECT_THAT(ZERO >= ZERO, IsTrue());
+    EXPECT_THAT(ZERO <= ZERO, IsTrue());
 
-    EXPECT_FALSE(ZERO != ZERO);
-    EXPECT_FALSE(ZERO > ZERO);
-    EXPECT_FALSE(ZERO < ZERO);
+    EXPECT_THAT(ZERO != ZERO, IsFalse());
+    EXPECT_THAT(ZERO > ZERO, IsFalse());
+    EXPECT_THAT(ZERO < ZERO, IsFalse());
 }
 
 TEST(Zero, ImplicitlyConvertsToNumericTypes) {


### PR DESCRIPTION
This converts exiting the existing boolean assertion checkers

- `ASSERT_TRUE`
- `ASSERT_FALSE`
- `EXPECT_TRUE`
- `EXPECT_FALSE`

to the appropriate matcher.  

This also puts any `using` declarations within the namespace scope.

Partial implementation for #404.
