### PR TITLE
Update documentation to matcher syntax

### DIFF
--- a/docs/discussion/concepts/quantity_point.md
+++ b/docs/discussion/concepts/quantity_point.md
@@ -119,7 +119,7 @@ Now we can see whether Au comes to the same conclusion.  Note how easy it is to 
 with clarity, despite mixing _three_ different temperature scales:
 
 ```cpp
-EXPECT_LT(fahrenheit_pt(-40) + celsius_qty(60), kelvins_pt(300));
+EXPECT_THAT(fahrenheit_pt(-40) + celsius_qty(60), Lt(kelvins_pt(300)));
 ```
 
 As hoped, this test passes.

--- a/docs/howto/interop/index.md
+++ b/docs/howto/interop/index.md
@@ -84,7 +84,7 @@ example for the `nholthaus/units` library:
         // Check that the equivalent Quantity type can be _implicitly_ converted back to the
         // original nholthaus type, and that this round trip is the identity.
         const NholthausType round_trip = implicitly_converted_to_quantity;
-        EXPECT_EQ(round_trip, original);
+        EXPECT_THAT(round_trip, Eq(original));
     }
     ```
 

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -138,22 +138,22 @@ If you need to check whether your magnitude `m` can be represented in a type `T`
     Here are some example test cases which will pass.
 
     ```cpp
-    EXPECT_TRUE(representable_in<int>(mag<1>()));
+    EXPECT_THAT(representable_in<int>(mag<1>()), IsTrue());
 
     // (1 / 2) is not an integer.
-    EXPECT_FALSE(representable_in<int>(mag<1>() / mag<2>()));
+    EXPECT_THAT(representable_in<int>(mag<1>() / mag<2>()), IsFalse());
 
-    EXPECT_TRUE(representable_in<float>(mag<1>() / mag<2>()));
+    EXPECT_THAT(representable_in<float>(mag<1>() / mag<2>()), IsTrue());
     ```
 
 ??? example "Example: range of the type"
     Here are some example test cases which will pass.
 
     ```cpp
