### PR TITLE
Convert existing EQ assertion checks to matchers

### DIFF
--- a/au/code/au/au_test.cc
+++ b/au/code/au/au_test.cc
@@ -30,16 +30,21 @@
 #include "au/units/miles.hh"
 #include "au/units/steradians.hh"
 #include "au/units/yards.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+namespace au {
+
+using ::testing::Eq;
 using ::testing::StaticAssertTypeEq;
 
-namespace au {
 namespace {
+
 template <typename T, typename U>
 auto IsBetween(T lower, U upper) {
     return ::testing::AllOf(::testing::Ge(lower), ::testing::Le(upper));
 }
+
 }  // namespace
 
 TEST(Conversions, SupportIntMHzToU32Hz) {
@@ -92,7 +97,7 @@ TEST(Xkcd, RoundAsReproducesXkcd2585) {
                                                   miles / hour);
 
     // Authoritative reference: https://xkcd.com/2585/
-    EXPECT_EQ((miles / hour)(45), rounded_speed);
+    EXPECT_THAT((miles / hour)(45), Eq(rounded_speed));
 }
 
 TEST(Xkcd, Xkcd3038GivesReasonableSpeedLimit) {

--- a/au/code/au/constants/test/reduced_planck_constant_test.cc
+++ b/au/code/au/constants/test/reduced_planck_constant_test.cc
@@ -18,6 +18,7 @@
 #include "au/testing.hh"
 #include "au/units/joules.hh"
 #include "au/units/seconds.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -25,6 +26,7 @@ namespace {
 
 using symbols::J;
 using symbols::s;
+using ::testing::Eq;
 using ::testing::StrEq;
 
 TEST(ReducedPlanckConstant, HasExpectedValue) {
@@ -44,7 +46,7 @@ TEST(ReducedPlanckConstant, ExactlyPlanckConstantDividedByTwoPi) {
     // `int` as a rep, and we know that the comparison to `1` would not compile unless all
     // dimensions had cancelled out.
     constexpr int result = ratio.as<int>();
-    EXPECT_EQ(result, 1);
+    EXPECT_THAT(result, Eq(1));
 }
 
 TEST(ReducedPlanckConstant, HasExpectedLabel) {

--- a/au/code/au/magnitude_test.cc
+++ b/au/code/au/magnitude_test.cc
@@ -41,30 +41,30 @@ constexpr T cubed(T x) {
 
 TEST(Magnitude, SupportsEqualityComparison) {
     constexpr auto mag_1 = mag<1>();
-    EXPECT_EQ(mag_1, mag_1);
+    EXPECT_THAT(mag_1, Eq(mag_1));
 
     constexpr auto mag_2 = mag<2>();
-    EXPECT_EQ(mag_2, mag_2);
+    EXPECT_THAT(mag_2, Eq(mag_2));
 
     EXPECT_NE(mag_1, mag_2);
 }
 
 TEST(Magnitude, ProductBehavesCorrectly) {
-    EXPECT_EQ(mag<4>() * mag<6>(), mag<24>());
-    EXPECT_EQ(mag<142857>() * mag<7>(), mag<999999>());
+    EXPECT_THAT(mag<4>() * mag<6>(), Eq(mag<24>()));
+    EXPECT_THAT(mag<142857>() * mag<7>(), Eq(mag<999999>()));
 }
 
 TEST(Magnitude, QuotientBehavesCorrectly) {
-    EXPECT_EQ(mag<999999>() / mag<142857>(), mag<7>());
-    EXPECT_EQ(mag<10>() / mag<6>(), mag<5>() / mag<3>());
+    EXPECT_THAT(mag<999999>() / mag<142857>(), Eq(mag<7>()));
+    EXPECT_THAT(mag<10>() / mag<6>(), Eq(mag<5>() / mag<3>()));
 }
 
 TEST(Magnitude, PowersBehaveCorrectly) {
-    EXPECT_EQ(pow<3>(mag<2>()), mag<8>());
-    EXPECT_EQ(pow<-2>(mag<5>()), mag<1>() / mag<25>());
+    EXPECT_THAT(pow<3>(mag<2>()), Eq(mag<8>()));
+    EXPECT_THAT(pow<-2>(mag<5>()), Eq(mag<1>() / mag<25>()));
 }
 
-TEST(Magnitude, RootsBehaveCorrectly) { EXPECT_EQ(root<3>(mag<8>()), mag<2>()); }
+TEST(Magnitude, RootsBehaveCorrectly) { EXPECT_THAT(root<3>(mag<8>()), Eq(mag<2>())); }
 
 TEST(Magnitude, CanNegate) {
     EXPECT_THAT(-mag<5>(), Eq(MagProductT<Magnitude<Negative>, decltype(mag<5>())>{}));
@@ -122,34 +122,34 @@ TEST(Pi, HasCorrectValue) {
     // It does, however, permit us to _build_ on such an architecture with no problem.
 
 #ifdef M_PIl
-    EXPECT_EQ(Pi::value(), M_PIl);
+    EXPECT_THAT(Pi::value(), Eq(M_PIl));
 #else
     ADD_FAILURE() << "M_PIl not available on this architecture";
 #endif
 }
 
 TEST(Inverse, RaisesToPowerNegativeOne) {
-    EXPECT_EQ(inverse(mag<8>()), mag<1>() / mag<8>());
-    EXPECT_EQ(inverse(-mag<2>()), -mag<1>() / mag<2>());
+    EXPECT_THAT(inverse(mag<8>()), Eq(mag<1>() / mag<8>()));
+    EXPECT_THAT(inverse(-mag<2>()), Eq(-mag<1>() / mag<2>()));
 }
 
-TEST(Squared, RaisesToPowerTwo) { EXPECT_EQ(squared(mag<7>()), mag<49>()); }
+TEST(Squared, RaisesToPowerTwo) { EXPECT_THAT(squared(mag<7>()), Eq(mag<49>())); }
 
-TEST(Cubed, RaisesToPowerThree) { EXPECT_EQ(cubed(mag<5>()), mag<125>()); }
+TEST(Cubed, RaisesToPowerThree) { EXPECT_THAT(cubed(mag<5>()), Eq(mag<125>())); }
 
-TEST(Sqrt, TakesSecondRoot) { EXPECT_EQ(sqrt(mag<81>()), mag<9>()); }
+TEST(Sqrt, TakesSecondRoot) { EXPECT_THAT(sqrt(mag<81>()), Eq(mag<9>())); }
 
-TEST(Cbrt, TakesThirdRoot) { EXPECT_EQ(cbrt(mag<27>()), mag<3>()); }
+TEST(Cbrt, TakesThirdRoot) { EXPECT_THAT(cbrt(mag<27>()), Eq(mag<3>())); }
 
 TEST(IntegerPart, IdentityForIntegers) {
-    EXPECT_EQ(integer_part(mag<1>()), mag<1>());
-    EXPECT_EQ(integer_part(mag<2>()), mag<2>());
-    EXPECT_EQ(integer_part(mag<2380>()), mag<2380>());
+    EXPECT_THAT(integer_part(mag<1>()), Eq(mag<1>()));
+    EXPECT_THAT(integer_part(mag<2>()), Eq(mag<2>()));
+    EXPECT_THAT(integer_part(mag<2380>()), Eq(mag<2380>()));
 }
 
 TEST(IntegerPart, PicksOutIntegersFromNumerator) {
     // sqrt(32) = 4 * sqrt(2)
-    EXPECT_EQ(integer_part(PI * sqrt(mag<32>()) / mag<15>()), mag<4>());
+    EXPECT_THAT(integer_part(PI * sqrt(mag<32>()) / mag<15>()), Eq(mag<4>()));
 }
 
 TEST(IntegerPart, PreservesSign) {
@@ -158,50 +158,50 @@ TEST(IntegerPart, PreservesSign) {
 }
 
 TEST(Numerator, IsIdentityForInteger) {
-    EXPECT_EQ(numerator(mag<2>()), mag<2>());
-    EXPECT_EQ(numerator(mag<31415>()), mag<31415>());
+    EXPECT_THAT(numerator(mag<2>()), Eq(mag<2>()));
+    EXPECT_THAT(numerator(mag<31415>()), Eq(mag<31415>()));
 }
 
 TEST(Numerator, PutsFractionInLowestTerms) {
-    EXPECT_EQ(numerator(mag<24>() / mag<16>()), mag<3>());
+    EXPECT_THAT(numerator(mag<24>() / mag<16>()), Eq(mag<3>()));
 }
 
 TEST(Numerator, NegativeForNegativeNumber) {
-    EXPECT_EQ(numerator(-mag<2>()), -mag<2>());
-    EXPECT_EQ(numerator(-mag<31415>()), -mag<31415>());
-    EXPECT_EQ(numerator(-mag<5>() / mag<7>()), -mag<5>());
+    EXPECT_THAT(numerator(-mag<2>()), Eq(-mag<2>()));
+    EXPECT_THAT(numerator(-mag<31415>()), Eq(-mag<31415>()));
+    EXPECT_THAT(numerator(-mag<5>() / mag<7>()), Eq(-mag<5>()));
 }
 
 TEST(Numerator, IncludesNonIntegersWithPositiveExponent) {
-    EXPECT_EQ(numerator(PI * sqrt(mag<24>() / mag<16>())), PI * sqrt(mag<3>()));
+    EXPECT_THAT(numerator(PI * sqrt(mag<24>() / mag<16>())), Eq(PI * sqrt(mag<3>())));
 }
 
 TEST(Denominator, PutsFractionInLowestTerms) {
-    EXPECT_EQ(denominator(mag<24>() / mag<16>()), mag<2>());
+    EXPECT_THAT(denominator(mag<24>() / mag<16>()), Eq(mag<2>()));
 }
 
 TEST(Denominator, IncludesNonIntegersWithNegativeExponent) {
-    EXPECT_EQ(denominator(sqrt(mag<24>() / mag<16>()) / PI), PI * sqrt(mag<2>()));
+    EXPECT_THAT(denominator(sqrt(mag<24>() / mag<16>()) / PI), Eq(PI * sqrt(mag<2>())));
 }
 
 TEST(Denominator, PositiveForNegativeNumber) {
-    EXPECT_EQ(denominator(-mag<5>() / mag<7>()), mag<7>());
-    EXPECT_EQ(denominator(mag<5>() / (-mag<7>())), mag<7>());
+    EXPECT_THAT(denominator(-mag<5>() / mag<7>()), Eq(mag<7>()));
+    EXPECT_THAT(denominator(mag<5>() / (-mag<7>())), Eq(mag<7>()));
 }
 
 TEST(Abs, IdentityForPositive) {
-    EXPECT_EQ(abs(mag<1>()), mag<1>());
-    EXPECT_EQ(abs(mag<2>()), mag<2>());
-    EXPECT_EQ(abs(mag<5>() / mag<7>()), mag<5>() / mag<7>());
+    EXPECT_THAT(abs(mag<1>()), Eq(mag<1>()));
+    EXPECT_THAT(abs(mag<2>()), Eq(mag<2>()));
+    EXPECT_THAT(abs(mag<5>() / mag<7>()), Eq(mag<5>() / mag<7>()));
 }
 
 TEST(Abs, FlipsSignForNegative) {
-    EXPECT_EQ(abs(-mag<1>()), mag<1>());
-    EXPECT_EQ(abs(-mag<5>() / mag<7>()), mag<5>() / mag<7>());
-    EXPECT_EQ(abs(-mag<2>() / PI), mag<2>() / PI);
+    EXPECT_THAT(abs(-mag<1>()), Eq(mag<1>()));
+    EXPECT_THAT(abs(-mag<5>() / mag<7>()), Eq(mag<5>() / mag<7>()));
+    EXPECT_THAT(abs(-mag<2>() / PI), Eq(mag<2>() / PI));
 }
 
-TEST(Abs, IdentityForZero) { EXPECT_EQ(abs(ZERO), ZERO); }
+TEST(Abs, IdentityForZero) { EXPECT_THAT(abs(ZERO), Eq(ZERO)); }
 
 TEST(IsPositive, TrueForPositive) {
     EXPECT_THAT(is_positive(mag<1>()), IsTrue());
@@ -296,7 +296,7 @@ TEST(GetValue, PiToArbitraryPowerPerformsComputationsInMostAccurateTypeAtCompile
 
     constexpr auto pi_cubed_value = get_value<float>(pi_cubed);
     ASSERT_NE(pi_cubed_value, result_via_float);
-    EXPECT_EQ(pi_cubed_value, result_via_long_double);
+    EXPECT_THAT(pi_cubed_value, Eq(result_via_long_double));
 }
 
 TEST(GetValue, ImpossibleRequestsArePreventedAtCompileTime) {
@@ -338,25 +338,25 @@ TEST(GetValue, WorksForNegativeNumber) {
 }
 
 TEST(CommonMagnitude, ReturnsCommonMagnitudeWhenBothAreIdentical) {
-    EXPECT_EQ(common_magnitude(mag<1>(), mag<1>()), mag<1>());
-    EXPECT_EQ(common_magnitude(PI, PI), PI);
+    EXPECT_THAT(common_magnitude(mag<1>(), mag<1>()), Eq(mag<1>()));
+    EXPECT_THAT(common_magnitude(PI, PI), Eq(PI));
 
     constexpr auto x = pow<3>(PI) / root<2>(mag<2>()) * mag<412>();
-    EXPECT_EQ(common_magnitude(x, x), x);
+    EXPECT_THAT(common_magnitude(x, x), Eq(x));
 }
 
 TEST(CommonMagnitude, ReturnsSmallerMagnitudeWhenItEvenlyDividesLarger) {
-    EXPECT_EQ(common_magnitude(mag<1>(), mag<8>()), mag<1>());
-    EXPECT_EQ(common_magnitude(mag<8>(), mag<1>()), mag<1>());
+    EXPECT_THAT(common_magnitude(mag<1>(), mag<8>()), Eq(mag<1>()));
+    EXPECT_THAT(common_magnitude(mag<8>(), mag<1>()), Eq(mag<1>()));
 
     constexpr auto one_eighth = mag<1>() / mag<8>();
-    EXPECT_EQ(common_magnitude(mag<1>(), one_eighth), one_eighth);
-    EXPECT_EQ(common_magnitude(one_eighth, mag<1>()), one_eighth);
+    EXPECT_THAT(common_magnitude(mag<1>(), one_eighth), Eq(one_eighth));
+    EXPECT_THAT(common_magnitude(one_eighth, mag<1>()), Eq(one_eighth));
 
     constexpr auto a = pow<3>(mag<2>()) * pow<-1>(mag<3>()) * pow<5>(mag<5>()) * pow<7>(mag<7>());
     constexpr auto b = /*              */ pow<-2>(mag<3>()) * /*                     */ mag<7>();
-    EXPECT_EQ(common_magnitude(a, b), b);
-    EXPECT_EQ(common_magnitude(b, a), b);
+    EXPECT_THAT(common_magnitude(a, b), Eq(b));
+    EXPECT_THAT(common_magnitude(b, a), Eq(b));
 }
 
 TEST(CommonMagnitude, DividesBothMagnitudes) {
@@ -366,41 +366,41 @@ TEST(CommonMagnitude, DividesBothMagnitudes) {
     ASSERT_THAT(is_integer(a / b), IsFalse());
     ASSERT_THAT(is_integer(b / a), IsFalse());
 
-    EXPECT_EQ(common_magnitude(a, b), common_magnitude(b, a));
+    EXPECT_THAT(common_magnitude(a, b), Eq(common_magnitude(b, a)));
     EXPECT_THAT(is_integer(a / common_magnitude(a, b)), IsTrue());
     EXPECT_THAT(is_integer(b / common_magnitude(a, b)), IsTrue());
 }
 
 TEST(CommonMagnitude, HandlesMultiplePositivePowers) {
-    EXPECT_EQ(common_magnitude(ONE, mag<1000>()), ONE);
+    EXPECT_THAT(common_magnitude(ONE, mag<1000>()), Eq(ONE));
 }
 
 TEST(CommonMagnitude, ZeroGetsIgnored) {
-    EXPECT_EQ(common_magnitude(ZERO, mag<1000>()), mag<1000>());
-    EXPECT_EQ(common_magnitude(PI, ZERO), PI);
+    EXPECT_THAT(common_magnitude(ZERO, mag<1000>()), Eq(mag<1000>()));
+    EXPECT_THAT(common_magnitude(PI, ZERO), Eq(PI));
 }
 
 TEST(CommonMagnitude, ZeroResultIndicatesAllInputsAreZero) {
-    EXPECT_EQ(common_magnitude(ZERO), ZERO);
-    EXPECT_EQ(common_magnitude(ZERO, ZERO), ZERO);
-    EXPECT_EQ(common_magnitude(ZERO, ZERO, ZERO), ZERO);
-    EXPECT_EQ(common_magnitude(ZERO, ZERO, ZERO, ZERO, ZERO), ZERO);
+    EXPECT_THAT(common_magnitude(ZERO), Eq(ZERO));
+    EXPECT_THAT(common_magnitude(ZERO, ZERO), Eq(ZERO));
+    EXPECT_THAT(common_magnitude(ZERO, ZERO, ZERO), Eq(ZERO));
+    EXPECT_THAT(common_magnitude(ZERO, ZERO, ZERO, ZERO, ZERO), Eq(ZERO));
 }
 
 TEST(CommonMagnitude, CommonMagOfPosAndNegIsPos) {
-    EXPECT_EQ(common_magnitude(mag<12>(), -mag<15>()), mag<3>());
-    EXPECT_EQ(common_magnitude(-mag<12>(), mag<15>()), mag<3>());
+    EXPECT_THAT(common_magnitude(mag<12>(), -mag<15>()), Eq(mag<3>()));
+    EXPECT_THAT(common_magnitude(-mag<12>(), mag<15>()), Eq(mag<3>()));
 
-    EXPECT_EQ(common_magnitude(mag<12>(), -mag<15>(), -mag<27>()), mag<3>());
-    EXPECT_EQ(common_magnitude(-mag<9>(), mag<12>(), -mag<15>(), -mag<27>()), mag<3>());
+    EXPECT_THAT(common_magnitude(mag<12>(), -mag<15>(), -mag<27>()), Eq(mag<3>()));
+    EXPECT_THAT(common_magnitude(-mag<9>(), mag<12>(), -mag<15>(), -mag<27>()), Eq(mag<3>()));
 
-    EXPECT_EQ(common_magnitude(mag<1>(), -mag<1>() / mag<5>()), mag<1>() / mag<5>());
+    EXPECT_THAT(common_magnitude(mag<1>(), -mag<1>() / mag<5>()), Eq(mag<1>() / mag<5>()));
 }
 
 TEST(CommonMagnitude, CommonMagOfNegAndNegIsNeg) {
-    EXPECT_EQ(common_magnitude(-mag<12>(), -mag<15>()), -mag<3>());
-    EXPECT_EQ(common_magnitude(-mag<12>(), -mag<15>(), -mag<27>()), -mag<3>());
-    EXPECT_EQ(common_magnitude(-mag<9>(), -mag<12>(), -mag<15>(), -mag<27>()), -mag<3>());
+    EXPECT_THAT(common_magnitude(-mag<12>(), -mag<15>()), Eq(-mag<3>()));
+    EXPECT_THAT(common_magnitude(-mag<12>(), -mag<15>(), -mag<27>()), Eq(-mag<3>()));
+    EXPECT_THAT(common_magnitude(-mag<9>(), -mag<12>(), -mag<15>(), -mag<27>()), Eq(-mag<3>()));
 }
 
 }  // namespace

--- a/au/code/au/math_test.cc
+++ b/au/code/au/math_test.cc
@@ -58,24 +58,24 @@ constexpr const T &std_clamp(const T &v, const T &lo, const T &hi) {
 }  // namespace
 
 TEST(abs, AlwaysReturnsNonnegativeVersionOfInput) {
-    EXPECT_EQ(abs(meters(-1)), meters(1));
-    EXPECT_EQ(abs(meters(0)), meters(0));
-    EXPECT_EQ(abs(meters(1)), meters(1));
+    EXPECT_THAT(abs(meters(-1)), Eq(meters(1)));
+    EXPECT_THAT(abs(meters(0)), Eq(meters(0)));
+    EXPECT_THAT(abs(meters(1)), Eq(meters(1)));
 
-    EXPECT_EQ(abs(radians(-2.f)), radians(2.f));
-    EXPECT_EQ(abs(radians(0.f)), radians(0.f));
-    EXPECT_EQ(abs(radians(2.f)), radians(2.f));
+    EXPECT_THAT(abs(radians(-2.f)), Eq(radians(2.f)));
+    EXPECT_THAT(abs(radians(0.f)), Eq(radians(0.f)));
+    EXPECT_THAT(abs(radians(2.f)), Eq(radians(2.f)));
 }
 
 TEST(abs, FollowsSamePolicyAsStdAbsForInf) {
-    EXPECT_EQ(abs(degrees(INFINITY)), degrees(std::abs(INFINITY)));
-    EXPECT_EQ(abs(degrees(-INFINITY)), degrees(std::abs(-INFINITY)));
+    EXPECT_THAT(abs(degrees(INFINITY)), Eq(degrees(std::abs(INFINITY))));
+    EXPECT_THAT(abs(degrees(-INFINITY)), Eq(degrees(std::abs(-INFINITY))));
 }
 
 TEST(abs, SameAsStdAbsForNumericTypes) {
-    EXPECT_EQ(abs(-1), 1);
-    EXPECT_EQ(abs(0), 0);
-    EXPECT_EQ(abs(1), 1);
+    EXPECT_THAT(abs(-1), Eq(1));
+    EXPECT_THAT(abs(0), Eq(0));
+    EXPECT_THAT(abs(1), Eq(1));
 }
 
 TEST(cbrt, OutputRepDependsOnInputRep) {
@@ -171,7 +171,7 @@ TEST(clamp, QuantityPointTakesOffsetIntoAccount) {
     constexpr auto celsius_origin = clamp(celsius_pt(0), kelvins_pt(200), kelvins_pt(300));
     ASSERT_THAT(is_integer(unit_ratio(Kelvins{} / mag<20>(), decltype(celsius_origin)::unit)),
                 IsTrue());
-    EXPECT_EQ(celsius_origin, centi(kelvins_pt)(273'15));
+    EXPECT_THAT(celsius_origin, Eq(centi(kelvins_pt)(273'15)));
 }
 
 TEST(clamp, SupportsZeroForLowerBoundaryArgument) {
@@ -270,15 +270,15 @@ TEST(cos, TypeDependsOnInputType) {
 }
 
 TEST(cos, SameAsStdCosForNumericTypes) {
-    EXPECT_EQ(cos(1), std::cos(1));
-    EXPECT_EQ(cos(1.), std::cos(1.));
-    EXPECT_EQ(cos(1.f), std::cos(1.f));
-    EXPECT_EQ(cos(1.L), std::cos(1.L));
+    EXPECT_THAT(cos(1), Eq(std::cos(1)));
+    EXPECT_THAT(cos(1.), Eq(std::cos(1.)));
+    EXPECT_THAT(cos(1.f), Eq(std::cos(1.f)));
+    EXPECT_THAT(cos(1.L), Eq(std::cos(1.L)));
 }
 
 TEST(cos, GivesSameAnswersAsRawNumbersButInStrongTypes) {
-    EXPECT_EQ(cos(radians(1.23)), std::cos(1.23));
-    EXPECT_EQ(cos(radians(4.56f)), std::cos(4.56f));
+    EXPECT_THAT(cos(radians(1.23)), Eq(std::cos(1.23)));
+    EXPECT_THAT(cos(radians(4.56f)), Eq(std::cos(4.56f)));
 }
 
 TEST(cos, GivesCorrectAnswersForInputsInDegrees) {
@@ -314,7 +314,7 @@ TEST(fmod, SameAsStdFmodForNumericTypes) {
     const auto a = 3.5;
     const auto b = 3;
 
-    EXPECT_EQ(fmod(a, b), std::fmod(a, b));
+    EXPECT_THAT(fmod(a, b), Eq(std::fmod(a, b)));
 }
 
 TEST(fmod, ReturnsSameTypesAsStdModForSameUnitInputs) {
@@ -343,8 +343,8 @@ TEST(fmod, HandlesIrrationalCommonUnit) {
 }
 
 TEST(remainder, SameAsStdRemainderForNumericTypes) {
-    EXPECT_EQ(remainder(3.5, 3), std::remainder(3.5, 3));
-    EXPECT_EQ(remainder(2.5, 3), std::remainder(2.5, 3));
+    EXPECT_THAT(remainder(3.5, 3), Eq(std::remainder(3.5, 3)));
+    EXPECT_THAT(remainder(2.5, 3), Eq(std::remainder(2.5, 3)));
 }
 
 TEST(remainder, ReturnsSameTypesAsStdRemainderForSameUnitInputs) {
@@ -381,12 +381,12 @@ TEST(remainder, CenteredAroundZero) {
 
 TEST(max, ReturnsLarger) {
     constexpr auto result = max(centi(meters)(1), inches(1));
-    EXPECT_EQ(result, inches(1));
+    EXPECT_THAT(result, Eq(inches(1)));
 }
 
 TEST(max, HandlesDifferentOriginQuantityPoints) {
     constexpr auto result = max(fahrenheit_pt(30), celsius_pt(0));
-    EXPECT_EQ(result, celsius_pt(0));
+    EXPECT_THAT(result, Eq(celsius_pt(0)));
 }
 
 TEST(max, ReturnsByValueForSameExactQuantityType) {
@@ -395,13 +395,13 @@ TEST(max, ReturnsByValueForSameExactQuantityType) {
     const auto b = meters(2);
     const auto &max_a_b = max(a, b);
 
-    EXPECT_EQ(max_a_b, b);
+    EXPECT_THAT(max_a_b, Eq(b));
     EXPECT_NE(&max_a_b, &b);
 }
 
 TEST(max, SupportsConstexprForSameExactQuantityType) {
     constexpr auto result = max(meters(1), meters(2));
-    EXPECT_EQ(result, meters(2));
+    EXPECT_THAT(result, Eq(meters(2)));
 }
 
 TEST(max, ReturnsByValueForSameExactQuantityPointType) {
@@ -410,13 +410,13 @@ TEST(max, ReturnsByValueForSameExactQuantityPointType) {
     const auto b = meters_pt(2);
     const auto &max_a_b = max(a, b);
 
-    EXPECT_EQ(max_a_b, b);
+    EXPECT_THAT(max_a_b, Eq(b));
     EXPECT_NE(&max_a_b, &b);
 }
 
 TEST(max, SupportsConstexprForSameExactQuantityPointType) {
     constexpr auto result = max(meters_pt(1), meters_pt(2));
-    EXPECT_EQ(result, meters_pt(2));
+    EXPECT_THAT(result, Eq(meters_pt(2)));
 }
 
 TEST(max, SameAsStdMaxForNumericTypes) {
@@ -425,7 +425,7 @@ TEST(max, SameAsStdMaxForNumericTypes) {
 
     const auto &max_result = max(a, b);
 
-    EXPECT_EQ(&b, &max_result);
+    EXPECT_THAT(&b, Eq(&max_result));
 }
 
 TEST(max, SupportsZeroForFirstArgument) {
@@ -446,12 +446,12 @@ TEST(max, SupportsZeroForSecondArgument) {
 
 TEST(min, ReturnsSmaller) {
     constexpr auto result = min(centi(meters)(1), inches(1));
-    EXPECT_EQ(result, centi(meters)(1));
+    EXPECT_THAT(result, Eq(centi(meters)(1)));
 }
 
 TEST(min, HandlesDifferentOriginQuantityPoints) {
     constexpr auto result = min(fahrenheit_pt(30), celsius_pt(0));
-    EXPECT_EQ(result, fahrenheit_pt(30));
+    EXPECT_THAT(result, Eq(fahrenheit_pt(30)));
 }
 
 TEST(min, ReturnsByValueForSameExactQuantityType) {
@@ -460,13 +460,13 @@ TEST(min, ReturnsByValueForSameExactQuantityType) {
     const auto b = meters(2);
     const auto &min_a_b = min(a, b);
 
-    EXPECT_EQ(min_a_b, a);
+    EXPECT_THAT(min_a_b, Eq(a));
     EXPECT_NE(&min_a_b, &a);
 }
 
 TEST(min, SupportsConstexprForSameExactQuantityType) {
     constexpr auto result = min(meters(1), meters(2));
-    EXPECT_EQ(result, meters(1));
+    EXPECT_THAT(result, Eq(meters(1)));
 }
 
 TEST(min, ReturnsByValueForSameExactQuantityPointType) {
@@ -475,13 +475,13 @@ TEST(min, ReturnsByValueForSameExactQuantityPointType) {
     const auto b = meters_pt(2);
     const auto &min_a_b = min(a, b);
 
-    EXPECT_EQ(min_a_b, a);
+    EXPECT_THAT(min_a_b, Eq(a));
     EXPECT_NE(&min_a_b, &a);
 }
 
 TEST(min, SupportsConstexprForSameExactQuantityPointType) {
     constexpr auto result = min(meters_pt(1), meters_pt(2));
-    EXPECT_EQ(result, meters_pt(1));
+    EXPECT_THAT(result, Eq(meters_pt(1)));
 }
 
 TEST(min, SameAsStdMinForNumericTypes) {
@@ -490,7 +490,7 @@ TEST(min, SameAsStdMinForNumericTypes) {
 
     const auto &min_result = min(a, b);
 
-    EXPECT_EQ(&a, &min_result);
+    EXPECT_THAT(&a, Eq(&min_result));
 }
 
 TEST(min, SupportsZeroForFirstArgument) {
@@ -542,15 +542,15 @@ TEST(sin, TypeDependsOnInputType) {
 }
 
 TEST(sin, SameAsStdSinForNumericTypes) {
-    EXPECT_EQ(sin(1), std::sin(1));
-    EXPECT_EQ(sin(1.), std::sin(1.));
-    EXPECT_EQ(sin(1.f), std::sin(1.f));
-    EXPECT_EQ(sin(1.L), std::sin(1.L));
+    EXPECT_THAT(sin(1), Eq(std::sin(1)));
+    EXPECT_THAT(sin(1.), Eq(std::sin(1.)));
+    EXPECT_THAT(sin(1.f), Eq(std::sin(1.f)));
+    EXPECT_THAT(sin(1.L), Eq(std::sin(1.L)));
 }
 
 TEST(sin, GivesSameAnswersAsRawNumbersButInStrongTypes) {
-    EXPECT_EQ(sin(radians(1.23)), std::sin(1.23));
-    EXPECT_EQ(sin(radians(4.56f)), std::sin(4.56f));
+    EXPECT_THAT(sin(radians(1.23)), Eq(std::sin(1.23)));
+    EXPECT_THAT(sin(radians(4.56f)), Eq(std::sin(4.56f)));
 }
 
 TEST(sin, GivesCorrectAnswersForInputsInDegrees) {
@@ -576,10 +576,10 @@ TEST(sqrt, MixedUnitsSupportedWithCasting) {
 }
 
 TEST(sqrt, SameAsStdSqrtForNumericTypes) {
-    EXPECT_EQ(sqrt(1), std::sqrt(1));
-    EXPECT_EQ(sqrt(1.), std::sqrt(1.));
-    EXPECT_EQ(sqrt(1.f), std::sqrt(1.f));
-    EXPECT_EQ(sqrt(1.L), std::sqrt(1.L));
+    EXPECT_THAT(sqrt(1), Eq(std::sqrt(1)));
+    EXPECT_THAT(sqrt(1.), Eq(std::sqrt(1.)));
+    EXPECT_THAT(sqrt(1.f), Eq(std::sqrt(1.f)));
+    EXPECT_THAT(sqrt(1.L), Eq(std::sqrt(1.L)));
 }
 
 TEST(sqrt, CanConvertIfConversionFactorRational) {
@@ -610,10 +610,10 @@ TEST(tan, TypeDependsOnInputType) {
 }
 
 TEST(tan, SameAsStdTanForNumericTypes) {
-    EXPECT_EQ(tan(1), std::tan(1));
-    EXPECT_EQ(tan(1.), std::tan(1.));
-    EXPECT_EQ(tan(1.f), std::tan(1.f));
-    EXPECT_EQ(tan(1.L), std::tan(1.L));
+    EXPECT_THAT(tan(1), Eq(std::tan(1)));
+    EXPECT_THAT(tan(1.), Eq(std::tan(1.)));
+    EXPECT_THAT(tan(1.f), Eq(std::tan(1.f)));
+    EXPECT_THAT(tan(1.L), Eq(std::tan(1.L)));
 }
 
 TEST(tan, GivesSameAnswersAsRawNumbersButInStrongTypes) {
@@ -716,9 +716,9 @@ TEST(isnan, TransparentlyActsOnSameAsValue) {
     }};
 
     for (const double x : values) {
-        EXPECT_EQ(isnan(meters(x)), std::isnan(x));
-        EXPECT_EQ(isnan(meters_pt(x)), std::isnan(x));
-        EXPECT_EQ(isnan((radians / second)(x)), std::isnan(x));
+        EXPECT_THAT(isnan(meters(x)), Eq(std::isnan(x)));
+        EXPECT_THAT(isnan(meters_pt(x)), Eq(std::isnan(x)));
+        EXPECT_THAT(isnan((radians / second)(x)), Eq(std::isnan(x)));
     }
 }
 
@@ -743,20 +743,20 @@ TEST(numeric_limits, MemberVariablesSetCorrectlyForQuantitySpecialization) {
     EXPECT_THAT(meters_limits_int::has_infinity, IsFalse());
     EXPECT_THAT(meters_limits_int::has_quiet_NaN, IsFalse());
     EXPECT_THAT(meters_limits_int::has_signaling_NaN, IsFalse());
-    EXPECT_EQ(meters_limits_int::has_denorm, std::denorm_absent);
+    EXPECT_THAT(meters_limits_int::has_denorm, Eq(std::denorm_absent));
     EXPECT_THAT(meters_limits_int::has_denorm_loss, IsFalse());
-    EXPECT_EQ(meters_limits_int::round_style, std::round_toward_zero);
+    EXPECT_THAT(meters_limits_int::round_style, Eq(std::round_toward_zero));
     EXPECT_THAT(meters_limits_int::is_iec559, IsFalse());
     EXPECT_THAT(meters_limits_int::is_bounded, IsTrue());
-    EXPECT_EQ(meters_limits_int::is_modulo, std::numeric_limits<int>::is_modulo);
-    EXPECT_EQ(meters_limits_int::digits, std::numeric_limits<int>::digits);
-    EXPECT_EQ(meters_limits_int::digits10, std::numeric_limits<int>::digits10);
-    EXPECT_EQ(meters_limits_int::max_digits10, 0);
-    EXPECT_EQ(meters_limits_int::radix, 2);
-    EXPECT_EQ(meters_limits_int::min_exponent, 0);
-    EXPECT_EQ(meters_limits_int::min_exponent10, 0);
-    EXPECT_EQ(meters_limits_int::max_exponent, 0);
-    EXPECT_EQ(meters_limits_int::max_exponent10, 0);
+    EXPECT_THAT(meters_limits_int::is_modulo, Eq(std::numeric_limits<int>::is_modulo));
+    EXPECT_THAT(meters_limits_int::digits, Eq(std::numeric_limits<int>::digits));
+    EXPECT_THAT(meters_limits_int::digits10, Eq(std::numeric_limits<int>::digits10));
+    EXPECT_THAT(meters_limits_int::max_digits10, Eq(0));
+    EXPECT_THAT(meters_limits_int::radix, Eq(2));
+    EXPECT_THAT(meters_limits_int::min_exponent, Eq(0));
+    EXPECT_THAT(meters_limits_int::min_exponent10, Eq(0));
+    EXPECT_THAT(meters_limits_int::max_exponent, Eq(0));
+    EXPECT_THAT(meters_limits_int::max_exponent10, Eq(0));
     EXPECT_THAT(meters_limits_int::traps, IsTrue());
     EXPECT_THAT(meters_limits_int::tinyness_before, IsFalse());
 
@@ -768,20 +768,20 @@ TEST(numeric_limits, MemberVariablesSetCorrectlyForQuantitySpecialization) {
     EXPECT_THAT(radians_limits_uint32_t::has_infinity, IsFalse());
     EXPECT_THAT(radians_limits_uint32_t::has_quiet_NaN, IsFalse());
     EXPECT_THAT(radians_limits_uint32_t::has_signaling_NaN, IsFalse());
-    EXPECT_EQ(radians_limits_uint32_t::has_denorm, std::denorm_absent);
+    EXPECT_THAT(radians_limits_uint32_t::has_denorm, Eq(std::denorm_absent));
     EXPECT_THAT(radians_limits_uint32_t::has_denorm_loss, IsFalse());
-    EXPECT_EQ(radians_limits_uint32_t::round_style, std::round_toward_zero);
+    EXPECT_THAT(radians_limits_uint32_t::round_style, Eq(std::round_toward_zero));
     EXPECT_THAT(radians_limits_uint32_t::is_iec559, IsFalse());
     EXPECT_THAT(radians_limits_uint32_t::is_bounded, IsTrue());
     EXPECT_THAT(radians_limits_uint32_t::is_modulo, IsTrue());
-    EXPECT_EQ(radians_limits_uint32_t::digits, std::numeric_limits<uint32_t>::digits);
-    EXPECT_EQ(radians_limits_uint32_t::digits10, std::numeric_limits<uint32_t>::digits10);
-    EXPECT_EQ(radians_limits_uint32_t::max_digits10, 0);
-    EXPECT_EQ(radians_limits_uint32_t::radix, 2);
-    EXPECT_EQ(radians_limits_uint32_t::min_exponent, 0);
-    EXPECT_EQ(radians_limits_uint32_t::min_exponent10, 0);
-    EXPECT_EQ(radians_limits_uint32_t::max_exponent, 0);
-    EXPECT_EQ(radians_limits_uint32_t::max_exponent10, 0);
+    EXPECT_THAT(radians_limits_uint32_t::digits, Eq(std::numeric_limits<uint32_t>::digits));
+    EXPECT_THAT(radians_limits_uint32_t::digits10, Eq(std::numeric_limits<uint32_t>::digits10));
+    EXPECT_THAT(radians_limits_uint32_t::max_digits10, Eq(0));
+    EXPECT_THAT(radians_limits_uint32_t::radix, Eq(2));
+    EXPECT_THAT(radians_limits_uint32_t::min_exponent, Eq(0));
+    EXPECT_THAT(radians_limits_uint32_t::min_exponent10, Eq(0));
+    EXPECT_THAT(radians_limits_uint32_t::max_exponent, Eq(0));
+    EXPECT_THAT(radians_limits_uint32_t::max_exponent10, Eq(0));
     EXPECT_THAT(radians_limits_uint32_t::traps, IsTrue());
     EXPECT_THAT(radians_limits_uint32_t::tinyness_before, IsFalse());
 
@@ -793,42 +793,44 @@ TEST(numeric_limits, MemberVariablesSetCorrectlyForQuantitySpecialization) {
     EXPECT_THAT(celsius_limits_float::has_infinity, IsTrue());
     EXPECT_THAT(celsius_limits_float::has_quiet_NaN, IsTrue());
     EXPECT_THAT(celsius_limits_float::has_signaling_NaN, IsTrue());
-    EXPECT_EQ(celsius_limits_float::has_denorm, std::denorm_present);
-    EXPECT_EQ(celsius_limits_float::has_denorm_loss, std::numeric_limits<float>::has_denorm_loss);
-    EXPECT_EQ(celsius_limits_float::round_style, std::round_to_nearest);
+    EXPECT_THAT(celsius_limits_float::has_denorm, Eq(std::denorm_present));
+    EXPECT_THAT(celsius_limits_float::has_denorm_loss,
+                Eq(std::numeric_limits<float>::has_denorm_loss));
+    EXPECT_THAT(celsius_limits_float::round_style, Eq(std::round_to_nearest));
     EXPECT_THAT(celsius_limits_float::is_iec559, IsTrue());
     EXPECT_THAT(celsius_limits_float::is_bounded, IsTrue());
     EXPECT_THAT(celsius_limits_float::is_modulo, IsFalse());
-    EXPECT_EQ(celsius_limits_float::digits, FLT_MANT_DIG);
-    EXPECT_EQ(celsius_limits_float::digits10, FLT_DIG);
-    EXPECT_EQ(celsius_limits_float::max_digits10, std::numeric_limits<float>::max_digits10);
-    EXPECT_EQ(celsius_limits_float::radix, FLT_RADIX);
-    EXPECT_EQ(celsius_limits_float::min_exponent, FLT_MIN_EXP);
-    EXPECT_EQ(celsius_limits_float::min_exponent10, FLT_MIN_10_EXP);
-    EXPECT_EQ(celsius_limits_float::max_exponent, FLT_MAX_EXP);
-    EXPECT_EQ(celsius_limits_float::max_exponent10, FLT_MAX_10_EXP);
+    EXPECT_THAT(celsius_limits_float::digits, Eq(FLT_MANT_DIG));
+    EXPECT_THAT(celsius_limits_float::digits10, Eq(FLT_DIG));
+    EXPECT_THAT(celsius_limits_float::max_digits10, Eq(std::numeric_limits<float>::max_digits10));
+    EXPECT_THAT(celsius_limits_float::radix, Eq(FLT_RADIX));
+    EXPECT_THAT(celsius_limits_float::min_exponent, Eq(FLT_MIN_EXP));
+    EXPECT_THAT(celsius_limits_float::min_exponent10, Eq(FLT_MIN_10_EXP));
+    EXPECT_THAT(celsius_limits_float::max_exponent, Eq(FLT_MAX_EXP));
+    EXPECT_THAT(celsius_limits_float::max_exponent10, Eq(FLT_MAX_10_EXP));
     EXPECT_THAT(celsius_limits_float::traps, IsFalse());
-    EXPECT_EQ(celsius_limits_float::tinyness_before, std::numeric_limits<float>::tinyness_before);
+    EXPECT_THAT(celsius_limits_float::tinyness_before,
+                Eq(std::numeric_limits<float>::tinyness_before));
 }
 
 TEST(numeric_limits, ProvidesLimitsForQuantity) {
     using nl1 = std::numeric_limits<Quantity<Meters, int>>;
-    EXPECT_EQ(nl1::max(), meters(std::numeric_limits<int>::max()));
-    EXPECT_EQ(nl1::lowest(), meters(std::numeric_limits<int>::lowest()));
-    EXPECT_EQ(nl1::min(), meters(std::numeric_limits<int>::min()));
-    EXPECT_EQ(nl1::epsilon(), meters(std::numeric_limits<int>::epsilon()));
-    EXPECT_EQ(nl1::round_error(), meters(std::numeric_limits<int>::round_error()));
-    EXPECT_EQ(nl1::infinity(), meters(std::numeric_limits<int>::infinity()));
-    EXPECT_EQ(nl1::denorm_min(), meters(std::numeric_limits<int>::denorm_min()));
+    EXPECT_THAT(nl1::max(), Eq(meters(std::numeric_limits<int>::max())));
+    EXPECT_THAT(nl1::lowest(), Eq(meters(std::numeric_limits<int>::lowest())));
+    EXPECT_THAT(nl1::min(), Eq(meters(std::numeric_limits<int>::min())));
+    EXPECT_THAT(nl1::epsilon(), Eq(meters(std::numeric_limits<int>::epsilon())));
+    EXPECT_THAT(nl1::round_error(), Eq(meters(std::numeric_limits<int>::round_error())));
+    EXPECT_THAT(nl1::infinity(), Eq(meters(std::numeric_limits<int>::infinity())));
+    EXPECT_THAT(nl1::denorm_min(), Eq(meters(std::numeric_limits<int>::denorm_min())));
 
     using nl2 = std::numeric_limits<Quantity<Ohms, float>>;
-    EXPECT_EQ(nl2::max(), ohms(std::numeric_limits<float>::max()));
-    EXPECT_EQ(nl2::lowest(), ohms(std::numeric_limits<float>::lowest()));
-    EXPECT_EQ(nl2::min(), ohms(std::numeric_limits<float>::min()));
-    EXPECT_EQ(nl2::epsilon(), ohms(std::numeric_limits<float>::epsilon()));
-    EXPECT_EQ(nl2::round_error(), ohms(std::numeric_limits<float>::round_error()));
-    EXPECT_EQ(nl2::infinity(), ohms(std::numeric_limits<float>::infinity()));
-    EXPECT_EQ(nl2::denorm_min(), ohms(std::numeric_limits<float>::denorm_min()));
+    EXPECT_THAT(nl2::max(), Eq(ohms(std::numeric_limits<float>::max())));
+    EXPECT_THAT(nl2::lowest(), Eq(ohms(std::numeric_limits<float>::lowest())));
+    EXPECT_THAT(nl2::min(), Eq(ohms(std::numeric_limits<float>::min())));
+    EXPECT_THAT(nl2::epsilon(), Eq(ohms(std::numeric_limits<float>::epsilon())));
+    EXPECT_THAT(nl2::round_error(), Eq(ohms(std::numeric_limits<float>::round_error())));
+    EXPECT_THAT(nl2::infinity(), Eq(ohms(std::numeric_limits<float>::infinity())));
+    EXPECT_THAT(nl2::denorm_min(), Eq(ohms(std::numeric_limits<float>::denorm_min())));
 
     // We cannot currently test `quiet_NaN` or `signaling_NaN`.  Later, we could provide overloads
     // for `isnan()`, which people could find via ADL.
@@ -837,39 +839,45 @@ TEST(numeric_limits, ProvidesLimitsForQuantity) {
 TEST(numeric_limits, InsensitiveToCvQualificationForQuantity) {
     using Q = Quantity<Degrees, float>;
 
-    EXPECT_EQ(std::numeric_limits<Q>::max(), std::numeric_limits<const Q>::max());
-    EXPECT_EQ(std::numeric_limits<Q>::max(), std::numeric_limits<volatile Q>::max());
-    EXPECT_EQ(std::numeric_limits<Q>::max(), std::numeric_limits<const volatile Q>::max());
+    EXPECT_THAT(std::numeric_limits<Q>::max(), Eq(std::numeric_limits<const Q>::max()));
+    EXPECT_THAT(std::numeric_limits<Q>::max(), Eq(std::numeric_limits<volatile Q>::max()));
+    EXPECT_THAT(std::numeric_limits<Q>::max(), Eq(std::numeric_limits<const volatile Q>::max()));
 
-    EXPECT_EQ(std::numeric_limits<Q>::lowest(), std::numeric_limits<const Q>::lowest());
-    EXPECT_EQ(std::numeric_limits<Q>::lowest(), std::numeric_limits<volatile Q>::lowest());
-    EXPECT_EQ(std::numeric_limits<Q>::lowest(), std::numeric_limits<const volatile Q>::lowest());
+    EXPECT_THAT(std::numeric_limits<Q>::lowest(), Eq(std::numeric_limits<const Q>::lowest()));
+    EXPECT_THAT(std::numeric_limits<Q>::lowest(), Eq(std::numeric_limits<volatile Q>::lowest()));
+    EXPECT_THAT(std::numeric_limits<Q>::lowest(),
+                Eq(std::numeric_limits<const volatile Q>::lowest()));
 
-    EXPECT_EQ(std::numeric_limits<Q>::min(), std::numeric_limits<const Q>::min());
-    EXPECT_EQ(std::numeric_limits<Q>::min(), std::numeric_limits<volatile Q>::min());
-    EXPECT_EQ(std::numeric_limits<Q>::min(), std::numeric_limits<const volatile Q>::min());
+    EXPECT_THAT(std::numeric_limits<Q>::min(), Eq(std::numeric_limits<const Q>::min()));
+    EXPECT_THAT(std::numeric_limits<Q>::min(), Eq(std::numeric_limits<volatile Q>::min()));
+    EXPECT_THAT(std::numeric_limits<Q>::min(), Eq(std::numeric_limits<const volatile Q>::min()));
 
-    EXPECT_EQ(std::numeric_limits<Q>::epsilon(), std::numeric_limits<const Q>::epsilon());
-    EXPECT_EQ(std::numeric_limits<Q>::epsilon(), std::numeric_limits<volatile Q>::epsilon());
-    EXPECT_EQ(std::numeric_limits<Q>::epsilon(), std::numeric_limits<const volatile Q>::epsilon());
+    EXPECT_THAT(std::numeric_limits<Q>::epsilon(), Eq(std::numeric_limits<const Q>::epsilon()));
+    EXPECT_THAT(std::numeric_limits<Q>::epsilon(), Eq(std::numeric_limits<volatile Q>::epsilon()));
+    EXPECT_THAT(std::numeric_limits<Q>::epsilon(),
+                Eq(std::numeric_limits<const volatile Q>::epsilon()));
 
-    EXPECT_EQ(std::numeric_limits<Q>::round_error(), std::numeric_limits<const Q>::round_error());
-    EXPECT_EQ(std::numeric_limits<Q>::round_error(),
-              std::numeric_limits<volatile Q>::round_error());
-    EXPECT_EQ(std::numeric_limits<Q>::round_error(),
-              std::numeric_limits<const volatile Q>::round_error());
+    EXPECT_THAT(std::numeric_limits<Q>::round_error(),
+                Eq(std::numeric_limits<const Q>::round_error()));
+    EXPECT_THAT(std::numeric_limits<Q>::round_error(),
+                Eq(std::numeric_limits<volatile Q>::round_error()));
+    EXPECT_THAT(std::numeric_limits<Q>::round_error(),
+                Eq(std::numeric_limits<const volatile Q>::round_error()));
 
-    EXPECT_EQ(std::numeric_limits<Q>::infinity(), std::numeric_limits<const Q>::infinity());
-    EXPECT_EQ(std::numeric_limits<Q>::infinity(), std::numeric_limits<volatile Q>::infinity());
-    EXPECT_EQ(std::numeric_limits<Q>::infinity(),
-              std::numeric_limits<const volatile Q>::infinity());
+    EXPECT_THAT(std::numeric_limits<Q>::infinity(), Eq(std::numeric_limits<const Q>::infinity()));
+    EXPECT_THAT(std::numeric_limits<Q>::infinity(),
+                Eq(std::numeric_limits<volatile Q>::infinity()));
+    EXPECT_THAT(std::numeric_limits<Q>::infinity(),
+                Eq(std::numeric_limits<const volatile Q>::infinity()));
 
     // It's hard to test `quiet_NaN` or `signaling_NaN`, because they have the property that x != x.
 
-    EXPECT_EQ(std::numeric_limits<Q>::denorm_min(), std::numeric_limits<const Q>::denorm_min());
-    EXPECT_EQ(std::numeric_limits<Q>::denorm_min(), std::numeric_limits<volatile Q>::denorm_min());
-    EXPECT_EQ(std::numeric_limits<Q>::denorm_min(),
-              std::numeric_limits<const volatile Q>::denorm_min());
+    EXPECT_THAT(std::numeric_limits<Q>::denorm_min(),
+                Eq(std::numeric_limits<const Q>::denorm_min()));
+    EXPECT_THAT(std::numeric_limits<Q>::denorm_min(),
+                Eq(std::numeric_limits<volatile Q>::denorm_min()));
+    EXPECT_THAT(std::numeric_limits<Q>::denorm_min(),
+                Eq(std::numeric_limits<const volatile Q>::denorm_min()));
 }
 
 TEST(RoundAs, SameAsStdRoundForSameUnits) {

--- a/au/code/au/operators_test.cc
+++ b/au/code/au/operators_test.cc
@@ -15,19 +15,23 @@
 #include "au/operators.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
+
+using ::testing::Eq;
+
 namespace detail {
 
 template <typename T>
 void expect_comparators_work(T a, T b) {
-    EXPECT_EQ(equal(a, b), (a == b));
-    EXPECT_EQ(not_equal(a, b), (a != b));
-    EXPECT_EQ(less(a, b), (a < b));
-    EXPECT_EQ(less_equal(a, b), (a <= b));
-    EXPECT_EQ(greater(a, b), (a > b));
-    EXPECT_EQ(greater_equal(a, b), (a >= b));
+    EXPECT_THAT(equal(a, b), Eq(a == b));
+    EXPECT_THAT(not_equal(a, b), Eq(a != b));
+    EXPECT_THAT(less(a, b), Eq(a < b));
+    EXPECT_THAT(less_equal(a, b), Eq(a <= b));
+    EXPECT_THAT(greater(a, b), Eq(a > b));
+    EXPECT_THAT(greater_equal(a, b), Eq(a >= b));
 }
 
 template <typename T, typename U>

--- a/au/code/au/prefix_test.cc
+++ b/au/code/au/prefix_test.cc
@@ -15,11 +15,13 @@
 #include "au/prefix.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using ::testing::StaticAssertTypeEq;
-
 namespace au {
+
+using ::testing::Eq;
+using ::testing::StaticAssertTypeEq;
 
 struct Bytes : UnitImpl<Information> {};
 
@@ -64,60 +66,60 @@ TEST(PrefixApplier, ConvertsSymbolForToCorrespondingPrefixedType) {
 }
 
 TEST(SiPrefixes, HaveCorrectAbsoluteValues) {
-    EXPECT_EQ(unit_ratio(Yotta<Bytes>{}, Bytes{}), pow<24>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Zetta<Bytes>{}, Bytes{}), pow<21>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Exa<Bytes>{}, Bytes{}), pow<18>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Peta<Bytes>{}, Bytes{}), pow<15>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Tera<Bytes>{}, Bytes{}), pow<12>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Giga<Bytes>{}, Bytes{}), pow<9>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Mega<Bytes>{}, Bytes{}), pow<6>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Kilo<Bytes>{}, Bytes{}), pow<3>(mag<10>()));
+    EXPECT_THAT(unit_ratio(Yotta<Bytes>{}, Bytes{}), Eq(pow<24>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Zetta<Bytes>{}, Bytes{}), Eq(pow<21>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Exa<Bytes>{}, Bytes{}), Eq(pow<18>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Peta<Bytes>{}, Bytes{}), Eq(pow<15>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Tera<Bytes>{}, Bytes{}), Eq(pow<12>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Giga<Bytes>{}, Bytes{}), Eq(pow<9>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Mega<Bytes>{}, Bytes{}), Eq(pow<6>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Kilo<Bytes>{}, Bytes{}), Eq(pow<3>(mag<10>())));
 
-    EXPECT_EQ(unit_ratio(Hecto<Bytes>{}, Bytes{}), pow<2>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Deka<Bytes>{}, Bytes{}), pow<1>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Deci<Bytes>{}, Bytes{}), pow<-1>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Centi<Bytes>{}, Bytes{}), pow<-2>(mag<10>()));
+    EXPECT_THAT(unit_ratio(Hecto<Bytes>{}, Bytes{}), Eq(pow<2>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Deka<Bytes>{}, Bytes{}), Eq(pow<1>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Deci<Bytes>{}, Bytes{}), Eq(pow<-1>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Centi<Bytes>{}, Bytes{}), Eq(pow<-2>(mag<10>())));
 
-    EXPECT_EQ(unit_ratio(Milli<Bytes>{}, Bytes{}), pow<-3>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Micro<Bytes>{}, Bytes{}), pow<-6>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Nano<Bytes>{}, Bytes{}), pow<-9>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Pico<Bytes>{}, Bytes{}), pow<-12>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Femto<Bytes>{}, Bytes{}), pow<-15>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Atto<Bytes>{}, Bytes{}), pow<-18>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Zepto<Bytes>{}, Bytes{}), pow<-21>(mag<10>()));
-    EXPECT_EQ(unit_ratio(Yocto<Bytes>{}, Bytes{}), pow<-24>(mag<10>()));
+    EXPECT_THAT(unit_ratio(Milli<Bytes>{}, Bytes{}), Eq(pow<-3>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Micro<Bytes>{}, Bytes{}), Eq(pow<-6>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Nano<Bytes>{}, Bytes{}), Eq(pow<-9>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Pico<Bytes>{}, Bytes{}), Eq(pow<-12>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Femto<Bytes>{}, Bytes{}), Eq(pow<-15>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Atto<Bytes>{}, Bytes{}), Eq(pow<-18>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Zepto<Bytes>{}, Bytes{}), Eq(pow<-21>(mag<10>())));
+    EXPECT_THAT(unit_ratio(Yocto<Bytes>{}, Bytes{}), Eq(pow<-24>(mag<10>())));
 }
 
 TEST(SiPrefixes, PrefixAppliersPredefined) {
     constexpr QuantityMaker<Inches> inches{};
 
-    EXPECT_EQ(quetta(inches)(1), ronna(inches)(1000));
-    EXPECT_EQ(ronna(inches)(1), yotta(inches)(1000));
-    EXPECT_EQ(yotta(inches)(1), zetta(inches)(1000));
-    EXPECT_EQ(zetta(inches)(1), exa(inches)(1000));
-    EXPECT_EQ(exa(inches)(1), peta(inches)(1000));
-    EXPECT_EQ(peta(inches)(1), tera(inches)(1000));
-    EXPECT_EQ(tera(inches)(1), giga(inches)(1000));
-    EXPECT_EQ(giga(inches)(1), mega(inches)(1000));
-    EXPECT_EQ(mega(inches)(1), kilo(inches)(1000));
+    EXPECT_THAT(quetta(inches)(1), Eq(ronna(inches)(1000)));
+    EXPECT_THAT(ronna(inches)(1), Eq(yotta(inches)(1000)));
+    EXPECT_THAT(yotta(inches)(1), Eq(zetta(inches)(1000)));
+    EXPECT_THAT(zetta(inches)(1), Eq(exa(inches)(1000)));
+    EXPECT_THAT(exa(inches)(1), Eq(peta(inches)(1000)));
+    EXPECT_THAT(peta(inches)(1), Eq(tera(inches)(1000)));
+    EXPECT_THAT(tera(inches)(1), Eq(giga(inches)(1000)));
+    EXPECT_THAT(giga(inches)(1), Eq(mega(inches)(1000)));
+    EXPECT_THAT(mega(inches)(1), Eq(kilo(inches)(1000)));
 
-    EXPECT_EQ(kilo(inches)(1), hecto(inches)(10));
-    EXPECT_EQ(hecto(inches)(1), deka(inches)(10));
-    EXPECT_EQ(deka(inches)(1), inches(10));
+    EXPECT_THAT(kilo(inches)(1), Eq(hecto(inches)(10)));
+    EXPECT_THAT(hecto(inches)(1), Eq(deka(inches)(10)));
+    EXPECT_THAT(deka(inches)(1), Eq(inches(10)));
 
-    EXPECT_EQ(inches(1), deci(inches)(10));
-    EXPECT_EQ(deci(inches)(1), centi(inches)(10));
-    EXPECT_EQ(centi(inches)(1), milli(inches)(10));
+    EXPECT_THAT(inches(1), Eq(deci(inches)(10)));
+    EXPECT_THAT(deci(inches)(1), Eq(centi(inches)(10)));
+    EXPECT_THAT(centi(inches)(1), Eq(milli(inches)(10)));
 
-    EXPECT_EQ(milli(inches)(1), micro(inches)(1000));
-    EXPECT_EQ(micro(inches)(1), nano(inches)(1000));
-    EXPECT_EQ(nano(inches)(1), pico(inches)(1000));
-    EXPECT_EQ(pico(inches)(1), femto(inches)(1000));
-    EXPECT_EQ(femto(inches)(1), atto(inches)(1000));
-    EXPECT_EQ(atto(inches)(1), zepto(inches)(1000));
-    EXPECT_EQ(zepto(inches)(1), yocto(inches)(1000));
-    EXPECT_EQ(yocto(inches)(1), ronto(inches)(1000));
-    EXPECT_EQ(ronto(inches)(1), quecto(inches)(1000));
+    EXPECT_THAT(milli(inches)(1), Eq(micro(inches)(1000)));
+    EXPECT_THAT(micro(inches)(1), Eq(nano(inches)(1000)));
+    EXPECT_THAT(nano(inches)(1), Eq(pico(inches)(1000)));
+    EXPECT_THAT(pico(inches)(1), Eq(femto(inches)(1000)));
+    EXPECT_THAT(femto(inches)(1), Eq(atto(inches)(1000)));
+    EXPECT_THAT(atto(inches)(1), Eq(zepto(inches)(1000)));
+    EXPECT_THAT(zepto(inches)(1), Eq(yocto(inches)(1000)));
+    EXPECT_THAT(yocto(inches)(1), Eq(ronto(inches)(1000)));
+    EXPECT_THAT(ronto(inches)(1), Eq(quecto(inches)(1000)));
 }
 
 TEST(SiPrefixes, CorrectlyLabelUnits) {
@@ -149,26 +151,26 @@ TEST(SiPrefixes, CorrectlyLabelUnits) {
 }
 
 TEST(BinaryPrefixes, HaveCorrectAbsoluteValues) {
-    EXPECT_EQ(unit_ratio(Yobi<Bytes>{}, Bytes{}), pow<8>(mag<1024>()));
-    EXPECT_EQ(unit_ratio(Zebi<Bytes>{}, Bytes{}), pow<7>(mag<1024>()));
-    EXPECT_EQ(unit_ratio(Exbi<Bytes>{}, Bytes{}), pow<6>(mag<1024>()));
-    EXPECT_EQ(unit_ratio(Pebi<Bytes>{}, Bytes{}), pow<5>(mag<1024>()));
-    EXPECT_EQ(unit_ratio(Tebi<Bytes>{}, Bytes{}), pow<4>(mag<1024>()));
-    EXPECT_EQ(unit_ratio(Gibi<Bytes>{}, Bytes{}), pow<3>(mag<1024>()));
-    EXPECT_EQ(unit_ratio(Mebi<Bytes>{}, Bytes{}), pow<2>(mag<1024>()));
-    EXPECT_EQ(unit_ratio(Kibi<Bytes>{}, Bytes{}), pow<1>(mag<1024>()));
+    EXPECT_THAT(unit_ratio(Yobi<Bytes>{}, Bytes{}), Eq(pow<8>(mag<1024>())));
+    EXPECT_THAT(unit_ratio(Zebi<Bytes>{}, Bytes{}), Eq(pow<7>(mag<1024>())));
+    EXPECT_THAT(unit_ratio(Exbi<Bytes>{}, Bytes{}), Eq(pow<6>(mag<1024>())));
+    EXPECT_THAT(unit_ratio(Pebi<Bytes>{}, Bytes{}), Eq(pow<5>(mag<1024>())));
+    EXPECT_THAT(unit_ratio(Tebi<Bytes>{}, Bytes{}), Eq(pow<4>(mag<1024>())));
+    EXPECT_THAT(unit_ratio(Gibi<Bytes>{}, Bytes{}), Eq(pow<3>(mag<1024>())));
+    EXPECT_THAT(unit_ratio(Mebi<Bytes>{}, Bytes{}), Eq(pow<2>(mag<1024>())));
+    EXPECT_THAT(unit_ratio(Kibi<Bytes>{}, Bytes{}), Eq(pow<1>(mag<1024>())));
 }
 
 TEST(BinaryPrefixes, PrefixAppliersPredefined) {
     constexpr QuantityMaker<Bytes> bytes{};
 
-    EXPECT_EQ(yobi(bytes)(1), zebi(bytes)(1024));
-    EXPECT_EQ(zebi(bytes)(1), exbi(bytes)(1024));
-    EXPECT_EQ(exbi(bytes)(1), pebi(bytes)(1024));
-    EXPECT_EQ(pebi(bytes)(1), tebi(bytes)(1024));
-    EXPECT_EQ(tebi(bytes)(1), gibi(bytes)(1024));
-    EXPECT_EQ(gibi(bytes)(1), mebi(bytes)(1024));
-    EXPECT_EQ(mebi(bytes)(1), kibi(bytes)(1024));
+    EXPECT_THAT(yobi(bytes)(1), Eq(zebi(bytes)(1024)));
+    EXPECT_THAT(zebi(bytes)(1), Eq(exbi(bytes)(1024)));
+    EXPECT_THAT(exbi(bytes)(1), Eq(pebi(bytes)(1024)));
+    EXPECT_THAT(pebi(bytes)(1), Eq(tebi(bytes)(1024)));
+    EXPECT_THAT(tebi(bytes)(1), Eq(gibi(bytes)(1024)));
+    EXPECT_THAT(gibi(bytes)(1), Eq(mebi(bytes)(1024)));
+    EXPECT_THAT(mebi(bytes)(1), Eq(kibi(bytes)(1024)));
 }
 
 TEST(BinaryPrefixes, CorrectlyLabelUnits) {

--- a/au/code/au/quantity_chrono_policy_correspondence_test.cc
+++ b/au/code/au/quantity_chrono_policy_correspondence_test.cc
@@ -22,6 +22,7 @@ using namespace std::chrono_literals;
 
 namespace au {
 
+using ::testing::Eq;
 using ::testing::IsTrue;
 
 namespace {
@@ -97,9 +98,9 @@ struct Subtraction {
     }
 };
 
-TEST(Assignment, ReturnsExpectedValue) { EXPECT_EQ(2s, Assignment{}(1s, 2s)); }
-TEST(Addition, ReturnsExpectedValue) { EXPECT_EQ(1001ms, Addition{}(1s, 1ms)); }
-TEST(Subtraction, ReturnsExpectedValue) { EXPECT_EQ(999ms, Subtraction{}(1s, 1ms)); }
+TEST(Assignment, ReturnsExpectedValue) { EXPECT_THAT(Assignment{}(1s, 2s), Eq(2s)); }
+TEST(Addition, ReturnsExpectedValue) { EXPECT_THAT(Addition{}(1s, 1ms), Eq(1001ms)); }
+TEST(Subtraction, ReturnsExpectedValue) { EXPECT_THAT(Subtraction{}(1s, 1ms), Eq(999ms)); }
 
 }  // namespace
 

--- a/au/code/au/quantity_point_test.cc
+++ b/au/code/au/quantity_point_test.cc
@@ -21,6 +21,7 @@
 
 namespace au {
 
+using ::testing::Eq;
 using ::testing::IsFalse;
 using ::testing::IsTrue;
 using ::testing::Not;
@@ -130,18 +131,18 @@ TEST(QuantityPoint, IntermediateTypeIsSignedIfExplicitRepIsSigned) {
 TEST(QuantityPoint, SupportsDirectAccessWithSameUnit) {
     auto p = celsius_pt(3);
     ++(p.data_in(Celsius{}));
-    EXPECT_EQ(p, celsius_pt(4));
+    EXPECT_THAT(p, Eq(celsius_pt(4)));
 }
 
 TEST(QuantityPoint, SupportsDirectConstAccessWithSameUnit) {
     const auto p = meters_pt(3.5);
-    EXPECT_EQ(static_cast<const void *>(&p.data_in(Meters{})), static_cast<const void *>(&p));
+    EXPECT_THAT(static_cast<const void *>(&p.data_in(Meters{})), Eq(static_cast<const void *>(&p)));
 }
 
 TEST(QuantityPoint, SupportsDirectAccessWithEquivalentUnit) {
     auto p = kelvins_pt(3);
     ++(p.data_in(Micro<Mega<Kelvins>>{}));
-    EXPECT_EQ(p, kelvins_pt(4));
+    EXPECT_THAT(p, Eq(kelvins_pt(4)));
 
     // Uncomment to test compile time failure:
     // ++(p.data_in(Celsius{}));
@@ -149,29 +150,30 @@ TEST(QuantityPoint, SupportsDirectAccessWithEquivalentUnit) {
 
 TEST(QuantityPoint, SupportsDirectConstAccessWithEquivalentUnit) {
     const auto p = milli(meters_pt)(3.5);
-    EXPECT_EQ(static_cast<const void *>(&p.data_in(Micro<Kilo<Meters>>{})),
-              static_cast<const void *>(&p));
+    EXPECT_THAT(static_cast<const void *>(&p.data_in(Micro<Kilo<Meters>>{})),
+                Eq(static_cast<const void *>(&p)));
 
     // Uncomment to test compile time failure:
-    // EXPECT_EQ(static_cast<const void *>(&p.data_in(Micro<Meters>{})),
-    //           static_cast<const void *>(&p));
+    // EXPECT_THAT(static_cast<const void *>(&p.data_in(Micro<Meters>{})),
+    //             Eq(static_cast<const void *>(&p)));
 }
 
 TEST(QuantityPoint, SupportsDirectAccessWithQuantityMakerOfSameUnit) {
     auto p = meters_pt(3);
     ++(p.data_in(meters_pt));
-    EXPECT_EQ(p, meters_pt(4));
+    EXPECT_THAT(p, Eq(meters_pt(4)));
 }
 
 TEST(QuantityPoint, SupportsDirectConstAccessWithQuantityMakerOfSameUnit) {
     const auto p = celsius_pt(3.5);
-    EXPECT_EQ(static_cast<const void *>(&p.data_in(celsius_pt)), static_cast<const void *>(&p));
+    EXPECT_THAT(static_cast<const void *>(&p.data_in(celsius_pt)),
+                Eq(static_cast<const void *>(&p)));
 }
 
 TEST(QuantityPoint, SupportsDirectAccessWithQuantityMakerOfEquivalentUnit) {
     auto p = kelvins_pt(3);
     ++(p.data_in(micro(mega(kelvins_pt))));
-    EXPECT_EQ(p, kelvins_pt(4));
+    EXPECT_THAT(p, Eq(kelvins_pt(4)));
 
     // Uncomment to test compile time failure:
     // ++(p.data_in(micro(kelvins_pt)));
@@ -179,11 +181,12 @@ TEST(QuantityPoint, SupportsDirectAccessWithQuantityMakerOfEquivalentUnit) {
 
 TEST(QuantityPoint, SupportsDirectConstAccessWithQuantityMakerOfEquivalentUnit) {
     const auto p = milli(meters_pt)(3.5);
-    EXPECT_EQ(static_cast<const void *>(&p.data_in(micro(kilo(meters_pt)))),
-              static_cast<const void *>(&p));
+    EXPECT_THAT(static_cast<const void *>(&p.data_in(micro(kilo(meters_pt)))),
+                Eq(static_cast<const void *>(&p)));
 
     // Uncomment to test compile time failure:
-    // EXPECT_EQ(static_cast<const void*>(&p.data_in(meters_pt)), static_cast<const void*>(&p));
+    // EXPECT_THAT(static_cast<const void*>(&p.data_in(meters_pt)), Eq(static_cast<const
+    // void*>(&p)));
 }
 
 TEST(QuantityPoint, HasDefaultConstructor) {
@@ -191,7 +194,7 @@ TEST(QuantityPoint, HasDefaultConstructor) {
     // default constructor must _exist_, so we can use it with, e.g., `std::atomic`.
     QuantityPointF<Celsius> qp;
     qp = celsius_pt(4.5f);
-    EXPECT_EQ(qp.in(celsius_pt), 4.5f);
+    EXPECT_THAT(qp.in(celsius_pt), Eq(4.5f));
 }
 
 TEST(QuantityPoint, InHandlesUnitsWithNonzeroOffset) {
@@ -201,11 +204,11 @@ TEST(QuantityPoint, InHandlesUnitsWithNonzeroOffset) {
 
 TEST(QuantityPoint, InHandlesIntegerRepInUnitsWithNonzeroOffset) {
     constexpr auto room_temperature = celsius_pt(20);
-    EXPECT_EQ(room_temperature.in(celsius_pt), 20);
+    EXPECT_THAT(room_temperature.in(celsius_pt), Eq(20));
 }
 
 TEST(QuantityPoint, CanRequestOutputRepWhenCallingIn) {
-    EXPECT_EQ(celsius_pt(5.2).in<int>(Celsius{}), 5);
+    EXPECT_THAT(celsius_pt(5.2).in<int>(Celsius{}), Eq(5));
 }
 
 TEST(QuantityPoint, CanCastToUnitWithDifferentMagnitude) {
@@ -229,7 +232,7 @@ TEST(QuantityPoint, CoerceAsWillForceLossyConversion) {
     EXPECT_THAT(inches_pt(30).coerce_as(feet_pt), SameTypeAndValue(feet_pt(2)));
 
     // Unsigned overflow.
-    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
     EXPECT_THAT(feet_pt(uint8_t{30}).coerce_as(inches_pt),
                 SameTypeAndValue(inches_pt(uint8_t{104})));
 }
@@ -243,7 +246,7 @@ TEST(QuantityPoint, CoerceAsExplicitRepSetsOutputType) {
     EXPECT_THAT(inches_pt(30).coerce_as<float>(feet_pt), SameTypeAndValue(feet_pt(2.5f)));
 
     // Coerced unsigned overflow.
-    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
     EXPECT_THAT(feet_pt(30).coerce_as<uint8_t>(inches_pt),
                 SameTypeAndValue(inches_pt(uint8_t{104})));
 }
@@ -253,7 +256,7 @@ TEST(QuantityPoint, CoerceInWillForceLossyConversion) {
     EXPECT_THAT(inches_pt(30).coerce_in(feet_pt), SameTypeAndValue(2));
 
     // Unsigned overflow.
-    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
     EXPECT_THAT(feet_pt(uint8_t{30}).coerce_in(inches_pt), SameTypeAndValue(uint8_t{104}));
 }
 
@@ -265,7 +268,7 @@ TEST(QuantityPoint, CoerceInExplicitRepSetsOutputType) {
     EXPECT_THAT(inches_pt(30).coerce_in<float>(feet_pt), SameTypeAndValue(2.5f));
 
     // Coerced unsigned overflow.
-    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
     EXPECT_THAT(feet_pt(30).coerce_in<uint8_t>(inches_pt), SameTypeAndValue(uint8_t{104}));
 }
 
@@ -306,25 +309,25 @@ TEST(QuantityPoint, CanSubtractDiffTFromRight) {
 TEST(QuantityPoint, ShortHandAdditionAssignmentWorks) {
     auto d = kelvins_pt(1.25);
     d += kelvins(2.75);
-    EXPECT_EQ(d, kelvins_pt(4.));
+    EXPECT_THAT(d, Eq(kelvins_pt(4.)));
 }
 
 TEST(QuantityPoint, ShortHandAdditionHasReferenceCharacter) {
     auto d = kelvins_pt(1);
     (d += kelvins(1234)) = kelvins_pt(3);
-    EXPECT_EQ(d, (kelvins_pt(3)));
+    EXPECT_THAT(d, Eq(kelvins_pt(3)));
 }
 
 TEST(QuantityPoint, ShortHandSubtractionAssignmentWorks) {
     auto d = kelvins_pt(4.75);
     d -= kelvins(2.75);
-    EXPECT_EQ(d, (kelvins_pt(2.)));
+    EXPECT_THAT(d, Eq(kelvins_pt(2.)));
 }
 
 TEST(QuantityPoint, ShortHandSubtractionHasReferenceCharacter) {
     auto d = kelvins_pt(4);
     (d -= kelvins(1234)) = kelvins_pt(3);
-    EXPECT_EQ(d, (kelvins_pt(3)));
+    EXPECT_THAT(d, Eq(kelvins_pt(3)));
 }
 
 TEST(QuantityPoint, MixedUnitAdditionUsesCommonDenominator) {
@@ -353,7 +356,7 @@ TEST(QuantityPoint, MixedUnitsWithIdenticalNonzeroOriginDontGetSubdivided) {
     // Just to leave no doubt: the centi-celsius units of the origin should _not_ influence the
     // units in which the result is expressed (although we _should_ compare _equal_ to that result).
     constexpr auto right_answer_wrong_units = centi(celsius_pt)(10000);
-    ASSERT_EQ(diff, right_answer_wrong_units);
+    ASSERT_THAT(diff, Eq(right_answer_wrong_units));
     EXPECT_THAT(diff, Not(PointEquivalent(right_answer_wrong_units)));
 }
 
@@ -399,7 +402,7 @@ TEST(QuantityPoint, AddingPosUnitQuantityToNegUnitPointGivesPosUnitPoint) {
 }
 
 TEST(QuantityPoint, CanSubtractIntegralInputsWithNonintegralOriginDifference) {
-    EXPECT_EQ(celsius_pt(0) - kelvins_pt(273), centi(kelvins)(15));
+    EXPECT_THAT(celsius_pt(0) - kelvins_pt(273), Eq(centi(kelvins)(15)));
 }
 
 TEST(QuantityPoint, InheritsOverflowSafetySurfaceFromUnderlyingQuantityTypes) {

--- a/au/code/au/quantity_test.cc
+++ b/au/code/au/quantity_test.cc
@@ -121,25 +121,27 @@ TEST(Quantity, HasCorrectRepNamedAliases) {
 TEST(Quantity, CanCreateAndReadValuesByNamingUnits) {
     constexpr auto x = feet(3.14);
     constexpr double output_value = x.in(feet);
-    EXPECT_EQ(output_value, 3.14);
+    EXPECT_THAT(output_value, Eq(3.14));
 }
 
-TEST(Quantity, CanRequestOutputRepWhenCallingIn) { EXPECT_EQ(feet(3.14).in<int>(feet), 3); }
+TEST(Quantity, CanRequestOutputRepWhenCallingIn) { EXPECT_THAT(feet(3.14).in<int>(feet), Eq(3)); }
 
 TEST(MakeQuantity, MakesQuantityInGivenUnit) {
-    EXPECT_EQ(make_quantity<Feet>(1.234), feet(1.234));
-    EXPECT_EQ(make_quantity<Feet>(99), feet(99));
+    EXPECT_THAT(make_quantity<Feet>(1.234), Eq(feet(1.234)));
+    EXPECT_THAT(make_quantity<Feet>(99), Eq(feet(99)));
 }
 
 TEST(Quantity, RationalConversionRecoversExactIntegerValues) {
     // This test would fail if our implementation multiplied by the float
     // representation of (1/13), instead of dividing by 13, under the hood.
     for (int i = 1; i < 100; ++i) {
-        EXPECT_EQ(feet(static_cast<float>(i * 13)).in(feet * mag<13>()), i);
+        EXPECT_THAT(feet(static_cast<float>(i * 13)).in(feet * mag<13>()), Eq(i));
     }
 }
 
-TEST(QuantityMaker, CreatesAppropriateQuantityIfCalled) { EXPECT_EQ(yards(3.14).in(yards), 3.14); }
+TEST(QuantityMaker, CreatesAppropriateQuantityIfCalled) {
+    EXPECT_THAT(yards(3.14).in(yards), Eq(3.14));
+}
 
 TEST(QuantityMaker, CanBeMultipliedBySingularUnitToGetMakerOfProductUnit) {
     StaticAssertTypeEq<decltype(hour * feet), QuantityMaker<UnitProductT<Feet, Hours>>>();
@@ -175,25 +177,25 @@ TEST(QuantityMaker, CanMultiplyByMultipleSingularUnits) {
 }
 
 TEST(Quantity, CanRetrieveInDifferentUnitsWithSameDimension) {
-    EXPECT_EQ(feet(4).in(inches), 48);
-    EXPECT_EQ(yards(4).in(inches), 144);
+    EXPECT_THAT(feet(4).in(inches), Eq(48));
+    EXPECT_THAT(yards(4).in(inches), Eq(144));
 }
 
 TEST(Quantity, SupportsDirectAccessWithSameUnit) {
     auto x = inches(3);
     ++(x.data_in(Inches{}));
-    EXPECT_EQ(x, inches(4));
+    EXPECT_THAT(x, Eq(inches(4)));
 }
 
 TEST(Quantity, SupportsDirectConstAccessWithSameUnit) {
     const auto x = meters(3.5);
-    EXPECT_EQ(static_cast<const void *>(&x.data_in(Meters{})), static_cast<const void *>(&x));
+    EXPECT_THAT(static_cast<const void *>(&x.data_in(Meters{})), Eq(static_cast<const void *>(&x)));
 }
 
 TEST(Quantity, SupportsDirectAccessWithEquivalentUnit) {
     auto x = (kilo(feet) / hour)(3);
     ++(x.data_in(Feet{} / Milli<Hours>{}));
-    EXPECT_EQ(x, (kilo(feet) / hour)(4));
+    EXPECT_THAT(x, Eq((kilo(feet) / hour)(4)));
 
     // Uncomment to test compile time failure:
     // ++(x.data_in(Feet{} / Kilo<Hours>{}));
@@ -201,29 +203,29 @@ TEST(Quantity, SupportsDirectAccessWithEquivalentUnit) {
 
 TEST(Quantity, SupportsDirectConstAccessWithEquivalentUnit) {
     const auto x = (milli(meters) / minute)(3.5);
-    EXPECT_EQ(static_cast<const void *>(&x.data_in(Meters{} / Kilo<Minutes>{})),
-              static_cast<const void *>(&x));
+    EXPECT_THAT(static_cast<const void *>(&x.data_in(Meters{} / Kilo<Minutes>{})),
+                Eq(static_cast<const void *>(&x)));
 
     // Uncomment to test compile time failure:
-    // EXPECT_EQ(static_cast<const void *>(&x.data_in(Meters{} / Mega<Minutes>{})),
-    //           static_cast<const void *>(&x));
+    // EXPECT_THAT(static_cast<const void *>(&x.data_in(Meters{} / Mega<Minutes>{})),
+    //             Eq(static_cast<const void *>(&x)));
 }
 
 TEST(Quantity, SupportsDirectAccessWithQuantityMakerOfSameUnit) {
     auto x = inches(3);
     ++(x.data_in(inches));
-    EXPECT_EQ(x, inches(4));
+    EXPECT_THAT(x, Eq(inches(4)));
 }
 
 TEST(Quantity, SupportsDirectConstAccessWithQuantityMakerOfSameUnit) {
     const auto x = meters(3.5);
-    EXPECT_EQ(static_cast<const void *>(&x.data_in(meters)), static_cast<const void *>(&x));
+    EXPECT_THAT(static_cast<const void *>(&x.data_in(meters)), Eq(static_cast<const void *>(&x)));
 }
 
 TEST(Quantity, SupportsDirectAccessWithQuantityMakerOfEquivalentUnit) {
     auto x = (kilo(feet) / hour)(3);
     ++(x.data_in(feet / milli(hour)));
-    EXPECT_EQ(x, (kilo(feet) / hour)(4));
+    EXPECT_THAT(x, Eq((kilo(feet) / hour)(4)));
 
     // Uncomment to test compile time failure:
     // ++(x.data_in(feet / micro(hour)));
@@ -231,12 +233,12 @@ TEST(Quantity, SupportsDirectAccessWithQuantityMakerOfEquivalentUnit) {
 
 TEST(Quantity, SupportsDirectConstAccessWithQuantityMakerOfEquivalentUnit) {
     const auto x = (milli(meters) / minute)(3.5);
-    EXPECT_EQ(static_cast<const void *>(&x.data_in(meters / kilo(minute))),
-              static_cast<const void *>(&x));
+    EXPECT_THAT(static_cast<const void *>(&x.data_in(meters / kilo(minute))),
+                Eq(static_cast<const void *>(&x)));
 
     // Uncomment to test compile time failure:
-    // EXPECT_EQ(static_cast<const void *>(&x.data_in(meters / mega(minute))),
-    //           static_cast<const void *>(&x));
+    // EXPECT_THAT(static_cast<const void *>(&x.data_in(meters / mega(minute))),
+    //             Eq(static_cast<const void *>(&x)));
 }
 
 TEST(Quantity, CoerceAsWillForceLossyConversion) {
@@ -244,7 +246,7 @@ TEST(Quantity, CoerceAsWillForceLossyConversion) {
     EXPECT_THAT(inches(30).coerce_as(feet), SameTypeAndValue(feet(2)));
 
     // Unsigned overflow.
-    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
     EXPECT_THAT(feet(uint8_t{30}).coerce_as(inches), SameTypeAndValue(inches(uint8_t{104})));
 }
 
@@ -256,7 +258,7 @@ TEST(Quantity, CoerceAsExplicitRepSetsOutputType) {
     EXPECT_THAT(inches(30).coerce_as<float>(feet), SameTypeAndValue(feet(2.5f)));
 
     // Coerced unsigned overflow.
-    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
     EXPECT_THAT(feet(30).coerce_as<uint8_t>(inches), SameTypeAndValue(inches(uint8_t{104})));
 }
 
@@ -265,7 +267,7 @@ TEST(Quantity, CoerceInWillForceLossyConversion) {
     EXPECT_THAT(inches(30).coerce_in(feet), SameTypeAndValue(2));
 
     // Unsigned overflow.
-    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
     EXPECT_THAT(feet(uint8_t{30}).coerce_in(inches), SameTypeAndValue(uint8_t{104}));
 }
 
@@ -277,7 +279,7 @@ TEST(Quantity, CoerceInExplicitRepSetsOutputType) {
     EXPECT_THAT(inches(30).coerce_in<float>(feet), SameTypeAndValue(2.5f));
 
     // Coerced unsigned overflow.
-    ASSERT_EQ(static_cast<uint8_t>(30 * 12), 104);
+    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
     EXPECT_THAT(feet(30).coerce_in<uint8_t>(inches), SameTypeAndValue(uint8_t{104}));
 }
 
@@ -289,31 +291,31 @@ TEST(Quantity, CoerceAsPerformsConversionInWidestType) {
 
 TEST(Quantity, CanImplicitlyConvertToDifferentUnitOfSameDimension) {
     constexpr QuantityI32<Inches> x = yards(2);
-    EXPECT_EQ(x.in(inches), 72);
+    EXPECT_THAT(x.in(inches), Eq(72));
 }
 
 TEST(Quantity, HandlesBaseDimensionsWithFractionalExponents) {
     using KiloRootFeet = decltype(root<2>(Mega<Feet>{}));
     constexpr auto x = make_quantity<KiloRootFeet>(5);
-    EXPECT_EQ(x.in(root<2>(Feet{})), 5'000);
-    EXPECT_EQ(x * x, mega(feet)(25));
+    EXPECT_THAT(x.in(root<2>(Feet{})), Eq(5'000));
+    EXPECT_THAT(x * x, Eq(mega(feet)(25)));
 }
 
 TEST(Quantity, HandlesMagnitudesWithFractionalExponents) {
     constexpr auto x = sqrt(kilo(feet))(3.0);
 
     // We can retrieve the value in the same unit (regardless of the scale's fractional powers).
-    EXPECT_EQ(x.in(sqrt(kilo(feet))), 3.0);
+    EXPECT_THAT(x.in(sqrt(kilo(feet))), Eq(3.0));
 
     // We can retrieve the value in a *different* unit, which *also* has fractional powers, as long
     // as their *ratio* has no fractional powers.
-    EXPECT_EQ(x.in(sqrt(milli(feet))), 3'000.0);
+    EXPECT_THAT(x.in(sqrt(milli(feet))), Eq(3'000.0));
 
     // We can also retrieve the value in a different unit whose ratio *does* have fractional powers.
     EXPECT_NEAR(x.in(sqrt(feet)), 94.86833, 1e-5);
 
     // Squaring the fractional base power gives us an exact non-fractional dimension and scale.
-    EXPECT_EQ(x * x, kilo(feet)(9.0));
+    EXPECT_THAT(x * x, Eq(kilo(feet)(9.0)));
 }
 
 // A custom "Quantity-equivalent" type, whose interop with Quantity we'll provide below.
@@ -336,7 +338,7 @@ struct CorrespondingQuantity<MyHours> {
 
 TEST(Quantity, ImplicitConstructionFromCorrespondingQuantity) {
     constexpr Quantity<Hours, int> x = MyHours{3};
-    EXPECT_EQ(x, hours(3));
+    EXPECT_THAT(x, Eq(hours(3)));
 }
 
 TEST(Quantity, ImplicitConstructionFromTwoHopCorrespondingQuantity) {
@@ -347,7 +349,7 @@ TEST(Quantity, ImplicitConstructionFromTwoHopCorrespondingQuantity) {
 TEST(Quantity, ImplicitConstructionFromLvalueCorrespondingQuantity) {
     MyHours original{10};
     const Quantity<Hours, int> converted = original;
-    EXPECT_EQ(converted, hours(10));
+    EXPECT_THAT(converted, Eq(hours(10)));
 }
 
 TEST(Quantity, ImplicitConversionToCorrespondingQuantity) {
@@ -374,7 +376,7 @@ TEST(AsQuantity, DeducesCorrespondingQuantity) {
 TEST(Quantity, EqualityComparisonWorks) {
     constexpr auto a = feet(-4.8);
     constexpr auto b = feet(-4.8);
-    EXPECT_EQ(a, b);
+    EXPECT_THAT(a, Eq(b));
 }
 
 TEST(Quantity, InequalityComparisonWorks) {
@@ -402,7 +404,7 @@ TEST(Quantity, RelativeComparisonsWork) {
 TEST(Quantity, CopyingWorksAndIsDeepCopy) {
     auto original = feet(1.5);
     const auto copy{original};
-    EXPECT_EQ(original, copy);
+    EXPECT_THAT(original, Eq(copy));
 
     // To test that we're deep copying, modify the original.
     original += feet(2.5);
@@ -413,14 +415,14 @@ TEST(Quantity, CanAddLikeQuantities) {
     constexpr auto a = inches(1);
     constexpr auto b = inches(2);
     constexpr auto c = inches(3);
-    EXPECT_EQ(a + b, c);
+    EXPECT_THAT(a + b, Eq(c));
 }
 
 TEST(Quantity, CanSubtractLikeQuantities) {
     constexpr auto a = feet(1);
     constexpr auto b = feet(2);
     constexpr auto c = feet(3);
-    EXPECT_EQ(c - b, a);
+    EXPECT_THAT(c - b, Eq(a));
 }
 
 TEST(Quantity, AdditionAndSubtractionCommuteWithUnitTagging) {
@@ -448,18 +450,18 @@ TEST(Quantity, CanMultiplyArbitraryQuantities) {
     constexpr auto d = feet(6);
 
     v *t;
-    EXPECT_EQ(d, v * t);
+    EXPECT_THAT(d, Eq(v * t));
 }
 
 TEST(Quantity, ProductOfReciprocalTypesIsImplicitlyConvertibleToRawNumber) {
     constexpr int count = hours(2) * pow<-1>(hours)(3);
-    EXPECT_EQ(count, 6);
+    EXPECT_THAT(count, Eq(6));
 }
 
 TEST(Quantity, ScalarMultiplicationWorks) {
     constexpr auto d = feet(3);
-    EXPECT_EQ(feet(6), 2 * d);
-    EXPECT_EQ(feet(9), d * 3);
+    EXPECT_THAT(feet(6), Eq(2 * d));
+    EXPECT_THAT(feet(9), Eq(d * 3));
 }
 
 TEST(Quantity, SupportsMultiplicationForComplexRep) {
@@ -549,7 +551,7 @@ TEST(Quantity, CanDivideArbitraryQuantities) {
 
     constexpr auto v = (feet / hour)(2.);
 
-    EXPECT_EQ(v, d / t);
+    EXPECT_THAT(v, Eq(d / t));
 }
 
 TEST(Quantity, RatioOfSameTypeIsScalar) {
@@ -574,68 +576,68 @@ TEST(Quantity, ProductOfInvertingUnitsIsScalar) {
     // The point is to make sure that the product-unit of `Days` and `PerDay` does **not** reduce to
     // something trivial, like `UnitProduct<>`.  Rather, it should be its own non-trivial
     // unit---although, naturally, it must be **quantity-equivalent** to `UnitProduct<>`.
-    ASSERT_EQ(num_units_in_product(UnitProductT<Days, PerDay>{}), 2);
+    ASSERT_THAT(num_units_in_product(UnitProductT<Days, PerDay>{}), Eq(2));
 
     EXPECT_THAT(days(3) * per_day(8), SameTypeAndValue(24));
 }
 
 TEST(Quantity, ScalarDivisionWorks) {
     constexpr auto x = feet(10);
-    EXPECT_EQ(x / 2, feet(5));
-    EXPECT_EQ(20. / x, inverse(feet)(2.));
+    EXPECT_THAT(x / 2, Eq(feet(5)));
+    EXPECT_THAT(20. / x, Eq(inverse(feet)(2.)));
 }
 
 TEST(Quantity, ScalarDivisionIsConstexprCompatible) {
     constexpr auto quotient = feet(10.) / 2;
-    EXPECT_EQ(quotient, feet(5.));
+    EXPECT_THAT(quotient, Eq(feet(5.)));
 }
 
 TEST(Quantity, ShortHandAdditionAssignmentWorks) {
     auto d = feet(1.25);
     d += feet(2.75);
-    EXPECT_EQ(d, feet(4.));
+    EXPECT_THAT(d, Eq(feet(4.)));
 }
 
 TEST(Quantity, ShortHandAdditionHasReferenceCharacter) {
     auto d = feet(1);
     d += feet(1234) = feet(3);
-    EXPECT_EQ(d, (feet(4)));
+    EXPECT_THAT(d, Eq(feet(4)));
 }
 
 TEST(Quantity, ShortHandSubtractionAssignmentWorks) {
     auto d = feet(4.75);
     d -= feet(2.75);
-    EXPECT_EQ(d, (feet(2.)));
+    EXPECT_THAT(d, Eq(feet(2.)));
 }
 
 TEST(Quantity, ShortHandSubtractionHasReferenceCharacter) {
     auto d = feet(4);
     d -= feet(1234) = feet(3);
-    EXPECT_EQ(d, (feet(1)));
+    EXPECT_THAT(d, Eq(feet(1)));
 }
 
 TEST(Quantity, ShortHandMultiplicationAssignmentWorks) {
     auto d = feet(1.25);
     d *= 2;
-    EXPECT_EQ(d, (feet(2.5)));
+    EXPECT_THAT(d, Eq(feet(2.5)));
 }
 
 TEST(Quantity, ShortHandMultiplicationHasReferenceCharacter) {
     auto d = feet(1);
     (d *= 3) = feet(19);
-    EXPECT_EQ(d, (feet(19)));
+    EXPECT_THAT(d, Eq(feet(19)));
 }
 
 TEST(Quantity, ShortHandDivisionAssignmentWorks) {
     auto d = feet(2.5);
     d /= 2;
-    EXPECT_EQ(d, (feet(1.25)));
+    EXPECT_THAT(d, Eq(feet(1.25)));
 }
 
 TEST(Quantity, ShortHandDivisionHasReferenceCharacter) {
     auto d = feet(19);
     (d /= 3) = feet(1);
-    EXPECT_EQ(d, (feet(1)));
+    EXPECT_THAT(d, Eq(feet(1)));
 }
 
 TEST(Quantity, UnaryPlusWorks) {
@@ -644,12 +646,12 @@ TEST(Quantity, UnaryPlusWorks) {
     //      test_my_function(+5_mpss);  // <-- needs unary plus!
     //      test_my_function(-5_mpss);
     constexpr auto d = hours(22);
-    EXPECT_EQ(d, +d);
+    EXPECT_THAT(d, Eq(+d));
 }
 
 TEST(Quantity, UnaryMinusWorks) {
     constexpr auto d = hours(25);
-    EXPECT_EQ((hours(-25)), -d);
+    EXPECT_THAT((hours(-25)), Eq(-d));
 }
 
 TEST(Quantity, RepCastSupportsConstexprAndConst) {
@@ -705,7 +707,7 @@ TEST(Quantity, QuantityCastAccurateForChangingUnitsAndGoingFromIntegralToFloatin
 
 TEST(Quantity, QuantityCastAvoidsPreventableOverflowWhenGoingToLargerType) {
     constexpr auto lots_of_inches = inches(uint32_t{4'000'000'000});
-    ASSERT_EQ(lots_of_inches.in(inches), 4'000'000'000);
+    ASSERT_THAT(lots_of_inches.in(inches), Eq(4'000'000'000));
 
     EXPECT_THAT(lots_of_inches.as<uint64_t>(nano(inches)),
                 SameTypeAndValue(nano(inches)(uint64_t{4'000'000'000ULL * 1'000'000'000ULL})));
@@ -718,7 +720,7 @@ TEST(Quantity, QuantityCastAvoidsPreventableOverflowWhenGoingToSmallerType) {
     constexpr auto lots_of_nanoinches = nano(inches)(would_overflow_uint32);
 
     // Make sure we don't overflow in uint64_t.
-    ASSERT_EQ(lots_of_nanoinches.in(nano(inches)), would_overflow_uint32);
+    ASSERT_THAT(lots_of_nanoinches.in(nano(inches)), Eq(would_overflow_uint32));
 
     EXPECT_THAT(lots_of_nanoinches.coerce_as<uint32_t>(inches),
                 SameTypeAndValue(inches(uint32_t{9})));
@@ -1013,7 +1015,7 @@ TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions
                 }() + ")";
             }
 
-            EXPECT_EQ(is_lossy, did_value_change)
+            EXPECT_THAT(is_lossy, Eq(did_value_change))
                 << "Conversion " << (is_lossy ? "is" : "is not") << " lossy" << reason
                 << ", but round-trip conversion " << (did_value_change ? "did" : "did not")
                 << " change the value.  original: " << original << ", converted: " << converted
@@ -1075,7 +1077,7 @@ TEST(UnblockIntDiv, IsNoOpForDivisionThatWouldBeAllowedAnyway) {
 
 TEST(Quantity, CanIntegerDivideQuantitiesOfQuantityEquivalentUnits) {
     constexpr auto ratio = meters(60) / meters(25);
-    EXPECT_EQ(ratio, 2);
+    EXPECT_THAT(ratio, Eq(2));
 }
 
 TEST(mod, ComputesRemainderForSameUnits) {
@@ -1089,11 +1091,11 @@ TEST(mod, ReturnsCommonUnitForDifferentInputUnits) {
 }
 
 TEST(Zero, ComparableToArbitraryQuantities) {
-    EXPECT_EQ(ZERO, meters(0));
+    EXPECT_THAT(ZERO, Eq(meters(0)));
     EXPECT_LT(ZERO, meters(1));
     EXPECT_GT(ZERO, meters(-1));
 
-    EXPECT_EQ(ZERO, hours(0));
+    EXPECT_THAT(ZERO, Eq(hours(0)));
     EXPECT_LT(ZERO, hours(1));
     EXPECT_GT(ZERO, hours(-1));
 }

--- a/au/code/au/rep_test.cc
+++ b/au/code/au/rep_test.cc
@@ -31,6 +31,7 @@
 
 namespace au {
 
+using ::testing::Eq;
 using ::testing::IsFalse;
 using ::testing::IsTrue;
 using ::testing::StaticAssertTypeEq;
@@ -116,7 +117,7 @@ TEST(IsProductValidRep, FalseIfProductDoesNotExist) {
 }
 
 TEST(IsProductValidRep, TrueOnlyForSideWhereProductExists) {
-    ASSERT_EQ(LeftMultiplyDoubleByThree{} * 4.5, 13.5);
+    ASSERT_THAT(LeftMultiplyDoubleByThree{} * 4.5, Eq(13.5));
 
     EXPECT_THAT((IsProductValidRep<LeftMultiplyDoubleByThree, double>::value), IsTrue());
     EXPECT_THAT((IsProductValidRep<double, LeftMultiplyDoubleByThree>::value), IsFalse());
@@ -134,7 +135,7 @@ TEST(IsQuotientValidRep, FalseIfQuotientIsQuantity) {
 }
 
 TEST(IsQuotientValidRep, TrueOnlyForSideWhereQuotientExists) {
-    ASSERT_EQ(DivideTenByFloat{} / 2.0f, 5.0f);
+    ASSERT_THAT(DivideTenByFloat{} / 2.0f, Eq(5.0f));
 
     EXPECT_THAT((IsQuotientValidRep<float, DivideTenByFloat>::value), IsFalse());
     EXPECT_THAT((IsQuotientValidRep<DivideTenByFloat, float>::value), IsTrue());

--- a/au/code/au/testing.hh
+++ b/au/code/au/testing.hh
@@ -21,6 +21,8 @@
 
 namespace au {
 
+using ::testing::Eq;
+
 MATCHER_P(SameType, target, "") {
     return std::is_same<stdx::remove_cvref_t<decltype(arg)>,
                         stdx::remove_cvref_t<decltype(target)>>::value;
@@ -57,7 +59,7 @@ MATCHER_P(PointEquivalent, target, "") {
 template <typename Unit, std::size_t N>
 void expect_label(const char (&label)[N]) {
     EXPECT_STREQ(unit_label<Unit>(), label);
-    EXPECT_EQ(sizeof(unit_label<Unit>()), N);
+    EXPECT_THAT(sizeof(unit_label<Unit>()), Eq(N));
 }
 
 namespace detail {

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -353,13 +353,13 @@ TEST(UnitRatio, ComputesRatioForSameDimensionedUnits) {
 }
 
 TEST(UnitRatio, FunctionalInterfaceHandlesInstancesCorrectly) {
-    EXPECT_EQ(unit_ratio(Yards{}, Inches{}), mag<36>());
-    EXPECT_EQ(unit_ratio(Inches{}, Inches{}), mag<1>());
-    EXPECT_EQ(unit_ratio(Inches{}, Yards{}), mag<1>() / mag<36>());
+    EXPECT_THAT(unit_ratio(Yards{}, Inches{}), Eq(mag<36>()));
+    EXPECT_THAT(unit_ratio(Inches{}, Inches{}), Eq(mag<1>()));
+    EXPECT_THAT(unit_ratio(Inches{}, Yards{}), Eq(mag<1>() / mag<36>()));
 }
 
 TEST(UnitRatio, FunctionalInterfaceHandlesQuantityMakersCorrectly) {
-    EXPECT_EQ(unit_ratio(yards, inches), mag<36>());
+    EXPECT_THAT(unit_ratio(yards, inches), Eq(mag<36>()));
 }
 
 TEST(AreUnitsQuantityEquivalent, UnitIsEquivalentToItself) {
@@ -435,13 +435,13 @@ TEST(OriginDisplacement, IdenticallyZeroForOriginsThatCompareEqual) {
 }
 
 TEST(OriginDisplacement, GivesDisplacementFromFirstToSecond) {
-    EXPECT_EQ(origin_displacement(Kelvins{}, Celsius{}), milli(kelvins)(273'150));
-    EXPECT_EQ(origin_displacement(Celsius{}, Kelvins{}), milli(kelvins)(-273'150));
+    EXPECT_THAT(origin_displacement(Kelvins{}, Celsius{}), Eq(milli(kelvins)(273'150)));
+    EXPECT_THAT(origin_displacement(Celsius{}, Kelvins{}), Eq(milli(kelvins)(-273'150)));
 }
 
 TEST(OriginDisplacement, FunctionalInterfaceHandlesInstancesCorrectly) {
-    EXPECT_EQ(origin_displacement(kelvins, celsius), milli(kelvins)(273'150));
-    EXPECT_EQ(origin_displacement(celsius, kelvins), milli(kelvins)(-273'150));
+    EXPECT_THAT(origin_displacement(kelvins, celsius), Eq(milli(kelvins)(273'150)));
+    EXPECT_THAT(origin_displacement(celsius, kelvins), Eq(milli(kelvins)(-273'150)));
 }
 
 struct OffsetCelsius : Celsius {
@@ -451,7 +451,7 @@ struct OffsetCelsius : Celsius {
 constexpr const char OffsetCelsius::label[];
 
 TEST(DisplaceOrigin, DisplacesOrigin) {
-    EXPECT_EQ(origin_displacement(Celsius{}, OffsetCelsius{}), kelvins(10));
+    EXPECT_THAT(origin_displacement(Celsius{}, OffsetCelsius{}), Eq(kelvins(10)));
 }
 
 TEST(CommonUnit, FindsCommonMagnitude) {
@@ -532,7 +532,7 @@ TEST(CommonUnit, UnpacksTypesInNestedCommonUnit) {
 }
 
 TEST(CommonUnit, CanCombineUnitsThatWouldBothBeAnonymousScaledUnits) {
-    EXPECT_EQ((feet / mag<3>())(1), (inches * mag<4>())(1));
+    EXPECT_THAT((feet / mag<3>())(1), Eq((inches * mag<4>())(1)));
 }
 
 TEST(CommonUnit, SupportsUnitSlots) {
@@ -547,8 +547,9 @@ TEST(CommonPointUnit, FindsCommonMagnitude) {
 }
 
 TEST(CommonPointUnit, HasMinimumOrigin) {
-    EXPECT_EQ(origin_displacement(CommonPointUnitT<Kelvins, Celsius>{}, Kelvins{}), ZERO);
-    EXPECT_EQ(origin_displacement(CommonPointUnitT<Fahrenheit, Celsius>{}, Fahrenheit{}), ZERO);
+    EXPECT_THAT(origin_displacement(CommonPointUnitT<Kelvins, Celsius>{}, Kelvins{}), Eq(ZERO));
+    EXPECT_THAT(origin_displacement(CommonPointUnitT<Fahrenheit, Celsius>{}, Fahrenheit{}),
+                Eq(ZERO));
 }
 
 TEST(CommonPointUnit, TakesOriginMagnitudeIntoAccount) {
@@ -556,7 +557,7 @@ TEST(CommonPointUnit, TakesOriginMagnitudeIntoAccount) {
     using CommonByPoint = CommonPointUnitT<Kelvins, Celsius>;
 
     // The definition of Celsius in this file uses millikelvin to define its constant.
-    EXPECT_EQ(unit_ratio(CommonByQuantity{}, CommonByPoint{}), mag<1000>());
+    EXPECT_THAT(unit_ratio(CommonByQuantity{}, CommonByPoint{}), Eq(mag<1000>()));
 
     // The common point-unit should not be the _same_ as mK (since we never named the latter, and
     // thus can't "conjure it up").  However, it _should_ be _point-equivalent_ to mK.
@@ -610,7 +611,7 @@ TEST(MakeCommonPoint, PreservesCategory) {
     constexpr auto celsenheit_pt = make_common_point(celsius_pt, fahrenheit_pt);
 
     // The origin of the common point unit is the lowest origin among all input units.
-    EXPECT_EQ(celsenheit_pt(0), fahrenheit_pt(0));
+    EXPECT_THAT(celsenheit_pt(0), Eq(fahrenheit_pt(0)));
     EXPECT_LT(celsenheit_pt(0), celsius_pt(0));
 
     // The common point unit should evenly divide both input units.
@@ -620,18 +621,18 @@ TEST(MakeCommonPoint, PreservesCategory) {
     constexpr auto one_f = fahrenheit_pt(1) - fahrenheit_pt(0);
     constexpr auto one_c = celsius_pt(1) - celsius_pt(0);
     constexpr auto one_ch = celsenheit_pt(1) - celsenheit_pt(0);
-    EXPECT_EQ(one_f % one_ch, ZERO);
-    EXPECT_EQ(one_c % one_ch, ZERO);
+    EXPECT_THAT(one_f % one_ch, Eq(ZERO));
+    EXPECT_THAT(one_c % one_ch, Eq(ZERO));
 }
 
 TEST(UnitLabel, DefaultsToUnlabeledUnit) {
     EXPECT_THAT(unit_label<UnlabeledUnit>(), StrEq("[UNLABELED UNIT]"));
-    EXPECT_EQ(sizeof(unit_label<UnlabeledUnit>()), 17);
+    EXPECT_THAT(sizeof(unit_label<UnlabeledUnit>()), Eq(17));
 }
 
 TEST(UnitLabel, PicksUpLabelForLabeledUnit) {
     EXPECT_THAT(unit_label<Feet>(), StrEq("ft"));
-    EXPECT_EQ(sizeof(unit_label<Feet>()), 3);
+    EXPECT_THAT(sizeof(unit_label<Feet>()), Eq(3));
 }
 
 TEST(UnitLabel, PrependsScaleFactorToLabelForScaledUnit) {
@@ -669,7 +670,7 @@ TEST(UnitLabel, EmptyForNullProduct) { EXPECT_THAT(unit_label<UnitProduct<>>(), 
 
 TEST(UnitLabel, NonintrusivelyLabelableByTrait) {
     EXPECT_THAT(unit_label<TraitLabeledUnit>(), StrEq("TLU"));
-    EXPECT_EQ(sizeof(unit_label<TraitLabeledUnit>()), 4);
+    EXPECT_THAT(sizeof(unit_label<TraitLabeledUnit>()), Eq(4));
 }
 
 TEST(UnitLabel, ProductComposesLabelsOfInputUnits) {

--- a/au/code/au/utility/test/factoring_test.cc
+++ b/au/code/au/utility/test/factoring_test.cc
@@ -27,6 +27,7 @@ using ::testing::IsTrue;
 using ::testing::Le;
 
 namespace detail {
+
 namespace {
 
 std::uintmax_t cube(std::uintmax_t n) { return n * n * n; }
@@ -47,13 +48,13 @@ TEST(FirstPrimes, HasOnlyPrimesInOrderAndDoesntSkipAny) {
 }
 
 TEST(FindFactor, ReturnsInputForPrimes) {
-    EXPECT_EQ(find_prime_factor(2u), 2u);
-    EXPECT_EQ(find_prime_factor(3u), 3u);
-    EXPECT_EQ(find_prime_factor(5u), 5u);
-    EXPECT_EQ(find_prime_factor(7u), 7u);
-    EXPECT_EQ(find_prime_factor(11u), 11u);
+    EXPECT_THAT(find_prime_factor(2u), Eq(2u));
+    EXPECT_THAT(find_prime_factor(3u), Eq(3u));
+    EXPECT_THAT(find_prime_factor(5u), Eq(5u));
+    EXPECT_THAT(find_prime_factor(7u), Eq(7u));
+    EXPECT_THAT(find_prime_factor(11u), Eq(11u));
 
-    EXPECT_EQ(find_prime_factor(196961u), 196961u);
+    EXPECT_THAT(find_prime_factor(196961u), Eq(196961u));
 }
 
 TEST(FindFactor, FindsFactorWhenFirstFactorIsSmall) {
@@ -132,10 +133,10 @@ TEST(IsPrime, CanHandleVeryLargePrimes) {
 
 TEST(Multiplicity, CountsFactors) {
     constexpr std::uintmax_t n = (2u * 2u * 2u) * (3u) * (5u * 5u);
-    EXPECT_EQ(multiplicity(2u, n), 3u);
-    EXPECT_EQ(multiplicity(3u, n), 1u);
-    EXPECT_EQ(multiplicity(5u, n), 2u);
-    EXPECT_EQ(multiplicity(7u, n), 0u);
+    EXPECT_THAT(multiplicity(2u, n), Eq(3u));
+    EXPECT_THAT(multiplicity(3u, n), Eq(1u));
+    EXPECT_THAT(multiplicity(5u, n), Eq(2u));
+    EXPECT_THAT(multiplicity(7u, n), Eq(0u));
 }
 
 }  // namespace detail

--- a/au/code/au/utility/test/mod_test.cc
+++ b/au/code/au/utility/test/mod_test.cc
@@ -20,48 +20,53 @@
 #include "gtest/gtest.h"
 
 namespace au {
+
+using ::testing::Eq;
+
 namespace detail {
 namespace {
 
 constexpr auto MAX = std::numeric_limits<uint64_t>::max();
 
 TEST(AddMod, HandlesSimpleCases) {
-    EXPECT_EQ(add_mod(1u, 2u, 5u), 3u);
-    EXPECT_EQ(add_mod(4u, 4u, 5u), 3u);
+    EXPECT_THAT(add_mod(1u, 2u, 5u), Eq(3u));
+    EXPECT_THAT(add_mod(4u, 4u, 5u), Eq(3u));
 }
 
-TEST(AddMod, HandlesVeryLargeNumbers) { EXPECT_EQ(add_mod(MAX - 1u, MAX - 2u, MAX), MAX - 3u); }
+TEST(AddMod, HandlesVeryLargeNumbers) {
+    EXPECT_THAT(add_mod(MAX - 1u, MAX - 2u, MAX), Eq(MAX - 3u));
+}
 
 TEST(SubMod, HandlesSimpleCases) {
-    EXPECT_EQ(sub_mod(2u, 1u, 5u), 1u);
-    EXPECT_EQ(sub_mod(1u, 2u, 5u), 4u);
+    EXPECT_THAT(sub_mod(2u, 1u, 5u), Eq(1u));
+    EXPECT_THAT(sub_mod(1u, 2u, 5u), Eq(4u));
 }
 
 TEST(SubMod, HandlesVeryLargeNumbers) {
-    EXPECT_EQ(sub_mod(MAX - 2u, MAX - 1u, MAX), MAX - 1u);
-    EXPECT_EQ(sub_mod(1u, MAX - 1u, MAX), 2u);
+    EXPECT_THAT(sub_mod(MAX - 2u, MAX - 1u, MAX), Eq(MAX - 1u));
+    EXPECT_THAT(sub_mod(1u, MAX - 1u, MAX), Eq(2u));
 }
 
 TEST(MulMod, HandlesSimpleCases) {
-    EXPECT_EQ(mul_mod(6u, 7u, 10u), 2u);
-    EXPECT_EQ(mul_mod(13u, 11u, 50u), 43u);
+    EXPECT_THAT(mul_mod(6u, 7u, 10u), Eq(2u));
+    EXPECT_THAT(mul_mod(13u, 11u, 50u), Eq(43u));
 }
 
 TEST(MulMod, HandlesHugeNumbers) {
     constexpr auto JUST_UNDER_HALF = MAX / 2u;
-    ASSERT_EQ(JUST_UNDER_HALF * 2u + 1u, MAX);
+    ASSERT_THAT(JUST_UNDER_HALF * 2u + 1u, Eq(MAX));
 
-    EXPECT_EQ(mul_mod(JUST_UNDER_HALF, 10u, MAX), MAX - 5u);
+    EXPECT_THAT(mul_mod(JUST_UNDER_HALF, 10u, MAX), Eq(MAX - 5u));
 }
 
 TEST(HalfModOdd, HalvesEvenNumbers) {
-    EXPECT_EQ(half_mod_odd(0u, 11u), 0u);
-    EXPECT_EQ(half_mod_odd(10u, 11u), 5u);
+    EXPECT_THAT(half_mod_odd(0u, 11u), Eq(0u));
+    EXPECT_THAT(half_mod_odd(10u, 11u), Eq(5u));
 }
 
 TEST(HalfModOdd, HalvesSumWithNForOddNumbers) {
-    EXPECT_EQ(half_mod_odd(1u, 11u), 6u);
-    EXPECT_EQ(half_mod_odd(9u, 11u), 10u);
+    EXPECT_THAT(half_mod_odd(1u, 11u), Eq(6u));
+    EXPECT_THAT(half_mod_odd(9u, 11u), Eq(10u));
 }
 
 TEST(HalfModOdd, SameAsMultiplyingByCeilOfNOver2WhenNIsOdd) {
@@ -81,7 +86,7 @@ TEST(HalfModOdd, SameAsMultiplyingByCeilOfNOver2WhenNIsOdd) {
 
         std::vector<uint64_t> x_values{0u, 1u, 2u, (n / 2u), (n / 2u + 1u), (n - 2u), (n - 1u)};
         for (const auto &x : x_values) {
-            EXPECT_EQ(half_mod_odd(x, n), mul_mod(x, half_n, n));
+            EXPECT_THAT(half_mod_odd(x, n), Eq(mul_mod(x, half_n, n)));
         }
     }
 }
@@ -93,10 +98,10 @@ TEST(PowMod, HandlesSimpleCases) {
         x *= x;
         return x;
     };
-    EXPECT_EQ(pow_mod(5u, 8u, 9u), to_the_eighth(5u) % 9u);
+    EXPECT_THAT(pow_mod(5u, 8u, 9u), Eq(to_the_eighth(5u) % 9u));
 }
 
-TEST(PowMod, HandlesNumbersThatWouldOverflow) { EXPECT_EQ(pow_mod(2u, 64u, MAX), 1u); }
+TEST(PowMod, HandlesNumbersThatWouldOverflow) { EXPECT_THAT(pow_mod(2u, 64u, MAX), Eq(1u)); }
 
 TEST(PowMod, ProducesSameAnswerAsRepeatedModMulForLargeNumbers) {
     const auto x = MAX / 3u * 2u;
@@ -106,7 +111,7 @@ TEST(PowMod, ProducesSameAnswerAsRepeatedModMulForLargeNumbers) {
     const auto to_pow_10 = mul_mod(to_pow_5, to_pow_5, MAX);
     const auto to_pow_11 = mul_mod(x, to_pow_10, MAX);
     const auto to_pow_22 = mul_mod(to_pow_11, to_pow_11, MAX);
-    EXPECT_EQ(pow_mod(x, 22u, MAX), to_pow_22);
+    EXPECT_THAT(pow_mod(x, 22u, MAX), Eq(to_pow_22));
 }
 
 }  // namespace

--- a/au/code/au/utility/test/probable_primes_test.cc
+++ b/au/code/au/utility/test/probable_primes_test.cc
@@ -316,8 +316,8 @@ TEST(Gcd, ResultIsAlwaysAFactorAndGCDFindsNoLargerFactor) {
     for (auto i = 0u; i < 500u; ++i) {
         for (auto j = 1u; j < i; ++j) {
             const auto g = gcd(i, j);
-            EXPECT_EQ(i % g, 0u);
-            EXPECT_EQ(j % g, 0u);
+            EXPECT_THAT(i % g, Eq(0u));
+            EXPECT_THAT(j % g, Eq(0u));
 
             // Brute force: no larger factors.
             for (auto k = g + 1u; k < j / 2u; ++k) {
@@ -329,9 +329,9 @@ TEST(Gcd, ResultIsAlwaysAFactorAndGCDFindsNoLargerFactor) {
 
 TEST(Gcd, HandlesZeroCorrectly) {
     // The usual convention: if one argument is 0, return the other argument.
-    EXPECT_EQ(gcd(0u, 0u), 0u);
-    EXPECT_EQ(gcd(10u, 0u), 10u);
-    EXPECT_EQ(gcd(0u, 10u), 10u);
+    EXPECT_THAT(gcd(0u, 0u), Eq(0u));
+    EXPECT_THAT(gcd(10u, 0u), Eq(10u));
+    EXPECT_THAT(gcd(0u, 10u), Eq(10u));
 }
 
 TEST(JacobiSymbol, ZeroWhenCommonFactorExists) {
@@ -339,7 +339,7 @@ TEST(JacobiSymbol, ZeroWhenCommonFactorExists) {
         for (auto j = 1u; j <= 19u; j += 2u) {
             for (auto factor = 3u; factor < 200u; factor += 2u) {
                 // Make sure that `j * factor` is odd, or else the result is undefined.
-                EXPECT_EQ(jacobi_symbol(i * static_cast<int>(factor), j * factor), 0)
+                EXPECT_THAT(jacobi_symbol(i * static_cast<int>(factor), j * factor), Eq(0))
                     << "jacobi(" << i * static_cast<int>(factor) << ", " << j * factor
                     << ") should be 0";
             }
@@ -349,23 +349,23 @@ TEST(JacobiSymbol, ZeroWhenCommonFactorExists) {
 
 TEST(JacobiSymbol, AlwaysOneWhenFirstInputIsOne) {
     for (auto i = 3u; i < 99u; i += 2u) {
-        EXPECT_EQ(jacobi_symbol(1, i), 1) << "jacobi(1, " << i << ") should be 1";
+        EXPECT_THAT(jacobi_symbol(1, i), Eq(1)) << "jacobi(1, " << i << ") should be 1";
     }
 }
 
 TEST(JacobiSymbol, ReproducesExamplesFromWikipedia) {
     // https://en.wikipedia.org/wiki/Jacobi_symbol#Example_of_calculations
-    EXPECT_EQ(jacobi_symbol(1001, 9907), -1);
+    EXPECT_THAT(jacobi_symbol(1001, 9907), Eq(-1));
 
     // https://en.wikipedia.org/wiki/Jacobi_symbol#Primality_testing
-    EXPECT_EQ(jacobi_symbol(19, 45), 1);
-    EXPECT_EQ(jacobi_symbol(8, 21), -1);
-    EXPECT_EQ(jacobi_symbol(5, 21), 1);
+    EXPECT_THAT(jacobi_symbol(19, 45), Eq(1));
+    EXPECT_THAT(jacobi_symbol(8, 21), Eq(-1));
+    EXPECT_THAT(jacobi_symbol(5, 21), Eq(1));
 }
 
 TEST(BoolSign, ReturnsCorrectValues) {
-    EXPECT_EQ(bool_sign(true), 1);
-    EXPECT_EQ(bool_sign(false), -1);
+    EXPECT_THAT(bool_sign(true), Eq(1));
+    EXPECT_THAT(bool_sign(false), Eq(-1));
 }
 
 }  // namespace

--- a/au/code/au/utility/test/string_constant_test.cc
+++ b/au/code/au/utility/test/string_constant_test.cc
@@ -19,9 +19,11 @@
 #include "gtest/gtest.h"
 
 namespace au {
-namespace detail {
 
+using ::testing::Eq;
 using ::testing::StrEq;
+
+namespace detail {
 
 TEST(StringConstant, CanCreateFromStringLiteral) {
     constexpr StringConstant<5> x{"hello"};
@@ -29,8 +31,8 @@ TEST(StringConstant, CanCreateFromStringLiteral) {
 }
 
 TEST(StringConstant, HasLengthMember) {
-    EXPECT_EQ(StringConstant<2>::length, 2);
-    EXPECT_EQ(StringConstant<13>::length, 13);
+    EXPECT_THAT(StringConstant<2>::length, Eq(2));
+    EXPECT_THAT(StringConstant<13>::length, Eq(13));
 }
 
 TEST(AsStringConstant, CanCreateFromStringLiteral) {
@@ -76,17 +78,17 @@ TEST(IToA, ValueHoldsStringVersionOfTemplateParameter) {
 }
 
 TEST(IToA, HasLengthMember) {
-    EXPECT_EQ(IToA<0>::length, 1);
+    EXPECT_THAT(IToA<0>::length, Eq(1));
 
-    EXPECT_EQ(IToA<2>::length, 1);
-    EXPECT_EQ(IToA<9>::length, 1);
-    EXPECT_EQ(IToA<10>::length, 2);
-    EXPECT_EQ(IToA<12345>::length, 5);
+    EXPECT_THAT(IToA<2>::length, Eq(1));
+    EXPECT_THAT(IToA<9>::length, Eq(1));
+    EXPECT_THAT(IToA<10>::length, Eq(2));
+    EXPECT_THAT(IToA<12345>::length, Eq(5));
 
-    EXPECT_EQ(IToA<-2>::length, 2);
-    EXPECT_EQ(IToA<-9>::length, 2);
-    EXPECT_EQ(IToA<-10>::length, 3);
-    EXPECT_EQ(IToA<-12345>::length, 6);
+    EXPECT_THAT(IToA<-2>::length, Eq(2));
+    EXPECT_THAT(IToA<-9>::length, Eq(2));
+    EXPECT_THAT(IToA<-10>::length, Eq(3));
+    EXPECT_THAT(IToA<-12345>::length, Eq(6));
 }
 
 TEST(UIToA, CanHandleNumbersBiggerThanIntmaxButWithinUintmax) {

--- a/au/code/au/zero_test.cc
+++ b/au/code/au/zero_test.cc
@@ -21,6 +21,7 @@ using namespace std::chrono_literals;
 
 namespace au {
 
+using ::testing::Eq;
 using ::testing::IsFalse;
 using ::testing::IsTrue;
 
@@ -54,20 +55,20 @@ TEST(WrappedInt, BasicInterfaceWorksAsExpected) {
 
 TEST(Zero, MinusZeroIsZero) {
     constexpr auto zero_minus_zero = ZERO - ZERO;
-    EXPECT_EQ(ZERO, zero_minus_zero);
+    EXPECT_THAT(zero_minus_zero, Eq(ZERO));
 }
 
 TEST(Zero, PlusZeroIsZero) {
     constexpr auto zero_plus_zero = ZERO + ZERO;
-    EXPECT_EQ(ZERO, zero_plus_zero);
+    EXPECT_THAT(zero_plus_zero, Eq(ZERO));
 }
 
 TEST(Zero, ComparableToArbitraryQuantities) {
-    EXPECT_EQ(ZERO, WrappedInt{0});
+    EXPECT_THAT(ZERO, Eq(WrappedInt{0}));
     EXPECT_LT(ZERO, WrappedInt{1});
     EXPECT_GT(ZERO, WrappedInt{-1});
 
-    EXPECT_EQ(ZERO, WrappedInt{0});
+    EXPECT_THAT(WrappedInt{0}, Eq(ZERO));
     EXPECT_LT(ZERO, WrappedInt{1});
     EXPECT_GT(ZERO, WrappedInt{-1});
 }
@@ -84,18 +85,18 @@ TEST(Zero, ComparesEqualToZero) {
 
 TEST(Zero, ImplicitlyConvertsToNumericTypes) {
     constexpr int zero_i = ZERO;
-    EXPECT_EQ(zero_i, 0);
+    EXPECT_THAT(zero_i, Eq(0));
 
     constexpr float zero_f = ZERO;
-    EXPECT_EQ(zero_f, 0.f);
+    EXPECT_THAT(zero_f, Eq(0.f));
 }
 
 TEST(Zero, ImplicitlyConvertsToChronoDuration) {
     constexpr std::chrono::nanoseconds zero_ns = ZERO;
-    EXPECT_EQ(zero_ns, 0ns);
+    EXPECT_THAT(zero_ns, Eq(0ns));
 
     constexpr std::chrono::duration<float, std::milli> zero_ms_f = ZERO;
-    EXPECT_EQ(zero_ms_f, (std::chrono::duration<float, std::milli>{0.f}));
+    EXPECT_THAT(zero_ms_f, Eq((std::chrono::duration<float, std::milli>{0.f})));
 }
 
 }  // namespace au

--- a/au/code/au/zero_test.cc
+++ b/au/code/au/zero_test.cc
@@ -96,7 +96,7 @@ TEST(Zero, ImplicitlyConvertsToChronoDuration) {
     EXPECT_THAT(zero_ns, Eq(0ns));
 
     constexpr std::chrono::duration<float, std::milli> zero_ms_f = ZERO;
-    EXPECT_THAT(zero_ms_f, Eq((std::chrono::duration<float, std::milli>{0.f})));
+    EXPECT_THAT(zero_ms_f, Eq(std::chrono::duration<float, std::milli>{0.f}));
 }
 
 }  // namespace au


### PR DESCRIPTION
This converts a bulk of the existing `ASSERT_EQ` and `EXPECT_EQ` assertion
checks to the matcher syntax.

Partial implementation for #404.
