### PR TITLE
Rename `detail` namespace to `auimpl`

### DIFF
--- a/au/code/au/apply_magnitude.hh
+++ b/au/code/au/apply_magnitude.hh
@@ -18,7 +18,7 @@
 #include "au/magnitude.hh"
 
 namespace au {
-namespace detail {
+namespace auimpl {
 
 // The various categories by which a magnitude can be applied to a numeric quantity.
 enum class ApplyAs {
@@ -236,5 +236,5 @@ constexpr T apply_magnitude(const T &x, Magnitude<BPs...>) {
     return ApplyMagnitudeT<T, Magnitude<BPs...>>{}(x);
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/apply_magnitude_test.cc
+++ b/au/code/au/apply_magnitude_test.cc
@@ -24,7 +24,7 @@ using ::testing::IsTrue;
 using ::testing::Not;
 
 namespace au {
-namespace detail {
+namespace auimpl {
 namespace {
 constexpr auto PI = Magnitude<Pi>{};
 
@@ -506,5 +506,5 @@ TEST(WouldTruncate, AlwaysFalseWhenApplyingIrrationalMagnitude) {
 
     EXPECT_THAT(ApplyPiByTwoToF::would_truncate(-3.402e38f), IsFalse());
 }
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/apply_rational_magnitude_to_integral.hh
+++ b/au/code/au/apply_rational_magnitude_to_integral.hh
@@ -35,7 +35,7 @@
 // every combination of integral type and numerator and denominator magnitudes.
 
 namespace au {
-namespace detail {
+namespace auimpl {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -266,5 +266,5 @@ struct MinNonOverflowingValue
                   "We assume the promoted type is also signed");
 };
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/apply_rational_magnitude_to_integral_test.cc
+++ b/au/code/au/apply_rational_magnitude_to_integral_test.cc
@@ -26,7 +26,7 @@ using ::testing::Lt;
 using ::testing::StaticAssertTypeEq;
 
 namespace au {
-namespace detail {
+namespace auimpl {
 namespace {
 
 template <typename... BPs>
@@ -432,5 +432,5 @@ TEST(MinNonOverflowingValue, IsTMinOverNTimesDWhenMoreConstrainingThanPMinOverN)
 }
 
 }  // namespace
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/constant.hh
+++ b/au/code/au/constant.hh
@@ -35,13 +35,13 @@ namespace au {
 // correctly representable value will succeed, and every unrepresentable conversion will fail.
 //
 template <typename Unit>
-struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
-                  detail::ScalesQuantity<Constant, Unit>,
-                  detail::ComposesWith<Constant, Unit, Constant, Constant>,
-                  detail::ComposesWith<Constant, Unit, QuantityMaker, QuantityMaker>,
-                  detail::ComposesWith<Constant, Unit, SingularNameFor, SingularNameFor>,
-                  detail::SupportsRationalPowers<Constant, Unit>,
-                  detail::CanScaleByMagnitude<Constant, Unit> {
+struct Constant : auimpl::MakesQuantityFromNumber<Constant, Unit>,
+                  auimpl::ScalesQuantity<Constant, Unit>,
+                  auimpl::ComposesWith<Constant, Unit, Constant, Constant>,
+                  auimpl::ComposesWith<Constant, Unit, QuantityMaker, QuantityMaker>,
+                  auimpl::ComposesWith<Constant, Unit, SingularNameFor, SingularNameFor>,
+                  auimpl::SupportsRationalPowers<Constant, Unit>,
+                  auimpl::CanScaleByMagnitude<Constant, Unit> {
     // Convert this constant to a Quantity of the given rep.
     template <typename T>
     constexpr auto as() const {

--- a/au/code/au/constants/avogadro_constant.hh
+++ b/au/code/au/constants/avogadro_constant.hh
@@ -17,7 +17,7 @@
 
 namespace au {
 
-namespace detail {
+namespace auimpl {
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
 // Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
@@ -30,8 +30,8 @@ struct AvogadroConstantUnit : decltype(inverse(Moles{}) * mag<602'214'076>() * p
                               AvogadroConstantLabel<void> {
     using AvogadroConstantLabel<void>::label;
 };
-}  // namespace detail
+}  // namespace auimpl
 
-constexpr auto AVOGADRO_CONSTANT = make_constant(detail::AvogadroConstantUnit{});
+constexpr auto AVOGADRO_CONSTANT = make_constant(auimpl::AvogadroConstantUnit{});
 
 }  // namespace au

--- a/au/code/au/constants/boltzmann_constant.hh
+++ b/au/code/au/constants/boltzmann_constant.hh
@@ -18,7 +18,7 @@
 
 namespace au {
 
-namespace detail {
+namespace auimpl {
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
 // Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
@@ -32,8 +32,8 @@ struct BoltzmannConstantUnit
       BoltzmannConstantLabel<void> {
     using BoltzmannConstantLabel<void>::label;
 };
-}  // namespace detail
+}  // namespace auimpl
 
-constexpr auto BOLTZMANN_CONSTANT = make_constant(detail::BoltzmannConstantUnit{});
+constexpr auto BOLTZMANN_CONSTANT = make_constant(auimpl::BoltzmannConstantUnit{});
 
 }  // namespace au

--- a/au/code/au/constants/cesium_hyperfine_transition_frequency.hh
+++ b/au/code/au/constants/cesium_hyperfine_transition_frequency.hh
@@ -17,7 +17,7 @@
 
 namespace au {
 
-namespace detail {
+namespace auimpl {
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
 // Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
@@ -30,9 +30,9 @@ struct CesiumHyperfineTransitionFrequencyUnit : decltype(Hertz{} * mag<9'192'631
                                                 CesiumHyperfineTransitionFrequencyLabel<void> {
     using CesiumHyperfineTransitionFrequencyLabel<void>::label;
 };
-}  // namespace detail
+}  // namespace auimpl
 
 constexpr auto CESIUM_HYPERFINE_TRANSITION_FREQUENCY =
-    make_constant(detail::CesiumHyperfineTransitionFrequencyUnit{});
+    make_constant(auimpl::CesiumHyperfineTransitionFrequencyUnit{});
 
 }  // namespace au

--- a/au/code/au/constants/elementary_charge.hh
+++ b/au/code/au/constants/elementary_charge.hh
@@ -17,7 +17,7 @@
 
 namespace au {
 
-namespace detail {
+namespace auimpl {
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
 // Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
@@ -30,8 +30,8 @@ struct ElementaryChargeUnit : decltype(Coulombs{} * mag<1'602'176'634>() * pow<-
                               ElementaryChargeLabel<void> {
     using ElementaryChargeLabel<void>::label;
 };
-}  // namespace detail
+}  // namespace auimpl
 
-constexpr auto ELEMENTARY_CHARGE = make_constant(detail::ElementaryChargeUnit{});
+constexpr auto ELEMENTARY_CHARGE = make_constant(auimpl::ElementaryChargeUnit{});
 
 }  // namespace au

--- a/au/code/au/constants/luminous_efficacy_540_terahertz.hh
+++ b/au/code/au/constants/luminous_efficacy_540_terahertz.hh
@@ -18,7 +18,7 @@
 
 namespace au {
 
-namespace detail {
+namespace auimpl {
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
 // Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
@@ -31,9 +31,9 @@ struct LuminousEfficacy540TerahertzUnit : decltype((Lumens{} / Watts{}) * mag<68
                                           LuminousEfficacy540TerahertzLabel<void> {
     using LuminousEfficacy540TerahertzLabel<void>::label;
 };
-}  // namespace detail
+}  // namespace auimpl
 
 constexpr auto LUMINOUS_EFFICACY_540_TERAHERTZ =
-    make_constant(detail::LuminousEfficacy540TerahertzUnit{});
+    make_constant(auimpl::LuminousEfficacy540TerahertzUnit{});
 
 }  // namespace au

--- a/au/code/au/constants/planck_constant.hh
+++ b/au/code/au/constants/planck_constant.hh
@@ -18,7 +18,7 @@
 
 namespace au {
 
-namespace detail {
+namespace auimpl {
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
 // Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
@@ -32,8 +32,8 @@ struct PlanckConstantUnit
       PlanckConstantLabel<void> {
     using PlanckConstantLabel<void>::label;
 };
-}  // namespace detail
+}  // namespace auimpl
 
-constexpr auto PLANCK_CONSTANT = make_constant(detail::PlanckConstantUnit{});
+constexpr auto PLANCK_CONSTANT = make_constant(auimpl::PlanckConstantUnit{});
 
 }  // namespace au

--- a/au/code/au/constants/reduced_planck_constant.hh
+++ b/au/code/au/constants/reduced_planck_constant.hh
@@ -18,7 +18,7 @@
 
 namespace au {
 
-namespace detail {
+namespace auimpl {
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
 // Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
@@ -32,8 +32,8 @@ struct ReducedPlanckConstantUnit : decltype(Joules{} * Seconds{} * mag<662'607'0
                                    ReducedPlanckConstantLabel<void> {
     using ReducedPlanckConstantLabel<void>::label;
 };
-}  // namespace detail
+}  // namespace auimpl
 
-constexpr auto REDUCED_PLANCK_CONSTANT = make_constant(detail::ReducedPlanckConstantUnit{});
+constexpr auto REDUCED_PLANCK_CONSTANT = make_constant(auimpl::ReducedPlanckConstantUnit{});
 
 }  // namespace au

--- a/au/code/au/constants/speed_of_light.hh
+++ b/au/code/au/constants/speed_of_light.hh
@@ -18,7 +18,7 @@
 
 namespace au {
 
-namespace detail {
+namespace auimpl {
 // DO NOT follow this pattern to define your own units.  This is for library-defined units.
 // Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
 template <typename T>
@@ -31,8 +31,8 @@ struct SpeedOfLightUnit : decltype(Meters{} / Seconds{} * mag<299'792'458>()),
                           SpeedOfLightLabel<void> {
     using SpeedOfLightLabel<void>::label;
 };
-}  // namespace detail
+}  // namespace auimpl
 
-constexpr auto SPEED_OF_LIGHT = make_constant(detail::SpeedOfLightUnit{});
+constexpr auto SPEED_OF_LIGHT = make_constant(auimpl::SpeedOfLightUnit{});
 
 }  // namespace au

--- a/au/code/au/conversion_policy.hh
+++ b/au/code/au/conversion_policy.hh
@@ -32,7 +32,7 @@ constexpr bool can_scale_without_overflow(Magnitude<BPs...> m, Rep value) {
            (std::numeric_limits<Rep>::max() / get_value<Rep>(abs(m)) >= value);
 }
 
-namespace detail {
+namespace auimpl {
 // Chosen so as to allow populating a `QuantityI32<Hertz>` with an input in MHz.
 constexpr auto OVERFLOW_THRESHOLD = 2'147;
 
@@ -54,7 +54,7 @@ struct CoreImplicitConversionPolicyImplAssumingReal
           std::is_floating_point<Rep>,
           stdx::conjunction<std::is_integral<SourceRep>,
                             IsInteger<ScaleFactor>,
-                            detail::CanScaleThresholdWithoutOverflow<Rep, ScaleFactor>>> {};
+                            auimpl::CanScaleThresholdWithoutOverflow<Rep, ScaleFactor>>> {};
 
 // Always permit the identity scaling.
 template <typename Rep>
@@ -102,10 +102,10 @@ template <typename Rep, typename ScaleFactor, typename SourceRep>
 using ImplicitConversionPolicy =
     stdx::disjunction<CoreImplicitConversionPolicy<Rep, ScaleFactor, SourceRep>,
                       PermitAsCarveOutForIntegerPromotion<Rep, ScaleFactor, SourceRep>>;
-}  // namespace detail
+}  // namespace auimpl
 
 template <typename Rep, typename ScaleFactor>
-struct ImplicitRepPermitted : detail::ImplicitConversionPolicy<Rep, ScaleFactor, Rep> {};
+struct ImplicitRepPermitted : auimpl::ImplicitConversionPolicy<Rep, ScaleFactor, Rep> {};
 
 template <typename Rep, typename SourceUnitSlot, typename TargetUnitSlot>
 constexpr bool implicit_rep_permitted_from_source_to_target(SourceUnitSlot, TargetUnitSlot) {
@@ -125,12 +125,12 @@ struct ConstructionPolicy {
     // build in this hard error for safety.  Here, we need a soft error, so we do the dimension
     // check manually below.
     template <typename SourceUnit>
-    using ScaleFactor = MagQuotientT<detail::MagT<SourceUnit>, detail::MagT<Unit>>;
+    using ScaleFactor = MagQuotientT<auimpl::MagT<SourceUnit>, auimpl::MagT<Unit>>;
 
     template <typename SourceUnit, typename SourceRep>
     using PermitImplicitFrom = stdx::conjunction<
         HasSameDimension<Unit, SourceUnit>,
-        detail::ImplicitConversionPolicy<Rep, ScaleFactor<SourceUnit>, SourceRep>>;
+        auimpl::ImplicitConversionPolicy<Rep, ScaleFactor<SourceUnit>, SourceRep>>;
 };
 
 }  // namespace au

--- a/au/code/au/magnitude.hh
+++ b/au/code/au/magnitude.hh
@@ -108,7 +108,7 @@ constexpr auto mag();
 // A base type for prime numbers.
 template <std::uintmax_t N>
 struct Prime {
-    static_assert(detail::is_prime(N), "Prime<N> requires that N is prime");
+    static_assert(auimpl::is_prime(N), "Prime<N> requires that N is prime");
 
     static constexpr std::uintmax_t value() { return N; }
 };
@@ -127,7 +127,7 @@ struct Pi {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Define the lexicographic ordering of bases for Magnitude.
 
-namespace detail {
+namespace auimpl {
 template <typename T, typename U>
 struct OrderByValue : stdx::bool_constant<(T::value() < U::value())> {};
 
@@ -139,10 +139,10 @@ struct OrderByValue<T, Negative> : std::false_type {};
 
 template <>
 struct OrderByValue<Negative, Negative> : std::false_type {};
-}  // namespace detail
+}  // namespace auimpl
 
 template <typename A, typename B>
-struct InOrderFor<Magnitude, A, B> : LexicographicTotalOrdering<A, B, detail::OrderByValue> {};
+struct InOrderFor<Magnitude, A, B> : LexicographicTotalOrdering<A, B, auimpl::OrderByValue> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Type trait based interface for Magnitude.
@@ -291,7 +291,7 @@ constexpr auto common_magnitude(Ms...) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `mag<N>()` implementation.
 
-namespace detail {
+namespace auimpl {
 
 // Helper to perform prime factorization.
 template <std::uintmax_t N>
@@ -315,11 +315,11 @@ struct PrimeFactorization {
                              PrimeFactorizationT<remainder>>;
 };
 
-}  // namespace detail
+}  // namespace auimpl
 
 template <std::size_t N>
 constexpr auto mag() {
-    return detail::PrimeFactorizationT<N>{};
+    return auimpl::PrimeFactorizationT<N>{};
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -365,7 +365,7 @@ struct NumeratorImpl<Magnitude<BPs...>>
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `get_value<T>(Magnitude)` implementation.
 
-namespace detail {
+namespace auimpl {
 
 enum class MagRepresentationOutcome {
     OK,
@@ -635,18 +635,18 @@ constexpr MagRepresentationOrError<T> get_value_result(Magnitude<Negative, BPs..
     }
     return {MagRepresentationOutcome::OK, static_cast<T>(-result.value)};
 }
-}  // namespace detail
+}  // namespace auimpl
 
 template <typename T, typename... BPs>
 constexpr bool representable_in(Magnitude<BPs...> m) {
-    using namespace detail;
+    using namespace auimpl;
 
     return get_value_result<T>(m).outcome == MagRepresentationOutcome::OK;
 }
 
 template <typename T, typename... BPs>
 constexpr T get_value(Magnitude<BPs...> m) {
-    using namespace detail;
+    using namespace auimpl;
 
     constexpr auto result = get_value_result<T>(m);
 
@@ -664,7 +664,7 @@ constexpr T get_value(Magnitude<BPs...> m) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `MagnitudeLabel` implementation.
 
-namespace detail {
+namespace auimpl {
 enum class MagLabelCategory {
     INTEGER,
     RATIONAL,
@@ -697,14 +697,14 @@ constexpr const bool MagnitudeLabelImplementation<MagT, Category>::has_exposed_s
 
 template <typename MagT>
 struct MagnitudeLabelImplementation<MagT, MagLabelCategory::INTEGER>
-    : detail::UIToA<get_value<std::uintmax_t>(MagT{})> {
+    : auimpl::UIToA<get_value<std::uintmax_t>(MagT{})> {
     static constexpr const bool has_exposed_slash = false;
 };
 template <typename MagT>
 constexpr const bool
     MagnitudeLabelImplementation<MagT, MagLabelCategory::INTEGER>::has_exposed_slash;
 
-// Analogous to `detail::ExtendedLabel`, but for magnitudes.
+// Analogous to `auimpl::ExtendedLabel`, but for magnitudes.
 //
 // This makes it easier to name the exact type for compound labels.
 template <std::size_t ExtensionStrlen, typename... Mags>
@@ -726,20 +726,20 @@ template <typename MagT>
 constexpr const bool
     MagnitudeLabelImplementation<MagT, MagLabelCategory::RATIONAL>::has_exposed_slash;
 
-}  // namespace detail
+}  // namespace auimpl
 
 template <typename... BPs>
 struct MagnitudeLabel<Magnitude<BPs...>>
-    : detail::MagnitudeLabelImplementation<Magnitude<BPs...>,
-                                           detail::categorize_mag_label(Magnitude<BPs...>{})> {};
+    : auimpl::MagnitudeLabelImplementation<Magnitude<BPs...>,
+                                           auimpl::categorize_mag_label(Magnitude<BPs...>{})> {};
 
 template <typename... BPs>
 struct MagnitudeLabel<Magnitude<Negative, BPs...>> :
     // Inherit for "has exposed slash".
     MagnitudeLabel<Magnitude<BPs...>> {
-    using LabelT = detail::ExtendedMagLabel<1u, Magnitude<BPs...>>;
+    using LabelT = auimpl::ExtendedMagLabel<1u, Magnitude<BPs...>>;
     static constexpr LabelT value =
-        detail::concatenate("-", MagnitudeLabel<Magnitude<BPs...>>::value);
+        auimpl::concatenate("-", MagnitudeLabel<Magnitude<BPs...>>::value);
 };
 template <typename... BPs>
 constexpr typename MagnitudeLabel<Magnitude<Negative, BPs...>>::LabelT
@@ -747,13 +747,13 @@ constexpr typename MagnitudeLabel<Magnitude<Negative, BPs...>>::LabelT
 
 template <typename MagT>
 constexpr const auto &mag_label(MagT) {
-    return detail::as_char_array(MagnitudeLabel<MagT>::value);
+    return auimpl::as_char_array(MagnitudeLabel<MagT>::value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `CommonMagnitude` implementation.
 
-namespace detail {
+namespace auimpl {
 // Helper: prepend a base power, but only if the Exp is negative.
 template <typename BP, typename MagT>
 struct PrependIfExpNegative;
@@ -766,7 +766,7 @@ struct PrependIfExpNegative<BP, Magnitude<Ts...>>
 // Remove all positive powers from M.
 template <typename M>
 using NegativePowers = MagQuotientT<M, NumeratorPartT<M>>;
-}  // namespace detail
+}  // namespace auimpl
 
 // 1-ary case: identity.
 template <typename M>
@@ -779,12 +779,12 @@ struct CommonMagnitude<Magnitude<>, Magnitude<>> : stdx::type_identity<Magnitude
 // 2-ary base case: only left Magnitude is null.
 template <typename Head, typename... Tail>
 struct CommonMagnitude<Magnitude<>, Magnitude<Head, Tail...>>
-    : stdx::type_identity<detail::NegativePowers<Magnitude<Head, Tail...>>> {};
+    : stdx::type_identity<auimpl::NegativePowers<Magnitude<Head, Tail...>>> {};
 
 // 2-ary base case: only right Magnitude is null.
 template <typename Head, typename... Tail>
 struct CommonMagnitude<Magnitude<Head, Tail...>, Magnitude<>>
-    : stdx::type_identity<detail::NegativePowers<Magnitude<Head, Tail...>>> {};
+    : stdx::type_identity<auimpl::NegativePowers<Magnitude<Head, Tail...>>> {};
 
 // 2-ary recursive case: two non-null Magnitudes.
 template <typename H1, typename... T1, typename H2, typename... T2>
@@ -793,12 +793,12 @@ struct CommonMagnitude<Magnitude<H1, T1...>, Magnitude<H2, T2...>> :
     // If the bases for H1 and H2 are in-order, prepend H1-if-negative to the remainder.
     std::conditional<
         (InOrderFor<Magnitude, BaseT<H1>, BaseT<H2>>::value),
-        detail::PrependIfExpNegativeT<H1, CommonMagnitudeT<Magnitude<T1...>, Magnitude<H2, T2...>>>,
+        auimpl::PrependIfExpNegativeT<H1, CommonMagnitudeT<Magnitude<T1...>, Magnitude<H2, T2...>>>,
 
         // If the bases for H2 and H1 are in-order, prepend H2-if-negative to the remainder.
         std::conditional_t<
             (InOrderFor<Magnitude, BaseT<H2>, BaseT<H1>>::value),
-            detail::PrependIfExpNegativeT<H2,
+            auimpl::PrependIfExpNegativeT<H2,
                                           CommonMagnitudeT<Magnitude<T2...>, Magnitude<H1, T1...>>>,
 
             // If we got here, the bases must be the same.  (We can assume that `InOrderFor` does
@@ -806,8 +806,8 @@ struct CommonMagnitude<Magnitude<H1, T1...>, Magnitude<H2, T2...>> :
             // violate total ordering.)
             std::conditional_t<
                 (std::ratio_subtract<ExpT<H1>, ExpT<H2>>::num < 0),
-                detail::PrependT<CommonMagnitudeT<Magnitude<T1...>, Magnitude<T2...>>, H1>,
-                detail::PrependT<CommonMagnitudeT<Magnitude<T1...>, Magnitude<T2...>>, H2>>>> {};
+                auimpl::PrependT<CommonMagnitudeT<Magnitude<T1...>, Magnitude<T2...>>, H1>,
+                auimpl::PrependT<CommonMagnitudeT<Magnitude<T1...>, Magnitude<T2...>>, H2>>>> {};
 
 // N-ary case: recurse.
 template <typename M1, typename M2, typename... Tail>

--- a/au/code/au/magnitude_test.cc
+++ b/au/code/au/magnitude_test.cc
@@ -407,7 +407,7 @@ TEST(CommonMagnitude, CommonMagOfNegAndNegIsNeg) {
 
 }  // namespace
 
-namespace detail {
+namespace auimpl {
 
 MATCHER(CannotFit, "") {
     return (arg.outcome == MagRepresentationOutcome::ERR_CANNOT_FIT) && (arg.value == 0);
@@ -582,5 +582,5 @@ TEST(DenominatorPart, OmitsSignForNegativeNumbers) {
     StaticAssertTypeEq<DenominatorPartT<decltype(-mag<3>() / mag<7>())>, decltype(mag<7>())>();
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/math.hh
+++ b/au/code/au/math.hh
@@ -43,7 +43,7 @@ using std::sin;
 using std::sqrt;
 using std::tan;
 
-namespace detail {
+namespace auimpl {
 
 // This utility handles converting Quantity to Radians in a uniform way, while also giving a more
 // direct error message via the static_assert if users make a coding error and pass the wrong type.
@@ -115,7 +115,7 @@ struct RoundingRep<Quantity<U, R>, RoundingUnits> {
 template <typename U, typename R, typename RoundingUnits>
 struct RoundingRep<QuantityPoint<U, R>, RoundingUnits>
     : RoundingRep<Quantity<U, R>, RoundingUnits> {};
-}  // namespace detail
+}  // namespace auimpl
 
 // The absolute value of a Quantity.
 template <typename U, typename R>
@@ -207,7 +207,7 @@ constexpr auto copysign(Quantity<U1, R1> mag, Quantity<U2, R2> sgn) {
 // Wrapper for std::cos() which accepts a strongly typed angle quantity.
 template <typename U, typename R>
 auto cos(Quantity<U, R> q) {
-    return std::cos(detail::in_radians(q));
+    return std::cos(auimpl::in_radians(q));
 }
 
 // The floating point remainder of two values of the same dimension.
@@ -224,7 +224,7 @@ constexpr auto int_pow(Quantity<U, R> q) {
     static_assert((!std::is_integral<R>::value) || (Exp >= 0),
                   "Negative exponent on integral represented units are not supported.");
 
-    return make_quantity<UnitPowerT<U, Exp>>(detail::int_pow_impl(q.in(U{}), Exp));
+    return make_quantity<UnitPowerT<U, Exp>>(auimpl::int_pow_impl(q.in(U{}), Exp));
 }
 
 //
@@ -312,7 +312,7 @@ constexpr bool isnan(QuantityPoint<U, R> p) {
     return std::isnan(p.in(U{}));
 }
 
-namespace detail {
+namespace auimpl {
 // We can't use lambdas in `constexpr` contexts until C++17, so we make a manual function object.
 struct StdMaxByValue {
     template <typename T>
@@ -320,14 +320,14 @@ struct StdMaxByValue {
         return std::max(a, b);
     }
 };
-}  // namespace detail
+}  // namespace auimpl
 
 // The maximum of two values of the same dimension.
 //
 // Unlike std::max, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr auto max(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
-    return detail::using_common_type(q1, q2, detail::StdMaxByValue{});
+    return auimpl::using_common_type(q1, q2, auimpl::StdMaxByValue{});
 }
 
 // The maximum of two point values of the same dimension.
@@ -335,7 +335,7 @@ constexpr auto max(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
 // Unlike std::max, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr auto max(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
-    return detail::using_common_point_unit(p1, p2, detail::StdMaxByValue{});
+    return auimpl::using_common_point_unit(p1, p2, auimpl::StdMaxByValue{});
 }
 
 // Overload to resolve ambiguity with `std::max` for identical `QuantityPoint` types.
@@ -344,7 +344,7 @@ constexpr auto max(QuantityPoint<U, R> a, QuantityPoint<U, R> b) {
     return std::max(a, b);
 }
 
-namespace detail {
+namespace auimpl {
 // We can't use lambdas in `constexpr` contexts until C++17, so we make a manual function object.
 struct StdMinByValue {
     template <typename T>
@@ -352,14 +352,14 @@ struct StdMinByValue {
         return std::min(a, b);
     }
 };
-}  // namespace detail
+}  // namespace auimpl
 
 // The minimum of two values of the same dimension.
 //
 // Unlike std::min, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr auto min(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
-    return detail::using_common_type(q1, q2, detail::StdMinByValue{});
+    return auimpl::using_common_type(q1, q2, auimpl::StdMinByValue{});
 }
 
 // The minimum of two point values of the same dimension.
@@ -367,7 +367,7 @@ constexpr auto min(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
 // Unlike std::min, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr auto min(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
-    return detail::using_common_point_unit(p1, p2, detail::StdMinByValue{});
+    return auimpl::using_common_point_unit(p1, p2, auimpl::StdMinByValue{});
 }
 
 // Overload to resolve ambiguity with `std::min` for identical `QuantityPoint` types.
@@ -392,13 +392,13 @@ auto remainder(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
 // a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
 auto round_in(RoundingUnits rounding_units, Quantity<U, R> q) {
-    using OurRoundingRep = detail::RoundingRepT<Quantity<U, R>, RoundingUnits>;
+    using OurRoundingRep = auimpl::RoundingRepT<Quantity<U, R>, RoundingUnits>;
     return std::round(q.template in<OurRoundingRep>(rounding_units));
 }
 // b) Version for QuantityPoint.
 template <typename RoundingUnits, typename U, typename R>
 auto round_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
-    using OurRoundingRep = detail::RoundingRepT<QuantityPoint<U, R>, RoundingUnits>;
+    using OurRoundingRep = auimpl::RoundingRepT<QuantityPoint<U, R>, RoundingUnits>;
     return std::round(p.template in<OurRoundingRep>(rounding_units));
 }
 
@@ -462,13 +462,13 @@ auto round_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
 // a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
 auto floor_in(RoundingUnits rounding_units, Quantity<U, R> q) {
-    using OurRoundingRep = detail::RoundingRepT<Quantity<U, R>, RoundingUnits>;
+    using OurRoundingRep = auimpl::RoundingRepT<Quantity<U, R>, RoundingUnits>;
     return std::floor(q.template in<OurRoundingRep>(rounding_units));
 }
 // b) Version for QuantityPoint.
 template <typename RoundingUnits, typename U, typename R>
 auto floor_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
-    using OurRoundingRep = detail::RoundingRepT<QuantityPoint<U, R>, RoundingUnits>;
+    using OurRoundingRep = auimpl::RoundingRepT<QuantityPoint<U, R>, RoundingUnits>;
     return std::floor(p.template in<OurRoundingRep>(rounding_units));
 }
 
@@ -531,13 +531,13 @@ auto floor_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
 // a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
 auto ceil_in(RoundingUnits rounding_units, Quantity<U, R> q) {
-    using OurRoundingRep = detail::RoundingRepT<Quantity<U, R>, RoundingUnits>;
+    using OurRoundingRep = auimpl::RoundingRepT<Quantity<U, R>, RoundingUnits>;
     return std::ceil(q.template in<OurRoundingRep>(rounding_units));
 }
 // b) Version for QuantityPoint.
 template <typename RoundingUnits, typename U, typename R>
 auto ceil_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
-    using OurRoundingRep = detail::RoundingRepT<QuantityPoint<U, R>, RoundingUnits>;
+    using OurRoundingRep = auimpl::RoundingRepT<QuantityPoint<U, R>, RoundingUnits>;
     return std::ceil(p.template in<OurRoundingRep>(rounding_units));
 }
 
@@ -594,7 +594,7 @@ auto ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
 // Wrapper for std::sin() which accepts a strongly typed angle quantity.
 template <typename U, typename R>
 auto sin(Quantity<U, R> q) {
-    return std::sin(detail::in_radians(q));
+    return std::sin(auimpl::in_radians(q));
 }
 
 // Wrapper for std::sqrt() which handles Quantity types.
@@ -606,7 +606,7 @@ auto sqrt(Quantity<U, R> q) {
 // Wrapper for std::tan() which accepts a strongly typed angle quantity.
 template <typename U, typename R>
 auto tan(Quantity<U, R> q) {
-    return std::tan(detail::in_radians(q));
+    return std::tan(auimpl::in_radians(q));
 }
 
 }  // namespace au

--- a/au/code/au/operators.hh
+++ b/au/code/au/operators.hh
@@ -30,7 +30,7 @@
 // say, `std::less<void>::operator()`, but work correctly with our alternatives.
 
 namespace au {
-namespace detail {
+namespace auimpl {
 
 //
 // Comparison operators.
@@ -114,5 +114,5 @@ struct Minus {
 };
 constexpr auto minus = Minus{};
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/operators_test.cc
+++ b/au/code/au/operators_test.cc
@@ -22,7 +22,7 @@ namespace au {
 
 using ::testing::Eq;
 
-namespace detail {
+namespace auimpl {
 
 template <typename T>
 void expect_comparators_work(T a, T b) {
@@ -51,5 +51,5 @@ TEST(Arithmetic, ResultsMatchUnderlyingOperatorForSameTypes) {
     expect_arithmetic_works(int8_t{5}, int8_t{10});
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/packs_test.cc
+++ b/au/code/au/packs_test.cc
@@ -378,7 +378,7 @@ TEST(AreAllPowersNonzero, AllMustSatisfyForMultiElementPack) {
         IsFalse());
 }
 
-namespace detail {
+namespace auimpl {
 
 TEST(SimplifyBasePowersT, SimplifiesEachIndividualBasePower) {
     StaticAssertTypeEq<SimplifyBasePowersT<Pack<B<2>,                      // A. Leave alone.
@@ -425,5 +425,5 @@ TEST(DenominatorPartT, PullsOutAndInvertsNegativePowers) {
                        Pack<Pow<B<3>, 6>, Pow<B<5>, 3>>>();
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/prefix.hh
+++ b/au/code/au/prefix.hh
@@ -62,194 +62,194 @@ struct PrefixApplier {
 
 template <typename U>
 struct Quetta : decltype(U{} * pow<30>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("Q", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("Q", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Quetta<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Quetta<U>::label;
 constexpr auto quetta = PrefixApplier<Quetta>{};
 
 template <typename U>
 struct Ronna : decltype(U{} * pow<27>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("R", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("R", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Ronna<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Ronna<U>::label;
 constexpr auto ronna = PrefixApplier<Ronna>{};
 
 template <typename U>
 struct Yotta : decltype(U{} * pow<24>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("Y", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("Y", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Yotta<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Yotta<U>::label;
 constexpr auto yotta = PrefixApplier<Yotta>{};
 
 template <typename U>
 struct Zetta : decltype(U{} * pow<21>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("Z", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("Z", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Zetta<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Zetta<U>::label;
 constexpr auto zetta = PrefixApplier<Zetta>{};
 
 template <typename U>
 struct Exa : decltype(U{} * pow<18>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("E", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("E", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Exa<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Exa<U>::label;
 constexpr auto exa = PrefixApplier<Exa>{};
 
 template <typename U>
 struct Peta : decltype(U{} * pow<15>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("P", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("P", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Peta<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Peta<U>::label;
 constexpr auto peta = PrefixApplier<Peta>{};
 
 template <typename U>
 struct Tera : decltype(U{} * pow<12>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("T", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("T", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Tera<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Tera<U>::label;
 constexpr auto tera = PrefixApplier<Tera>{};
 
 template <typename U>
 struct Giga : decltype(U{} * pow<9>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("G", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("G", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Giga<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Giga<U>::label;
 constexpr auto giga = PrefixApplier<Giga>{};
 
 template <typename U>
 struct Mega : decltype(U{} * pow<6>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("M", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("M", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Mega<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Mega<U>::label;
 constexpr auto mega = PrefixApplier<Mega>{};
 
 template <typename U>
 struct Kilo : decltype(U{} * pow<3>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("k", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("k", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Kilo<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Kilo<U>::label;
 constexpr auto kilo = PrefixApplier<Kilo>{};
 
 template <typename U>
 struct Hecto : decltype(U{} * pow<2>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("h", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("h", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Hecto<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Hecto<U>::label;
 constexpr auto hecto = PrefixApplier<Hecto>{};
 
 template <typename U>
 struct Deka : decltype(U{} * pow<1>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<2, U> label = detail::concatenate("da", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<2, U> label = auimpl::concatenate("da", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<2, U> Deka<U>::label;
+constexpr auimpl::ExtendedLabel<2, U> Deka<U>::label;
 constexpr auto deka = PrefixApplier<Deka>{};
 
 template <typename U>
 struct Deci : decltype(U{} * pow<-1>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("d", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("d", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Deci<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Deci<U>::label;
 constexpr auto deci = PrefixApplier<Deci>{};
 
 template <typename U>
 struct Centi : decltype(U{} * pow<-2>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("c", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("c", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Centi<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Centi<U>::label;
 constexpr auto centi = PrefixApplier<Centi>{};
 
 template <typename U>
 struct Milli : decltype(U{} * pow<-3>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("m", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("m", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Milli<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Milli<U>::label;
 constexpr auto milli = PrefixApplier<Milli>{};
 
 template <typename U>
 struct Micro : decltype(U{} * pow<-6>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("u", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("u", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Micro<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Micro<U>::label;
 constexpr auto micro = PrefixApplier<Micro>{};
 
 template <typename U>
 struct Nano : decltype(U{} * pow<-9>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("n", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("n", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Nano<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Nano<U>::label;
 constexpr auto nano = PrefixApplier<Nano>{};
 
 template <typename U>
 struct Pico : decltype(U{} * pow<-12>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("p", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("p", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Pico<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Pico<U>::label;
 constexpr auto pico = PrefixApplier<Pico>{};
 
 template <typename U>
 struct Femto : decltype(U{} * pow<-15>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("f", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("f", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Femto<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Femto<U>::label;
 constexpr auto femto = PrefixApplier<Femto>{};
 
 template <typename U>
 struct Atto : decltype(U{} * pow<-18>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("a", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("a", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Atto<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Atto<U>::label;
 constexpr auto atto = PrefixApplier<Atto>{};
 
 template <typename U>
 struct Zepto : decltype(U{} * pow<-21>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("z", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("z", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Zepto<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Zepto<U>::label;
 constexpr auto zepto = PrefixApplier<Zepto>{};
 
 template <typename U>
 struct Yocto : decltype(U{} * pow<-24>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("y", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("y", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Yocto<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Yocto<U>::label;
 constexpr auto yocto = PrefixApplier<Yocto>{};
 
 template <typename U>
 struct Ronto : decltype(U{} * pow<-27>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("r", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("r", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Ronto<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Ronto<U>::label;
 constexpr auto ronto = PrefixApplier<Ronto>{};
 
 template <typename U>
 struct Quecto : decltype(U{} * pow<-30>(mag<10>())) {
-    static constexpr detail::ExtendedLabel<1, U> label = detail::concatenate("q", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<1, U> label = auimpl::concatenate("q", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<1, U> Quecto<U>::label;
+constexpr auimpl::ExtendedLabel<1, U> Quecto<U>::label;
 constexpr auto quecto = PrefixApplier<Quecto>{};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -257,66 +257,66 @@ constexpr auto quecto = PrefixApplier<Quecto>{};
 
 template <typename U>
 struct Yobi : decltype(U{} * pow<80>(mag<2>())) {
-    static constexpr detail::ExtendedLabel<2, U> label = detail::concatenate("Yi", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<2, U> label = auimpl::concatenate("Yi", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<2, U> Yobi<U>::label;
+constexpr auimpl::ExtendedLabel<2, U> Yobi<U>::label;
 constexpr auto yobi = PrefixApplier<Yobi>{};
 
 template <typename U>
 struct Zebi : decltype(U{} * pow<70>(mag<2>())) {
-    static constexpr detail::ExtendedLabel<2, U> label = detail::concatenate("Zi", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<2, U> label = auimpl::concatenate("Zi", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<2, U> Zebi<U>::label;
+constexpr auimpl::ExtendedLabel<2, U> Zebi<U>::label;
 constexpr auto zebi = PrefixApplier<Zebi>{};
 
 template <typename U>
 struct Exbi : decltype(U{} * pow<60>(mag<2>())) {
-    static constexpr detail::ExtendedLabel<2, U> label = detail::concatenate("Ei", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<2, U> label = auimpl::concatenate("Ei", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<2, U> Exbi<U>::label;
+constexpr auimpl::ExtendedLabel<2, U> Exbi<U>::label;
 constexpr auto exbi = PrefixApplier<Exbi>{};
 
 template <typename U>
 struct Pebi : decltype(U{} * pow<50>(mag<2>())) {
-    static constexpr detail::ExtendedLabel<2, U> label = detail::concatenate("Pi", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<2, U> label = auimpl::concatenate("Pi", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<2, U> Pebi<U>::label;
+constexpr auimpl::ExtendedLabel<2, U> Pebi<U>::label;
 constexpr auto pebi = PrefixApplier<Pebi>{};
 
 template <typename U>
 struct Tebi : decltype(U{} * pow<40>(mag<2>())) {
-    static constexpr detail::ExtendedLabel<2, U> label = detail::concatenate("Ti", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<2, U> label = auimpl::concatenate("Ti", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<2, U> Tebi<U>::label;
+constexpr auimpl::ExtendedLabel<2, U> Tebi<U>::label;
 constexpr auto tebi = PrefixApplier<Tebi>{};
 
 template <typename U>
 struct Gibi : decltype(U{} * pow<30>(mag<2>())) {
-    static constexpr detail::ExtendedLabel<2, U> label = detail::concatenate("Gi", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<2, U> label = auimpl::concatenate("Gi", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<2, U> Gibi<U>::label;
+constexpr auimpl::ExtendedLabel<2, U> Gibi<U>::label;
 constexpr auto gibi = PrefixApplier<Gibi>{};
 
 template <typename U>
 struct Mebi : decltype(U{} * pow<20>(mag<2>())) {
-    static constexpr detail::ExtendedLabel<2, U> label = detail::concatenate("Mi", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<2, U> label = auimpl::concatenate("Mi", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<2, U> Mebi<U>::label;
+constexpr auimpl::ExtendedLabel<2, U> Mebi<U>::label;
 constexpr auto mebi = PrefixApplier<Mebi>{};
 
 template <typename U>
 struct Kibi : decltype(U{} * pow<10>(mag<2>())) {
-    static constexpr detail::ExtendedLabel<2, U> label = detail::concatenate("Ki", unit_label<U>());
+    static constexpr auimpl::ExtendedLabel<2, U> label = auimpl::concatenate("Ki", unit_label<U>());
 };
 template <typename U>
-constexpr detail::ExtendedLabel<2, U> Kibi<U>::label;
+constexpr auimpl::ExtendedLabel<2, U> Kibi<U>::label;
 constexpr auto kibi = PrefixApplier<Kibi>{};
 
 }  // namespace au

--- a/au/code/au/quantity_point_test.cc
+++ b/au/code/au/quantity_point_test.cc
@@ -445,8 +445,8 @@ TEST(QuantityPoint, PreservesRep) {
 }
 
 TEST(OriginDisplacement, IdenticallyZeroForOriginsThatCompareEqual) {
-    ASSERT_THAT(detail::OriginOf<Celsius>::value(),
-                Not(SameTypeAndValue(detail::OriginOf<AlternateCelsius>::value())));
+    ASSERT_THAT(auimpl::OriginOf<Celsius>::value(),
+                Not(SameTypeAndValue(auimpl::OriginOf<AlternateCelsius>::value())));
     EXPECT_THAT(origin_displacement(Celsius{}, AlternateCelsius{}), SameTypeAndValue(ZERO));
 }
 

--- a/au/code/au/rep.hh
+++ b/au/code/au/rep.hh
@@ -49,7 +49,7 @@ struct IsQuotientValidRep;
 // Implementation details below.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace detail {
+namespace auimpl {
 template <typename T>
 struct IsAuType : std::false_type {};
 
@@ -121,21 +121,21 @@ using QuotientType = decltype(std::declval<T>() / std::declval<U>());
 
 template <typename T, typename U>
 using QuotientTypeOrVoid = stdx::experimental::detected_or_t<void, QuotientType, T, U>;
-}  // namespace detail
+}  // namespace auimpl
 
 // Implementation for `IsValidRep`.
 //
 // For now, we'll accept anything that isn't explicitly known to be invalid.  We may tighten this up
 // later, but this seems like a reasonable starting point.
 template <typename T>
-struct IsValidRep : stdx::negation<detail::IsKnownInvalidRep<T>> {};
+struct IsValidRep : stdx::negation<auimpl::IsKnownInvalidRep<T>> {};
 
 template <typename T, typename U>
 struct IsProductValidRep
-    : IsValidRep<detail::ResultIfNoneAreQuantityT<detail::ProductTypeOrVoid, T, U>> {};
+    : IsValidRep<auimpl::ResultIfNoneAreQuantityT<auimpl::ProductTypeOrVoid, T, U>> {};
 
 template <typename T, typename U>
 struct IsQuotientValidRep
-    : IsValidRep<detail::ResultIfNoneAreQuantityT<detail::QuotientTypeOrVoid, T, U>> {};
+    : IsValidRep<auimpl::ResultIfNoneAreQuantityT<auimpl::QuotientTypeOrVoid, T, U>> {};
 
 }  // namespace au

--- a/au/code/au/rep_test.cc
+++ b/au/code/au/rep_test.cc
@@ -141,7 +141,7 @@ TEST(IsQuotientValidRep, TrueOnlyForSideWhereQuotientExists) {
     EXPECT_THAT((IsQuotientValidRep<DivideTenByFloat, float>::value), IsTrue());
 }
 
-namespace detail {
+namespace auimpl {
 
 TEST(ResultIfNoneAreQuantity, GivesResultWhenNoneAreQuantity) {
     StaticAssertTypeEq<int, ResultIfNoneAreQuantityT<std::common_type_t, int, int>>();
@@ -170,5 +170,5 @@ TEST(ProductTypeOrVoid, GivesVoidForInputsWithNoProductType) {
     StaticAssertTypeEq<void, ProductTypeOrVoid<int, IntWithNoOps>>();
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/static_cast_checkers.hh
+++ b/au/code/au/static_cast_checkers.hh
@@ -20,7 +20,7 @@
 #include <type_traits>
 
 namespace au {
-namespace detail {
+namespace auimpl {
 
 template <typename Source, typename Dest>
 struct StaticCastChecker;
@@ -204,5 +204,5 @@ struct StaticCastChecker
     : StaticCastOverflowImpl<Source, Dest, categorize_overflow_situation<Source, Dest>()>,
       StaticCastTruncateImpl<Source, Dest, categorize_truncation_situation<Source, Dest>()> {};
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/static_cast_checkers_test.cc
+++ b/au/code/au/static_cast_checkers_test.cc
@@ -22,7 +22,7 @@ namespace au {
 using ::testing::IsFalse;
 using ::testing::IsTrue;
 
-namespace detail {
+namespace auimpl {
 
 TEST(WillStaticCastOverflow, DependsOnValueForUnsignedToNonContainingSigned) {
     EXPECT_THAT(will_static_cast_overflow<int8_t>(uint8_t{127}), IsFalse());
@@ -115,5 +115,5 @@ TEST(WillStaticCastTruncate, IgnoresLimitsOfDestinationType) {
     EXPECT_THAT(will_static_cast_truncate<uint8_t>(9999999.0), IsFalse());
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/stdx/experimental/is_detected.hh
+++ b/au/code/au/stdx/experimental/is_detected.hh
@@ -35,7 +35,7 @@ struct nonesuch {
 // `is_detected` and friends: adapted from
 // (https://en.cppreference.com/w/cpp/experimental/is_detected).
 
-namespace detail {
+namespace auimpl {
 template <class Default, class AlwaysVoid, template <class...> class Op, class... Args>
 struct detector {
     using value_t = std::false_type;
@@ -48,16 +48,16 @@ struct detector<Default, stdx::void_t<Op<Args...>>, Op, Args...> {
     using type = Op<Args...>;
 };
 
-}  // namespace detail
+}  // namespace auimpl
 
 template <template <class...> class Op, class... Args>
-using is_detected = typename detail::detector<nonesuch, void, Op, Args...>::value_t;
+using is_detected = typename auimpl::detector<nonesuch, void, Op, Args...>::value_t;
 
 template <template <class...> class Op, class... Args>
-using detected_t = typename detail::detector<nonesuch, void, Op, Args...>::type;
+using detected_t = typename auimpl::detector<nonesuch, void, Op, Args...>::type;
 
 template <class Default, template <class...> class Op, class... Args>
-using detected_or = detail::detector<Default, void, Op, Args...>;
+using detected_or = auimpl::detector<Default, void, Op, Args...>;
 
 template <class Default, template <class...> class Op, class... Args>
 using detected_or_t = typename detected_or<Default, Op, Args...>::type;

--- a/au/code/au/testing.hh
+++ b/au/code/au/testing.hh
@@ -63,7 +63,7 @@ void expect_label(const char (&label)[N]) {
     EXPECT_THAT(sizeof(unit_label<Unit>()), Eq(N));
 }
 
-namespace detail {
+namespace auimpl {
 // Compute the absolute difference in a specified Unit, with a floating point Rep.
 template <typename ResultUnit, typename Q1, typename Q2>
 auto absolute_diff(Q1 q1, Q2 q2) {
@@ -84,7 +84,7 @@ template <typename ArgT, typename TargetT, typename ToleranceUnit, typename Tole
            << (within_tolerance ? "does not exceed" : "exceeds") << " tolerance " << tolerance
            << ".";
 }
-}  // namespace detail
+}  // namespace auimpl
 
 //
 // Custom GMock matcher to match a Quantity to a target within a given tolerance.
@@ -94,7 +94,7 @@ template <typename ArgT, typename TargetT, typename ToleranceUnit, typename Tole
 //
 MATCHER_P2(IsNear, target, tolerance, "") {
     const auto assertion_result =
-        detail::arg_matches_target_within_tolerance(arg, target, tolerance);
+        auimpl::arg_matches_target_within_tolerance(arg, target, tolerance);
     *result_listener << assertion_result.message();
     return assertion_result;
 }

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -30,8 +30,8 @@
 
 namespace au {
 
-using ::au::detail::DimT;
-using ::au::detail::MagT;
+using ::au::auimpl::DimT;
+using ::au::auimpl::MagT;
 using ::testing::AnyOf;
 using ::testing::Eq;
 using ::testing::IsFalse;
@@ -115,7 +115,7 @@ TEST(Unit, OriginRetainedForProductWithMagnitudeButNotWithUnit) {
 
     constexpr auto scaled_by_unit = UnitWithOrigin{} * One{};
     EXPECT_THAT(
-        (stdx::experimental::is_detected<detail::OriginMemberType, decltype(scaled_by_unit)>{}),
+        (stdx::experimental::is_detected<auimpl::OriginMemberType, decltype(scaled_by_unit)>{}),
         IsFalse());
 }
 
@@ -373,7 +373,7 @@ TEST(AreUnitsQuantityEquivalent, InequivalentUnitCanBeMadeEquivalentByAppropriat
     EXPECT_THAT((AreUnitsQuantityEquivalent<Feet, Inches>::value), IsFalse());
 
     using Stretchedinches = decltype(Inches{} * unit_ratio(Feet{}, Inches{}));
-    ASSERT_THAT((detail::SameTypeIgnoringCvref<Feet, Stretchedinches>::value), IsFalse());
+    ASSERT_THAT((auimpl::SameTypeIgnoringCvref<Feet, Stretchedinches>::value), IsFalse());
     EXPECT_THAT((AreUnitsQuantityEquivalent<Feet, Stretchedinches>::value), IsTrue());
 }
 
@@ -398,7 +398,7 @@ TEST(AreUnitsPointEquivalent, InequivalentUnitCanBeMadeEquivalentByAppropriateSc
     EXPECT_THAT((AreUnitsPointEquivalent<Feet, Inches>::value), IsFalse());
 
     using Stretchedinches = decltype(Inches{} * unit_ratio(Feet{}, Inches{}));
-    ASSERT_THAT((detail::SameTypeIgnoringCvref<Feet, Stretchedinches>::value), IsFalse());
+    ASSERT_THAT((auimpl::SameTypeIgnoringCvref<Feet, Stretchedinches>::value), IsFalse());
     EXPECT_THAT((AreUnitsPointEquivalent<Feet, Stretchedinches>::value), IsTrue());
 }
 
@@ -436,7 +436,7 @@ struct OffsetCelsius : Celsius {
     // be in units of [(1/3000) K].  However, the difference should boil down to a constant of
     // exactly (5/3 K)
     static constexpr auto origin() {
-        return detail::OriginOf<Celsius>::value() + (kelvins / mag<6>())(10);
+        return auimpl::OriginOf<Celsius>::value() + (kelvins / mag<6>())(10);
     }
     static constexpr const char label[] = "offset_deg_C";
 };
@@ -511,13 +511,13 @@ struct Z : decltype(Inches{} * mag<7>()) {};
 
 TEST(CommonUnit, UnpacksTypesInNestedCommonUnit) {
     using C1 = CommonUnitT<W, X>;
-    ASSERT_THAT((detail::IsPackOf<CommonUnit, C1>{}), IsTrue());
+    ASSERT_THAT((auimpl::IsPackOf<CommonUnit, C1>{}), IsTrue());
 
     using C2 = CommonUnitT<Y, Z>;
-    ASSERT_THAT((detail::IsPackOf<CommonUnit, C2>{}), IsTrue());
+    ASSERT_THAT((auimpl::IsPackOf<CommonUnit, C2>{}), IsTrue());
 
     using Common = CommonUnitT<C1, C2>;
-    ASSERT_THAT((detail::IsPackOf<CommonUnit, Common>{}), IsTrue());
+    ASSERT_THAT((auimpl::IsPackOf<CommonUnit, Common>{}), IsTrue());
 
     // Check that `c(c(w, x), c(y, z))` is the same as `c(w, x, y, z)`.
     StaticAssertTypeEq<Common, CommonUnitT<W, X, Y, Z>>();
@@ -569,13 +569,13 @@ TEST(CommonPointUnit, PrefersUnitFromListIfAnyIdentical) {
 
 TEST(CommonPointUnit, UnpacksTypesInNestedCommonUnit) {
     using C1 = CommonPointUnitT<W, X>;
-    ASSERT_THAT((detail::IsPackOf<CommonPointUnit, C1>{}), IsTrue());
+    ASSERT_THAT((auimpl::IsPackOf<CommonPointUnit, C1>{}), IsTrue());
 
     using C2 = CommonPointUnitT<Y, Z>;
-    ASSERT_THAT((detail::IsPackOf<CommonPointUnit, C2>{}), IsTrue());
+    ASSERT_THAT((auimpl::IsPackOf<CommonPointUnit, C2>{}), IsTrue());
 
     using Common = CommonPointUnitT<C1, C2>;
-    ASSERT_THAT((detail::IsPackOf<CommonPointUnit, Common>{}), IsTrue());
+    ASSERT_THAT((auimpl::IsPackOf<CommonPointUnit, Common>{}), IsTrue());
 
     // Check that `c(c(w, x), c(y, z))` is the same as `c(w, x, y, z)`.
     StaticAssertTypeEq<Common, CommonPointUnitT<W, X, Y, Z>>();
@@ -590,7 +590,7 @@ TEST(MakeCommon, PreservesCategory) {
     constexpr auto feeters = make_common(feet, meters);
     EXPECT_THAT(feet(1u) % feeters(1u), Eq(ZERO));
     EXPECT_THAT(meters(1u) % feeters(1u), Eq(ZERO));
-    EXPECT_THAT(detail::gcd(feet(1u).in(feeters), meters(1u).in(feeters)), Eq(1u));
+    EXPECT_THAT(auimpl::gcd(feet(1u).in(feeters), meters(1u).in(feeters)), Eq(1u));
 
     using symbols::ft;
     using symbols::m;
@@ -773,7 +773,7 @@ TEST(UnitLabel, CommonUnitOfCommonPointUnitsPerformsFlattening) {
 
 TEST(UnitLabel, APICompatibleWithUnitSlots) { EXPECT_THAT(unit_label(feet), StrEq("ft")); }
 
-namespace detail {
+namespace auimpl {
 
 TEST(Origin, ZeroForUnitWithNoSpecifiedOrigin) {
     EXPECT_THAT(OriginOf<Kelvins>::value(), SameTypeAndValue(ZERO));
@@ -884,5 +884,5 @@ TEST(SimplifyIfOnlyOneUnscaledUnit, IdentityForNonCommonUnit) {
                        decltype(Feet{} * mag<3>())>();
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/unit_symbol.hh
+++ b/au/code/au/unit_symbol.hh
@@ -28,11 +28,11 @@ namespace au {
 //     constexpr auto m = SymbolFor<Meters>{};
 //
 template <typename Unit>
-struct SymbolFor : detail::MakesQuantityFromNumber<SymbolFor, Unit>,
-                   detail::ScalesQuantity<SymbolFor, Unit>,
-                   detail::ComposesWith<SymbolFor, Unit, SymbolFor, SymbolFor>,
-                   detail::SupportsRationalPowers<SymbolFor, Unit>,
-                   detail::CanScaleByMagnitude<SymbolFor, Unit> {};
+struct SymbolFor : auimpl::MakesQuantityFromNumber<SymbolFor, Unit>,
+                   auimpl::ScalesQuantity<SymbolFor, Unit>,
+                   auimpl::ComposesWith<SymbolFor, Unit, SymbolFor, SymbolFor>,
+                   auimpl::SupportsRationalPowers<SymbolFor, Unit>,
+                   auimpl::CanScaleByMagnitude<SymbolFor, Unit> {};
 
 //
 // Create a unit symbol using the more fluent APIs that unit slots make possible.  For example:

--- a/au/code/au/utility/factoring.hh
+++ b/au/code/au/utility/factoring.hh
@@ -20,7 +20,7 @@
 #include "au/utility/probable_primes.hh"
 
 namespace au {
-namespace detail {
+namespace auimpl {
 
 // Check whether a number is prime.
 constexpr bool is_prime(std::uintmax_t n) {
@@ -152,5 +152,5 @@ constexpr T int_pow(T base, std::uintmax_t exp) {
     return square(int_pow(base, exp / 2u));
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/utility/mod.hh
+++ b/au/code/au/utility/mod.hh
@@ -18,7 +18,7 @@
 #include <limits>
 
 namespace au {
-namespace detail {
+namespace auimpl {
 
 // (a + b) % n
 //
@@ -98,5 +98,5 @@ constexpr uint64_t pow_mod(uint64_t base, uint64_t exp, uint64_t n) {
     return result;
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/utility/probable_primes.hh
+++ b/au/code/au/utility/probable_primes.hh
@@ -19,7 +19,7 @@
 #include "au/utility/mod.hh"
 
 namespace au {
-namespace detail {
+namespace auimpl {
 
 //
 // The possible results of a probable prime test.
@@ -346,5 +346,5 @@ constexpr PrimeResult baillie_psw(uint64_t n) {
     return strong_lucas(n);
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/utility/string_constant.hh
+++ b/au/code/au/utility/string_constant.hh
@@ -21,7 +21,7 @@
 #include "au/stdx/type_traits.hh"
 
 namespace au {
-namespace detail {
+namespace auimpl {
 
 //
 // A constexpr-compatible string constant class of a given size.
@@ -306,5 +306,5 @@ constexpr auto as_char_array(const StringConstant<N> &x) -> const char (&)[N + 1
     return x.char_array();
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/utility/test/factoring_test.cc
+++ b/au/code/au/utility/test/factoring_test.cc
@@ -26,7 +26,7 @@ using ::testing::IsFalse;
 using ::testing::IsTrue;
 using ::testing::Le;
 
-namespace detail {
+namespace auimpl {
 
 namespace {
 
@@ -139,5 +139,5 @@ TEST(Multiplicity, CountsFactors) {
     EXPECT_THAT(multiplicity(7u, n), Eq(0u));
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/utility/test/mod_test.cc
+++ b/au/code/au/utility/test/mod_test.cc
@@ -23,7 +23,7 @@ namespace au {
 
 using ::testing::Eq;
 
-namespace detail {
+namespace auimpl {
 namespace {
 
 constexpr auto MAX = std::numeric_limits<uint64_t>::max();
@@ -115,5 +115,5 @@ TEST(PowMod, ProducesSameAnswerAsRepeatedModMulForLargeNumbers) {
 }
 
 }  // namespace
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/utility/test/probable_primes_test.cc
+++ b/au/code/au/utility/test/probable_primes_test.cc
@@ -30,7 +30,7 @@ using ::testing::Gt;
 using ::testing::IsFalse;
 using ::testing::Lt;
 
-namespace detail {
+namespace auimpl {
 
 // Make test output for `PrimeResult` easier to read.
 std::ostream &operator<<(std::ostream &out, const PrimeResult &m) {
@@ -369,5 +369,5 @@ TEST(BoolSign, ReturnsCorrectValues) {
 }
 
 }  // namespace
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/utility/test/string_constant_test.cc
+++ b/au/code/au/utility/test/string_constant_test.cc
@@ -24,7 +24,7 @@ using ::testing::Eq;
 using ::testing::IsEmpty;
 using ::testing::StrEq;
 
-namespace detail {
+namespace auimpl {
 
 TEST(StringConstant, CanCreateFromStringLiteral) {
     constexpr StringConstant<5> x{"hello"};
@@ -149,5 +149,5 @@ TEST(ParensIf, WrapsInParensIfTrue) {
     EXPECT_THAT(parens_if<false>("123"), StrEq("123"));
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/utility/test/type_traits_test.cc
+++ b/au/code/au/utility/test/type_traits_test.cc
@@ -23,7 +23,7 @@ using ::testing::IsFalse;
 using ::testing::IsTrue;
 using ::testing::StaticAssertTypeEq;
 
-namespace detail {
+namespace auimpl {
 
 template <typename... Ts>
 struct Pack;
@@ -75,5 +75,5 @@ TEST(IncludeInPackIf, MakesPackOfEverythingThatMatches) {
         Pack<uint8_t, uint64_t>>();
 }
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/utility/type_traits.hh
+++ b/au/code/au/utility/type_traits.hh
@@ -19,7 +19,7 @@
 #include "au/stdx/type_traits.hh"
 
 namespace au {
-namespace detail {
+namespace auimpl {
 
 template <typename PackT, typename T>
 struct Prepend;
@@ -110,7 +110,7 @@ template <typename T, template <class...> class Pack, typename H, typename... Ts
 struct DropAllImpl<T, Pack<H, Ts...>>
     : std::conditional<std::is_same<T, H>::value,
                        DropAll<T, Pack<Ts...>>,
-                       detail::PrependT<DropAll<T, Pack<Ts...>>, H>> {};
+                       auimpl::PrependT<DropAll<T, Pack<Ts...>>, H>> {};
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/wrapper_operations.hh
+++ b/au/code/au/wrapper_operations.hh
@@ -34,7 +34,7 @@
 // take two more template parameters: the wrapper we're composing with, and the resulting wrapper.
 
 namespace au {
-namespace detail {
+namespace auimpl {
 
 // A SFINAE helper that is the identity, but only if we think a type is a valid rep.
 //
@@ -239,5 +239,5 @@ struct SupportsRationalPowers {
     }
 };
 
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/au/code/au/wrapper_operations_test.cc
+++ b/au/code/au/wrapper_operations_test.cc
@@ -23,7 +23,7 @@
 using ::testing::StaticAssertTypeEq;
 
 namespace au {
-namespace detail {
+namespace auimpl {
 namespace {
 
 constexpr auto PI = Magnitude<Pi>{};
@@ -183,5 +183,5 @@ TEST(ForbidsComposingWith, FailsToCompileWhenMultiplyingOrDividingWithForbiddenW
 }
 
 }  // namespace
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au

--- a/compatibility/nholthaus_units.hh
+++ b/compatibility/nholthaus_units.hh
@@ -38,7 +38,7 @@
 
 namespace au {
 
-namespace detail {
+namespace auimpl {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // This utility lets us extract a single template parameter.
@@ -214,7 +214,7 @@ struct NholthausUnitType;
 template <class U, class R, template <class> class S>
 struct NholthausUnitType<units::unit_t<U, R, S>> : stdx::type_identity<U> {};
 
-}  // namespace detail
+}  // namespace auimpl
 
 // Define 1:1 mapping from each nholthaus type to its corresponding `au::Quantity` type.
 template <class R, class RationalScale, class BaseUnit, class PiPower>
@@ -222,10 +222,10 @@ struct CorrespondingQuantity<
     units::unit_t<units::unit<RationalScale, BaseUnit, PiPower, std::ratio<0>>,
                   R,
                   units::linear_scale>> {
-    using NholthausType = typename detail::SoleTemplateParameter<CorrespondingQuantity>::type;
-    using NholthausUnit = typename detail::NholthausUnitType<NholthausType>::type;
+    using NholthausType = typename auimpl::SoleTemplateParameter<CorrespondingQuantity>::type;
+    using NholthausUnit = typename auimpl::NholthausUnitType<NholthausType>::type;
 
-    using Unit = typename detail::AuUnit<NholthausUnit>::type;
+    using Unit = typename auimpl::AuUnit<NholthausUnit>::type;
     using Rep = R;
 
     static constexpr Rep extract_value(NholthausType d) { return d.template to<Rep>(); }
@@ -239,9 +239,9 @@ struct CorrespondingQuantity<
     units::unit_t<units::unit<RationalScale, units::base_unit<>, std::ratio<0>, std::ratio<0>>,
                   R,
                   units::linear_scale>> {
-    using NholthausType = typename detail::SoleTemplateParameter<CorrespondingQuantity>::type;
-    using NholthausUnit = typename detail::NholthausUnitType<NholthausType>::type;
-    using Mag = detail::NholthausUnitMagT<NholthausUnit>;
+    using NholthausType = typename auimpl::SoleTemplateParameter<CorrespondingQuantity>::type;
+    using NholthausUnit = typename auimpl::NholthausUnitType<NholthausType>::type;
+    using Mag = auimpl::NholthausUnitMagT<NholthausUnit>;
 
     using Unit = UnitImpl<Dimension<>, Mag>;
     using Rep = R;

--- a/single-file-test.cc
+++ b/single-file-test.cc
@@ -32,7 +32,7 @@ using ::au::symbols::s;
 constexpr auto ns = ::au::nano(s);
 
 namespace au {
-namespace detail {
+namespace auimpl {
 std::ostream &operator<<(std::ostream &out, IsAbsMagLessThanOne val) {
     switch (val) {
         case IsAbsMagLessThanOne::DEFINITELY:
@@ -42,7 +42,7 @@ std::ostream &operator<<(std::ostream &out, IsAbsMagLessThanOne val) {
     }
     return out;
 }
-}  // namespace detail
+}  // namespace auimpl
 }  // namespace au
 
 // This ad hoc utility is a stand-in for GTEST, which we can't use here.
@@ -61,10 +61,10 @@ int main(int argc, char **argv) {
         {
             expect_equal((meters / second)(5) * seconds(6), meters(30)),
             expect_equal(SPEED_OF_LIGHT.as<int>(m / s), 299'792'458 * m / s),
-            expect_equal(detail::is_abs_known_to_be_less_than_one(mag<5>() / mag<7>()),
-                         detail::IsAbsMagLessThanOne::DEFINITELY),
-            expect_equal(detail::is_abs_known_to_be_less_than_one(mag<7>() / mag<5>()),
-                         detail::IsAbsMagLessThanOne::MAYBE_NOT),
+            expect_equal(auimpl::is_abs_known_to_be_less_than_one(mag<5>() / mag<7>()),
+                         auimpl::IsAbsMagLessThanOne::DEFINITELY),
+            expect_equal(auimpl::is_abs_known_to_be_less_than_one(mag<7>() / mag<5>()),
+                         auimpl::IsAbsMagLessThanOne::MAYBE_NOT),
             expect_equal((10 * m).coerce_in(m * mag<5>() / mag<7>()), 14),
             expect_equal(inverse_as(ns, 333 / s), 3'003'003 * ns),
         },


### PR DESCRIPTION
I think a "bite the bullet megadiff" makes the most sense here, because
the changes should all be the same length, so the PR should be fairly
easy to review.  The reviewer can check the Viewed box for one file at a
time, and thus not be forced to do it all in one pass --- as long as we
do end up landing this relatively soon before we try other changes.

Fixes #412.