### PR TITLE
Update units test cases with EXPECT_EQ to matcher syntax

### DIFF
--- a/au/code/au/units/test/bars_test.cc
+++ b/au/code/au/units/test/bars_test.cc
@@ -16,13 +16,16 @@
 
 #include "au/testing.hh"
 #include "au/units/pascals.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Bars, HasExpectedLabel) { expect_label<Bars>("bar"); }
 
-TEST(Bars, HasCorrectRelationshipWithPascals) { EXPECT_EQ(bars(1), kilo(pascals)(100)); }
+TEST(Bars, HasCorrectRelationshipWithPascals) { EXPECT_THAT(bars(1), Eq(kilo(pascals)(100))); }
 
 TEST(Bars, HasExpectedSymbol) {
     using symbols::bar;

--- a/au/code/au/units/test/bits_test.cc
+++ b/au/code/au/units/test/bits_test.cc
@@ -16,13 +16,16 @@
 
 #include "au/testing.hh"
 #include "au/units/bytes.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Bits, HasExpectedLabel) { expect_label<Bits>("b"); }
 
-TEST(Bits, OneEighthOfAByte) { EXPECT_EQ(bits(1.0), bytes(1.0 / 8.0)); }
+TEST(Bits, OneEighthOfAByte) { EXPECT_THAT(bits(1.0), Eq(bytes(1.0 / 8.0))); }
 
 TEST(Bits, HasExpectedSymbol) {
     using symbols::b;

--- a/au/code/au/units/test/bytes_test.cc
+++ b/au/code/au/units/test/bytes_test.cc
@@ -16,13 +16,16 @@
 
 #include "au/testing.hh"
 #include "au/units/bits.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Bytes, HasExpectedLabel) { expect_label<Bytes>("B"); }
 
-TEST(Bytes, EquivalentTo8Bits) { EXPECT_EQ(bytes(1), bits(8)); }
+TEST(Bytes, EquivalentTo8Bits) { EXPECT_THAT(bytes(1), Eq(bits(8))); }
 
 TEST(Bytes, HasExpectedSymbol) {
     using symbols::B;

--- a/au/code/au/units/test/celsius_test.cc
+++ b/au/code/au/units/test/celsius_test.cc
@@ -18,9 +18,12 @@
 #include "au/testing.hh"
 #include "au/units/fahrenheit.hh"
 #include "au/units/kelvins.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
+
+using ::testing::Eq;
 
 TEST(Celsius, HasExpectedLabel) { expect_label<Celsius>("degC"); }
 
@@ -29,12 +32,12 @@ TEST(Celsius, QuantityEquivalentToKelvins) {
 }
 
 TEST(Celsius, QuantityPointHasCorrectOffsetFromKelvins) {
-    EXPECT_EQ(milli(kelvins_pt)(273'150).as(milli(celsius_pt)), milli(celsius_pt)(0));
+    EXPECT_THAT(milli(kelvins_pt)(273'150).as(milli(celsius_pt)), Eq(milli(celsius_pt)(0)));
 }
 
 TEST(Celsius, QuantityPointMatchesUpCorrectlyWithFahrenheit) {
-    EXPECT_EQ(celsius_pt(0), fahrenheit_pt(32));
-    EXPECT_EQ(celsius_pt(100), fahrenheit_pt(212));
+    EXPECT_THAT(celsius_pt(0), Eq(fahrenheit_pt(32)));
+    EXPECT_THAT(celsius_pt(100), Eq(fahrenheit_pt(212)));
 }
 
 TEST(Celsius, HasExpectedSymbol) {

--- a/au/code/au/units/test/days_test.cc
+++ b/au/code/au/units/test/days_test.cc
@@ -15,13 +15,16 @@
 #include "au/units/days.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Days, HasExpectedLabel) { expect_label<Days>("d"); }
 
-TEST(Days, EquivalentTo24Hours) { EXPECT_EQ(days(1), hours(24)); }
+TEST(Days, EquivalentTo24Hours) { EXPECT_THAT(days(1), Eq(hours(24))); }
 
 TEST(Days, HasExpectedSymbol) {
     using symbols::d;

--- a/au/code/au/units/test/degrees_test.cc
+++ b/au/code/au/units/test/degrees_test.cc
@@ -16,9 +16,12 @@
 
 #include "au/testing.hh"
 #include "au/units/revolutions.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
+
+using ::testing::Eq;
 
 TEST(Degrees, HasExpectedLabel) { expect_label<Degrees>("deg"); }
 
@@ -26,7 +29,7 @@ TEST(Degrees, RoughlyEquivalentToPiOver180Radians) {
     EXPECT_DOUBLE_EQ(degrees(1.0).in(radians), get_value<double>(Magnitude<Pi>{} / mag<180>()));
 }
 
-TEST(Degrees, One360thOfARevolution) { EXPECT_EQ(degrees(360), revolutions(1)); }
+TEST(Degrees, One360thOfARevolution) { EXPECT_THAT(degrees(360), Eq(revolutions(1))); }
 
 TEST(Degrees, HasExpectedSymbol) {
     using symbols::deg;

--- a/au/code/au/units/test/fahrenheit_test.cc
+++ b/au/code/au/units/test/fahrenheit_test.cc
@@ -16,14 +16,17 @@
 
 #include "au/testing.hh"
 #include "au/units/celsius.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Fahrenheit, HasExpectedLabel) { expect_label<Fahrenheit>("degF"); }
 
 TEST(Fahrenheit, HasCorrectQuantityRelationshipWithCelsius) {
-    EXPECT_EQ(fahrenheit_qty(9), celsius_qty(5));
+    EXPECT_THAT(fahrenheit_qty(9), Eq(celsius_qty(5)));
 }
 
 TEST(Fahrenheit, HasCorrectRelationshipsWithCelsius) {

--- a/au/code/au/units/test/fathoms_test.cc
+++ b/au/code/au/units/test/fathoms_test.cc
@@ -16,13 +16,16 @@
 
 #include "au/testing.hh"
 #include "au/units/feet.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Fathoms, HasExpectedLabel) { expect_label<Fathoms>("ftm"); }
 
-TEST(Fathoms, EquivalentTo6Feet) { EXPECT_EQ(fathoms(1), feet(6)); }
+TEST(Fathoms, EquivalentTo6Feet) { EXPECT_THAT(fathoms(1), Eq(feet(6))); }
 
 TEST(Fathoms, HasExpectedSymbol) {
     using symbols::ftm;

--- a/au/code/au/units/test/feet_test.cc
+++ b/au/code/au/units/test/feet_test.cc
@@ -15,13 +15,16 @@
 #include "au/units/feet.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Feet, HasExpectedLabel) { expect_label<Feet>("ft"); }
 
-TEST(Feet, EquivalentTo12Inches) { EXPECT_EQ(feet(1), inches(12)); }
+TEST(Feet, EquivalentTo12Inches) { EXPECT_THAT(feet(1), Eq(inches(12))); }
 
 TEST(Feet, HasExpectedSymbol) {
     using symbols::ft;

--- a/au/code/au/units/test/furlongs_test.cc
+++ b/au/code/au/units/test/furlongs_test.cc
@@ -16,13 +16,16 @@
 
 #include "au/testing.hh"
 #include "au/units/miles.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Furlongs, HasExpectedLabel) { expect_label<Furlongs>("fur"); }
 
-TEST(Furlongs, EquivalentToOneEighthMile) { EXPECT_EQ(furlongs(8), miles(1)); }
+TEST(Furlongs, EquivalentToOneEighthMile) { EXPECT_THAT(furlongs(8), Eq(miles(1))); }
 
 TEST(Furlongs, HasExpectedSymbol) {
     using symbols::fur;

--- a/au/code/au/units/test/grams_test.cc
+++ b/au/code/au/units/test/grams_test.cc
@@ -16,14 +16,17 @@
 
 #include "au/testing.hh"
 #include "au/units/pounds_mass.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Grams, HasExpectedLabel) { expect_label<Grams>("g"); }
 
 TEST(Grams, HasCorrectRelationshipWithPoundsMass) {
-    EXPECT_EQ(micro(grams)(453'592'370L), pounds_mass(1L));
+    EXPECT_THAT(micro(grams)(453'592'370L), Eq(pounds_mass(1L)));
 }
 
 TEST(Grams, HasExpectedSymbol) {

--- a/au/code/au/units/test/hours_test.cc
+++ b/au/code/au/units/test/hours_test.cc
@@ -15,13 +15,16 @@
 #include "au/units/hours.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Hours, HasExpectedLabel) { expect_label<Hours>("h"); }
 
-TEST(Hours, EquivalentTo60Minutes) { EXPECT_EQ(hours(3), minutes(180)); }
+TEST(Hours, EquivalentTo60Minutes) { EXPECT_THAT(hours(3), Eq(minutes(180))); }
 
 TEST(Hours, HasExpectedSymbol) {
     using symbols::h;

--- a/au/code/au/units/test/inches_test.cc
+++ b/au/code/au/units/test/inches_test.cc
@@ -15,13 +15,16 @@
 #include "au/units/inches.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Inches, HasExpectedLabel) { expect_label<Inches>("in"); }
 
-TEST(Inches, EquivalentTo2Point54CentiMeters) { EXPECT_EQ(centi(meters)(254), inches(100)); }
+TEST(Inches, EquivalentTo2Point54CentiMeters) { EXPECT_THAT(centi(meters)(254), Eq(inches(100))); }
 
 TEST(Inches, HasExpectedSymbol) {
     using symbols::in;

--- a/au/code/au/units/test/joules_test.cc
+++ b/au/code/au/units/test/joules_test.cc
@@ -17,13 +17,16 @@
 #include "au/testing.hh"
 #include "au/units/meters.hh"
 #include "au/units/newtons.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Joules, HasExpectedLabel) { expect_label<Joules>("J"); }
 
-TEST(Joules, EquivalentToNewtonMeters) { EXPECT_EQ(joules(18), (newton * meters)(18)); }
+TEST(Joules, EquivalentToNewtonMeters) { EXPECT_THAT(joules(18), Eq((newton * meters)(18))); }
 
 TEST(Joules, HasExpectedSymbol) {
     using symbols::J;

--- a/au/code/au/units/test/knots_test.cc
+++ b/au/code/au/units/test/knots_test.cc
@@ -18,13 +18,18 @@
 #include "au/units/hours.hh"
 #include "au/units/knots.hh"
 #include "au/units/meters.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Knots, HasExpectedLabel) { expect_label<Knots>("kn"); }
 
-TEST(Knots, EquivalentToNauticalMilesPerHour) { EXPECT_EQ(knots(1), (nautical_miles / hour)(1)); }
+TEST(Knots, EquivalentToNauticalMilesPerHour) {
+    EXPECT_THAT(knots(1), Eq((nautical_miles / hour)(1)));
+}
 
 TEST(Knots, HasExpectedSymbol) {
     using symbols::kn;

--- a/au/code/au/units/test/liters_test.cc
+++ b/au/code/au/units/test/liters_test.cc
@@ -15,17 +15,20 @@
 #include "au/units/liters.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Liters, HasExpectedLabel) { expect_label<Liters>("L"); }
 
 TEST(Liters, HasExpectedRelationshipsWithLinearUnits) {
-    EXPECT_EQ(liters(1), cubed(deci(meters))(1));
+    EXPECT_THAT(liters(1), Eq(cubed(deci(meters))(1)));
 
     // 1 mL == 1 c.c.
-    EXPECT_EQ(milli(liters)(1), cubed(centi(meters))(1));
+    EXPECT_THAT(milli(liters)(1), Eq(cubed(centi(meters))(1)));
 }
 
 TEST(Liters, HasExpectedSymbol) {

--- a/au/code/au/units/test/meters_test.cc
+++ b/au/code/au/units/test/meters_test.cc
@@ -17,13 +17,18 @@
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/inches.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Meters, HasExpectedLabel) { expect_label<Meters>("m"); }
 
-TEST(Meters, HasExpectedRelationshipsWithInches) { EXPECT_EQ(centi(meters)(254), inches(100)); }
+TEST(Meters, HasExpectedRelationshipsWithInches) {
+    EXPECT_THAT(centi(meters)(254), Eq(inches(100)));
+}
 
 TEST(Meters, HasExpectedSymbol) {
     using symbols::m;

--- a/au/code/au/units/test/miles_test.cc
+++ b/au/code/au/units/test/miles_test.cc
@@ -15,13 +15,16 @@
 #include "au/units/miles.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Miles, HasExpectedLabel) { expect_label<Miles>("mi"); }
 
-TEST(Miles, EquivalentTo5280Feet) { EXPECT_EQ(miles(1), feet(5280)); }
+TEST(Miles, EquivalentTo5280Feet) { EXPECT_THAT(miles(1), Eq(feet(5280))); }
 
 TEST(Miles, HasExpectedSymbol) {
     using symbols::mi;

--- a/au/code/au/units/test/minutes_test.cc
+++ b/au/code/au/units/test/minutes_test.cc
@@ -15,13 +15,16 @@
 #include "au/units/minutes.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Minutes, HasExpectedLabel) { expect_label<Minutes>("min"); }
 
-TEST(Minutes, EquivalentTo60Seconds) { EXPECT_EQ(minutes(3), seconds(180)); }
+TEST(Minutes, EquivalentTo60Seconds) { EXPECT_THAT(minutes(3), Eq(seconds(180))); }
 
 TEST(Minutes, HasExpectedSymbol) {
     using symbols::min;

--- a/au/code/au/units/test/nautical_miles_test.cc
+++ b/au/code/au/units/test/nautical_miles_test.cc
@@ -18,15 +18,20 @@
 #include "au/units/hours.hh"
 #include "au/units/knots.hh"
 #include "au/units/meters.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(NauticalMiles, HasExpectedLabel) { expect_label<NauticalMiles>("nmi"); }
 
-TEST(NauticalMiles, EquivalentTo1852Meters) { EXPECT_EQ(nautical_miles(1), meters(1'852)); }
+TEST(NauticalMiles, EquivalentTo1852Meters) { EXPECT_THAT(nautical_miles(1), Eq(meters(1'852))); }
 
-TEST(NauticalMiles, EquivalentToKnotHours) { EXPECT_EQ(nautical_miles(1), (knot * hours)(1)); }
+TEST(NauticalMiles, EquivalentToKnotHours) {
+    EXPECT_THAT(nautical_miles(1), Eq((knot * hours)(1)));
+}
 
 TEST(NauticalMiles, HasExpectedSymbol) {
     using symbols::nmi;

--- a/au/code/au/units/test/ohms_test.cc
+++ b/au/code/au/units/test/ohms_test.cc
@@ -18,9 +18,12 @@
 #include "au/units/ohms.hh"
 #include "au/units/volts.hh"
 #include "au/units/watts.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
+
+using ::testing::Eq;
 
 TEST(Ohms, HasExpectedLabel) { expect_label<Ohms>("ohm"); }
 
@@ -30,10 +33,10 @@ TEST(Ohms, SatisfiesOhmsLaw) {
 
 TEST(Ohms, SatisfiesOhmicHeatingEquation) {
     // P = I^2 R   -->  R = P / I^2
-    EXPECT_EQ(ohms(10.0), watts(250.0) / (amperes(5.0) * amperes(5.0)));
+    EXPECT_THAT(ohms(10.0), Eq(watts(250.0) / (amperes(5.0) * amperes(5.0))));
 
     // P = V^2 / R -->  R = V^2 / P
-    EXPECT_EQ(ohms(10.0), (volts(50.0) * volts(50.0)) / watts(250.0));
+    EXPECT_THAT(ohms(10.0), Eq((volts(50.0) * volts(50.0)) / watts(250.0)));
 }
 
 TEST(Ohms, HasExpectedSymbol) {

--- a/au/code/au/units/test/percent_test.cc
+++ b/au/code/au/units/test/percent_test.cc
@@ -17,13 +17,16 @@
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/unos.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Percent, HasExpectedLabel) { expect_label<Percent>("%"); }
 
-TEST(Percent, OneHundredthOfUnos) { EXPECT_EQ(percent(75.0), unos(0.75)); }
+TEST(Percent, OneHundredthOfUnos) { EXPECT_THAT(percent(75.0), Eq(unos(0.75))); }
 
 TEST(Percent, HasExpectedSymbol) {
     using symbols::pct;

--- a/au/code/au/units/test/pounds_mass_test.cc
+++ b/au/code/au/units/test/pounds_mass_test.cc
@@ -15,14 +15,17 @@
 #include "au/units/pounds_mass.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(PoundsMass, HasExpectedLabel) { expect_label<PoundsMass>("lb"); }
 
 TEST(PoundsMass, EquivalentToAppropriateQuantityOfKilograms) {
-    EXPECT_EQ(pounds_mass(100'000'000L), (kilo(grams)(45'359'237L)));
+    EXPECT_THAT(pounds_mass(100'000'000L), Eq(kilo(grams)(45'359'237L)));
 }
 
 TEST(PoundsMass, HasExpectedSymbol) {

--- a/au/code/au/units/test/revolutions_test.cc
+++ b/au/code/au/units/test/revolutions_test.cc
@@ -15,13 +15,16 @@
 #include "au/units/revolutions.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Revolutions, HasExpectedLabel) { expect_label<Revolutions>("rev"); }
 
-TEST(Revolutions, ExactlyEquivalentTo360Degrees) { EXPECT_EQ(revolutions(1), degrees(360)); }
+TEST(Revolutions, ExactlyEquivalentTo360Degrees) { EXPECT_THAT(revolutions(1), Eq(degrees(360))); }
 
 TEST(Revolutions, HasExpectedSymbol) {
     using symbols::rev;

--- a/au/code/au/units/test/seconds_test.cc
+++ b/au/code/au/units/test/seconds_test.cc
@@ -16,13 +16,16 @@
 
 #include "au/testing.hh"
 #include "au/units/minutes.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Seconds, HasExpectedLabel) { expect_label<Seconds>("s"); }
 
-TEST(Seconds, SixtyPerMinute) { EXPECT_EQ(seconds(60), minutes(1)); }
+TEST(Seconds, SixtyPerMinute) { EXPECT_THAT(seconds(60), Eq(minutes(1))); }
 
 TEST(Seconds, HasExpectedSymbol) {
     using symbols::s;

--- a/au/code/au/units/test/slugs_test.cc
+++ b/au/code/au/units/test/slugs_test.cc
@@ -18,9 +18,12 @@
 #include "au/testing.hh"
 #include "au/units/grams.hh"
 #include "au/units/pounds_mass.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
+
+using ::testing::Eq;
 
 TEST(Slugs, HasExpectedLabel) { expect_label<Slugs>("slug"); }
 
@@ -28,7 +31,7 @@ TEST(Slugs, ExactDefinitionIsCorrect) {
     // The automatic conversions to the common unit here will cause overflow.  However, _unsigned_
     // integer overflow is well defined.  And if these values both overflow to the same number, it
     // adds confidence that the definition is correct.
-    EXPECT_EQ(slugs(609'600'000'000ULL), kilo(grams)(8'896'443'230'521ULL));
+    EXPECT_THAT(slugs(609'600'000'000ULL), Eq(kilo(grams)(8'896'443'230'521ULL)));
 
     // These test cases check for _approximate_ correctness of the definition, within some
     // tolerance.  They complement the overflowing-integer test case just above.

--- a/au/code/au/units/test/standard_gravity_test.cc
+++ b/au/code/au/units/test/standard_gravity_test.cc
@@ -18,14 +18,17 @@
 #include "au/testing.hh"
 #include "au/units/meters.hh"
 #include "au/units/seconds.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(StandardGravity, HasExpectedLabel) { expect_label<StandardGravity>("g_0"); }
 
 TEST(StandardGravity, HasExpectedValue) {
-    EXPECT_EQ(standard_gravity(1L), (micro(meters) / squared(second))(9'806'650L));
+    EXPECT_THAT(standard_gravity(1L), Eq((micro(meters) / squared(second))(9'806'650L)));
 }
 
 TEST(StandardGravity, HasExpectedSymbol) {

--- a/au/code/au/units/test/unos_test.cc
+++ b/au/code/au/units/test/unos_test.cc
@@ -16,13 +16,16 @@
 
 #include "au/testing.hh"
 #include "au/units/percent.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Unos, HasExpectedLabel) { expect_label<Unos>("U"); }
 
-TEST(Unos, OneHundredPercent) { EXPECT_EQ(unos(2), percent(200)); }
+TEST(Unos, OneHundredPercent) { EXPECT_THAT(unos(2), Eq(percent(200))); }
 
 TEST(Unos, ImplicitlyConvertToRawNumbers) {
     constexpr double x = unos(1.23);

--- a/au/code/au/units/test/us_gallons_test.cc
+++ b/au/code/au/units/test/us_gallons_test.cc
@@ -17,13 +17,16 @@
 #include "au/testing.hh"
 #include "au/units/inches.hh"
 #include "au/units/liters.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(USGallons, HasExpectedLabel) { expect_label<USGallons>("US_gal"); }
 
-TEST(USGallons, EquivalentTo231CubicInches) { EXPECT_EQ(us_gallons(1), cubed(inches)(231)); }
+TEST(USGallons, EquivalentTo231CubicInches) { EXPECT_THAT(us_gallons(1), Eq(cubed(inches)(231))); }
 
 TEST(USGallons, WithinExpectationComparedToLiters) {
     EXPECT_THAT(us_gallons(1), IsNear(liters(3.785), milli(liters)(1)));

--- a/au/code/au/units/test/us_pints_test.cc
+++ b/au/code/au/units/test/us_pints_test.cc
@@ -16,13 +16,16 @@
 
 #include "au/testing.hh"
 #include "au/units/us_gallons.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(USPints, HasExpectedLabel) { expect_label<USPints>("US_pt"); }
 
-TEST(USPints, EightInAGallon) { EXPECT_EQ(us_pints(8), us_gallons(1)); }
+TEST(USPints, EightInAGallon) { EXPECT_THAT(us_pints(8), Eq(us_gallons(1))); }
 
 TEST(USPints, HasExpectedSymbol) {
     using symbols::US_pt;

--- a/au/code/au/units/test/us_quarts_test.cc
+++ b/au/code/au/units/test/us_quarts_test.cc
@@ -16,13 +16,16 @@
 
 #include "au/testing.hh"
 #include "au/units/us_gallons.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(USQuarts, HasExpectedLabel) { expect_label<USQuarts>("US_qt"); }
 
-TEST(USQuarts, FourInAGallon) { EXPECT_EQ(us_quarts(4), us_gallons(1)); }
+TEST(USQuarts, FourInAGallon) { EXPECT_THAT(us_quarts(4), Eq(us_gallons(1))); }
 
 TEST(USQuarts, HasExpectedSymbol) {
     using symbols::US_qt;

--- a/au/code/au/units/test/yards_test.cc
+++ b/au/code/au/units/test/yards_test.cc
@@ -15,13 +15,16 @@
 #include "au/units/yards.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::Eq;
+
 TEST(Yards, HasExpectedLabel) { expect_label<Yards>("yd"); }
 
-TEST(Yards, EquivalentTo3Feet) { EXPECT_EQ(yards(1), feet(3)); }
+TEST(Yards, EquivalentTo3Feet) { EXPECT_THAT(yards(1), Eq(feet(3))); }
 
 TEST(Yards, HasExpectedSymbol) {
     using symbols::yd;


### PR DESCRIPTION
This addresses all existing test cases in the units portion of the library.
All `EXPECT_EQ` assertion checks are updated to the appropriate matcher.

Partial implementation for #404.
