### PR TITLE
Move UnitAvoidance Out Of Detail Issue 429

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1153,10 +1153,10 @@ ordering!
         struct Trinches : decltype(Inches{} * mag<3>()) {};
         constexpr auto trinches = QuantityMaker<Trinches>{};
 
-        namespace au { namespace detail {
+        namespace au {
         template <>
         struct UnitAvoidance<::Trinches> : std::integral_constant<int, 100> {};
-        }}
+        }
 
         // (FIXED): Trinches has high "unit avoidance", so it goes after Quarterfeet
         if (quarterfeet(10) == trinches(10)) {


### PR DESCRIPTION
# Description

Move `UnitAvoidance` out of the `detail` namespace. This communicates to users that they can use it in their code.

# Test

```
bazel test //au:unit_of_measure_test
```

# Issue

https://github.com/aurora-opensource/au/issues/429