### PR TITLE
Convert `EXPECT_NEAR` assertions to matcher syntax

### DIFF
--- a/au/code/au/math_test.cc
+++ b/au/code/au/math_test.cc
@@ -283,10 +283,10 @@ TEST(cos, GivesSameAnswersAsRawNumbersButInStrongTypes) {
 
 TEST(cos, GivesCorrectAnswersForInputsInDegrees) {
     constexpr auto TOL = 1e-15;
-    EXPECT_NEAR(cos(degrees(0)), 1.0, TOL);
-    EXPECT_NEAR(cos(degrees(45)), std::sqrt(0.5), TOL);
-    EXPECT_NEAR(cos(degrees(60)), 0.5, TOL);
-    EXPECT_NEAR(cos(degrees(90)), 0.0, TOL);
+    EXPECT_THAT(cos(degrees(0)), DoubleNear(1.0, TOL));
+    EXPECT_THAT(cos(degrees(45)), DoubleNear(std::sqrt(0.5), TOL));
+    EXPECT_THAT(cos(degrees(60)), DoubleNear(0.5, TOL));
+    EXPECT_THAT(cos(degrees(90)), DoubleNear(0.0, TOL));
 }
 
 // Our `fmod` and `remainder` overloads mix conversions and computations.
@@ -555,10 +555,10 @@ TEST(sin, GivesSameAnswersAsRawNumbersButInStrongTypes) {
 
 TEST(sin, GivesCorrectAnswersForInputsInDegrees) {
     constexpr auto TOL = 1e-15;
-    EXPECT_NEAR(sin(degrees(0)), 0.0, TOL);
-    EXPECT_NEAR(sin(degrees(30)), 0.5, TOL);
-    EXPECT_NEAR(sin(degrees(45)), std::sqrt(0.5), TOL);
-    EXPECT_NEAR(sin(degrees(90)), 1.0, TOL);
+    EXPECT_THAT(sin(degrees(0)), DoubleNear(0.0, TOL));
+    EXPECT_THAT(sin(degrees(30)), DoubleNear(0.5, TOL));
+    EXPECT_THAT(sin(degrees(45)), DoubleNear(std::sqrt(0.5), TOL));
+    EXPECT_THAT(sin(degrees(90)), DoubleNear(1.0, TOL));
 }
 
 TEST(sqrt, OutputRepDependsOnInputRep) {

--- a/au/code/au/quantity_point_test.cc
+++ b/au/code/au/quantity_point_test.cc
@@ -21,6 +21,7 @@
 
 namespace au {
 
+using ::testing::DoubleNear;
 using ::testing::Eq;
 using ::testing::IsFalse;
 using ::testing::IsTrue;
@@ -205,7 +206,7 @@ TEST(QuantityPoint, HasDefaultConstructor) {
 
 TEST(QuantityPoint, InHandlesUnitsWithNonzeroOffset) {
     constexpr auto room_temperature = kelvins_pt(293.15);
-    EXPECT_NEAR(room_temperature.in(Celsius{}), 20, 1e-12);
+    EXPECT_THAT(room_temperature.in(Celsius{}), DoubleNear(20, 1e-12));
 }
 
 TEST(QuantityPoint, InHandlesIntegerRepInUnitsWithNonzeroOffset) {

--- a/au/code/au/quantity_test.cc
+++ b/au/code/au/quantity_test.cc
@@ -25,6 +25,7 @@
 namespace au {
 
 using ::testing::DoubleEq;
+using ::testing::DoubleNear;
 using ::testing::Each;
 using ::testing::Eq;
 using ::testing::Gt;
@@ -312,7 +313,7 @@ TEST(Quantity, HandlesMagnitudesWithFractionalExponents) {
     EXPECT_THAT(x.in(sqrt(milli(feet))), Eq(3'000.0));
 
     // We can also retrieve the value in a different unit whose ratio *does* have fractional powers.
-    EXPECT_NEAR(x.in(sqrt(feet)), 94.86833, 1e-5);
+    EXPECT_THAT(x.in(sqrt(feet)), DoubleNear(94.86833, 1e-5));
 
     // Squaring the fractional base power gives us an exact non-fractional dimension and scale.
     EXPECT_THAT(x * x, Eq(kilo(feet)(9.0)));


### PR DESCRIPTION
All the existing uses of `EXPECT_NEAR` could be converted to `DoubleNear`.

Partial implementation for #404.
