### PR TITLE
Avoid implicit sign conversion

### DIFF
--- a/au/code/au/utility/string_constant.hh
+++ b/au/code/au/utility/string_constant.hh
@@ -103,7 +103,7 @@ constexpr std::make_unsigned_t<S> abs_as_unsigned(S x) {
     constexpr auto UMAX = std::numeric_limits<U>::max();
 
     auto result = static_cast<U>(x);
-    return (result > SMAX) ? (UMAX - result + 1u) : result;
+    return (result > SMAX) ? static_cast<U>(UMAX - result + 1u) : result;
 }
 
 // The string-length needed to hold a representation of this unsigned integer.


### PR DESCRIPTION
Avoid implicit sign conversion in `au::detail::abs_as_unsigned(S x)`
when `S` is narrower than `int`. This warning was previously suppressed
when building with Bazel due to au headers being included as system
headers (See #440.)

Without this change, this function fails the `StringConstant` test suite
(`au/code/au/utility/test/string_constant_test.cc`) with `-Wconversion`.

GCC10:
```
In file included from au/utility/test/string_constant_test.cc:15:
./au/utility/string_constant.hh: In instantiation of 'constexpr std::make_unsigned_t<S> au::detail::abs_as_unsigned(S) [with S = signed char; std::make_unsigned_t<S> = unsigned char]':
au/utility/test/string_constant_test.cc:50:5:   required from here
./au/utility/string_constant.hh:106:28: error: conversion from 'unsigned int' to 'std::make_unsigned_t<signed char>' {aka 'unsigned char'} may change value [-Werror=conversion]
  106 |     return (result > SMAX) ? (UMAX - result + 1u) : result;
      |            ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

Clang11: No error

Clang14: No error