-    EXPECT_TRUE(representable_in<uint32_t>(mag<4'000'000'000>()));
+    EXPECT_THAT(representable_in<uint32_t>(mag<4'000'000'000>()), IsTrue());
 
     // 4 billion is larger than the max value representable in `int32_t`.
-    EXPECT_FALSE(representable_in<int32_t>(mag<4'000'000'000>()));
+    EXPECT_THAT(representable_in<int32_t>(mag<4'000'000'000>()), IsFalse());
     ```
 
 Note that this function's return value also depends on _whether we can compute_ the value, not just

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -314,7 +314,7 @@ the [`std::sin` documentation](https://en.cppreference.com/w/cpp/numeric/math/si
     This example is taken from a test case in the library.
 
     ```cpp
-    EXPECT_NEAR(sin(degrees(30)), 0.5, 1e-15);
+    EXPECT_THAT(sin(degrees(30)), DoubleNear(0.5, 1e-15));
     ```
 
 #### `arcsin`, `arccos`, `arctan`

--- a/docs/tutorial/exercise/101-quantity-makers.md
+++ b/docs/tutorial/exercise/101-quantity-makers.md
@@ -76,26 +76,26 @@ to write how you expect it to be printed.
         For example, if you see this:
 
         ```cpp
-        EXPECT_EQ(stream_to_string(squared(meters)(100)), "");
+        EXPECT_THAT(stream_to_string(squared(meters)(100)), StrEq(""));
         ```
 
         then you would replace it with this:
 
         ```cpp
-        EXPECT_EQ(stream_to_string(squared(meters)(100)), "100 m^2");
+        EXPECT_THAT(stream_to_string(squared(meters)(100)), StrEq("100 m^2"));
         ```
 
     === "Solution and Discussion"
         When you're done, your assertions should look something like this:
 
         ```cpp
-        EXPECT_EQ(stream_to_string(meters(100)), "100 m");
+        EXPECT_THAT(stream_to_string(meters(100)), StrEq("100 m"));
 
-        EXPECT_EQ(stream_to_string(meters(100.0) / seconds(8.0)), "12.5 m / s");
-        EXPECT_EQ(stream_to_string((meters / second)(12.5)), "12.5 m / s");
+        EXPECT_THAT(stream_to_string(meters(100.0) / seconds(8.0)), StrEq("12.5 m / s"));
+        EXPECT_THAT(stream_to_string((meters / second)(12.5)), StrEq("12.5 m / s"));
 
-        EXPECT_EQ(stream_to_string((meters / second)(10.0) / seconds(8.0)), "1.25 m / s^2");
-        EXPECT_EQ(stream_to_string((meters / second)(10.0) * seconds(8.0)), "80 m");
+        EXPECT_THAT(stream_to_string((meters / second)(10.0) / seconds(8.0)), StrEq("1.25 m / s^2"));
+        EXPECT_THAT(stream_to_string((meters / second)(10.0) * seconds(8.0)), StrEq("80 m"));
         ```
 
         The first is a warm-up problem: a checkpoint to make sure you're doing the exercise

--- a/docs/tutorial/exercise/103-unit-conversions.md
+++ b/docs/tutorial/exercise/103-unit-conversions.md
@@ -53,7 +53,7 @@ Replace it with an ad hoc inline conversion based on Au.
             // TODO: replace `angle_rad` computation with an ad hoc conversion, using Au.
             constexpr double angle_rad = angle_deg * RAD_PER_DEG;
 
-            EXPECT_DOUBLE_EQ(angle_rad, 3.0 * M_PI / 4.0);
+            EXPECT_THAT(angle_rad, DoubleEq(3.0 * M_PI / 4.0));
         }
         ```
 
@@ -69,7 +69,7 @@ Replace it with an ad hoc inline conversion based on Au.
 
             constexpr double angle_rad = degrees(angle_deg).in(radians);
 
-            EXPECT_DOUBLE_EQ(angle_rad, 3.0 * M_PI / 4.0);
+            EXPECT_THAT(angle_rad, DoubleEq(3.0 * M_PI / 4.0));
         }
         ```
 
@@ -107,7 +107,7 @@ Replace it with an ad hoc inline conversion based on Au.
             // TODO: replace `speed_mps` computation with an ad hoc conversion, using Au.
             constexpr double speed_mps = speed_mph * MPS_PER_MPH;
 
-            EXPECT_DOUBLE_EQ(speed_mps, 29.0576);
+            EXPECT_THAT(speed_mps, DoubleEq(29.0576));
         }
         ```
 
@@ -132,7 +132,7 @@ Replace it with an ad hoc inline conversion based on Au.
 
             constexpr double speed_mps = (miles / hour)(speed_mph).in(meters / second);
 
-            EXPECT_DOUBLE_EQ(speed_mps, 29.0576);
+            EXPECT_THAT(speed_mps, DoubleEq(29.0576));
         }
         ```
 

--- a/tutorial/101_quantity_makers.cc
+++ b/tutorial/101_quantity_makers.cc
@@ -17,11 +17,15 @@
 #include "au/io.hh"
 #include "au/units/meters.hh"
 #include "au/units/seconds.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "tutorial/utils.hh"
 
 // For testing/tutorial purposes.
 using namespace au;
+
+using ::testing::DoubleEq;
+using ::testing::StrEq;
 
 // An API we'll upgrade later, along with some tests.
 double stopping_accel_mpss(double initial_speed_mps, double stopping_distance_m);
@@ -29,7 +33,7 @@ double stopping_accel_mpss(double initial_speed_mps, double stopping_distance_m)
 TEST(StoppingAccelMpss, ReturnsZeroIfAlreadyStopped) {
     constexpr double speed_mps = 0.0;
     constexpr double stopping_distance_m = 1.0;
-    EXPECT_EQ(stopping_accel_mpss(speed_mps, stopping_distance_m), 0.0);
+    EXPECT_THAT(stopping_accel_mpss(speed_mps, stopping_distance_m), DoubleEq(0.0));
 }
 
 TEST(StoppingAccelMpss, ReturnsCorrectAnswerForNonzeroValues) {
@@ -40,9 +44,9 @@ TEST(StoppingAccelMpss, ReturnsCorrectAnswerForNonzeroValues) {
     constexpr double expected_accel_mpss = -2.0;
     constexpr double t_s = -speed_mps / expected_accel_mpss;
     constexpr double distance_m = speed_mps * t_s + 0.5 * expected_accel_mpss * t_s * t_s;
-    ASSERT_DOUBLE_EQ(distance_m, stopping_distance_m);
+    ASSERT_THAT(distance_m, DoubleEq(stopping_distance_m));
 
-    EXPECT_EQ(stopping_accel_mpss(speed_mps, stopping_distance_m), expected_accel_mpss);
+    EXPECT_THAT(stopping_accel_mpss(speed_mps, stopping_distance_m), DoubleEq(expected_accel_mpss));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -78,23 +82,23 @@ void print_raw_number_and_quantity() {
 // "", as the expected answer.  This is just a placeholder.  Replace it with the answer you expect.
 // For example, if you see this:
 //
-//     EXPECT_EQ(stream_to_string(squared(meters)(100)), "");
+//     EXPECT_THAT(stream_to_string(squared(meters)(100)), StrEq(""));
 //
 // then you would replace it with this:
 //
-//     EXPECT_EQ(stream_to_string(squared(meters)(100)), "100 m^2");
+//     EXPECT_THAT(stream_to_string(squared(meters)(100)), StrEq("100 m^2"));
 //
 // TIP: you may find it useful to uncomment the lines one at a time.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 TEST(Quantity, PrintsAsExpected) {
-    // EXPECT_EQ(stream_to_string(meters(100)), "");
+    // EXPECT_THAT(stream_to_string(meters(100)), StrEq(""));
 
-    // EXPECT_EQ(stream_to_string(meters(100.0) / seconds(8.0)), "");
-    // EXPECT_EQ(stream_to_string((meters / second)(12.5)), "");
+    // EXPECT_THAT(stream_to_string(meters(100.0) / seconds(8.0)), StrEq(""));
+    // EXPECT_THAT(stream_to_string((meters / second)(12.5)), StrEq(""));
 
-    // EXPECT_EQ(stream_to_string((meters / second)(10.0) / seconds(8.0)), "");
-    // EXPECT_EQ(stream_to_string((meters / second)(10.0) * seconds(8.0)), "");
+    // EXPECT_THAT(stream_to_string((meters / second)(10.0) / seconds(8.0)), StrEq(""));
+    // EXPECT_THAT(stream_to_string((meters / second)(10.0) * seconds(8.0)), StrEq(""));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tutorial/102_api_types_test.cc
+++ b/tutorial/102_api_types_test.cc
@@ -15,7 +15,10 @@
 #include "tutorial/102_api_types.hh"
 
 #include "au/testing.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+using ::testing::DoubleNear;
 
 TEST(StoppingDistanceM, GivesCorrectAnswerForZeroSpeed) {
     const double speed_mps = 0.0;
@@ -23,7 +26,7 @@ TEST(StoppingDistanceM, GivesCorrectAnswerForZeroSpeed) {
     const double distance_m = stopping_distance_m(speed_mps, acceleration_mpss);
 
     // If we are stopped already, the stopping distance should be zero.
-    EXPECT_NEAR(distance_m, 0.0, 1e-9);
+    EXPECT_THAT(distance_m, DoubleNear(0.0, 1e-9));
 }
 
 TEST(StoppingDistanceM, GivesCorrectAnswerForNonzeroSpeed) {
@@ -32,7 +35,7 @@ TEST(StoppingDistanceM, GivesCorrectAnswerForNonzeroSpeed) {
     const double distance_m = stopping_distance_m(speed_mps, acceleration_mpss);
 
     // If we slam on the brakes at low speed, we can stop in a very short distance.
-    EXPECT_NEAR(distance_m, 2.5, 1e-9);
+    EXPECT_THAT(distance_m, DoubleNear(2.5, 1e-9));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tutorial/103_unit_conversions_test.cc
+++ b/tutorial/103_unit_conversions_test.cc
@@ -19,10 +19,14 @@
 #include "au/units/miles.hh"
 #include "au/units/radians.hh"
 #include "au/units/seconds.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 // For testing/tutorial purposes.
 using namespace au;
+
+using ::testing::DoubleEq;
+using ::testing::Eq;
 
 // Replace this constant with an appropriate conversion function, wherever it occurs.
 constexpr auto PLACEHOLDER = ZERO;
@@ -42,7 +46,7 @@ TEST(AdHocConversions, DegreesToRadians) {
     // TODO: replace `angle_rad` computation with an ad hoc conversion, using Au.
     constexpr double angle_rad = angle_deg * RAD_PER_DEG;
 
-    EXPECT_DOUBLE_EQ(angle_rad, 3.0 * M_PI / 4.0);
+    EXPECT_THAT(angle_rad, DoubleEq(3.0 * M_PI / 4.0));
 }
 
 TEST(AdHocConversions, MilesPerHourToMetersPerSecond) {
@@ -62,7 +66,7 @@ TEST(AdHocConversions, MilesPerHourToMetersPerSecond) {
     // TODO: replace `speed_mps` computation with an ad hoc conversion, using Au.
     constexpr double speed_mps = speed_mph * MPS_PER_MPH;
 
-    EXPECT_DOUBLE_EQ(speed_mps, 29.0576);
+    EXPECT_THAT(speed_mps, DoubleEq(29.0576));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -100,6 +104,6 @@ Height decompose_height(QuantityU32<Inches> total_height) {
 }
 
 TEST(Height, DecomposesCorrectly) {
-    EXPECT_EQ(decompose_height(inches(60)), (Height{feet(5), inches(0)}));
-    EXPECT_EQ(decompose_height(inches(83)), (Height{feet(6), inches(11)}));
+    EXPECT_THAT(decompose_height(inches(60)), Eq(Height{feet(5), inches(0)}));
+    EXPECT_THAT(decompose_height(inches(83)), Eq(Height{feet(6), inches(11)}));
 }


### PR DESCRIPTION
This updates our documentation and tutorial examples to use the matcher
syntax.

Ran through the exercises for 101, 102, and 103.

Partial implementation for #404.