### PR TITLE
Convert EXPECT_STREQ to matcher syntax

### DIFF
--- a/au/code/au/testing.hh
+++ b/au/code/au/testing.hh
@@ -22,6 +22,7 @@
 namespace au {
 
 using ::testing::Eq;
+using ::testing::StrEq;
 
 MATCHER_P(SameType, target, "") {
     return std::is_same<stdx::remove_cvref_t<decltype(arg)>,
@@ -58,7 +59,7 @@ MATCHER_P(PointEquivalent, target, "") {
 
 template <typename Unit, std::size_t N>
 void expect_label(const char (&label)[N]) {
-    EXPECT_STREQ(unit_label<Unit>(), label);
+    EXPECT_THAT(unit_label<Unit>(), StrEq(label));
     EXPECT_THAT(sizeof(unit_label<Unit>()), Eq(N));
 }
 

--- a/au/code/au/utility/test/string_constant_test.cc
+++ b/au/code/au/utility/test/string_constant_test.cc
@@ -21,13 +21,14 @@
 namespace au {
 
 using ::testing::Eq;
+using ::testing::IsEmpty;
 using ::testing::StrEq;
 
 namespace detail {
 
 TEST(StringConstant, CanCreateFromStringLiteral) {
     constexpr StringConstant<5> x{"hello"};
-    EXPECT_STREQ(x.c_str(), "hello");
+    EXPECT_THAT(x, StrEq("hello"));
 }
 
 TEST(StringConstant, HasLengthMember) {
@@ -37,12 +38,12 @@ TEST(StringConstant, HasLengthMember) {
 
 TEST(AsStringConstant, CanCreateFromStringLiteral) {
     constexpr auto x = as_string_constant("hello");
-    EXPECT_STREQ(x.c_str(), "hello");
+    EXPECT_THAT(x, StrEq("hello"));
 }
 
 TEST(AsStringConstant, PassingStringConstantIsIdentity) {
     constexpr auto x = as_string_constant(as_string_constant("goodbye"));
-    EXPECT_STREQ(x.c_str(), "goodbye");
+    EXPECT_THAT(x, StrEq("goodbye"));
 }
 
 TEST(AbsAsUnsigned, IdentityForPositiveNumbers) {
@@ -58,16 +59,16 @@ TEST(AbsAsUnsigned, NegatesNegativeNumbers) {
 }
 
 TEST(IToA, ValueHoldsStringVersionOfTemplateParameter) {
-    EXPECT_THAT(IToA<0>::value.c_str(), StrEq("0"));
+    EXPECT_THAT(IToA<0>::value, StrEq("0"));
 
-    EXPECT_THAT(IToA<1>::value.c_str(), StrEq("1"));
-    EXPECT_THAT(IToA<9>::value.c_str(), StrEq("9"));
-    EXPECT_THAT(IToA<10>::value.c_str(), StrEq("10"));
-    EXPECT_THAT(IToA<91>::value.c_str(), StrEq("91"));
-    EXPECT_THAT(IToA<312839>::value.c_str(), StrEq("312839"));
+    EXPECT_THAT(IToA<1>::value, StrEq("1"));
+    EXPECT_THAT(IToA<9>::value, StrEq("9"));
+    EXPECT_THAT(IToA<10>::value, StrEq("10"));
+    EXPECT_THAT(IToA<91>::value, StrEq("91"));
+    EXPECT_THAT(IToA<312839>::value, StrEq("312839"));
 
-    EXPECT_THAT(IToA<-1>::value.c_str(), StrEq("-1"));
-    EXPECT_THAT(IToA<-83294>::value.c_str(), StrEq("-83294"));
+    EXPECT_THAT(IToA<-1>::value, StrEq("-1"));
+    EXPECT_THAT(IToA<-83294>::value, StrEq("-83294"));
 
     // This funny way of writing it is because `-9'223'372'036'854'775'808` isn't a literal.  The
     // actual literal is `9'223'372'036'854'775'808`, which is too big (by one) to fit into
@@ -92,23 +93,23 @@ TEST(IToA, HasLengthMember) {
 }
 
 TEST(UIToA, CanHandleNumbersBiggerThanIntmaxButWithinUintmax) {
-    EXPECT_STREQ(UIToA<10000000000000000000u>::value.c_str(), "10000000000000000000");
+    EXPECT_THAT(UIToA<10'000'000'000'000'000'000u>::value, StrEq("10000000000000000000"));
 }
 
 TEST(join, EmptyStringForNoArguments) {
     constexpr auto x = as_string_constant("sep").join();
-    EXPECT_STREQ(x.c_str(), "");
+    EXPECT_THAT(x, IsEmpty());
 }
 
 TEST(join, InputStringForOneArgument) {
     constexpr auto fish = as_string_constant("sep").join(as_string_constant("fish"));
-    EXPECT_STREQ(fish.c_str(), "fish");
+    EXPECT_THAT(fish, StrEq("fish"));
 }
 
 TEST(join, JoinsMultipleArgumentsWithSep) {
     constexpr auto letter_groups = as_string_constant(" | ").join(
         as_string_constant("a"), as_string_constant("b"), as_string_constant("cde"));
-    EXPECT_STREQ(letter_groups.c_str(), "a | b | cde");
+    EXPECT_THAT(letter_groups, StrEq("a | b | cde"));
 }
 
 TEST(JoinBy, SupportsStringConstants) {
@@ -116,22 +117,22 @@ TEST(JoinBy, SupportsStringConstants) {
 
     constexpr auto letter_groups = join_by(" # ", "a", b, "cde");
 
-    EXPECT_STREQ(letter_groups.c_str(), "a # b # cde");
+    EXPECT_THAT(letter_groups, StrEq("a # b # cde"));
 }
 
 TEST(concatenate, EmptyStringForNoArguments) {
     constexpr auto x = concatenate();
-    EXPECT_STREQ(x.c_str(), "");
+    EXPECT_THAT(x, IsEmpty());
 }
 
 TEST(concatenate, ReturnsInputStringForOneArgument) {
     constexpr auto x = concatenate("foo");
-    EXPECT_STREQ(x.c_str(), "foo");
+    EXPECT_THAT(x, StrEq("foo"));
 }
 
 TEST(concatenate, ConcatenatesMultipleArguments) {
     constexpr auto x = concatenate("a", "b", "cde");
-    EXPECT_STREQ(x.c_str(), "abcde");
+    EXPECT_THAT(x, StrEq("abcde"));
 }
 
 TEST(concatenate, SupportsStringConstants) {
@@ -140,12 +141,12 @@ TEST(concatenate, SupportsStringConstants) {
 
     constexpr auto x = concatenate(a, "b", cde);
 
-    EXPECT_STREQ(x.c_str(), "abcde");
+    EXPECT_THAT(x, StrEq("abcde"));
 }
 
 TEST(ParensIf, WrapsInParensIfTrue) {
-    EXPECT_STREQ(parens_if<true>("a"), "(a)");
-    EXPECT_STREQ(parens_if<false>("123"), "123");
+    EXPECT_THAT(parens_if<true>("a"), StrEq("(a)"));
+    EXPECT_THAT(parens_if<false>("123"), StrEq("123"));
 }
 
 }  // namespace detail


### PR DESCRIPTION
This converts existing uses of `EXPECT_STREQ` to use the `StrEq` and `IsEmpty`
matchers.  Note that we really want to test the `StringContstant`'s ability to
do string things.  If we want to test the behavior of `c_str`, that should be a
specific test.

Partial implementation for #404.
