### PR TITLE
Handle lowest signed integrals in `get_value`

### DIFF
--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -642,10 +642,29 @@ constexpr MagRepresentationOrError<T> get_value_result(Magnitude<>) {
     return {MagRepresentationOutcome::OK, static_cast<T>(1)};
 }
 
+template <typename T, typename MagT, bool IsCandidate>
+struct IsExactlyLowestOfSignedIntegral : std::false_type {};
 template <typename T, typename... BPs>
-constexpr MagRepresentationOrError<T> get_value_result(Magnitude<Negative, BPs...>) {
+struct IsExactlyLowestOfSignedIntegral<T, Magnitude<Negative, BPs...>, true>
+    : std::is_same<
+          decltype(mag<static_cast<std::make_unsigned_t<T>>(std::numeric_limits<T>::max()) + 1u>()),
+          Magnitude<BPs...>> {};
+template <typename T, typename... BPs>
+constexpr bool is_exactly_lowest_of_signed_integral(Magnitude<BPs...>) {
+    return IsExactlyLowestOfSignedIntegral<
+        T,
+        Magnitude<BPs...>,
+        stdx::conjunction<std::is_integral<T>, std::is_signed<T>>::value>::value;
+}
+
+template <typename T, typename... BPs>
+constexpr MagRepresentationOrError<T> get_value_result(Magnitude<Negative, BPs...> m) {
     if (std::is_unsigned<T>::value) {
         return {MagRepresentationOutcome::ERR_NEGATIVE_NUMBER_IN_UNSIGNED_TYPE};
+    }
+
+    if (is_exactly_lowest_of_signed_integral<T>(m)) {
+        return {MagRepresentationOutcome::OK, std::numeric_limits<T>::lowest()};
     }
 
     const auto result = get_value_result<T>(Magnitude<BPs...>{});

--- a/au/magnitude_test.cc
+++ b/au/magnitude_test.cc
@@ -349,6 +349,13 @@ TEST(GetValue, WorksForNegativeNumber) {
     EXPECT_THAT(get_value<float>(neg_5), SameTypeAndValue(-5.f));
 }
 
+TEST(GetValue, HandlesMostNegativeValue) {
+    EXPECT_THAT(detail::get_value_result<int16_t>(-mag<32769>()).outcome,
+                Eq(detail::MagRepresentationOutcome::ERR_CANNOT_FIT));
+    EXPECT_THAT(get_value<int16_t>(-mag<32768>()),
+                SameTypeAndValue(std::numeric_limits<int16_t>::lowest()));
+}
+
 TEST(CommonMagnitude, ReturnsCommonMagnitudeWhenBothAreIdentical) {
     EXPECT_THAT(common_magnitude(mag<1>(), mag<1>()), Eq(mag<1>()));
     EXPECT_THAT(common_magnitude(PI, PI), Eq(PI));


### PR DESCRIPTION
Currently, we can't represent `-mag<128>()` in `int8_t`, even though the
value `-128` _is_ representable.  The problem is that we're using the
max of the type to decide what we can represent, and then just negating
it.  This special case logic enables us to handle all integer values
correctly.

Helps pave the way for #349.