### PR TITLE
Remove `srcs` from `:stdx` definition

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -565,10 +565,6 @@ cc_test(
 
 cc_library(
     name = "stdx",
-    srcs = glob([
-        "stdx/*.cc",
-        "stdx/experimental/*.cc",
-    ]),
     hdrs = glob([
         "stdx/*.hh",
         "stdx/experimental/*.hh",


### PR DESCRIPTION
It's really weird that these ever existed in the first place, as Au is a
header only library.  Apparently I added them in #8.  Anyway, they are
globs that evaluate to an empty set, so I am just removing them now.