### PR TITLE
Add lower-bound overflow checker for `StaticCast`

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -430,6 +430,27 @@ cc_test(
 )
 
 cc_library(
+    name = "overflow_boundary",
+    hdrs = ["overflow_boundary.hh"],
+    deps = [
+        ":abstract_operations",
+        ":magnitude",
+        ":stdx",
+    ],
+)
+
+cc_test(
+    name = "overflow_boundary_test",
+    size = "small",
+    srcs = ["overflow_boundary_test.cc"],
+    deps = [
+        ":overflow_boundary",
+        ":testing",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "packs",
     hdrs = ["packs.hh"],
     deps = [

--- a/au/overflow_boundary.hh
+++ b/au/overflow_boundary.hh
@@ -1,0 +1,212 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <limits>
+
+#include "au/abstract_operations.hh"
+#include "au/magnitude.hh"
+#include "au/stdx/type_traits.hh"
+
+// These utilities help assess overflow risk for an operation `Op` by finding the minimum and
+// maximum values in the "scalar type" of `OpInput<Op>` that are guaranteed to not overflow.
+//
+// The "scalar type" of `T` is usually just `T`, but if `T` is something like `std::complex<U>`, or
+// `Eigen::Vector<U, N>`, then it would be `U`.
+
+namespace au {
+namespace detail {
+
+//
+// `MinGood<Op>::value()` is a constexpr constant of the "scalar type" for `OpInput<Op>` that is the
+// minimum value that does not overflow.
+//
+// IMPORTANT: the result must always be non-positive.  The code is structured on this assumption.
+//
+template <typename Op, typename Limits>
+struct MinGoodImpl;
+template <typename Op, typename Limits = void>
+using MinGood = typename MinGoodImpl<Op, Limits>::type;
+
+//
+// `MaxGood<Op>::value()` is a constexpr constant of the "scalar type" for `OpInput<Op>` that is the
+// maximum value that does not overflow.
+//
+// IMPORTANT: the result must always be non-negative.  The code is structured on this assumption.
+//
+template <typename Op, typename Limits = void>
+struct MaxGoodImpl;
+template <typename Op, typename Limits = void>
+using MaxGood = typename MaxGoodImpl<Op, Limits>::type;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// IMPLEMENTATION DETAILS
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// The implementation strategy will be to decompose to increasingly specific cases, using
+// `std::conditional` constructs that are _at most one layer deep_.  This should keep every
+// individual piece as easy to understand as possible, although it does mean we'll tend to be
+// navigating many layers deep from the top-level API to the ultimate implementation.
+//
+// It's easier to navigate these helpers if we put a shorthand comment at the top of each.  Here's
+// the key:
+//
+// (A) = arithmetic (integral or floating point)
+// (F) = floating point
+// (I) = integral (signed or unsigned)
+// (N) = non-arithmetic
+// (S) = signed integral
+// (U) = unsigned integral
+// (X) = any type
+
+// `LowerLimit<T, Limits>::value()` returns `Limits::lower()` (assumed to be of type `T`), unless
+// `Limits` is `void`, in which case it means "no limit" and we return the lowest possible value.
+template <typename T, typename Limits>
+struct LowerLimit {
+    static constexpr T value() { return Limits::lower(); }
+};
+template <typename T>
+struct LowerLimit<T, void> {
+    static constexpr T value() { return std::numeric_limits<T>::lowest(); }
+};
+
+// Inherit from this struct to produce a compiler error in case we try to use a combination of types
+// that isn't yet supported.
+template <typename T>
+struct OverflowBoundaryNotYetImplemented {
+    struct NotYetImplemented {};
+    static_assert(std::is_same<T, NotYetImplemented>::value,
+                  "Overflow boundary not yet implemented for this type.");
+};
+
+// A type whose `::value()` function returns `0`, expressed in `T`.
+template <typename T>
+struct ValueIsZero {
+    static constexpr T value() { return T{0}; }
+};
+
+// A type whose `::value()` function returns the higher of `std::numeric_limits<T>::lowest()`, or
+// `LowerLimit<U, ULimit>` expressed in `T`.  Assumes that `U` is more expansive than `T`, so that
+// we can cast everything to `U` to do the comparisons.
+template <typename T, typename U, typename ULimit>
+struct ValueIsSourceLowestUnlessDestLimitIsHigher {
+    static constexpr T value() {
+        constexpr auto LOWEST_T_IN_U = static_cast<U>(std::numeric_limits<T>::lowest());
+        constexpr auto U_LIMIT = LowerLimit<U, ULimit>::value();
+        return (LOWEST_T_IN_U <= U_LIMIT) ? static_cast<T>(U_LIMIT)
+                                          : std::numeric_limits<T>::lowest();
+    }
+};
+
+// A type whose `::value()` function returns the lowest value of `U`, expressed in `T`.
+template <typename T, typename U = T, typename ULimit = void>
+struct ValueIsLowestInDestination {
+    static constexpr T value() { return static_cast<T>(LowerLimit<U, ULimit>::value()); }
+
+    static_assert(static_cast<U>(value()) == LowerLimit<U, ULimit>::value(),
+                  "This utility assumes lossless round trips");
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `StaticCast<T, U>` implementation.
+
+//
+// `MinGood<StaticCast<T, U>>` implementation cluster.
+//
+// See comment above for meanings of (N), (X), (A), etc.
+//
+
+// (N) -> (X) (placeholder)
+template <typename T, typename U, typename ULimit>
+struct MinGoodImplForStaticCastFromNonArithmetic
+    : OverflowBoundaryNotYetImplemented<StaticCast<T, U>> {};
+
+// (A) -> (N) (placeholder)
+template <typename T, typename U, typename ULimit>
+struct MinGoodImplForStaticCastFromArithmeticToNonArithmetic
+    : OverflowBoundaryNotYetImplemented<StaticCast<T, U>> {};
+
+// (S) -> (S)
+template <typename T, typename U, typename ULimit>
+struct MinGoodImplForStaticCastFromSignedToSigned
+    : std::conditional<sizeof(T) <= sizeof(U),
+                       ValueIsSourceLowestUnlessDestLimitIsHigher<T, U, ULimit>,
+                       ValueIsLowestInDestination<T, U, ULimit>> {};
+
+// (S) -> (I)
+template <typename T, typename U, typename ULimit>
+struct MinGoodImplForStaticCastFromSignedToIntegral
+    : std::conditional_t<std::is_unsigned<U>::value,
+                         stdx::type_identity<ValueIsZero<T>>,
+                         MinGoodImplForStaticCastFromSignedToSigned<T, U, ULimit>> {};
+
+// (S) -> (A)
+template <typename T, typename U, typename ULimit>
+struct MinGoodImplForStaticCastFromSignedToArithmetic
+    : std::conditional_t<
+          std::is_floating_point<U>::value,
+          stdx::type_identity<ValueIsSourceLowestUnlessDestLimitIsHigher<T, U, ULimit>>,
+          MinGoodImplForStaticCastFromSignedToIntegral<T, U, ULimit>> {};
+
+// (I) -> (A)
+template <typename T, typename U, typename ULimit>
+struct MinGoodImplForStaticCastFromIntegralToArithmetic
+    : std::conditional_t<
+          std::is_unsigned<T>::value,
+          stdx::type_identity<ValueIsSourceLowestUnlessDestLimitIsHigher<T, U, ULimit>>,
+          MinGoodImplForStaticCastFromSignedToArithmetic<T, U, ULimit>> {};
+
+// (F) -> (F)
+template <typename T, typename U, typename ULimit>
+struct MinGoodImplForStaticCastFromFloatingPointToFloatingPoint
+    : std::conditional<sizeof(T) <= sizeof(U),
+                       ValueIsSourceLowestUnlessDestLimitIsHigher<T, U, ULimit>,
+                       ValueIsLowestInDestination<T, U, ULimit>> {};
+
+// (F) -> (A)
+template <typename T, typename U, typename ULimit>
+struct MinGoodImplForStaticCastFromFloatingPointToArithmetic
+    : std::conditional_t<std::is_floating_point<U>::value,
+                         MinGoodImplForStaticCastFromFloatingPointToFloatingPoint<T, U, ULimit>,
+                         stdx::type_identity<ValueIsLowestInDestination<T, U, ULimit>>> {};
+
+// (A) -> (A)
+template <typename T, typename U, typename ULimit>
+struct MinGoodImplForStaticCastFromArithmeticToArithmetic
+    : std::conditional_t<std::is_integral<T>::value,
+                         MinGoodImplForStaticCastFromIntegralToArithmetic<T, U, ULimit>,
+                         MinGoodImplForStaticCastFromFloatingPointToArithmetic<T, U, ULimit>> {};
+
+// (A) -> (X)
+template <typename T, typename U, typename ULimit>
+struct MinGoodImplForStaticCastFromArithmetic
+    : std::conditional_t<std::is_arithmetic<U>::value,
+                         MinGoodImplForStaticCastFromArithmeticToArithmetic<T, U, ULimit>,
+                         MinGoodImplForStaticCastFromArithmeticToNonArithmetic<T, U, ULimit>> {};
+
+// (X) -> (X)
+template <typename T, typename U, typename ULimit>
+struct MinGoodImplForStaticCastUsingRealPart
+    : std::conditional_t<
+          std::is_arithmetic<RealPart<T>>::value,
+          MinGoodImplForStaticCastFromArithmetic<RealPart<T>, RealPart<U>, ULimit>,
+          MinGoodImplForStaticCastFromNonArithmetic<RealPart<T>, RealPart<U>, ULimit>> {};
+
+template <typename T, typename U, typename ULimit>
+struct MinGoodImpl<StaticCast<T, U>, ULimit> : MinGoodImplForStaticCastUsingRealPart<T, U, ULimit> {
+};
+
+}  // namespace detail
+}  // namespace au

--- a/au/overflow_boundary_test.cc
+++ b/au/overflow_boundary_test.cc
@@ -1,0 +1,285 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/overflow_boundary.hh"
+
+#include <complex>
+
+#include "au/testing.hh"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::Eq;
+using ::testing::FloatEq;
+using ::testing::IsFalse;
+using ::testing::IsTrue;
+using ::testing::StaticAssertTypeEq;
+
+namespace au {
+namespace detail {
+namespace {
+
+template <typename T>
+struct NoUpperLimit {
+    static constexpr T upper() { return std::numeric_limits<T>::max(); }
+};
+
+template <typename T>
+struct LowerLimitIsZero : NoUpperLimit<T> {
+    static constexpr T lower() { return T{0}; }
+};
+
+template <typename T>
+struct ImplicitLimits {
+    static constexpr T lower() { return std::numeric_limits<T>::lowest(); }
+    static constexpr T upper() { return std::numeric_limits<T>::max(); }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `StaticCast` section:
+
+//
+// `MinGood<StaticCast>`:
+//
+
+TEST(StaticCast, MinGoodIsLowestIfDestinationEqualsSource) {
+    EXPECT_THAT((MinGood<StaticCast<int8_t, int8_t>>::value()),
+                Eq(std::numeric_limits<int8_t>::lowest()));
+
+    EXPECT_THAT((MinGood<StaticCast<uint16_t, uint16_t>>::value()),
+                Eq(std::numeric_limits<uint16_t>::lowest()));
+
+    EXPECT_THAT((MinGood<StaticCast<float, float>>::value()),
+                Eq(std::numeric_limits<float>::lowest()));
+}
+
+TEST(StaticCast, MinGoodIsLowestIfCastWidens) {
+    EXPECT_THAT((MinGood<StaticCast<int8_t, int16_t>>::value()),
+                Eq(std::numeric_limits<int8_t>::lowest()));
+
+    EXPECT_THAT((MinGood<StaticCast<uint8_t, uint16_t>>::value()),
+                Eq(std::numeric_limits<uint8_t>::lowest()));
+
+    EXPECT_THAT((MinGood<StaticCast<float, double>>::value()),
+                Eq(std::numeric_limits<float>::lowest()));
+}
+
+TEST(StaticCast, MinGoodIsZeroFromAnySignedToAnyUnsigned) {
+    EXPECT_THAT((MinGood<StaticCast<int8_t, uint64_t>>::value()), SameTypeAndValue(int8_t{0}));
+    EXPECT_THAT((MinGood<StaticCast<int16_t, uint8_t>>::value()), SameTypeAndValue(int16_t{0}));
+    EXPECT_THAT((MinGood<StaticCast<int32_t, uint32_t>>::value()), SameTypeAndValue(int32_t{0}));
+}
+
+TEST(StaticCast, MinGoodIsZeroFromAnyUnsignedToAnyArithmetic) {
+    EXPECT_THAT((MinGood<StaticCast<uint8_t, int64_t>>::value()), Eq(uint8_t{0}));
+    EXPECT_THAT((MinGood<StaticCast<uint16_t, uint8_t>>::value()), Eq(uint16_t{0}));
+    EXPECT_THAT((MinGood<StaticCast<uint32_t, int16_t>>::value()), Eq(uint32_t{0}));
+    EXPECT_THAT((MinGood<StaticCast<uint64_t, int64_t>>::value()), Eq(uint64_t{0}));
+    EXPECT_THAT((MinGood<StaticCast<uint64_t, float>>::value()), Eq(uint64_t{0}));
+    EXPECT_THAT((MinGood<StaticCast<uint8_t, double>>::value()), Eq(uint8_t{0}));
+}
+
+TEST(StaticCast, MinGoodIsLowestInDestinationWhenNarrowingToSameFamily) {
+    EXPECT_THAT((MinGood<StaticCast<int64_t, int32_t>>::value()),
+                SameTypeAndValue(static_cast<int64_t>(std::numeric_limits<int32_t>::lowest())));
+    EXPECT_THAT((MinGood<StaticCast<double, float>>::value()),
+                SameTypeAndValue(static_cast<double>(std::numeric_limits<float>::lowest())));
+}
+
+TEST(StaticCast, MinGoodIsZeroFromAnyFloatingPointToAnyUnsigned) {
+    EXPECT_THAT((MinGood<StaticCast<double, uint8_t>>::value()), SameTypeAndValue(0.0));
+    EXPECT_THAT((MinGood<StaticCast<float, uint64_t>>::value()), SameTypeAndValue(0.0f));
+}
+
+TEST(StaticCast, MinGoodIsLowestInDestinationFromAnyFloatingPointToAnySigned) {
+    EXPECT_THAT((MinGood<StaticCast<double, int32_t>>::value()),
+                SameTypeAndValue(static_cast<double>(std::numeric_limits<int32_t>::lowest())));
+    EXPECT_THAT((MinGood<StaticCast<float, int64_t>>::value()),
+                SameTypeAndValue(static_cast<float>(std::numeric_limits<int64_t>::lowest())));
+}
+
+TEST(StaticCast, MinGoodIsLowestFromAnySignedToAnyFloatingPoint) {
+    // We could imagine some hypothetical floating point and integral types for which this is not
+    // true.  But floating point is designed to cover a very wide range between its min and max
+    // values, and in practice, this is true for all commonly used floating point and integral
+    // types.
+    EXPECT_THAT((MinGood<StaticCast<int8_t, double>>::value()),
+                Eq(std::numeric_limits<int8_t>::lowest()));
+
+    EXPECT_THAT((MinGood<StaticCast<int64_t, float>>::value()),
+                Eq(std::numeric_limits<int64_t>::lowest()));
+}
+
+TEST(StaticCast, MinGoodUnchangedWithExplicitLimitOfLowestInTargetType) {
+    // What all these test cases have in common is that the destination type is already the most
+    // constraining factor.  Therefore, the only way to add an _explicit_ limit, which nevertheless
+    // does _not_ constrain the answer, is to make that explicit limit equal to the implicit limit:
+    // that is, the lowest value of the destination type.
+
+    EXPECT_THAT((MinGood<StaticCast<int8_t, int8_t>, ImplicitLimits<int8_t>>::value()),
+                Eq(MinGood<StaticCast<int8_t, int8_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<uint16_t, uint16_t>, ImplicitLimits<uint16_t>>::value()),
+                Eq(MinGood<StaticCast<uint16_t, uint16_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<float, float>, ImplicitLimits<float>>::value()),
+                Eq(MinGood<StaticCast<float, float>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<uint32_t, int32_t>, ImplicitLimits<int32_t>>::value()),
+                Eq(MinGood<StaticCast<uint32_t, int32_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<int64_t, uint64_t>, ImplicitLimits<uint64_t>>::value()),
+                Eq(MinGood<StaticCast<int64_t, uint64_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<double, float>, ImplicitLimits<float>>::value()),
+                Eq(MinGood<StaticCast<double, float>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<float, uint64_t>, ImplicitLimits<uint64_t>>::value()),
+                Eq(MinGood<StaticCast<float, uint64_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<float, int64_t>, ImplicitLimits<int64_t>>::value()),
+                Eq(MinGood<StaticCast<float, int64_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<float, int32_t>, ImplicitLimits<int32_t>>::value()),
+                Eq(MinGood<StaticCast<float, int32_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<uint32_t, uint16_t>, ImplicitLimits<uint16_t>>::value()),
+                Eq(MinGood<StaticCast<uint32_t, uint16_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<uint32_t, int8_t>, ImplicitLimits<int8_t>>::value()),
+                Eq(MinGood<StaticCast<uint32_t, int8_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<int64_t, int32_t>, ImplicitLimits<int32_t>>::value()),
+                Eq(MinGood<StaticCast<int64_t, int32_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<int64_t, uint32_t>, ImplicitLimits<uint32_t>>::value()),
+                Eq(MinGood<StaticCast<int64_t, uint32_t>>::value()));
+}
+
+TEST(StaticCast, MinGoodUnchangedWithExplicitLimitLessConstrainingThanExistingResult) {
+    // In these cases, we are applying a non-trivial lower limit (i.e., it is higher than the
+    // `lowest()` value), but it does not constrain the result enough to change it.
+
+    struct DoubleLimitTwiceFloatLowest : NoUpperLimit<double> {
+        static constexpr double lower() {
+            return static_cast<double>(std::numeric_limits<float>::lowest()) * 2.0;
+        }
+    };
+
+    EXPECT_THAT((MinGood<StaticCast<float, double>, DoubleLimitTwiceFloatLowest>::value()),
+                Eq(MinGood<StaticCast<float, double>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<int32_t, double>, DoubleLimitTwiceFloatLowest>::value()),
+                Eq(MinGood<StaticCast<int32_t, double>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<uint16_t, double>, DoubleLimitTwiceFloatLowest>::value()),
+                Eq(MinGood<StaticCast<uint16_t, double>>::value()));
+
+    struct FloatLimitHalfFloatLowest : NoUpperLimit<float> {
+        static constexpr float lower() { return std::numeric_limits<float>::lowest() / 2.0f; }
+    };
+
+    EXPECT_THAT((MinGood<StaticCast<uint64_t, float>, FloatLimitHalfFloatLowest>::value()),
+                Eq(MinGood<StaticCast<uint64_t, float>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<int64_t, float>, FloatLimitHalfFloatLowest>::value()),
+                Eq(MinGood<StaticCast<int64_t, float>>::value()));
+
+    struct SignedLimitHalfInt64Lowest : NoUpperLimit<int64_t> {
+        static constexpr int64_t lower() { return std::numeric_limits<int64_t>::lowest() / 2; }
+    };
+
+    EXPECT_THAT((MinGood<StaticCast<uint32_t, int64_t>, SignedLimitHalfInt64Lowest>::value()),
+                Eq(MinGood<StaticCast<uint32_t, int64_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<int32_t, int64_t>, SignedLimitHalfInt64Lowest>::value()),
+                Eq(MinGood<StaticCast<int32_t, int64_t>>::value()));
+}
+
+TEST(StaticCast, MinGoodUnchangedForUnsignedDestinationAndExplicitLimitOfZero) {
+    EXPECT_THAT((MinGood<StaticCast<uint8_t, uint16_t>, LowerLimitIsZero<uint16_t>>::value()),
+                Eq(MinGood<StaticCast<uint8_t, uint16_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<int32_t, uint64_t>, LowerLimitIsZero<uint64_t>>::value()),
+                Eq(MinGood<StaticCast<int32_t, uint64_t>>::value()));
+
+    EXPECT_THAT((MinGood<StaticCast<double, uint32_t>, LowerLimitIsZero<uint32_t>>::value()),
+                Eq(MinGood<StaticCast<double, uint32_t>>::value()));
+}
+
+TEST(StaticCast, MinGoodCappedByExplicitFloatLimit) {
+    struct FloatLowerLimitMinusOne : NoUpperLimit<float> {
+        static constexpr float lower() { return -1.0f; }
+    };
+
+    EXPECT_THAT((MinGood<StaticCast<int16_t, float>, FloatLowerLimitMinusOne>::value()),
+                SameTypeAndValue(int16_t{-1}));
+
+    EXPECT_THAT((MinGood<StaticCast<int64_t, float>, FloatLowerLimitMinusOne>::value()),
+                SameTypeAndValue(int64_t{-1}));
+
+    EXPECT_THAT((MinGood<StaticCast<float, float>, FloatLowerLimitMinusOne>::value()),
+                SameTypeAndValue(-1.0f));
+
+    EXPECT_THAT((MinGood<StaticCast<double, float>, FloatLowerLimitMinusOne>::value()),
+                SameTypeAndValue(-1.0));
+}
+
+TEST(StaticCast, MinGoodCappedByExplicitDoubleLimit) {
+    struct DoubleLowerLimitMinusOne : NoUpperLimit<double> {
+        static constexpr double lower() { return -1.0; }
+    };
+
+    EXPECT_THAT((MinGood<StaticCast<float, double>, DoubleLowerLimitMinusOne>::value()),
+                SameTypeAndValue(-1.0f));
+}
+
+TEST(StaticCast, MinGoodCappedByExplicitI64Limit) {
+    struct I64LowerLimitMinusOne : NoUpperLimit<int64_t> {
+        static constexpr int64_t lower() { return -1; }
+    };
+
+    EXPECT_THAT((MinGood<StaticCast<int32_t, int64_t>, I64LowerLimitMinusOne>::value()),
+                SameTypeAndValue(int32_t{-1}));
+
+    EXPECT_THAT((MinGood<StaticCast<int64_t, int64_t>, I64LowerLimitMinusOne>::value()),
+                SameTypeAndValue(int64_t{-1}));
+
+    EXPECT_THAT((MinGood<StaticCast<float, int64_t>, I64LowerLimitMinusOne>::value()),
+                SameTypeAndValue(-1.0f));
+}
+
+TEST(StaticCast, MinGoodCappedByExplicitI16Limit) {
+    struct I16LowerLimitMinusOne : NoUpperLimit<int16_t> {
+        static constexpr int16_t lower() { return -1; }
+    };
+
+    EXPECT_THAT((MinGood<StaticCast<int32_t, int16_t>, I16LowerLimitMinusOne>::value()),
+                SameTypeAndValue(int32_t{-1}));
+
+    EXPECT_THAT((MinGood<StaticCast<double, int16_t>, I16LowerLimitMinusOne>::value()),
+                SameTypeAndValue(-1.0));
+}
+
+TEST(StaticCast, MinGoodForComplexOfTProvidesAnswerAsT) {
+    EXPECT_THAT((MinGood<StaticCast<std::complex<float>, std::complex<double>>>::value()),
+                SameTypeAndValue(std::numeric_limits<float>::lowest()));
+
+    EXPECT_THAT((MinGood<StaticCast<std::complex<double>, std::complex<float>>>::value()),
+                SameTypeAndValue(static_cast<double>(std::numeric_limits<float>::lowest())));
+}
+
+}  // namespace
+}  // namespace detail
+}  // namespace au


### PR DESCRIPTION
The new `:overflow_boundary` target will check any operation (from
`:abstract_operations`) and find the minimum and maximum acceptable
value.  Here, we are starting with `StaticCast` only, and `MinGood`
only, to get us up and running.  (The final implementation for all
operations is currently almost 900 lines of code and almost 1600 lines
of tests!)

Strategically, we're thinking about non-arithmetic reps too (#52), even
though we're not ready to actually support them formally.  The strategy
will be to ask any supplier of a non-arithmetic rep to carefully
specialize `std::numeric_limits`.  Then, we'll rely on the answers they
give to judge overflow or truncation risk.  If they don't give answers,
we'll just assume conversions are risky.  `std::numeric_limits` is
probably pretty flawed in general, but I think this will be far more
workable than asking users of a non-arithmetic rep to specialize Au
specific traits.

One other important distinction is that these traits don't return their
values in `OpInput<T>`, but in `RealPart<OpInput<T>>`.  If we think
about, say, a full complex number, then notions of "max" and "min" don't
even make sense, because complex numbers are not ordered!  In fact, we
expect to replace `RealPart<T>` with a more general notion of
`ScalarPart<T>` in order to support #70, because the same considerations
apply to vectors and matrices.  But we will save that for when we are
ready to tackle #70 in earnest.

Helps #349.