### PR TITLE
Add traits for sign of units and magnitudes

### DIFF
--- a/au/code/au/magnitude.hh
+++ b/au/code/au/magnitude.hh
@@ -158,6 +158,11 @@ template <typename MagT>
 using Abs = typename AbsImpl<MagT>::type;
 
 template <typename MagT>
+struct SignImpl;
+template <typename MagT>
+using Sign = typename SignImpl<MagT>::type;
+
+template <typename MagT>
 struct NumeratorImpl;
 template <typename MagT>
 using NumeratorT = typename NumeratorImpl<MagT>::type;
@@ -246,6 +251,11 @@ constexpr auto abs(Magnitude<BPs...>) {
     return Abs<Magnitude<BPs...>>{};
 }
 constexpr auto abs(Zero z) { return z; }
+
+template <typename... BPs>
+constexpr auto sign(Magnitude<BPs...>) {
+    return Sign<Magnitude<BPs...>>{};
+}
 
 template <typename... BPs>
 constexpr auto numerator(Magnitude<BPs...>) {
@@ -353,6 +363,15 @@ struct AbsImpl<Magnitude<BPs...>> : stdx::type_identity<Magnitude<BPs...>> {};
 
 template <>
 struct AbsImpl<Zero> : stdx::type_identity<Zero> {};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `sign()` implementation.
+
+template <typename... BPs>
+struct SignImpl<Magnitude<BPs...>> : stdx::type_identity<Magnitude<>> {};
+
+template <typename... BPs>
+struct SignImpl<Magnitude<Negative, BPs...>> : stdx::type_identity<Magnitude<Negative>> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `numerator()` implementation.

--- a/au/code/au/magnitude_test.cc
+++ b/au/code/au/magnitude_test.cc
@@ -205,6 +205,16 @@ TEST(Abs, FlipsSignForNegative) {
 
 TEST(Abs, IdentityForZero) { EXPECT_THAT(abs(ZERO), Eq(ZERO)); }
 
+TEST(Sign, OneForPositiveNumber) {
+    EXPECT_THAT(sign(mag<1>()), Eq(mag<1>()));
+    EXPECT_THAT(sign(mag<3>() / mag<8>()), Eq(mag<1>()));
+}
+
+TEST(Sign, MinusOneForNegativeNumber) {
+    EXPECT_THAT(sign(-mag<1>()), Eq(-mag<1>()));
+    EXPECT_THAT(sign(-mag<3>() / mag<8>()), Eq(-mag<1>()));
+}
+
 TEST(IsPositive, TrueForPositive) {
     EXPECT_THAT(is_positive(mag<1>()), IsTrue());
     EXPECT_THAT(is_positive(mag<2>()), IsTrue());

--- a/au/code/au/unit_of_measure.hh
+++ b/au/code/au/unit_of_measure.hh
@@ -135,6 +135,10 @@ struct UnitRatio : stdx::type_identity<MagQuotientT<detail::MagT<U1>, detail::Ma
 template <typename U1, typename U2>
 using UnitRatioT = typename UnitRatio<U1, U2>::type;
 
+// The sign of a unit: almost always `mag<1>()`, but `-mag<1>()` for "negative" units.
+template <typename U>
+using UnitSign = Sign<detail::MagT<U>>;
+
 template <typename U>
 struct AssociatedUnit : stdx::type_identity<U> {};
 template <typename U>
@@ -236,6 +240,12 @@ constexpr bool is_unitless_unit(U) {
 // Useful in doing unit conversions.
 template <typename U1, typename U2>
 constexpr UnitRatioT<AssociatedUnitT<U1>, AssociatedUnitT<U2>> unit_ratio(U1, U2) {
+    return {};
+}
+
+// Type trait for the sign of a Unit (represented as a Magnitude).
+template <typename U>
+constexpr UnitSign<AssociatedUnitT<U>> unit_sign(U) {
     return {};
 }
 

--- a/au/code/au/unit_of_measure_test.cc
+++ b/au/code/au/unit_of_measure_test.cc
@@ -616,6 +616,28 @@ TEST(MakeCommonPoint, PreservesCategory) {
     EXPECT_THAT(one_c % one_ch, Eq(ZERO));
 }
 
+TEST(UnitSignTrait, OneForPositiveUnits) {
+    StaticAssertTypeEq<UnitSign<Feet>, Magnitude<>>();
+    StaticAssertTypeEq<UnitSign<Inches>, Magnitude<>>();
+}
+
+TEST(UnitSignTrait, MinusOneForNegativeUnits) {
+    using NegFeet = decltype(Feet{} * (-mag<1>()));
+    using NegInches = decltype(Inches{} * (-mag<1>()));
+    StaticAssertTypeEq<UnitSign<NegFeet>, Magnitude<Negative>>();
+    StaticAssertTypeEq<UnitSign<NegInches>, Magnitude<Negative>>();
+}
+
+TEST(UnitSign, OneForPositiveUnits) {
+    EXPECT_THAT(unit_sign(feet), Eq(mag<1>()));
+    EXPECT_THAT(unit_sign(inches), Eq(mag<1>()));
+}
+
+TEST(UnitSign, MinusOneForNegativeUnits) {
+    EXPECT_THAT(unit_sign(feet * (-mag<5280>())), Eq(-mag<1>()));
+    EXPECT_THAT(unit_sign(inches * (-mag<36>())), Eq(-mag<1>()));
+}
+
 TEST(UnitLabel, DefaultsToUnlabeledUnit) {
     EXPECT_THAT(unit_label<UnlabeledUnit>(), StrEq("[UNLABELED UNIT]"));
     EXPECT_THAT(sizeof(unit_label<UnlabeledUnit>()), Eq(17));

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -251,7 +251,7 @@ a magnitude instance `m`, you can write `sqrt(m)` as a more readable alternative
 
 These traits provide information, at compile time, about the number represented by a `Magnitude`.
 
-### Integer test
+### Is Integer?
 
 **Result:** A `bool` indicating whether a `Magnitude` represents an _integer_ (`true` if it does;
 `false` otherwise).
@@ -263,7 +263,7 @@ These traits provide information, at compile time, about the number represented 
 - For an _instance_ `m`:
     - `is_integer(m)`
 
-### Rational test
+### Is Rational?
 
 **Result:** A `bool` indicating whether a `Magnitude` represents a _rational number_ (`true` if it
 does; `false` otherwise).
@@ -274,6 +274,18 @@ does; `false` otherwise).
     - `IsRational<M>::value`
 - For an _instance_ `m`:
     - `is_rational(m)`
+
+### Is Positive?
+
+**Result:** A `bool` indicating whether a `Magnitude` represents a _positive number_ (`true` if it
+does; `false` otherwise).
+
+**Syntax:**
+
+- For a _type_ `M`:
+    - `IsPositive<M>::value`
+- For an _instance_ `m`:
+    - `is_positive(m)`
 
 ### Integer part
 
@@ -328,3 +340,27 @@ For example, the "denominator" of $\frac{3\sqrt{3}}{5\pi}$ would be $5\pi$.
     - `DenominatorT<M>`
 - For an _instance_ `m`:
     - `denominator(m)`
+
+### Absolute value
+
+**Result:** The absolute value of a `Magnitude`, which is another `Magnitude`.
+
+**Syntax:**
+
+- For a _type_ `M`:
+    - `Abs<M>`
+- For an _instance_ `m`:
+    - `abs(m)`
+
+### Sign
+
+**Result:** A `Magnitude`: `1` if the input is positive, and `-1` if the input is negative.
+
+We expect that the relation `m == sign(m) * abs(m)` will hold for every `Magnitude` `m`.
+
+**Syntax:**
+
+- For a _type_ `M`:
+    - `Sign<M>`
+- For an _instance_ `m`:
+    - `sign(m)`

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -477,6 +477,20 @@ as an inch.
 - For _instances_ `u1` and `u2`:
     - `unit_ratio(u1, u2)`
 
+### Unit sign
+
+**Result:** The [magnitude](./magnitude.md) representing the sign of the unit.  This takes the value
+`mag<1>()` if increases in the underlying stored value correspond to _increases_ in the quantity,
+and `-mag<1>()` if increases in the underlying stored value correspond to _decreases_ in the
+quantity.
+
+**Syntax:**
+
+- For a _type_ `U`:
+    - `UnitSign<U>`
+- For an _instance_ `u`:
+    - `unit_sign(u)`
+
 ### Origin displacement
 
 **Result:** The displacement from the first unit's origin to the second unit's origin.


### PR DESCRIPTION
The "sign" of a unit or magnitude is always `mag<1>()` (i.e.,
`Magnitude<>{}`) if positive, or `-mag<1>()` (i.e.,
`Magnitude<Negative>{}`) if negative.

We also update the docs, including adding docs for a few new traits that
we had missed, and updating the headings for the magnitude traits to
phrase the boolean ones in the form of a question (in case we ever get
on Jeopardy).

Helps #428.