### PR TITLE
Add `UnitOfLowestOrigin` helper

### DIFF
--- a/au/code/au/packs_test.cc
+++ b/au/code/au/packs_test.cc
@@ -238,6 +238,33 @@ TEST(LexicographicTotalOrdering, SecondArgumentBreaksTieInFirst) {
     EXPECT_THAT((InOrderFor<LexiPack, TwoIndex<0, 0>, TwoIndex<0, 1>>::value), IsTrue());
 }
 
+TEST(InsertUsingOrderingFor, UsesRequestedOrdering) {
+    StaticAssertTypeEq<InsertUsingOrderingFor<LexiPack, TwoIndex<5, 0>, LexiPack<>>,
+                       LexiPack<TwoIndex<5, 0>>>();
+    StaticAssertTypeEq<InsertUsingOrderingFor<LexiPack, TwoIndex<4, 0>, LexiPack<TwoIndex<5, 0>>>,
+                       LexiPack<TwoIndex<4, 0>, TwoIndex<5, 0>>>();
+    StaticAssertTypeEq<InsertUsingOrderingFor<LexiPack, TwoIndex<6, 0>, LexiPack<TwoIndex<5, 0>>>,
+                       LexiPack<TwoIndex<5, 0>, TwoIndex<6, 0>>>();
+    StaticAssertTypeEq<
+        InsertUsingOrderingFor<LexiPack, TwoIndex<5, 1>, LexiPack<TwoIndex<5, 0>, TwoIndex<6, 0>>>,
+        LexiPack<TwoIndex<5, 0>, TwoIndex<5, 1>, TwoIndex<6, 0>>>();
+}
+
+TEST(SortAs, SortsAs) {
+    StaticAssertTypeEq<SortAs<LexiPack, Pack<>>, Pack<>>();
+
+    StaticAssertTypeEq<SortAs<LexiPack, Pack<TwoIndex<1, 1>>>, Pack<TwoIndex<1, 1>>>();
+
+    StaticAssertTypeEq<SortAs<LexiPack, Pack<TwoIndex<1, 1>, TwoIndex<2, 2>>>,
+                       Pack<TwoIndex<1, 1>, TwoIndex<2, 2>>>();
+
+    StaticAssertTypeEq<SortAs<LexiPack, Pack<TwoIndex<2, 2>, TwoIndex<1, 1>>>,
+                       Pack<TwoIndex<1, 1>, TwoIndex<2, 2>>>();
+
+    StaticAssertTypeEq<SortAs<LexiPack, Pack<TwoIndex<2, 2>, TwoIndex<3, 3>, TwoIndex<1, 1>>>,
+                       Pack<TwoIndex<1, 1>, TwoIndex<2, 2>, TwoIndex<3, 3>>>();
+}
+
 TEST(InStandardPackOrder, NullPackComesBeforeEveryNonNullPack) {
     EXPECT_THAT((InStandardPackOrder<Pack<>, Pack<>>::value), IsFalse());
 

--- a/au/code/au/unit_of_measure.hh
+++ b/au/code/au/unit_of_measure.hh
@@ -818,6 +818,19 @@ struct CommonOrigin<Head, Tail...> :
                                OriginOf<Head>,
                                CommonOrigin<Tail...>>>> {};
 
+// `UnitOfLowestOrigin<Us...>` is any unit among `Us` whose origin equals `CommonOrigin<Us...>`.
+template <typename... Us>
+struct UnitOfLowestOriginImpl;
+template <typename... Us>
+using UnitOfLowestOrigin = typename SortAs<UnitProduct, UnitOfLowestOriginImpl<Us...>>::type;
+template <typename U>
+struct UnitOfLowestOriginImpl<U> : stdx::type_identity<U> {};
+template <typename U, typename U1, typename... Us>
+struct UnitOfLowestOriginImpl<U, U1, Us...>
+    : std::conditional<(OriginOf<U>::value() == CommonOrigin<U, U1, Us...>::value()),
+                       U,
+                       UnitOfLowestOrigin<U1, Us...>> {};
+
 template <typename U1, typename U2>
 struct OriginDisplacementUnit {
     static_assert(OriginOf<U1>::value() != OriginOf<U2>::value(),

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -788,6 +788,21 @@ TEST(CommonOrigin, SymmetricUnderReordering) {
     EXPECT_THAT(common_origin_value, Not(SameTypeAndValue(AlternateCelsius::origin())));
 }
 
+TEST(UnitOfLowestOrigin, SelectsSingleUnit) {
+    StaticAssertTypeEq<UnitOfLowestOrigin<Celsius>, Celsius>();
+    StaticAssertTypeEq<UnitOfLowestOrigin<Kelvins>, Kelvins>();
+}
+
+TEST(UnitOfLowestOrigin, SelectsLowestOriginUnit) {
+    StaticAssertTypeEq<UnitOfLowestOrigin<Celsius, Kelvins>, Kelvins>();
+    StaticAssertTypeEq<UnitOfLowestOrigin<Kelvins, Celsius>, Kelvins>();
+}
+
+TEST(UnitOfLowestOrigin, ProducesConsistentResultsRegardlessOfOrdering) {
+    StaticAssertTypeEq<UnitOfLowestOrigin<Celsius, Milli<Celsius>>,
+                       UnitOfLowestOrigin<Milli<Celsius>, Celsius>>();
+}
+
 TEST(ComputeOriginDisplacementUnit, ZeroForSameOrigin) {
     StaticAssertTypeEq<ComputeOriginDisplacementUnit<Celsius, Milli<Celsius>>, Zero>();
 }


### PR DESCRIPTION
`UnitOfLowestOrigin<Us...>` picks out some unit from among `Us...` whose
origin is equal to the lowest origin.  It will always pick out the same
unit every time, regardless of the ordering of the inputs.  (To get this
behavior, we needed to add a couple more utilities to `:packs`.)

Helps https://github.com/aurora-opensource/au/issues/369.