### PR TITLE
Fix comparisons for mixed-signedness integral reps

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -408,6 +408,7 @@ cc_library(
     name = "operators",
     hdrs = ["code/au/operators.hh"],
     includes = ["code"],
+    deps = [":stdx"],
 )
 
 cc_test(

--- a/au/code/au/operators.hh
+++ b/au/code/au/operators.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "au/stdx/type_traits.hh"
+#include "au/stdx/utility.hh"
+
 // This file provides alternatives to certain standard library function objects for comparison and
 // arithmetic: `std::less<void>`, `std::plus<void>`, etc.
 //
@@ -21,14 +24,32 @@
 // specific use cases in this library.  External user code should not use these utilities: their
 // contract is subject to change at any time to suit the needs of Au.
 //
-// There are two main reasons we rolled our own versions instead of just using the ones from the
-// standard library (as we had initially done).  First, the `<functional>` header is moderately
+// The biggest change is that these function objects produce mathematically correct results when
+// comparing built-in integral types with mixed signedness.  As a concrete example: in the C++
+// language, `-1 < 1u` is `false`, because the common type of the input types is `unsigned int`, and
+// the `int` input `-1` gets converted to a (very large) `unsigned int` value.  However, using these
+// types, `Lt{}(-1, 1u)` will correctly return `true`!
+//
+// There were two initial motivations to roll our own versions instead of just using the ones from
+// the standard library (as we had done earlier).  First, the `<functional>` header is moderately
 // expensive to include---using these alternatives could save 100 ms or more on every file.  Second,
 // certain compilers (such as the Green Hills compiler) struggle with the trailing return types in,
 // say, `std::less<void>::operator()`, but work correctly with our alternatives.
 
 namespace au {
 namespace detail {
+
+// These tag types act as a kind of "compile time enum".
+struct CompareBuiltInIntegers {};
+struct DefaultComparison {};
+
+// `ComparisonCategory<T, U>` acts like a function which takes two _types_, and returns the correct
+// instance of the above "compile time enum".
+template <typename T, typename U>
+using ComparisonCategory =
+    std::conditional_t<stdx::conjunction<std::is_integral<T>, std::is_integral<U>>::value,
+                       CompareBuiltInIntegers,
+                       DefaultComparison>;
 
 //
 // Comparison operators.
@@ -37,7 +58,17 @@ namespace detail {
 struct Equal {
     template <typename T, typename U>
     constexpr bool operator()(const T &a, const U &b) const {
+        return op_impl(ComparisonCategory<T, U>{}, a, b);
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a == b;
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+        return stdx::cmp_equal(a, b);
     }
 };
 constexpr auto equal = Equal{};
@@ -45,7 +76,17 @@ constexpr auto equal = Equal{};
 struct NotEqual {
     template <typename T, typename U>
     constexpr bool operator()(const T &a, const U &b) const {
+        return op_impl(ComparisonCategory<T, U>{}, a, b);
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a != b;
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+        return stdx::cmp_not_equal(a, b);
     }
 };
 constexpr auto not_equal = NotEqual{};
@@ -53,7 +94,17 @@ constexpr auto not_equal = NotEqual{};
 struct Greater {
     template <typename T, typename U>
     constexpr bool operator()(const T &a, const U &b) const {
+        return op_impl(ComparisonCategory<T, U>{}, a, b);
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a > b;
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+        return stdx::cmp_greater(a, b);
     }
 };
 constexpr auto greater = Greater{};
@@ -61,7 +112,17 @@ constexpr auto greater = Greater{};
 struct Less {
     template <typename T, typename U>
     constexpr bool operator()(const T &a, const U &b) const {
+        return op_impl(ComparisonCategory<T, U>{}, a, b);
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a < b;
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+        return stdx::cmp_less(a, b);
     }
 };
 constexpr auto less = Less{};
@@ -69,7 +130,17 @@ constexpr auto less = Less{};
 struct GreaterEqual {
     template <typename T, typename U>
     constexpr bool operator()(const T &a, const U &b) const {
+        return op_impl(ComparisonCategory<T, U>{}, a, b);
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a >= b;
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+        return stdx::cmp_greater_equal(a, b);
     }
 };
 constexpr auto greater_equal = GreaterEqual{};
@@ -77,7 +148,17 @@ constexpr auto greater_equal = GreaterEqual{};
 struct LessEqual {
     template <typename T, typename U>
     constexpr bool operator()(const T &a, const U &b) const {
+        return op_impl(ComparisonCategory<T, U>{}, a, b);
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a <= b;
+    }
+
+    template <typename T, typename U>
+    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+        return stdx::cmp_less_equal(a, b);
     }
 };
 constexpr auto less_equal = LessEqual{};
@@ -86,6 +167,10 @@ constexpr auto less_equal = LessEqual{};
 struct ThreeWayCompare {
     template <typename T, typename U>
     constexpr auto operator()(const T &a, const U &b) const {
+        // Note that we do not need special treatment for the case where `T` and `U` are both
+        // integral types, because the C++ language already prohibits narrowing conversions (such as
+        // `int` to `uint`) for `operator<=>`.  We can rely on this implicit warning to induce users
+        // to fix their code.
         return a <=> b;
     }
 };

--- a/au/code/au/operators_test.cc
+++ b/au/code/au/operators_test.cc
@@ -21,8 +21,63 @@
 namespace au {
 
 using ::testing::Eq;
+using ::testing::Not;
 
 namespace detail {
+
+std::ostream &operator<<(std::ostream &out, Equal) { return out << " == "; }
+std::ostream &operator<<(std::ostream &out, NotEqual) { return out << " != "; }
+std::ostream &operator<<(std::ostream &out, Less) { return out << " < "; }
+std::ostream &operator<<(std::ostream &out, LessEqual) { return out << " <= "; }
+std::ostream &operator<<(std::ostream &out, Greater) { return out << " > "; }
+std::ostream &operator<<(std::ostream &out, GreaterEqual) { return out << " >= "; }
+
+template <typename Comparison, typename T, typename U, typename Listener>
+auto cmp(Comparison compare, T t, U u, Listener *listener) {
+    auto result = compare(t, u);
+    *listener << t << compare << u << ": " << (result ? "true" : "false");
+    return result;
+}
+
+MATCHER_P(OpEqual, target, "") { return cmp(equal, arg, target, result_listener); }
+MATCHER_P(OpNotEqual, target, "") { return cmp(not_equal, arg, target, result_listener); }
+MATCHER_P(OpLess, target, "") { return cmp(less, arg, target, result_listener); }
+MATCHER_P(OpLessEqual, target, "") { return cmp(less_equal, arg, target, result_listener); }
+MATCHER_P(OpGreater, target, "") { return cmp(greater, arg, target, result_listener); }
+MATCHER_P(OpGreaterEqual, target, "") { return cmp(greater_equal, arg, target, result_listener); }
+
+template <typename T>
+auto OpConsistentlyLessThan(T target) {
+    return ::testing::AllOf(OpNotEqual(target),
+                            OpLess(target),
+                            OpLessEqual(target),
+
+                            Not(OpEqual(target)),
+                            Not(OpGreater(target)),
+                            Not(OpGreaterEqual(target)));
+}
+
+template <typename T>
+auto OpConsistentlyGreaterThan(T target) {
+    return ::testing::AllOf(OpNotEqual(target),
+                            OpGreater(target),
+                            OpGreaterEqual(target),
+
+                            Not(OpEqual(target)),
+                            Not(OpLess(target)),
+                            Not(OpLessEqual(target)));
+}
+
+template <typename T>
+auto OpConsistentlyEqual(T target) {
+    return ::testing::AllOf(OpEqual(target),
+                            OpLessEqual(target),
+                            OpGreaterEqual(target),
+
+                            Not(OpNotEqual(target)),
+                            Not(OpLess(target)),
+                            Not(OpGreater(target)));
+}
 
 template <typename T>
 void expect_comparators_work(T a, T b) {
@@ -43,6 +98,13 @@ void expect_arithmetic_works(T t, U u) {
 TEST(Comparators, ResultsMatchUnderlyingOperatorForSameType) {
     expect_comparators_work(1, 2);
     expect_comparators_work(1.5, 1.49999999999);
+}
+
+TEST(Comparators, HandleInternetComparisonCorrectly) {
+    EXPECT_THAT(-1, OpConsistentlyLessThan(1u));
+
+    // This specific test case adds more meaningful coverage for equality operators.
+    EXPECT_THAT(int32_t{-1}, OpConsistentlyLessThan(uint32_t{0} - 1u));
 }
 
 TEST(Arithmetic, ResultsMatchUnderlyingOperatorForSameTypes) {

--- a/au/code/au/quantity_point_test.cc
+++ b/au/code/au/quantity_point_test.cc
@@ -403,6 +403,10 @@ TEST(QuantityPoint, ComparisonsWithNegativeUnitHaveAppropriatelyReversedResults)
     EXPECT_THAT(neg_celsius_pt(1), ConsistentlyEqualTo(milli(neg_kelvins_pt)(-272'150)));
 }
 
+TEST(QuantityPoint, ComparisonsWithMixedSignednessIntegralTypesAreCorrect) {
+    EXPECT_THAT(celsius_pt(-1), ConsistentlyLessThan(celsius_pt(1u)));
+}
+
 TEST(QuantityPoint, AddingPosUnitQuantityToNegUnitPointGivesPosUnitPoint) {
     constexpr auto neg_celsius_pt = celsius_pt * (-mag<1>());
     EXPECT_THAT(neg_celsius_pt(40) + celsius_qty(15), PointEquivalent(celsius_pt(-25)));

--- a/au/code/au/quantity_test.cc
+++ b/au/code/au/quantity_test.cc
@@ -403,6 +403,10 @@ TEST(Quantity, RelativeComparisonsWork) {
     EXPECT_THAT(one_a >= two, IsFalse());
 }
 
+TEST(Quantity, RelativeComparisonsHandleMixedSignIntegersProperly) {
+    EXPECT_THAT(feet(-1), Lt(inches(1u)));
+}
+
 TEST(Quantity, CopyingWorksAndIsDeepCopy) {
     auto original = feet(1.5);
     const auto copy{original};

--- a/release/common_test_cases.hh
+++ b/release/common_test_cases.hh
@@ -50,5 +50,7 @@ TEST(CommonSingleFile, IncludesMathFunctions) {
     EXPECT_DOUBLE_EQ(sin(radians(get_value<double>(PI / mag<2>()))), 1.0);
 }
 
+TEST(CommonSingleFile, MixedSignQuantityComparisonWorks) { EXPECT_LT(meters(-1), meters(1u)); }
+
 }  // namespace
 }  // namespace au


### PR DESCRIPTION
We upgrade our operator replacements (`Less`, `Equal`, etc.) to detect
the situation where both reps have integral type, and delegate to the
more robust comparators that handle that case directly.

Fixes #428.