### PR TITLE
Add `FlattenAs<Pack, Ts...>` helper

### DIFF
--- a/au/utility/test/type_traits_test.cc
+++ b/au/utility/test/type_traits_test.cc
@@ -69,6 +69,20 @@ TEST(DropAll, DropsAllInstancesOfTarget) {
     StaticAssertTypeEq<DropAll<int, Pack<int, char, int, double>>, Pack<char, double>>();
 }
 
+TEST(FlattenAs, CombinesElementsIfNotAlreadyOfPack) {
+    StaticAssertTypeEq<FlattenAs<Pack, int, char, double>, Pack<int, char, double>>();
+}
+
+TEST(FlattenAs, ConcatenatesExistingPacks) {
+    StaticAssertTypeEq<FlattenAs<Pack, Pack<int>, Pack<char, double>>, Pack<int, char, double>>();
+}
+
+TEST(FlattenAs, HandlesArbitraryNesting) {
+    StaticAssertTypeEq<
+        FlattenAs<Pack, Pack<int, Pack<char>>, Pack<>, Pack<Pack<Pack<Pack<double>>>>>,
+        Pack<int, char, double>>();
+}
+
 TEST(IncludeInPackIf, MakesPackOfEverythingThatMatches) {
     StaticAssertTypeEq<
         IncludeInPackIf<std::is_unsigned, Pack, int32_t, uint8_t, double, char, uint64_t, int16_t>,

--- a/au/utility/type_traits.hh
+++ b/au/utility/type_traits.hh
@@ -36,6 +36,11 @@ struct DropAllImpl;
 template <typename T, typename Pack>
 using DropAll = typename DropAllImpl<T, Pack>::type;
 
+template <template <class...> class Pack, typename... Ts>
+struct FlattenAsImpl;
+template <template <class...> class Pack, typename... Ts>
+using FlattenAs = typename FlattenAsImpl<Pack, Ts...>::type;
+
 template <typename T, typename U>
 struct SameTypeIgnoringCvref : std::is_same<stdx::remove_cvref_t<T>, stdx::remove_cvref_t<U>> {};
 
@@ -117,6 +122,43 @@ struct DropAllImpl<T, Pack<H, Ts...>>
     : std::conditional<std::is_same<T, H>::value,
                        DropAll<T, Pack<Ts...>>,
                        detail::PrependT<DropAll<T, Pack<Ts...>>, H>> {};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `FlattenAs` implementation.
+
+template <typename P1, typename P2>
+struct ConcatImpl;
+template <typename P1, typename P2>
+using Concat = typename ConcatImpl<P1, P2>::type;
+
+template <template <class...> class Pack, typename... T1s, typename... T2s>
+struct ConcatImpl<Pack<T1s...>, Pack<T2s...>> : stdx::type_identity<Pack<T1s..., T2s...>> {};
+
+template <template <class...> class Pack, typename ResultPack, typename... Ts>
+struct FlattenAsImplHelper;
+
+template <template <class...> class Pack, typename ResultPack>
+struct FlattenAsImplHelper<Pack, ResultPack> : stdx::type_identity<ResultPack> {};
+
+// Skip empty packs.
+template <template <class...> class Pack, typename ResultPack, typename... Us>
+struct FlattenAsImplHelper<Pack, ResultPack, Pack<>, Us...>
+    : FlattenAsImplHelper<Pack, ResultPack, Us...> {};
+
+template <template <class...> class Pack,
+          typename ResultPack,
+          typename T,
+          typename... Ts,
+          typename... Us>
+struct FlattenAsImplHelper<Pack, ResultPack, Pack<T, Ts...>, Us...>
+    : FlattenAsImplHelper<Pack, ResultPack, T, Pack<Ts...>, Us...> {};
+
+template <template <class...> class Pack, typename ResultPack, typename T, typename... Us>
+struct FlattenAsImplHelper<Pack, ResultPack, T, Us...>
+    : FlattenAsImplHelper<Pack, Concat<ResultPack, Pack<T>>, Us...> {};
+
+template <template <class...> class Pack, typename... Ts>
+struct FlattenAsImpl : FlattenAsImplHelper<Pack, Pack<>, Ts...> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `CommonTypeButPreserveIntSignedness` implementation.


### PR DESCRIPTION
This will take any and all instances of `Pack<...>`, regardless of
nesting, and replace them with the contents of the pack.  All results
will be wrapped in one overarching `Pack<...>` instance.

The point of this is to make it easy to keep the future `OpSequence` in
a canonical form.  We could easily have an `OpSequence` as one of the
elements of an `OpSequence`.  This helper will let us avoid having weird
combinations persist.  This helps pave the way for #349.