### PR TITLE
Add abstract operations

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -180,6 +180,24 @@ cc_test(
 # Implementation detail libraries and tests
 
 cc_library(
+    name = "abstract_operations",
+    hdrs = ["abstract_operations.hh"],
+    deps = [":magnitude"],
+)
+
+cc_test(
+    name = "abstract_operations_test",
+    size = "small",
+    srcs = ["abstract_operations_test.cc"],
+    deps = [
+        ":abstract_operations",
+        ":magnitude",
+        ":testing",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "apply_magnitude",
     hdrs = ["apply_magnitude.hh"],
     deps = [

--- a/au/abstract_operations.hh
+++ b/au/abstract_operations.hh
@@ -1,0 +1,168 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/magnitude.hh"
+
+namespace au {
+namespace detail {
+
+//
+// `OpInput<Op>` and `OpOutput<Op>` are the input and output types of an operation.
+//
+template <typename Op>
+struct OpInputImpl;
+template <typename Op>
+using OpInput = typename OpInputImpl<Op>::type;
+
+template <typename Op>
+struct OpOutputImpl;
+template <typename Op>
+using OpOutput = typename OpOutputImpl<Op>::type;
+
+//
+// `StaticCast<T, U>` represents an operation that converts from `T` to `U` via `static_cast`.
+//
+template <typename T, typename U>
+struct StaticCast;
+
+//
+// `MultiplyTypeBy<T, M>` represents an operation that multiplies a value of type `T` by the
+// magnitude `M`.
+//
+// Note that this operation does *not* model integer promotion.  It will always force the result to
+// be `T`.  To model integer promotion, form a compound operation with `OpSequence` that includes
+// appropriate `StaticCast`.
+//
+template <typename T, typename M>
+struct MultiplyTypeBy;
+
+//
+// `DivideTypeByInteger<T, M>` represents an operation that divides a value of type `T` by the
+// magnitude `M`.
+//
+// Note that this operation does *not* model integer promotion.  It will always force the result to
+// be `T`.  To model integer promotion, form a compound operation with `OpSequence` that includes
+// appropriate `StaticCast`.
+//
+template <typename T, typename M>
+struct DivideTypeByInteger;
+
+//
+// `OpSequence<Ops...>` represents an ordered sequence of operations.
+//
+// We require that the output type of each operation is the same as the input type of the next one
+// (see below for `OpInput` and `OpOutput`).
+//
+template <typename... Ops>
+struct OpSequenceImpl;
+template <typename... Ops>
+using OpSequence = FlattenAs<OpSequenceImpl, Ops...>;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// IMPLEMENTATION DETAILS (`abstract_operations.hh`):
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `StaticCast<T, U>` implementation.
+
+// `OpInput` and `OpOutput`:
+template <typename T, typename U>
+struct OpInputImpl<StaticCast<T, U>> : stdx::type_identity<T> {};
+template <typename T, typename U>
+struct OpOutputImpl<StaticCast<T, U>> : stdx::type_identity<U> {};
+
+// `StaticCast<T, U>` operation:
+template <typename T, typename U>
+struct StaticCast {
+    static constexpr U apply_to(T value) { return static_cast<U>(value); }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `MultiplyTypeBy<T, M>` implementation.
+
+// `OpInput` and `OpOutput`:
+template <typename T, typename M>
+struct OpInputImpl<MultiplyTypeBy<T, M>> : stdx::type_identity<T> {};
+template <typename T, typename M>
+struct OpOutputImpl<MultiplyTypeBy<T, M>> : stdx::type_identity<T> {};
+
+// `MultiplyTypeBy<T, M>` operation:
+template <typename T, typename Mag>
+struct MultiplyTypeBy {
+    static constexpr T apply_to(T value) {
+        return static_cast<T>(value * get_value<RealPart<T>>(Mag{}));
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `DivideTypeByInteger<T, M>` implementation.
+
+// `OpInput` and `OpOutput`:
+template <typename T, typename M>
+struct OpInputImpl<DivideTypeByInteger<T, M>> : stdx::type_identity<T> {};
+template <typename T, typename M>
+struct OpOutputImpl<DivideTypeByInteger<T, M>> : stdx::type_identity<T> {};
+
+template <typename T, typename M, MagRepresentationOutcome MagOutcome>
+struct DivideTypeByIntegerImpl {
+    static constexpr T apply_to(T value) {
+        static_assert(MagOutcome == MagRepresentationOutcome::OK, "Internal library error");
+        return static_cast<T>(value / get_value<RealPart<T>>(M{}));
+    }
+};
+
+template <typename T, typename M>
+struct DivideTypeByIntegerImpl<T, M, MagRepresentationOutcome::ERR_CANNOT_FIT> {
+    // If a number is too big to fit in the type, then dividing by it should produce 0.
+    static constexpr T apply_to(T) { return T{0}; }
+};
+
+template <typename T, typename M>
+struct DivideTypeByInteger
+    : DivideTypeByIntegerImpl<T, M, get_value_result<RealPart<T>>(M{}).outcome> {
+    static_assert(IsInteger<M>::value,
+                  "Internal library error: inappropriate operation"
+                  " (use `MultiplyTypeBy` with inverse instead)");
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `OpSequence<Ops...>` implementation.
+
+// `OpInput`:
+template <typename Op, typename... Ops>
+struct OpInputImpl<OpSequenceImpl<Op, Ops...>> : stdx::type_identity<OpInput<Op>> {};
+
+// `OpOutput`:
+template <typename Op, typename... Ops>
+struct OpOutputImpl<OpSequenceImpl<Op, Ops...>>
+    : stdx::type_identity<OpOutput<OpSequence<Ops...>>> {};
+template <typename OnlyOp>
+struct OpOutputImpl<OpSequenceImpl<OnlyOp>> : stdx::type_identity<OpOutput<OnlyOp>> {};
+
+template <typename Op>
+struct OpSequenceImpl<Op> {
+    static constexpr auto apply_to(OpInput<OpSequenceImpl> value) { return Op::apply_to(value); }
+};
+
+template <typename Op, typename... Ops>
+struct OpSequenceImpl<Op, Ops...> {
+    static constexpr auto apply_to(OpInput<OpSequenceImpl> value) {
+        return OpSequenceImpl<Ops...>::apply_to(Op::apply_to(value));
+    }
+};
+
+}  // namespace detail
+}  // namespace au

--- a/au/abstract_operations_test.cc
+++ b/au/abstract_operations_test.cc
@@ -1,0 +1,129 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/abstract_operations.hh"
+
+#include "au/testing.hh"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::StaticAssertTypeEq;
+
+namespace au {
+namespace detail {
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `StaticCast` section:
+
+TEST(StaticCast, HasExpectedInputAndOutputTypes) {
+    StaticAssertTypeEq<OpInput<StaticCast<int16_t, float>>, int16_t>();
+    StaticAssertTypeEq<OpOutput<StaticCast<int16_t, float>>, float>();
+}
+
+TEST(StaticCast, PerformsStaticCast) {
+    EXPECT_THAT((StaticCast<int16_t, float>::apply_to(int16_t{123})), SameTypeAndValue(123.0f));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `MultiplyTypeBy` section:
+
+TEST(MultiplyTypeBy, InputTypeIsTypeParameter) {
+    StaticAssertTypeEq<OpInput<MultiplyTypeBy<int16_t, decltype(mag<2>())>>, int16_t>();
+    StaticAssertTypeEq<OpInput<MultiplyTypeBy<uint32_t, decltype(mag<3>() / mag<4>())>>,
+                       uint32_t>();
+}
+
+TEST(MultiplyTypeBy, OutputTypeIsTypeParameter) {
+    StaticAssertTypeEq<OpOutput<MultiplyTypeBy<int16_t, decltype(mag<2>())>>, int16_t>();
+    StaticAssertTypeEq<OpOutput<MultiplyTypeBy<double, decltype(mag<3>() / mag<4>())>>, double>();
+}
+
+TEST(MultiplyTypeBy, IntegerTypeCanBeMultipliedByIntegerMag) {
+    EXPECT_THAT((MultiplyTypeBy<int16_t, decltype(mag<2>())>::apply_to(int16_t{3})),
+                SameTypeAndValue(int16_t{6}));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `DivideTypeByInteger` section:
+
+TEST(DivideTypeByInteger, InputTypeIsTypeParameter) {
+    StaticAssertTypeEq<OpInput<DivideTypeByInteger<int16_t, decltype(mag<2>())>>, int16_t>();
+    StaticAssertTypeEq<OpInput<DivideTypeByInteger<uint32_t, decltype(mag<3>() / mag<4>())>>,
+                       uint32_t>();
+}
+
+TEST(DivideTypeByInteger, OutputTypeIsTypeParameter) {
+    StaticAssertTypeEq<OpOutput<DivideTypeByInteger<int16_t, decltype(mag<2>())>>, int16_t>();
+    StaticAssertTypeEq<OpOutput<DivideTypeByInteger<double, decltype(mag<3>() / mag<4>())>>,
+                       double>();
+}
+
+TEST(DivideTypeByInteger, IntegerTypeCanBeDividedByIntegerMag) {
+    EXPECT_THAT((DivideTypeByInteger<uint16_t, decltype(mag<3>())>::apply_to(uint16_t{16})),
+                SameTypeAndValue(uint16_t{5}));
+}
+
+TEST(DivideTypeByInteger, IntegerTypeDividedByIntegerTooBigToRepresentGivesZero) {
+    EXPECT_THAT((DivideTypeByInteger<uint8_t, decltype(mag<256>())>::apply_to(uint8_t{1})),
+                SameTypeAndValue(uint8_t{0}));
+}
+
+TEST(DivideTypeByInteger, FloatingPointTypeDividedByNumberTooBigToRepresentGivesZero) {
+    EXPECT_THAT((DivideTypeByInteger<float, decltype(-pow<40>(mag<10>()))>::apply_to(float{1.0f})),
+                SameTypeAndValue(0.0f));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `OpSequence` section:
+
+TEST(OpSequence, InputTypeIsInputTypeOfFirstOperation) {
+    StaticAssertTypeEq<OpInput<OpSequence<MultiplyTypeBy<uint32_t, decltype(mag<3>() / mag<4>())>>>,
+                       uint32_t>();
+
+    StaticAssertTypeEq<OpInput<OpSequence<StaticCast<int16_t, uint16_t>,
+                                          MultiplyTypeBy<uint16_t, decltype(mag<2>())>>>,
+                       int16_t>();
+}
+
+TEST(OpSequence, OutputTypeIsOutputTypeOfLastOperation) {
+    StaticAssertTypeEq<
+        OpOutput<OpSequence<MultiplyTypeBy<uint32_t, decltype(mag<3>() / mag<4>())>>>,
+        uint32_t>();
+
+    StaticAssertTypeEq<OpOutput<OpSequence<StaticCast<int16_t, uint16_t>,
+                                           MultiplyTypeBy<uint16_t, decltype(mag<2>())>,
+                                           StaticCast<uint16_t, double>>>,
+                       double>();
+}
+
+TEST(OpSequence, AppliesOperationsInSequence) {
+    EXPECT_THAT((OpSequence<StaticCast<float, int>,
+                            MultiplyTypeBy<int, decltype(mag<3>())>,
+                            StaticCast<int, double>>::apply_to(2.9f)),
+                SameTypeAndValue(6.0));
+}
+
+TEST(OpSequence, EliminatesRedundantOperations) {
+    StaticAssertTypeEq<
+        OpSequence<StaticCast<int, float>,
+                   OpSequence<OpSequence<OpSequence<>>>,
+                   OpSequence<MultiplyTypeBy<float, decltype(mag<2>())>>,
+                   OpSequence<>>,
+        OpSequence<StaticCast<int, float>, MultiplyTypeBy<float, decltype(mag<2>())>>>();
+}
+
+}  // namespace
+}  // namespace detail
+}  // namespace au


### PR DESCRIPTION
We add special types for the kinds of operations that can occur in unit
conversions.  Later on, we'll create traits that judge the risks of
these operations for overflow and truncation, and can even determine
which individual values will be lossy in these ways.

For now, the operations are:

- `StaticCast<T, U>` represents a static cast from type `T` to `U`.
- `MultiplyTypeBy<T, M>` represents multiplying a value of `T` by the
  magnitude `M`.
- `DivideTypeByInteger<T, M>` represents dividing a value of `T` by the
  magnitude `M`, which must be an integer.
- `OpSequence<Ops...>` chains any sequence of operations, and is
  automatically flattened to a single layer.

We also provide the `OpInput<Op>` and `OpOutput<Op>` traits.  For
`OpSequence`, we also explicitly check that the output type of one
operation equals the input type of the next.  This has helped prevent a
few errors already.

Helps #349.