### PR TITLE
Simplify common point unit implementation

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -518,6 +518,7 @@ cc_library(
     hdrs = ["code/au/quantity_point.hh"],
     includes = ["code"],
     deps = [
+        ":constant",
         ":fwd",
         ":quantity",
         ":stdx",
@@ -623,6 +624,7 @@ cc_test(
     size = "small",
     srcs = ["code/au/unit_of_measure_test.cc"],
     deps = [
+        ":constant",
         ":prefix",
         ":testing",
         ":unit_of_measure",

--- a/au/code/au/quantity_point.hh
+++ b/au/code/au/quantity_point.hh
@@ -77,7 +77,7 @@ template <typename UnitT, typename RepT>
 class QuantityPoint {
     // Q: When should we enable IMPLICIT construction from another QuantityPoint type?
     // A: EXACTLY WHEN our own Diff type can be IMPLICITLY constructed from BOTH the target's Diff
-    //    type, AND the offset between our Units' zero points.
+    //    type AND the offset between our Units' zero points.
     //
     // In other words, there are two ways to fail implicit convertibility.
     //

--- a/au/code/au/quantity_point.hh
+++ b/au/code/au/quantity_point.hh
@@ -159,12 +159,11 @@ class QuantityPoint {
     template <typename NewUnit,
               typename = std::enable_if_t<IsUnit<AssociatedUnitForPointsT<NewUnit>>::value>>
     constexpr Rep in(NewUnit) const {
-        using TargetUnit = AssociatedUnitForPointsT<NewUnit>;
-        // `rep_cast` is needed because if these are integral types, their difference might become a
-        // different type due to integer promotion.
-        return rep_cast<Rep>(x_.as(TargetUnit{}) +
-                             Quantity<TargetUnit, Rep>{origin_displacement(TargetUnit{}, Unit{})})
-            .in(TargetUnit{});
+        constexpr auto target = AssociatedUnitForPointsT<NewUnit>{};
+
+        // The explicit `<Rep>` is needed because if these are integral types, their difference
+        // might become a different type due to integer promotion.
+        return (x_.as(target) + origin_displacement(target, Unit{})).template in<Rep>(target);
     }
 
     // "Forcing" conversions, which explicitly ignore safety checks for overflow and truncation.

--- a/au/code/au/quantity_point.hh
+++ b/au/code/au/quantity_point.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "au/constant.hh"
 #include "au/fwd.hh"
 #include "au/quantity.hh"
 #include "au/stdx/type_traits.hh"
@@ -46,19 +47,37 @@ template <typename P1, typename P2>
 struct AreQuantityPointTypesEquivalent;
 
 namespace detail {
-template <typename TargetRep, typename U1, typename U2>
-struct OriginDisplacementFitsIn;
+template <typename U, typename R, typename ConstUnit>
+constexpr Quantity<U, R> coerce_as_quantity(Constant<ConstUnit> c) {
+    return c.template coerce_as<R>(U{});
+}
+template <typename U, typename R>
+constexpr Quantity<U, R> coerce_as_quantity(Zero z) {
+    return z;
+}
 
 template <typename FromRep, typename ToRep>
 struct IntermediateRep;
 }  // namespace detail
 
+// Some units have an "origin".  This is not meaningful by itself, but its difference w.r.t. the
+// "origin" of another unit of the same Dimension _is_ meaningful.  This type trait provides access
+// to that difference.
+template <typename U1, typename U2>
+constexpr auto origin_displacement(U1, U2) {
+    return make_constant(detail::ComputeOriginDisplacementUnit<AssociatedUnitForPointsT<U1>,
+                                                               AssociatedUnitForPointsT<U2>>{});
+}
+
+template <typename U1, typename U2>
+using OriginDisplacement = decltype(origin_displacement(U1{}, U2{}));
+
 // QuantityPoint implementation and API elaboration.
 template <typename UnitT, typename RepT>
 class QuantityPoint {
     // Q: When should we enable IMPLICIT construction from another QuantityPoint type?
-    // A: EXACTLY WHEN our own Diff type can be IMPLICITLY constructed from the SUM of the target's
-    //    Diff type, and the offset between our Units' zero points.
+    // A: EXACTLY WHEN our own Diff type can be IMPLICITLY constructed from BOTH the target's Diff
+    //    type, AND the offset between our Units' zero points.
     //
     // In other words, there are two ways to fail implicit convertibility.
     //
@@ -72,10 +91,8 @@ class QuantityPoint {
     //      OK : QuantityPoint<Celsius, int> -> QuantityPoint<Milli<Kelvins>, int>
     template <typename OtherUnit, typename OtherRep>
     static constexpr bool should_enable_implicit_construction_from() {
-        return std::is_convertible<
-            decltype(std::declval<typename QuantityPoint<OtherUnit, OtherRep>::Diff>() +
-                     origin_displacement(UnitT{}, OtherUnit{})),
-            QuantityPoint::Diff>::value;
+        using Com = CommonUnitT<OtherUnit, detail::ComputeOriginDisplacementUnit<Unit, OtherUnit>>;
+        return std::is_convertible<Quantity<Com, OtherRep>, QuantityPoint::Diff>::value;
     }
 
     // This machinery exists to give us a conditionally explicit constructor, using SFINAE to select
@@ -131,27 +148,23 @@ class QuantityPoint {
     template <typename NewRep,
               typename NewUnit,
               typename = std::enable_if_t<IsUnit<AssociatedUnitForPointsT<NewUnit>>::value>>
-    constexpr NewRep in(NewUnit u) const {
+    constexpr NewRep in(NewUnit) const {
         using CalcRep = typename detail::IntermediateRep<Rep, NewRep>::type;
-        return (rep_cast<CalcRep>(x_) -
-                rep_cast<CalcRep>(
-                    OriginDisplacement<Unit, AssociatedUnitForPointsT<NewUnit>>::value()))
-            .template in<NewRep>(associated_unit_for_points(u));
+        using Target = AssociatedUnitForPointsT<NewUnit>;
+        return (x_.template as<CalcRep>(Target{}) +
+                detail::coerce_as_quantity<Target, CalcRep>(origin_displacement(Target{}, Unit{})))
+            .template in<NewRep>(Target{});
     }
 
     template <typename NewUnit,
               typename = std::enable_if_t<IsUnit<AssociatedUnitForPointsT<NewUnit>>::value>>
-    constexpr Rep in(NewUnit u) const {
-        static_assert(
-            detail::OriginDisplacementFitsIn<Rep, AssociatedUnitForPointsT<NewUnit>, Unit>::value,
-            "Cannot represent origin displacement in desired Rep");
-
+    constexpr Rep in(NewUnit) const {
+        using TargetUnit = AssociatedUnitForPointsT<NewUnit>;
         // `rep_cast` is needed because if these are integral types, their difference might become a
         // different type due to integer promotion.
-        return rep_cast<Rep>(
-                   x_ + rep_cast<Rep>(
-                            OriginDisplacement<AssociatedUnitForPointsT<NewUnit>, Unit>::value()))
-            .in(associated_unit_for_points(u));
+        return rep_cast<Rep>(x_.as(TargetUnit{}) +
+                             Quantity<TargetUnit, Rep>{origin_displacement(TargetUnit{}, Unit{})})
+            .in(TargetUnit{});
     }
 
     // "Forcing" conversions, which explicitly ignore safety checks for overflow and truncation.
@@ -395,23 +408,6 @@ constexpr auto operator<=>(const QuantityPoint<U1, R1> &lhs, const QuantityPoint
 #endif
 
 namespace detail {
-
-template <typename TargetRep, typename U, typename R>
-constexpr bool underlying_value_in_range(Quantity<U, R> q) {
-    return stdx::in_range<TargetRep>(q.in(U{}));
-}
-
-template <typename TargetRep>
-constexpr bool underlying_value_in_range(Zero) {
-    return true;
-}
-
-template <typename TargetRep, typename U1, typename U2>
-struct OriginDisplacementFitsIn
-    : std::conditional_t<std::is_integral<TargetRep>::value,
-                         stdx::bool_constant<underlying_value_in_range<TargetRep>(
-                             OriginDisplacement<U1, U2>::value())>,
-                         std::true_type> {};
 
 // We simply want a version of `std::make_signed_t` that won't choke on non-integral types.
 template <typename T, bool IsInt = std::is_integral<T>::value>

--- a/au/code/au/quantity_point_test.cc
+++ b/au/code/au/quantity_point_test.cc
@@ -450,13 +450,13 @@ TEST(OriginDisplacement, IdenticallyZeroForOriginsThatCompareEqual) {
 }
 
 TEST(OriginDisplacement, GivesDisplacementFromFirstToSecond) {
-    EXPECT_EQ(origin_displacement(Kelvins{}, Celsius{}), milli(kelvins)(273'150));
-    EXPECT_EQ(origin_displacement(Celsius{}, Kelvins{}), milli(kelvins)(-273'150));
+    EXPECT_THAT(origin_displacement(Kelvins{}, Celsius{}), Eq(milli(kelvins)(273'150)));
+    EXPECT_THAT(origin_displacement(Celsius{}, Kelvins{}), Eq(milli(kelvins)(-273'150)));
 }
 
 TEST(OriginDisplacement, FunctionalInterfaceHandlesInstancesCorrectly) {
-    EXPECT_EQ(origin_displacement(kelvins_pt, celsius_pt), milli(kelvins)(273'150));
-    EXPECT_EQ(origin_displacement(celsius_pt, kelvins_pt), milli(kelvins)(-273'150));
+    EXPECT_THAT(origin_displacement(kelvins_pt, celsius_pt), Eq(milli(kelvins)(273'150)));
+    EXPECT_THAT(origin_displacement(celsius_pt, kelvins_pt), Eq(milli(kelvins)(-273'150)));
 }
 
 TEST(QuantityPointMaker, CanApplyPrefix) {

--- a/au/code/au/quantity_point_test.cc
+++ b/au/code/au/quantity_point_test.cc
@@ -57,17 +57,17 @@ constexpr QuantityMaker<Kelvins> kelvins{};
 constexpr QuantityPointMaker<Kelvins> kelvins_pt{};
 
 struct Celsius : Kelvins {
-    // We must divide by 100 to turn the integer value of `273'15` into the decimal `273.15`.  We
-    // split that division between the unit and the value.  The goal is to divide the unit by as
-    // little as possible (while still keeping the value an integer), because that will make the
-    // conversion factor as small as possible in converting to the common-point-unit.
-    static constexpr auto origin() { return (kelvins / mag<20>())(273'15 / 5); }
+    static constexpr auto origin() { return centi(kelvins)(273'15); }
 
     static constexpr const char label[] = "degC";
 };
 constexpr const char Celsius::label[];
 constexpr QuantityMaker<Celsius> celsius_qty{};
 constexpr QuantityPointMaker<Celsius> celsius_pt{};
+
+struct AlternateCelsius : Kelvins {
+    static constexpr auto origin() { return micro(kelvins)(273'150'000); }
+};
 
 TEST(Quantity, HasCorrectRepNamedAliases) {
     StaticAssertTypeEq<QuantityPointD<Meters>, QuantityPoint<Meters, double>>();
@@ -126,6 +126,12 @@ TEST(QuantityPoint, CanGetValueInDifferentUnits) {
 TEST(QuantityPoint, IntermediateTypeIsSignedIfExplicitRepIsSigned) {
     EXPECT_THAT(milli(kelvins_pt)(0u).coerce_as<int>(celsius_pt),
                 SameTypeAndValue(celsius_pt(-273)));
+}
+
+TEST(QuantityPoint, CanConstructExpected) {
+    using Com = CommonPointUnitT<Kelvins, Celsius>;
+    QuantityPointI<Com> pt{celsius_pt(0)};
+    EXPECT_THAT(pt, Eq((kelvins_pt / mag<20>())(273'15 / 5)));
 }
 
 TEST(QuantityPoint, SupportsDirectAccessWithSameUnit) {
@@ -374,8 +380,8 @@ TEST(QuantityPoint, MixedUnitAndRepDifferenceUsesCommonPointType) {
 
 TEST(QuantityPoint, CommonPointUnitLabel) {
     EXPECT_THAT(stream_to_string(celsius_pt(0) - kelvins_pt(0)),
-                AnyOf(StrEq("5463 EQUIV{[(1 / 20) K], [(1 / 20) degC]}"),
-                      StrEq("5463 EQUIV{[(1 / 20) degC], [(1 / 20) K]}")));
+                AnyOf(StrEq("5463 EQUIV{[(1 / 20) K], [(1 / 5463) (@(0 degC) - @(0 K))]}"),
+                      StrEq("5463 EQUIV{[(1 / 5463) (@(0 degC) - @(0 K))], [(1 / 20) K]}")));
 }
 
 TEST(QuantityPoint, CanCompareUnitsWithDifferentOrigins) {
@@ -437,6 +443,22 @@ TEST(QuantityPoint, PreservesRep) {
                 SameTypeAndValue(static_cast<uint16_t>(27'315 / 5)));
 }
 
+TEST(OriginDisplacement, IdenticallyZeroForOriginsThatCompareEqual) {
+    ASSERT_THAT(detail::OriginOf<Celsius>::value(),
+                Not(SameTypeAndValue(detail::OriginOf<AlternateCelsius>::value())));
+    EXPECT_THAT(origin_displacement(Celsius{}, AlternateCelsius{}), SameTypeAndValue(ZERO));
+}
+
+TEST(OriginDisplacement, GivesDisplacementFromFirstToSecond) {
+    EXPECT_EQ(origin_displacement(Kelvins{}, Celsius{}), milli(kelvins)(273'150));
+    EXPECT_EQ(origin_displacement(Celsius{}, Kelvins{}), milli(kelvins)(-273'150));
+}
+
+TEST(OriginDisplacement, FunctionalInterfaceHandlesInstancesCorrectly) {
+    EXPECT_EQ(origin_displacement(kelvins_pt, celsius_pt), milli(kelvins)(273'150));
+    EXPECT_EQ(origin_displacement(celsius_pt, kelvins_pt), milli(kelvins)(-273'150));
+}
+
 TEST(QuantityPointMaker, CanApplyPrefix) {
     EXPECT_THAT(centi(kelvins_pt)(12), SameTypeAndValue(make_quantity_point<Centi<Kelvins>>(12)));
 }
@@ -447,46 +469,4 @@ TEST(QuantityPointMaker, CanScaleByMagnitude) {
     StaticAssertTypeEq<decltype(kelvins_pt / mag<5>()),
                        QuantityPointMaker<decltype(Kelvins{} / mag<5>())>>();
 }
-
-namespace detail {
-
-TEST(OriginDisplacementFitsIn, CanRetrieveValueInGivenRep) {
-    EXPECT_THAT((OriginDisplacementFitsIn<uint64_t, Kelvins, Celsius>::value), IsTrue());
-    EXPECT_THAT((OriginDisplacementFitsIn<int64_t, Kelvins, Celsius>::value), IsTrue());
-
-    EXPECT_THAT((OriginDisplacementFitsIn<uint32_t, Kelvins, Celsius>::value), IsTrue());
-    EXPECT_THAT((OriginDisplacementFitsIn<int32_t, Kelvins, Celsius>::value), IsTrue());
-
-    EXPECT_THAT((OriginDisplacementFitsIn<uint16_t, Kelvins, Celsius>::value), IsTrue());
-    EXPECT_THAT((OriginDisplacementFitsIn<int16_t, Kelvins, Celsius>::value), IsTrue());
-
-    EXPECT_THAT((OriginDisplacementFitsIn<uint8_t, Kelvins, Celsius>::value), IsFalse());
-    EXPECT_THAT((OriginDisplacementFitsIn<int8_t, Kelvins, Celsius>::value), IsFalse());
-}
-
-TEST(OriginDisplacementFitsIn, AlwaysTrueForZero) {
-    EXPECT_THAT((OriginDisplacementFitsIn<uint64_t, Celsius, Celsius>::value), IsTrue());
-    EXPECT_THAT((OriginDisplacementFitsIn<int64_t, Celsius, Celsius>::value), IsTrue());
-
-    EXPECT_THAT((OriginDisplacementFitsIn<uint32_t, Celsius, Celsius>::value), IsTrue());
-    EXPECT_THAT((OriginDisplacementFitsIn<int32_t, Celsius, Celsius>::value), IsTrue());
-
-    EXPECT_THAT((OriginDisplacementFitsIn<uint16_t, Celsius, Celsius>::value), IsTrue());
-    EXPECT_THAT((OriginDisplacementFitsIn<int16_t, Celsius, Celsius>::value), IsTrue());
-
-    EXPECT_THAT((OriginDisplacementFitsIn<uint8_t, Celsius, Celsius>::value), IsTrue());
-    EXPECT_THAT((OriginDisplacementFitsIn<int8_t, Celsius, Celsius>::value), IsTrue());
-}
-
-TEST(OriginDisplacementFitsIn, FailsNegativeDisplacementForUnsignedRep) {
-    EXPECT_THAT((OriginDisplacementFitsIn<uint64_t, Celsius, Kelvins>::value), IsFalse());
-    EXPECT_THAT((OriginDisplacementFitsIn<uint32_t, Celsius, Kelvins>::value), IsFalse());
-    EXPECT_THAT((OriginDisplacementFitsIn<uint16_t, Celsius, Kelvins>::value), IsFalse());
-
-    EXPECT_THAT((OriginDisplacementFitsIn<int64_t, Celsius, Kelvins>::value), IsTrue());
-    EXPECT_THAT((OriginDisplacementFitsIn<int32_t, Celsius, Kelvins>::value), IsTrue());
-    EXPECT_THAT((OriginDisplacementFitsIn<int16_t, Celsius, Kelvins>::value), IsTrue());
-}
-
-}  // namespace detail
 }  // namespace au

--- a/au/code/au/unit_of_measure.hh
+++ b/au/code/au/unit_of_measure.hh
@@ -500,7 +500,7 @@ struct MagSign<true> : stdx::type_identity<Magnitude<Negative>> {};
 template <std::intmax_t N>
 constexpr auto signed_mag() {
     constexpr auto sign = typename MagSign<(N < 0)>::type{};
-    return sign * mag<(N < 0 ? (-N) : N)>();
+    return sign * mag<static_cast<std::size_t>(N < 0 ? (-N) : N)>();
 }
 
 // Unequal values case implementation: scale up the magnitude of the diff's _unit_ by the diff's

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -36,6 +36,7 @@ using ::testing::AnyOf;
 using ::testing::Eq;
 using ::testing::IsFalse;
 using ::testing::IsTrue;
+using ::testing::Lt;
 using ::testing::Not;
 using ::testing::StaticAssertTypeEq;
 using ::testing::StrEq;

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -14,6 +14,7 @@
 
 #include "au/unit_of_measure.hh"
 
+#include "au/constant.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/fahrenheit.hh"
@@ -428,30 +429,20 @@ TEST(AreUnitsPointEquivalent, DifferentUnitsWithDifferentButEquivalentOriginsAre
     EXPECT_THAT(are_units_point_equivalent(Celsius{}, AlternateCelsius{}), IsTrue());
 }
 
-TEST(OriginDisplacement, IdenticallyZeroForOriginsThatCompareEqual) {
-    ASSERT_THAT(detail::OriginOf<Celsius>::value(),
-                Not(SameTypeAndValue(detail::OriginOf<AlternateCelsius>::value())));
-    EXPECT_THAT(origin_displacement(Celsius{}, AlternateCelsius{}), SameTypeAndValue(ZERO));
-}
-
-TEST(OriginDisplacement, GivesDisplacementFromFirstToSecond) {
-    EXPECT_THAT(origin_displacement(Kelvins{}, Celsius{}), Eq(milli(kelvins)(273'150)));
-    EXPECT_THAT(origin_displacement(Celsius{}, Kelvins{}), Eq(milli(kelvins)(-273'150)));
-}
-
-TEST(OriginDisplacement, FunctionalInterfaceHandlesInstancesCorrectly) {
-    EXPECT_THAT(origin_displacement(kelvins, celsius), Eq(milli(kelvins)(273'150)));
-    EXPECT_THAT(origin_displacement(celsius, kelvins), Eq(milli(kelvins)(-273'150)));
-}
-
 struct OffsetCelsius : Celsius {
-    static constexpr auto origin() { return detail::OriginOf<Celsius>::value() + kelvins(10); }
+    // The origin is _specified_ in the common units of the Celsius origin (which we gave in mK),
+    // and a difference of 10 in units of [(1/6) K].  This means that the type of the origin should
+    // be in units of [(1/3000) K].  However, the difference should boil down to a constant of
+    // exactly (5/3 K)
+    static constexpr auto origin() {
+        return detail::OriginOf<Celsius>::value() + (kelvins / mag<6>())(10);
+    }
     static constexpr const char label[] = "offset_deg_C";
 };
 constexpr const char OffsetCelsius::label[];
 
 TEST(DisplaceOrigin, DisplacesOrigin) {
-    EXPECT_THAT(origin_displacement(Celsius{}, OffsetCelsius{}), Eq(kelvins(10)));
+    EXPECT_THAT(origin_displacement(Celsius{}, OffsetCelsius{}), Eq((kelvins / mag<3>())(5)));
 }
 
 TEST(CommonUnit, FindsCommonMagnitude) {
@@ -556,13 +547,11 @@ TEST(CommonPointUnit, TakesOriginMagnitudeIntoAccount) {
     using CommonByQuantity = CommonUnitT<Kelvins, Celsius>;
     using CommonByPoint = CommonPointUnitT<Kelvins, Celsius>;
 
-    // The definition of Celsius in this file uses millikelvin to define its constant.
-    EXPECT_THAT(unit_ratio(CommonByQuantity{}, CommonByPoint{}), Eq(mag<1000>()));
+    EXPECT_THAT(unit_ratio(CommonByQuantity{}, CommonByPoint{}), Eq(mag<20>()));
 
-    // The common point-unit should not be the _same_ as mK (since we never named the latter, and
-    // thus can't "conjure it up").  However, it _should_ be _point-equivalent_ to mK.
-    ASSERT_THAT((std::is_same<CommonByPoint, Milli<Kelvins>>::value), IsFalse());
-    EXPECT_THAT(CommonByPoint{}, PointEquivalentToUnit(milli(Kelvins{})));
+    constexpr auto expected = Kelvins{} / mag<20>();
+    EXPECT_THAT(CommonByPoint{}, PointEquivalentToUnit(expected))
+        << "Expected " << unit_label(expected) << ", got " << unit_label(CommonByPoint{});
 }
 
 TEST(CommonPointUnit, IndependentOfOrderingAndRepetitions) {
@@ -612,7 +601,8 @@ TEST(MakeCommonPoint, PreservesCategory) {
 
     // The origin of the common point unit is the lowest origin among all input units.
     EXPECT_THAT(celsenheit_pt(0), Eq(fahrenheit_pt(0)));
-    EXPECT_LT(celsenheit_pt(0), celsius_pt(0));
+    EXPECT_LT(celsenheit_pt(0), celsius_pt(0))
+        << "Difference: " << celsius_pt(0) - celsenheit_pt(0);
 
     // The common point unit should evenly divide both input units.
     //
@@ -746,17 +736,10 @@ TEST(UnitLabel, CommonPointUnitLabelWorksWithUnitProduct) {
 }
 
 TEST(UnitLabel, CommonPointUnitLabelTakesOriginOffsetIntoAccount) {
-    // NOTE: the (1 / 1000) scaling comes about because we're still using `Quantity` to define our
-    // origins.  We may be able to do better, and re-found them on `Constant`, at least once we add
-    // some kind of subtraction that works at least some of the time.  The ideal end point would be
-    // that the common point unit for `Celsius` and `OffsetCelsius` would be simply `Celsius`
-    // (because `OffsetCelsius` is just `Celsius` with a _higher_ origin).  At that point, we'll
-    // need to construct a more complicated example here that will force us to use
-    // `CommonPointUnit<...>`, because it will be meaningfully different from all of its parameters.
     using U = CommonPointUnitT<Celsius, OffsetCelsius>;
     EXPECT_THAT(unit_label(U{}),
-                AnyOf(StrEq("EQUIV{[(1 / 1000) deg_C], [(1 / 1000) offset_deg_C]}"),
-                      StrEq("EQUIV{[(1 / 1000) offset_deg_C], [(1 / 1000) deg_C]}")));
+                AnyOf(StrEq("EQUIV{[(1 / 3) deg_C], [(1 / 5) (@(0 offset_deg_C) - @(0 deg_C))]}"),
+                      StrEq("EQUIV{[(1 / 5) (@(0 offset_deg_C) - @(0 deg_C))], [(1 / 3) deg_C]}")));
 }
 
 TEST(UnitLabel, APICompatibleWithUnitSlots) { EXPECT_THAT(unit_label(feet), StrEq("ft")); }

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -601,7 +601,7 @@ TEST(MakeCommonPoint, PreservesCategory) {
 
     // The origin of the common point unit is the lowest origin among all input units.
     EXPECT_THAT(celsenheit_pt(0), Eq(fahrenheit_pt(0)));
-    EXPECT_LT(celsenheit_pt(0), celsius_pt(0))
+    EXPECT_THAT(celsenheit_pt(0), Lt(celsius_pt(0)))
         << "Difference: " << celsius_pt(0) - celsenheit_pt(0);
 
     // The common point unit should evenly divide both input units.

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -488,6 +488,26 @@ that is what this trait produces.
 For example, the origin displacement from `Kelvins` to `Celsius` is equivalent to
 $273.15 \,\text{K}$.
 
+Rather than returning a `Quantity`, we return a "shapeshifter" type: that is, a [monovalue
+type](./detail/monovalue_types.md) that can _initialize_ any appropriate `Quantity` type.  The
+conversion will succeed if and only if the value can be represented in the target `Quantity` without
+overflow or truncation --- and if it fails, it will fail _at compile time_.  The specific
+shapeshifter type we return will be:
+
+- [Zero](./zero.md) if the origins of the two units coincide; or,
+- [Constant](./constant.md) if they differ.
+
+!!! note
+    Au 0.4.1 was the last release where the `OriginDisplacement` trait could be found in
+    `"au/unit_of_measure.hh"`, along with all of the other traits documented here.  For all
+    subsequent releases, it can be found in `"au/quantity_point.hh"`.
+
+    The reason we moved it was because `"au/constant.hh"` (which defines `Constant`) depends on
+    `"au/quantity.hh"`, which in turn depends on `"au/unit_of_measure.hh"`.  Therefore, we could
+    never have used `Constant` inside of `"au/unit_of_measure.hh"`.  However,
+    `"au/quantity_point.hh"` _could_ depend on `"au/constant.hh"`.  Origin displacements aren't very
+    useful without `QuantityPoint` anyway, so this new home is acceptable.
+
 **Syntax:**
 
 - For _types_ `U1` and `U2`:


### PR DESCRIPTION
Now, the common point unit is just the _common unit_, except that
instead of just looking at all of the input units, we also consider
their mutual origin displacements (treated as new ad hoc units).  And,
we set an origin that is equal to the lowest origin among those inputs.
That's it!  No more ugly hacks... goodbye `TypeHoldingCommonOrigin`!

This simplifies our logic for conversion checking in `QuantityPoint`,
and maximally expands the set of allowed operations.  This is made
possible because the origin displacement is now always a shapeshifter
type, which has a perfect conversion policy, known at compile time, to
every destination type.  I believe this is a first among units
libraries.

Some people might have been using the `OriginDisplacement` trait, so we
retain it, but it has to move from `unit_of_measure.hh` to
`quantity_point.hh`, because now it depends on `:constant`.  We document
this.

We did need to refine the ordering by adding another tiebreaker based on
the origin displacement unit, too.

Fixes https://github.com/aurora-opensource/au/issues/369.