### PR TITLE
Move `PromotedType<T>` to `:utility`

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -185,6 +185,7 @@ cc_library(
     deps = [
         ":apply_rational_magnitude_to_integral",
         ":magnitude",
+        ":utility",
     ],
 )
 
@@ -202,7 +203,11 @@ cc_test(
 cc_library(
     name = "apply_rational_magnitude_to_integral",
     hdrs = ["apply_rational_magnitude_to_integral.hh"],
-    deps = [":magnitude"],
+    deps = [
+        ":magnitude",
+        ":stdx",
+        ":utility",
+    ],
 )
 
 cc_test(

--- a/au/apply_magnitude.hh
+++ b/au/apply_magnitude.hh
@@ -16,6 +16,7 @@
 
 #include "au/apply_rational_magnitude_to_integral.hh"
 #include "au/magnitude.hh"
+#include "au/utility/type_traits.hh"
 
 namespace au {
 namespace detail {

--- a/au/apply_rational_magnitude_to_integral.hh
+++ b/au/apply_rational_magnitude_to_integral.hh
@@ -18,6 +18,7 @@
 
 #include "au/magnitude.hh"
 #include "au/stdx/utility.hh"
+#include "au/utility/type_traits.hh"
 
 // This file exists to analyze one single calculation: `x * N / D`, where `x` is
 // some integral type, and `N` and `D` are the numerator and denominator of a
@@ -36,21 +37,6 @@
 
 namespace au {
 namespace detail {
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// `PromotedType<T>` is the result type for arithmetic operations involving `T`.  Of course, this is
-// normally just `T`, but integer promotion for small integral types can change this.
-//
-template <typename T>
-struct PromotedTypeImpl {
-    using type = decltype(std::declval<T>() * std::declval<T>());
-
-    static_assert(std::is_same<type, typename PromotedTypeImpl<type>::type>::value,
-                  "We explicitly assume that promoted types are not again promotable");
-};
-template <typename T>
-using PromotedType = typename PromotedTypeImpl<T>::type;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/au/apply_rational_magnitude_to_integral_test.cc
+++ b/au/apply_rational_magnitude_to_integral_test.cc
@@ -36,24 +36,6 @@ constexpr void ensure_relevant_kind_of_magnitude(Magnitude<BPs...> m) {
     static_assert(!is_integer(ONE / m), "Magnitude must not be purely inverse-integer");
 }
 
-TEST(PromotedType, IdentityForInt) {
-    // `int` does not undergo type promotion.
-    StaticAssertTypeEq<int, PromotedType<int>>();
-}
-
-TEST(PromotedType, PromotesUint8TIntoLargerType) {
-    using PromotedU8 = PromotedType<uint8_t>;
-
-    // Technically, this need not be true on every conceivable architecture.  However, it is true on
-    // the vast majority that are used in practice.  Moreover, the failure mode if it's not is
-    // simply that a test would fail when run on some obscure architecture, and the failure would
-    // direct the user to this comment.  This doesn't affect the actual library usage one way or
-    // another.
-    ASSERT_THAT((std::is_same<uint8_t, PromotedU8>::value), IsFalse());
-
-    EXPECT_THAT(sizeof(PromotedU8), Gt(sizeof(uint8_t)));
-}
-
 TEST(IsAbsKnownToBeLessThanOne, ProducesExpectedResultsForMagnitudesThatCanFitInUintmax) {
     EXPECT_THAT(is_abs_known_to_be_less_than_one(mag<1>() / mag<2>()),
                 Eq(IsAbsMagLessThanOne::DEFINITELY));

--- a/au/utility/test/type_traits_test.cc
+++ b/au/utility/test/type_traits_test.cc
@@ -19,6 +19,7 @@
 
 namespace au {
 
+using ::testing::Gt;
 using ::testing::IsFalse;
 using ::testing::IsTrue;
 using ::testing::StaticAssertTypeEq;
@@ -98,6 +99,24 @@ TEST(CommonTypeButPreserveIntSignedness, CommonTypeIfItIsNotIntegral) {
 TEST(CommonTypeButPreserveIntSignedness, UsesSignOfFirstArgumentIfCommonTypeIsIntegral) {
     StaticAssertTypeEq<CommonTypeButPreserveIntSignedness<int, uint8_t>, int>();
     StaticAssertTypeEq<CommonTypeButPreserveIntSignedness<uint8_t, int>, uint>();
+}
+
+TEST(PromotedType, IdentityForInt) {
+    // `int` does not undergo type promotion.
+    StaticAssertTypeEq<int, PromotedType<int>>();
+}
+
+TEST(PromotedType, PromotesUint8TIntoLargerType) {
+    using PromotedU8 = PromotedType<uint8_t>;
+
+    // Technically, this need not be true on every conceivable architecture.  However, it is true on
+    // the vast majority that are used in practice.  Moreover, the failure mode if it's not is
+    // simply that a test would fail when run on some obscure architecture, and the failure would
+    // direct the user to this comment.  This doesn't affect the actual library usage one way or
+    // another.
+    ASSERT_THAT((std::is_same<uint8_t, PromotedU8>::value), IsFalse());
+
+    EXPECT_THAT(sizeof(PromotedU8), Gt(sizeof(uint8_t)));
 }
 
 }  // namespace detail

--- a/au/utility/type_traits.hh
+++ b/au/utility/type_traits.hh
@@ -58,6 +58,15 @@ template <typename R1, typename R2>
 using CommonTypeButPreserveIntSignedness =
     typename CommonTypeButPreserveIntSignednessImpl<R1, R2>::type;
 
+//
+// `PromotedType<T>` is the result type for arithmetic operations involving `T`.  Of course, this is
+// normally just `T`, but integer promotion for small integral types can change this.
+//
+template <typename T>
+struct PromotedTypeImpl;
+template <typename T>
+using PromotedType = typename PromotedTypeImpl<T>::type;
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Implementation details below.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -183,6 +192,17 @@ struct CopySignednessIfIntType
 template <typename R1, typename R2>
 struct CommonTypeButPreserveIntSignednessImpl
     : CopySignednessIfIntType<R1, std::common_type_t<R1, R2>> {};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `PromotedType<T>` implementation.
+
+template <typename T>
+struct PromotedTypeImpl {
+    using type = decltype(std::declval<T>() * std::declval<T>());
+
+    static_assert(std::is_same<type, typename PromotedTypeImpl<type>::type>::value,
+                  "We explicitly assume that promoted types are not again promotable");
+};
 
 }  // namespace detail
 }  // namespace au


### PR DESCRIPTION
It's a pretty generic utility, and it'll be handy to have it in a more
common location.

Helps pave the way for #349.