### PR TITLE
Convert unconditional `EXPECT_*` to `ADD_FAILURE`

### DIFF
--- a/au/code/au/magnitude_test.cc
+++ b/au/code/au/magnitude_test.cc
@@ -119,7 +119,7 @@ TEST(Pi, HasCorrectValue) {
 #ifdef M_PIl
     EXPECT_EQ(Pi::value(), M_PIl);
 #else
-    EXPECT_TRUE(false) << "M_PIl not available on this architecture";
+    ADD_FAILURE() << "M_PIl not available on this architecture";
 #endif
 }
 
@@ -279,7 +279,7 @@ TEST(GetValue, PiToThePower1HasCorrectValues) {
 #ifdef M_PIl
     EXPECT_THAT(get_value<long double>(PI), SameTypeAndValue(M_PIl));
 #else
-    EXPECT_TRUE(false) << "M_PIl not available on this architecture";
+    ADD_FAILURE() << "M_PIl not available on this architecture";
 #endif
 }
 


### PR DESCRIPTION
`ADD_FAILURE` is a specific way ta indicate a failure without stopping current test.

Tested by pulling an `ADD_FAILURE` out of the `#ifdef`:

```gtest
[ RUN      ] GetValue.SupportsNegativePowersOfIntegerBase
[       OK ] GetValue.SupportsNegativePowersOfIntegerBase (0 ms)
[ RUN      ] GetValue.PiToThePower1HasCorrectValues
au/code/au/magnitude_test.cc:283: Failure
Failed
M_PIl not available on this architecture
[  FAILED  ] GetValue.PiToThePower1HasCorrectValues (0 ms)
[ RUN      ] GetValue.PiToArbitraryPowerPerformsComputationsInMostAccurateTypeAtCompileTime
[       OK ] GetValue.PiToArbitraryPowerPerformsComputationsInMostAccurateTypeAtCompileTime (0 ms)
```

Partial implementation for aurora-opensource/au#404.