### PR TITLE
Implement `lerp`

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -71,6 +71,9 @@ cc_test(
     srcs = ["code/au/cpp20_test.cc"],
     tags = ["manual"],
     deps = [
+        ":constants",
+        ":math",
+        ":prefix",
         ":quantity",
         ":quantity_point",
         ":testing",

--- a/au/code/au/cpp20_test.cc
+++ b/au/code/au/cpp20_test.cc
@@ -23,6 +23,7 @@
 #include "au/units/celsius.hh"
 #include "au/units/kelvins.hh"
 #include "au/units/meters.hh"
+#include "au/units/percent.hh"
 #include "au/units/seconds.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -30,6 +31,10 @@
 namespace au {
 
 using symbols::m;
+using symbols::s;
+
+constexpr auto mm = milli(m);
+
 using ::testing::Eq;
 using ::testing::Lt;
 
@@ -90,10 +95,22 @@ TEST(Lerp, SupportsZero) {
 
 TEST(Lerp, SupportsConstant) {
     constexpr auto c = SPEED_OF_LIGHT;
-    using symbols::m;
-    using symbols::s;
     EXPECT_THAT(lerp(0 * m / s, c, 0.75), SameTypeAndValue(c.as<double>(m / s) * 0.75));
     EXPECT_THAT(lerp(c, 0 * m / s, 0.75), SameTypeAndValue(c.as<double>(m / s) * 0.25));
+}
+
+TEST(Lerp, SupportsPercentForThirdArgument) {
+    // `Quantity`, same type.
+    EXPECT_THAT(lerp(0 * m, 10 * m, percent(75.0)), SameTypeAndValue(7.5 * m));
+
+    // Mixed `Quantity` types.
+    EXPECT_THAT(lerp(0 * m, 10 * mm, percent(35.0)), SameTypeAndValue(3.5 * mm));
+
+    // `Quantity` with a shapeshifter argument.
+    EXPECT_THAT(lerp(ZERO, 10 * m, percent(37.5)), SameTypeAndValue(3.75 * m));
+
+    // `QuantityPoint`, same type.
+    EXPECT_THAT(lerp(meters_pt(0), meters_pt(10), percent(75.0)), SameTypeAndValue(meters_pt(7.5)));
 }
 
 TEST(Lerp, QuantityPointConsistentWithStdLerpWhenTypesAreIdentical) {

--- a/au/code/au/math.hh
+++ b/au/code/au/math.hh
@@ -312,6 +312,29 @@ constexpr bool isnan(QuantityPoint<U, R> p) {
     return std::isnan(p.in(U{}));
 }
 
+//
+// Linear interpolation between two values of the same dimension, as per `std::lerp`.
+//
+// Note that `std::lerp` is not defined until C++20, so neither is `au::lerp`.
+//
+// Note, too, that the implementation for same-type `Quantity` instances lives inside of the
+// `Quantity` class implementation as a hidden friend, so that we can support shapeshifter types
+// such as `Zero` or `Constant<U>`.
+//
+#if defined(__cpp_lib_interpolate) && __cpp_lib_interpolate >= 201902L
+template <typename U1, typename R1, typename U2, typename R2, typename T>
+constexpr auto lerp(Quantity<U1, R1> q1, Quantity<U2, R2> q2, T t) {
+    using U = CommonUnitT<U1, U2>;
+    return make_quantity<U>(std::lerp(q1.in(U{}), q2.in(U{}), t));
+}
+
+template <typename U1, typename R1, typename U2, typename R2, typename T>
+constexpr auto lerp(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2, T t) {
+    using U = CommonPointUnitT<U1, U2>;
+    return make_quantity_point<U>(std::lerp(p1.in(U{}), p2.in(U{}), t));
+}
+#endif
+
 namespace detail {
 // We can't use lambdas in `constexpr` contexts until C++17, so we make a manual function object.
 struct StdMaxByValue {

--- a/au/code/au/math.hh
+++ b/au/code/au/math.hh
@@ -325,13 +325,13 @@ constexpr bool isnan(QuantityPoint<U, R> p) {
 template <typename U1, typename R1, typename U2, typename R2, typename T>
 constexpr auto lerp(Quantity<U1, R1> q1, Quantity<U2, R2> q2, T t) {
     using U = CommonUnitT<U1, U2>;
-    return make_quantity<U>(std::lerp(q1.in(U{}), q2.in(U{}), t));
+    return make_quantity<U>(std::lerp(q1.in(U{}), q2.in(U{}), as_raw_number(t)));
 }
 
 template <typename U1, typename R1, typename U2, typename R2, typename T>
 constexpr auto lerp(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2, T t) {
     using U = CommonPointUnitT<U1, U2>;
-    return make_quantity_point<U>(std::lerp(p1.in(U{}), p2.in(U{}), t));
+    return make_quantity_point<U>(std::lerp(p1.in(U{}), p2.in(U{}), as_raw_number(t)));
 }
 #endif
 

--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -100,6 +100,18 @@ constexpr auto as_quantity(T &&x) -> CorrespondingQuantityT<T> {
     return make_quantity<typename Q::Unit>(value);
 }
 
+// Callsite-readable way to convert a `Quantity` to a raw number.
+//
+// Only works for dimensionless `Quantities`; will return a compile-time error otherwise.
+//
+// Identity for non-`Quantity` types.
+template <typename U, typename R>
+constexpr R as_raw_number(Quantity<U, R> q);
+template <typename T>
+constexpr T as_raw_number(T x) {
+    return x;
+}
+
 namespace detail {
 enum class UnitSign {
     POSITIVE,
@@ -438,7 +450,7 @@ class Quantity {
     // `std::lerp` requires C++20 support.
     template <typename T>
     friend constexpr auto lerp(Quantity a, Quantity b, T t) {
-        return make_quantity<UnitT>(std::lerp(a.in(unit), b.in(unit), t));
+        return make_quantity<UnitT>(std::lerp(a.in(unit), b.in(unit), as_raw_number(t)));
     }
 #endif
 
@@ -558,18 +570,10 @@ constexpr auto operator%(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return make_quantity<U>(q1.in(U{}) % q2.in(U{}));
 }
 
-// Callsite-readable way to convert a `Quantity` to a raw number.
-//
-// Only works for dimensionless `Quantities`; will return a compile-time error otherwise.
-//
-// Identity for non-`Quantity` types.
+// Now that `Quantity` has been defined, we can finish defining this `as_raw_number` overload.
 template <typename U, typename R>
 constexpr R as_raw_number(Quantity<U, R> q) {
     return q.as(UnitProductT<>{});
-}
-template <typename T>
-constexpr T as_raw_number(T x) {
-    return x;
 }
 
 // Type trait to detect whether two Quantity types are equivalent.

--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -434,6 +434,14 @@ class Quantity {
         return (v < lo) ? lo : ((hi < v) ? hi : v);
     }
 
+#if defined(__cpp_lib_interpolate) && __cpp_lib_interpolate >= 201902L
+    // `std::lerp` requires C++20 support.
+    template <typename T>
+    friend constexpr auto lerp(Quantity a, Quantity b, T t) {
+        return make_quantity<UnitT>(std::lerp(a.in(unit), b.in(unit), t));
+    }
+#endif
+
  private:
     template <typename OtherUnit, typename OtherRep>
     static constexpr void warn_if_integer_division() {

--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -106,7 +106,9 @@ constexpr auto as_quantity(T &&x) -> CorrespondingQuantityT<T> {
 //
 // Identity for non-`Quantity` types.
 template <typename U, typename R>
-constexpr R as_raw_number(Quantity<U, R> q);
+constexpr R as_raw_number(Quantity<U, R> q) {
+    return q.as(UnitProductT<>{});
+}
 template <typename T>
 constexpr T as_raw_number(T x) {
     return x;
@@ -568,12 +570,6 @@ template <typename U1, typename R1, typename U2, typename R2>
 constexpr auto operator%(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     using U = CommonUnitT<U1, U2>;
     return make_quantity<U>(q1.in(U{}) % q2.in(U{}));
-}
-
-// Now that `Quantity` has been defined, we can finish defining this `as_raw_number` overload.
-template <typename U, typename R>
-constexpr R as_raw_number(Quantity<U, R> q) {
-    return q.as(UnitProductT<>{});
 }
 
 // Type trait to detect whether two Quantity types are equivalent.

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -199,12 +199,12 @@ expand the note below for further details.
 #### `lerp` (C++20)
 
 !!! warning
-    `lerp`, based on `std::lerp`, is only available for C++20 and later.
+    `lerp`, based on [std::lerp], is only available for C++20 and later.
 
 Linearly interpolate between two `Quantity` or `QuantityPoint` values, based on a parameter `t`,
 such that `t=0` corresponds to the first argument, and `t=1` corresponds to the second argument.
 That is, `lerp(a, b, t)` is logically equivalent to `a + (b - a) * t`, but with all of the special
-case handling found in [`std::lerp`].
+case handling found in [std::lerp].
 
 **Signatures:**
 
@@ -219,10 +219,10 @@ constexpr auto lerp(QuantityPoint<U1, R1> a, QuantityPoint<U2, R2> b, T t);
 ```
 
 **Returns:** The value notionally equivalent to $a + t(b - a)$, subject to all of the special case
-handling outlined in [`std::lerp`].  The return value will be expressed in the common unit of the
+handling outlined in [std::lerp].  The return value will be expressed in the common unit of the
 units of the inputs `a` and `b`.
 
-[`std::lerp`]: https://en.cppreference.com/w/cpp/numeric/lerp
+[std::lerp]: https://en.cppreference.com/w/cpp/numeric/lerp
 
 ### Exponentiation
 

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -194,6 +194,36 @@ expand the note below for further details.
     arguments have the same type.  Write `clamp(a, b, c)`, not `au::clamp(a, b, c)`: the latter will
     frequently result in the right overload not being found.
 
+### Interpolating functions
+
+#### `lerp` (C++20)
+
+!!! warning
+    `lerp`, based on `std::lerp`, is only available for C++20 and later.
+
+Linearly interpolate between two `Quantity` or `QuantityPoint` values, based on a parameter `t`,
+such that `t=0` corresponds to the first argument, and `t=1` corresponds to the second argument.
+That is, `lerp(a, b, t)` is logically equivalent to `a + (b - a) * t`, but with all of the special
+case handling found in [`std::lerp`].
+
+**Signatures:**
+
+```cpp
+// 1. `Quantity` inputs
+template <typename U1, typename R1, typename U2, typename R2, typename T>
+constexpr auto lerp(Quantity<U1, R1> a, Quantity<U2, R2> b, T t);
+
+// 2. `QuantityPoint` inputs
+template <typename U1, typename R1, typename U2, typename R2, typename T>
+constexpr auto lerp(QuantityPoint<U1, R1> a, QuantityPoint<U2, R2> b, T t);
+```
+
+**Returns:** The value notionally equivalent to $a + t(b - a)$, subject to all of the special case
+handling outlined in [`std::lerp`].  The return value will be expressed in the common unit of the
+units of the inputs `a` and `b`.
+
+[`std::lerp`]: https://en.cppreference.com/w/cpp/numeric/lerp
+
 ### Exponentiation
 
 #### `int_pow`


### PR DESCRIPTION
This wraps `std::lerp`.  Includes documentation.

The main implementations, in `math.hh`, convert each input to the common
unit before performing the calculation, and then wrap the result.

The hidden friend implementation, in `Quantity`, is necessary to support
shapeshifter types such as `Zero` and `Constant<U>`.  We would need to
add one in `QuantityPoint` too in order to support shapeshifter
overloads, but `QuantityPoint` doesn't have any shapeshifter types in
the current design.

Fixes #390.