### PR TITLE
Avoid changing signedness of integral rep

### DIFF
--- a/au/code/au/quantity.hh
+++ b/au/code/au/quantity.hh
@@ -765,9 +765,10 @@ constexpr auto using_common_type(T t, U u, Func f) {
 template <typename Op, typename U1, typename U2, typename R1, typename R2>
 constexpr auto convert_and_compare(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     using U = CommonUnitT<U1, U2>;
-    using R = std::common_type_t<R1, R2>;
-    return detail::SignAwareComparison<UnitSign<U>, Op>{}(q1.template in<R>(U{}),
-                                                          q2.template in<R>(U{}));
+    using ComRep1 = detail::CommonTypeButPreserveIntSignedness<R1, R2>;
+    using ComRep2 = detail::CommonTypeButPreserveIntSignedness<R2, R1>;
+    return detail::SignAwareComparison<UnitSign<U>, Op>{}(q1.template in<ComRep1>(U{}),
+                                                          q2.template in<ComRep2>(U{}));
 }
 }  // namespace detail
 

--- a/au/code/au/quantity_point.hh
+++ b/au/code/au/quantity_point.hh
@@ -335,9 +335,10 @@ constexpr auto using_common_point_unit(X x, Y y, Func f) {
 template <typename Op, typename U1, typename U2, typename R1, typename R2>
 constexpr auto convert_and_compare(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     using U = CommonPointUnitT<U1, U2>;
-    using R = std::common_type_t<R1, R2>;
-    return detail::SignAwareComparison<UnitSign<U>, Op>{}(p1.template in<R>(U{}),
-                                                          p2.template in<R>(U{}));
+    using ComRep1 = detail::CommonTypeButPreserveIntSignedness<R1, R2>;
+    using ComRep2 = detail::CommonTypeButPreserveIntSignedness<R2, R1>;
+    return detail::SignAwareComparison<UnitSign<U>, Op>{}(p1.template in<ComRep1>(U{}),
+                                                          p2.template in<ComRep2>(U{}));
 }
 }  // namespace detail
 

--- a/au/code/au/utility/test/type_traits_test.cc
+++ b/au/code/au/utility/test/type_traits_test.cc
@@ -75,5 +75,16 @@ TEST(IncludeInPackIf, MakesPackOfEverythingThatMatches) {
         Pack<uint8_t, uint64_t>>();
 }
 
+TEST(CommonTypeButPreserveIntSignedness, CommonTypeIfItIsNotIntegral) {
+    StaticAssertTypeEq<CommonTypeButPreserveIntSignedness<int, double>, double>();
+    StaticAssertTypeEq<CommonTypeButPreserveIntSignedness<float, int>, float>();
+    StaticAssertTypeEq<CommonTypeButPreserveIntSignedness<double, float>, double>();
+}
+
+TEST(CommonTypeButPreserveIntSignedness, UsesSignOfFirstArgumentIfCommonTypeIsIntegral) {
+    StaticAssertTypeEq<CommonTypeButPreserveIntSignedness<int, uint8_t>, int>();
+    StaticAssertTypeEq<CommonTypeButPreserveIntSignedness<uint8_t, int>, uint>();
+}
+
 }  // namespace detail
 }  // namespace au

--- a/au/code/au/utility/test/type_traits_test.cc
+++ b/au/code/au/utility/test/type_traits_test.cc
@@ -77,7 +77,7 @@ TEST(IncludeInPackIf, MakesPackOfEverythingThatMatches) {
 
 TEST(CommonTypeButPreserveIntSignedness, CommonTypeIfItIsNotIntegral) {
     StaticAssertTypeEq<CommonTypeButPreserveIntSignedness<int, double>, double>();
-    StaticAssertTypeEq<CommonTypeButPreserveIntSignedness<float, int>, float>();
+    StaticAssertTypeEq<CommonTypeButPreserveIntSignedness<float, uint>, float>();
     StaticAssertTypeEq<CommonTypeButPreserveIntSignedness<double, float>, double>();
 }
 


### PR DESCRIPTION
The rep we use with our comparison logic is really tricky and subtle.

At first blush, it would be appealing to simply pass `q.in(U{})` for
both arguments, because `U` is a common unit, so this should just be an
integer multiplication.  This way, we automatically opt in to overflow
checks.

We tried this, though, and it was a disaster: tons of tests failed.  It
turns out that there are many situations where we compare, say, a "large
unit, small rep" quantity to a "small unit, large rep" quantity.  In
these cases, it's natural and good to use something as big as the common
rep when converting the first quantity: we can safely take advantage of
the "extra room" in the bigger type.

The real problem comes when the common rep type is _integral_, **and**
it _changes the sign_ of an input type.  That's how we get things like
`-1 < 1u` being false.

To tackle this problem head-on, we make a new trait with an explicit
name: `CommonTypeButPreserveIntSignedness<R1, R2>` is the common type of
`R1` and `R2`, except that _if_ it is integral, then it _preserves the
signedeness_ of the **first** argument.

By using this in our comparison functions, we are now faithfully
preserving the "category" of the inputs all the way until they are
compared.  This means that `inches(-1) < inches(1u)` _will_ reduce to
`-1 < 1u`, instead of masking the situation with a hidden explicit cast
under the hood.

Helps #428, but does not _quite_ fix it: we'll see why in the next PR,
which does.