### PR TITLE
Compare underlying values of hetereogeneous types

### DIFF
--- a/au/code/au/operators.hh
+++ b/au/code/au/operators.hh
@@ -14,14 +14,12 @@
 
 #pragma once
 
-// This file provides drop-in replacements for certain standard library function objects for
-// comparison and arithmetic: `std::less<void>`, `std::plus<void>`, etc.
+// This file provides alternatives to certain standard library function objects for comparison and
+// arithmetic: `std::less<void>`, `std::plus<void>`, etc.
 //
 // These are _not_ intended as _fully general_ replacements.  They are _only_ intended for certain
-// specific use cases in this library, where we can ensure certain preconditions are met before they
-// are called.  For example, these utilities don't handle comparing signed and unsigned integral
-// types, because we only ever use them in places where we've already explicitly cast our quantities
-// to the same Rep.
+// specific use cases in this library.  External user code should not use these utilities: they are
+// subject to change their contract at any time to suit the needs of Au.
 //
 // There are two main reasons we rolled our own versions instead of just using the ones from the
 // standard library (as we had initially done).  First, the `<functional>` header is moderately
@@ -37,48 +35,48 @@ namespace detail {
 //
 
 struct Equal {
-    template <typename T>
-    constexpr bool operator()(const T &a, const T &b) const {
+    template <typename T, typename U>
+    constexpr bool operator()(const T &a, const U &b) const {
         return a == b;
     }
 };
 constexpr auto equal = Equal{};
 
 struct NotEqual {
-    template <typename T>
-    constexpr bool operator()(const T &a, const T &b) const {
+    template <typename T, typename U>
+    constexpr bool operator()(const T &a, const U &b) const {
         return a != b;
     }
 };
 constexpr auto not_equal = NotEqual{};
 
 struct Greater {
-    template <typename T>
-    constexpr bool operator()(const T &a, const T &b) const {
+    template <typename T, typename U>
+    constexpr bool operator()(const T &a, const U &b) const {
         return a > b;
     }
 };
 constexpr auto greater = Greater{};
 
 struct Less {
-    template <typename T>
-    constexpr bool operator()(const T &a, const T &b) const {
+    template <typename T, typename U>
+    constexpr bool operator()(const T &a, const U &b) const {
         return a < b;
     }
 };
 constexpr auto less = Less{};
 
 struct GreaterEqual {
-    template <typename T>
-    constexpr bool operator()(const T &a, const T &b) const {
+    template <typename T, typename U>
+    constexpr bool operator()(const T &a, const U &b) const {
         return a >= b;
     }
 };
 constexpr auto greater_equal = GreaterEqual{};
 
 struct LessEqual {
-    template <typename T>
-    constexpr bool operator()(const T &a, const T &b) const {
+    template <typename T, typename U>
+    constexpr bool operator()(const T &a, const U &b) const {
         return a <= b;
     }
 };
@@ -86,8 +84,8 @@ constexpr auto less_equal = LessEqual{};
 
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 struct ThreeWayCompare {
-    template <typename T>
-    constexpr auto operator()(const T &a, const T &b) const {
+    template <typename T, typename U>
+    constexpr auto operator()(const T &a, const U &b) const {
         return a <=> b;
     }
 };

--- a/au/code/au/operators.hh
+++ b/au/code/au/operators.hh
@@ -18,8 +18,8 @@
 // arithmetic: `std::less<void>`, `std::plus<void>`, etc.
 //
 // These are _not_ intended as _fully general_ replacements.  They are _only_ intended for certain
-// specific use cases in this library.  External user code should not use these utilities: they are
-// subject to change their contract at any time to suit the needs of Au.
+// specific use cases in this library.  External user code should not use these utilities: their
+// contract is subject to change at any time to suit the needs of Au.
 //
 // There are two main reasons we rolled our own versions instead of just using the ones from the
 // standard library (as we had initially done).  First, the `<functional>` header is moderately

--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -115,6 +115,9 @@ constexpr T as_raw_number(T x) {
 }
 
 namespace detail {
+// We implement `Quantity` comparisons by converting to a common unit, and comparing the values
+// stored in the underlying Rep types.  This means we need to know the _sign_ of that common unit,
+// so we can know which order to pass those underlying values (it gets reversed for negative units).
 template <typename SignMag, typename Op>
 struct SignAwareComparison;
 }  // namespace detail

--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -115,13 +115,8 @@ constexpr T as_raw_number(T x) {
 }
 
 namespace detail {
-enum class UnitSign {
-    POSITIVE,
-    NEGATIVE,
-};
-
-template <typename Rep, UnitSign>
-struct CompareUnderlyingValues;
+template <typename SignMag, typename Op>
+struct SignAwareComparison;
 }  // namespace detail
 
 template <typename UnitT, typename RepT>
@@ -130,18 +125,17 @@ class Quantity {
     using EnableIfImplicitOkIs = std::enable_if_t<
         ImplicitOk ==
         ConstructionPolicy<UnitT, RepT>::template PermitImplicitFrom<OtherUnit, OtherRep>::value>;
-    using Vals = detail::CompareUnderlyingValues<RepT,
-                                                 (IsPositive<detail::MagT<UnitT>>::value
-                                                      ? detail::UnitSign::POSITIVE
-                                                      : detail::UnitSign::NEGATIVE)>;
+
+    // We could consider making this public someday, if we had a use case.
+    using Sign = UnitSign<UnitT>;
 
     // Not strictly necessary, but we want to keep each comparator implementation to one line.
-    using Eq = detail::Equal;
-    using Ne = detail::NotEqual;
-    using Lt = detail::Less;
-    using Le = detail::LessEqual;
-    using Gt = detail::Greater;
-    using Ge = detail::GreaterEqual;
+    using Eq = detail::SignAwareComparison<Sign, detail::Equal>;
+    using Ne = detail::SignAwareComparison<Sign, detail::NotEqual>;
+    using Lt = detail::SignAwareComparison<Sign, detail::Less>;
+    using Le = detail::SignAwareComparison<Sign, detail::LessEqual>;
+    using Gt = detail::SignAwareComparison<Sign, detail::Greater>;
+    using Ge = detail::SignAwareComparison<Sign, detail::GreaterEqual>;
 
  public:
     using Rep = RepT;
@@ -283,16 +277,16 @@ class Quantity {
     friend struct QuantityMaker<UnitT>;
 
     // Comparison operators.
-    friend constexpr bool operator==(Quantity a, Quantity b) { return Vals::cmp(a, b, Eq{}); }
-    friend constexpr bool operator!=(Quantity a, Quantity b) { return Vals::cmp(a, b, Ne{}); }
-    friend constexpr bool operator<(Quantity a, Quantity b) { return Vals::cmp(a, b, Lt{}); }
-    friend constexpr bool operator<=(Quantity a, Quantity b) { return Vals::cmp(a, b, Le{}); }
-    friend constexpr bool operator>(Quantity a, Quantity b) { return Vals::cmp(a, b, Gt{}); }
-    friend constexpr bool operator>=(Quantity a, Quantity b) { return Vals::cmp(a, b, Ge{}); }
+    friend constexpr bool operator==(Quantity a, Quantity b) { return Eq{}(a.value_, b.value_); }
+    friend constexpr bool operator!=(Quantity a, Quantity b) { return Ne{}(a.value_, b.value_); }
+    friend constexpr bool operator<(Quantity a, Quantity b) { return Lt{}(a.value_, b.value_); }
+    friend constexpr bool operator<=(Quantity a, Quantity b) { return Le{}(a.value_, b.value_); }
+    friend constexpr bool operator>(Quantity a, Quantity b) { return Gt{}(a.value_, b.value_); }
+    friend constexpr bool operator>=(Quantity a, Quantity b) { return Ge{}(a.value_, b.value_); }
 
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
-    using Twc = detail::ThreeWayCompare;
-    friend constexpr auto operator<=>(Quantity a, Quantity b) { return Vals::cmp(a, b, Twc{}); }
+    using Twc = detail::SignAwareComparison<Sign, detail::ThreeWayCompare>;
+    friend constexpr auto operator<=>(Quantity a, Quantity b) { return Twc{}(a.value_, b.value_); }
 #endif
 
     // Addition and subtraction for like quantities.
@@ -764,32 +758,40 @@ constexpr auto using_common_type(T t, U u, Func f) {
 
     return f(cast_to_common_type<C>(t), cast_to_common_type<C>(u));
 }
+
+template <typename Op, typename U1, typename U2, typename R1, typename R2>
+constexpr auto convert_and_compare(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+    using U = CommonUnitT<U1, U2>;
+    using R = std::common_type_t<R1, R2>;
+    return detail::SignAwareComparison<UnitSign<U>, Op>{}(q1.template in<R>(U{}),
+                                                          q2.template in<R>(U{}));
+}
 }  // namespace detail
 
 // Comparison functions for compatible Quantity types.
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr bool operator==(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
-    return detail::using_common_type(q1, q2, detail::equal);
+    return detail::convert_and_compare<detail::Equal>(q1, q2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr bool operator!=(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
-    return detail::using_common_type(q1, q2, detail::not_equal);
+    return detail::convert_and_compare<detail::NotEqual>(q1, q2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr bool operator<(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
-    return detail::using_common_type(q1, q2, detail::less);
+    return detail::convert_and_compare<detail::Less>(q1, q2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr bool operator<=(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
-    return detail::using_common_type(q1, q2, detail::less_equal);
+    return detail::convert_and_compare<detail::LessEqual>(q1, q2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr bool operator>(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
-    return detail::using_common_type(q1, q2, detail::greater);
+    return detail::convert_and_compare<detail::Greater>(q1, q2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr bool operator>=(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
-    return detail::using_common_type(q1, q2, detail::greater_equal);
+    return detail::convert_and_compare<detail::GreaterEqual>(q1, q2);
 }
 
 // Addition and subtraction functions for compatible Quantity types.
@@ -871,19 +873,19 @@ constexpr auto operator>=(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q
 }
 
 namespace detail {
-template <typename Rep>
-struct CompareUnderlyingValues<Rep, UnitSign::POSITIVE> {
-    template <typename U, typename Comp>
-    static constexpr auto cmp(Quantity<U, Rep> lhs, Quantity<U, Rep> rhs, Comp comp) {
-        return comp(lhs.in(U{}), rhs.in(U{}));
+template <typename Op>
+struct SignAwareComparison<Magnitude<>, Op> {
+    template <typename T1, typename T2>
+    constexpr auto operator()(const T1 &lhs, const T2 &rhs) const {
+        return Op{}(lhs, rhs);
     }
 };
 
-template <typename Rep>
-struct CompareUnderlyingValues<Rep, UnitSign::NEGATIVE> {
-    template <typename U, typename Comp>
-    static constexpr auto cmp(Quantity<U, Rep> lhs, Quantity<U, Rep> rhs, Comp comp) {
-        return comp(rhs.in(U{}), lhs.in(U{}));
+template <typename Op>
+struct SignAwareComparison<Magnitude<Negative>, Op> {
+    template <typename T1, typename T2>
+    constexpr auto operator()(const T1 &lhs, const T2 &rhs) const {
+        return Op{}(rhs, lhs);
     }
 };
 }  // namespace detail
@@ -891,7 +893,7 @@ struct CompareUnderlyingValues<Rep, UnitSign::NEGATIVE> {
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 template <typename U1, typename R1, typename U2, typename R2>
 constexpr auto operator<=>(const Quantity<U1, R1> &lhs, const Quantity<U2, R2> &rhs) {
-    return detail::using_common_type(lhs, rhs, detail::ThreeWayCompare{});
+    return detail::convert_and_compare<detail::ThreeWayCompare>(lhs, rhs);
 }
 #endif
 

--- a/au/code/au/quantity_point.hh
+++ b/au/code/au/quantity_point.hh
@@ -331,32 +331,40 @@ constexpr auto using_common_point_unit(X x, Y y, Func f) {
     constexpr auto u = CommonPointUnitT<typename X::Unit, typename Y::Unit>{};
     return f(rep_cast<R>(x).as(u), rep_cast<R>(y).as(u));
 }
+
+template <typename Op, typename U1, typename U2, typename R1, typename R2>
+constexpr auto convert_and_compare(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+    using U = CommonPointUnitT<U1, U2>;
+    using R = std::common_type_t<R1, R2>;
+    return detail::SignAwareComparison<UnitSign<U>, Op>{}(p1.template in<R>(U{}),
+                                                          p2.template in<R>(U{}));
+}
 }  // namespace detail
 
 // Comparison functions for compatible QuantityPoint types.
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr auto operator<(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
-    return detail::using_common_point_unit(p1, p2, detail::less);
+    return detail::convert_and_compare<detail::Less>(p1, p2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr auto operator>(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
-    return detail::using_common_point_unit(p1, p2, detail::greater);
+    return detail::convert_and_compare<detail::Greater>(p1, p2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr auto operator<=(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
-    return detail::using_common_point_unit(p1, p2, detail::less_equal);
+    return detail::convert_and_compare<detail::LessEqual>(p1, p2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr auto operator>=(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
-    return detail::using_common_point_unit(p1, p2, detail::greater_equal);
+    return detail::convert_and_compare<detail::GreaterEqual>(p1, p2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr auto operator==(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
-    return detail::using_common_point_unit(p1, p2, detail::equal);
+    return detail::convert_and_compare<detail::Equal>(p1, p2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
 constexpr auto operator!=(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
-    return detail::using_common_point_unit(p1, p2, detail::not_equal);
+    return detail::convert_and_compare<detail::NotEqual>(p1, p2);
 }
 
 namespace detail {
@@ -401,8 +409,7 @@ constexpr auto operator-(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 template <typename U1, typename R1, typename U2, typename R2>
 constexpr auto operator<=>(const QuantityPoint<U1, R1> &lhs, const QuantityPoint<U2, R2> &rhs) {
-    using U = CommonPointUnitT<U1, U2>;
-    return lhs.in(U{}) <=> rhs.in(U{});
+    return detail::convert_and_compare<detail::ThreeWayCompare>(lhs, rhs);
 }
 #endif
 


### PR DESCRIPTION
Formerly, in `Quantity`, we used a `CompareUnderlyingValues` helper,
and a `UnitSign` enum.  The helper was responsible for taking two
_identical_ `Quantity` types, and extracting their values.  (We built
out this machinery to support negative units.)

Now, we refactor to use a new helper, `SignAwareComparison`.  This
brings two simplifications and one generalization.

- **Simplification:** stop doing the extraction in the helper; let the
  callers extract and pass the values.  (This gives the helper just one
  responsibility: namely, take the unit sign into account when deciding
  which order to pass the parameters.)

- **Simplification:** lose the enum; just use the new `UnitSign` trait.

- **Generalization:** accept _heterogeneous_ parameters.

This last change will allow us to detect when we are passing mixed
signed and unsigned integral arguments.  Of course, this PR is a no-op
refactor, so we're not actually taking advantage of this yet.  That will
come in a follow-on PR.

Helps #428.