### PR TITLE
Convert remaining assertion checks to matcher syntax

### DIFF
--- a/au/code/au/au_test.cc
+++ b/au/code/au/au_test.cc
@@ -36,6 +36,7 @@
 namespace au {
 
 using ::testing::Eq;
+using ::testing::Lt;
 using ::testing::StaticAssertTypeEq;
 
 namespace {
@@ -112,7 +113,7 @@ TEST(Xkcd, Xkcd3038GivesReasonableSpeedLimit) {
 }
 
 TEST(QuantityPoint, DocumentationExampleIsCorrect) {
-    EXPECT_LT(fahrenheit_pt(-40) + celsius_qty(60), kelvins_pt(300));
+    EXPECT_THAT(fahrenheit_pt(-40) + celsius_qty(60), Lt(kelvins_pt(300)));
 }
 
 }  // namespace au

--- a/au/code/au/cpp20_test.cc
+++ b/au/code/au/cpp20_test.cc
@@ -18,11 +18,14 @@
 #include "au/quantity_point.hh"
 #include "au/testing.hh"
 #include "au/units/meters.hh"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace au {
 
 using symbols::m;
 using ::testing::Eq;
+using ::testing::Lt;
 
 struct Foo {
     auto operator<=>(const Foo &) const = default;
@@ -36,7 +39,7 @@ struct FooPt {
     QuantityPointD<Meters> position;
 };
 
-TEST(Quantity, SupportsSpaceship) { EXPECT_LT(Foo{5 * m}, Foo{6 * m}); }
+TEST(Quantity, SupportsSpaceship) { EXPECT_THAT(Foo{5 * m}, Lt(Foo{6 * m})); }
 
 TEST(Quantity, SpaceshipCorrectForMixedSignUnits) {
     constexpr auto negm = m * (-mag<1>());
@@ -45,6 +48,8 @@ TEST(Quantity, SpaceshipCorrectForMixedSignUnits) {
     EXPECT_THAT((1 * m) <=> (-2 * negm), Eq((1 * m) <=> (2 * m)));
 }
 
-TEST(QuantityPoint, SupportsSpaceship) { EXPECT_LT(FooPt{meters_pt(5)}, FooPt{meters_pt(6)}); }
+TEST(QuantityPoint, SupportsSpaceship) {
+    EXPECT_THAT(FooPt{meters_pt(5)}, Lt(FooPt{meters_pt(6)}));
+}
 
 }  // namespace au

--- a/au/code/au/magnitude_test.cc
+++ b/au/code/au/magnitude_test.cc
@@ -27,6 +27,8 @@ using ::testing::Eq;
 using ::testing::FloatEq;
 using ::testing::IsFalse;
 using ::testing::IsTrue;
+using ::testing::Le;
+using ::testing::Ne;
 using ::testing::StaticAssertTypeEq;
 using ::testing::StrEq;
 
@@ -46,7 +48,7 @@ TEST(Magnitude, SupportsEqualityComparison) {
     constexpr auto mag_2 = mag<2>();
     EXPECT_THAT(mag_2, Eq(mag_2));
 
-    EXPECT_NE(mag_1, mag_2);
+    EXPECT_THAT(mag_1, Ne(mag_2));
 }
 
 TEST(Magnitude, ProductBehavesCorrectly) {
@@ -295,7 +297,7 @@ TEST(GetValue, PiToArbitraryPowerPerformsComputationsInMostAccurateTypeAtCompile
     constexpr auto result_via_long_double = static_cast<float>(cubed(get_value<long double>(PI)));
 
     constexpr auto pi_cubed_value = get_value<float>(pi_cubed);
-    ASSERT_NE(pi_cubed_value, result_via_float);
+    ASSERT_THAT(pi_cubed_value, Ne(result_via_float));
     EXPECT_THAT(pi_cubed_value, Eq(result_via_long_double));
 }
 
@@ -322,7 +324,7 @@ TEST(GetValue, ImpossibleRequestsArePreventedAtCompileTime) {
 
 TEST(GetValue, HandlesRoots) {
     constexpr auto sqrt_2 = get_value<double>(root<2>(mag<2>()));
-    EXPECT_DOUBLE_EQ(sqrt_2 * sqrt_2, 2.0);
+    EXPECT_THAT(sqrt_2 * sqrt_2, DoubleEq(2.0));
 }
 
 TEST(GetValue, WorksForEmptyPack) {
@@ -548,7 +550,7 @@ TEST(Root, ResultAtLeastAsGoodAsStdPowForRationalPowers) {
         for (const auto power : std::vector<RationalPower>{{5, 2}, {2, 3}, {7, 4}}) {
             const auto error_from_root = round_trip_error(base, power, result_via_root);
             const auto error_from_std_pow = round_trip_error(base, power, result_via_std_pow);
-            EXPECT_LE(error_from_root, error_from_std_pow);
+            EXPECT_THAT(error_from_root, Le(error_from_std_pow));
         }
     }
 }

--- a/au/code/au/math_test.cc
+++ b/au/code/au/math_test.cc
@@ -37,6 +37,7 @@ using ::testing::DoubleNear;
 using ::testing::Eq;
 using ::testing::IsFalse;
 using ::testing::IsTrue;
+using ::testing::Ne;
 using ::testing::StaticAssertTypeEq;
 
 namespace {
@@ -396,7 +397,7 @@ TEST(max, ReturnsByValueForSameExactQuantityType) {
     const auto &max_a_b = max(a, b);
 
     EXPECT_THAT(max_a_b, Eq(b));
-    EXPECT_NE(&max_a_b, &b);
+    EXPECT_THAT(&max_a_b, Ne(&b));
 }
 
 TEST(max, SupportsConstexprForSameExactQuantityType) {
@@ -411,7 +412,7 @@ TEST(max, ReturnsByValueForSameExactQuantityPointType) {
     const auto &max_a_b = max(a, b);
 
     EXPECT_THAT(max_a_b, Eq(b));
-    EXPECT_NE(&max_a_b, &b);
+    EXPECT_THAT(&max_a_b, Ne(&b));
 }
 
 TEST(max, SupportsConstexprForSameExactQuantityPointType) {
@@ -461,7 +462,7 @@ TEST(min, ReturnsByValueForSameExactQuantityType) {
     const auto &min_a_b = min(a, b);
 
     EXPECT_THAT(min_a_b, Eq(a));
-    EXPECT_NE(&min_a_b, &a);
+    EXPECT_THAT(&min_a_b, Ne(&a));
 }
 
 TEST(min, SupportsConstexprForSameExactQuantityType) {
@@ -476,7 +477,7 @@ TEST(min, ReturnsByValueForSameExactQuantityPointType) {
     const auto &min_a_b = min(a, b);
 
     EXPECT_THAT(min_a_b, Eq(a));
-    EXPECT_NE(&min_a_b, &a);
+    EXPECT_THAT(&min_a_b, Ne(&a));
 }
 
 TEST(min, SupportsConstexprForSameExactQuantityPointType) {

--- a/au/code/au/quantity_test.cc
+++ b/au/code/au/quantity_test.cc
@@ -32,6 +32,7 @@ using ::testing::Gt;
 using ::testing::IsFalse;
 using ::testing::IsTrue;
 using ::testing::Lt;
+using ::testing::Ne;
 using ::testing::StaticAssertTypeEq;
 
 struct Feet : UnitImpl<Length> {
@@ -383,7 +384,7 @@ TEST(Quantity, EqualityComparisonWorks) {
 TEST(Quantity, InequalityComparisonWorks) {
     constexpr auto a = hours(3.9);
     constexpr auto b = hours(5.7);
-    EXPECT_NE(a, b);
+    EXPECT_THAT(a, Ne(b));
 }
 
 TEST(Quantity, RelativeComparisonsWork) {
@@ -409,7 +410,7 @@ TEST(Quantity, CopyingWorksAndIsDeepCopy) {
 
     // To test that we're deep copying, modify the original.
     original += feet(2.5);
-    EXPECT_NE(original, copy);
+    EXPECT_THAT(original, Ne(copy));
 }
 
 TEST(Quantity, CanAddLikeQuantities) {
@@ -716,7 +717,7 @@ TEST(Quantity, QuantityCastAvoidsPreventableOverflowWhenGoingToLargerType) {
 
 TEST(Quantity, QuantityCastAvoidsPreventableOverflowWhenGoingToSmallerType) {
     constexpr uint64_t would_overflow_uint32 = 9'000'000'000;
-    ASSERT_GT(would_overflow_uint32, std::numeric_limits<uint32_t>::max());
+    ASSERT_THAT(would_overflow_uint32, Gt(std::numeric_limits<uint32_t>::max()));
 
     constexpr auto lots_of_nanoinches = nano(inches)(would_overflow_uint32);
 
@@ -813,7 +814,7 @@ TEST(QuantityNTTP, CanConvertFromNttpToAnyCompatibleQuantityType) {
 TEST(Quantity, CommonTypeRespectsImplicitRepSafetyChecks) {
     // The following test should fail to compile.  Uncomment both lines to check.
     // constexpr auto feeters = QuantityMaker<CommonUnitT<Meters, Feet>>{};
-    // EXPECT_NE(meters(uint16_t{53}), feeters(uint16_t{714}));
+    // EXPECT_THAT(meters(uint16_t{53}), Ne(feeters(uint16_t{714})));
 
     // Why the above values?  The common unit of Meters and Feet (herein called the "Feeter") is
     // (Meters / 1250); a.k.a., (Feet / 381).  (For reference, think of it as "a little less than a
@@ -1093,12 +1094,12 @@ TEST(mod, ReturnsCommonUnitForDifferentInputUnits) {
 
 TEST(Zero, ComparableToArbitraryQuantities) {
     EXPECT_THAT(ZERO, Eq(meters(0)));
-    EXPECT_LT(ZERO, meters(1));
-    EXPECT_GT(ZERO, meters(-1));
+    EXPECT_THAT(ZERO, Lt(meters(1)));
+    EXPECT_THAT(ZERO, Gt(meters(-1)));
 
     EXPECT_THAT(ZERO, Eq(hours(0)));
-    EXPECT_LT(ZERO, hours(1));
-    EXPECT_GT(ZERO, hours(-1));
+    EXPECT_THAT(ZERO, Lt(hours(1)));
+    EXPECT_THAT(ZERO, Gt(hours(-1)));
 }
 
 TEST(Zero, AssignableToArbitraryQuantities) {

--- a/au/code/au/units/test/degrees_test.cc
+++ b/au/code/au/units/test/degrees_test.cc
@@ -21,12 +21,14 @@
 
 namespace au {
 
+using ::testing::DoubleEq;
 using ::testing::Eq;
 
 TEST(Degrees, HasExpectedLabel) { expect_label<Degrees>("deg"); }
 
 TEST(Degrees, RoughlyEquivalentToPiOver180Radians) {
-    EXPECT_DOUBLE_EQ(degrees(1.0).in(radians), get_value<double>(Magnitude<Pi>{} / mag<180>()));
+    EXPECT_THAT(degrees(1.0).in(radians),
+                DoubleEq(get_value<double>(Magnitude<Pi>{} / mag<180>())));
 }
 
 TEST(Degrees, One360thOfARevolution) { EXPECT_THAT(degrees(360), Eq(revolutions(1))); }

--- a/au/code/au/units/test/radians_test.cc
+++ b/au/code/au/units/test/radians_test.cc
@@ -16,14 +16,18 @@
 
 #include "au/testing.hh"
 #include "au/units/revolutions.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
 
+using ::testing::DoubleEq;
+
 TEST(Radians, HasExpectedLabel) { expect_label<Radians>("rad"); }
 
 TEST(Radians, TwoPiPerRevolution) {
-    EXPECT_DOUBLE_EQ(radians(get_value<double>(mag<2>() * Magnitude<Pi>{})).in(revolutions), 1.0);
+    EXPECT_THAT(radians(get_value<double>(mag<2>() * Magnitude<Pi>{})).in(revolutions),
+                DoubleEq(1.0));
 }
 
 TEST(Radians, HasExpectedSymbol) {

--- a/au/code/au/zero_test.cc
+++ b/au/code/au/zero_test.cc
@@ -22,8 +22,10 @@ using namespace std::chrono_literals;
 namespace au {
 
 using ::testing::Eq;
+using ::testing::Gt;
 using ::testing::IsFalse;
 using ::testing::IsTrue;
+using ::testing::Lt;
 
 // Example for supporting implicit construction from Zero.
 class WrappedInt {
@@ -65,12 +67,8 @@ TEST(Zero, PlusZeroIsZero) {
 
 TEST(Zero, ComparableToArbitraryQuantities) {
     EXPECT_THAT(ZERO, Eq(WrappedInt{0}));
-    EXPECT_LT(ZERO, WrappedInt{1});
-    EXPECT_GT(ZERO, WrappedInt{-1});
-
-    EXPECT_THAT(WrappedInt{0}, Eq(ZERO));
-    EXPECT_LT(ZERO, WrappedInt{1});
-    EXPECT_GT(ZERO, WrappedInt{-1});
+    EXPECT_THAT(ZERO, Lt(WrappedInt{1}));
+    EXPECT_THAT(ZERO, Gt(WrappedInt{-1}));
 }
 
 TEST(Zero, ComparesEqualToZero) {


### PR DESCRIPTION
This last batch involves all the remaining assertion style checks.  Validated
using:

```bash
grep -HnR --perl-regexp '(EXPECT|ASSERT)_(?!THAT)' au/code/au
```

Remove some redundant tests in `zero_test` that were identified in a
[previous PR](https://github.com/aurora-opensource/au/pull/417#discussion_r2078317120).

This should complete #404.
