### PR TITLE
Implement `MinGood<MultiplyTypeBy<T, M>>`

### DIFF
--- a/au/overflow_boundary.hh
+++ b/au/overflow_boundary.hh
@@ -238,14 +238,13 @@ struct ValueOfMaxFloatNotExceedingMaxInt {
     }
 };
 
-template <typename T, typename MagT, MagRepresentationOutcome>
+template <typename T, typename MagT, MagRepresentationOutcome Outcome>
 struct MagHelper {
     static constexpr T div(const T &, const T &) {
-        // We assume the most likely reason to be here is that the magnitude was too large to
-        // represent in the type, so we treat this as a "divide by infinity" and return zero.
-        //
-        // Really, this should probably just not be called, but it definitely needs to exist for the
-        // code to compile.
+        static_assert(Outcome == MagRepresentationOutcome::ERR_CANNOT_FIT,
+                      "Internal library error");
+
+        // Dividing by a number that is too big to fit in the type implies a result of 0.
         return T{0};
     }
 };

--- a/au/overflow_boundary_test.cc
+++ b/au/overflow_boundary_test.cc
@@ -31,6 +31,8 @@ namespace au {
 namespace detail {
 namespace {
 
+constexpr auto PI = Magnitude<Pi>{};
+
 template <typename T>
 struct NoUpperLimit {
     static constexpr T upper() { return std::numeric_limits<T>::max(); }
@@ -51,6 +53,86 @@ struct ImplicitLimits {
     static constexpr T lower() { return std::numeric_limits<T>::lowest(); }
     static constexpr T upper() { return std::numeric_limits<T>::max(); }
 };
+
+template <typename T, typename M>
+MultiplyTypeBy<T, M> multiply_type_by(M) {
+    return MultiplyTypeBy<T, M>{};
+}
+
+template <typename Op>
+auto min_good_value(Op) {
+    return MinGood<Op>::value();
+}
+
+template <typename Op, typename Limits>
+auto min_good_value(Op, Limits) {
+    return MinGood<Op, Limits>::value();
+}
+
+template <bool IsPositive>
+struct MagSignIfPositiveIs : stdx::type_identity<Magnitude<>> {};
+template <>
+struct MagSignIfPositiveIs<false> : stdx::type_identity<Magnitude<Negative>> {};
+template <bool IsPositive>
+constexpr auto mag_sign_if_positive_is() {
+    return typename MagSignIfPositiveIs<IsPositive>::type{};
+}
+
+// Handy little utility to turn an arbitrary floating point number into a Magnitude.
+template <typename T, typename ValConst>
+struct MagFromFloatingPointConstantImpl {
+    static_assert(std::is_floating_point<T>::value,
+                  "Must be floating point (internal library error)");
+
+    struct Breakdown {
+        bool is_positive = true;
+        uint64_t coeff = 0u;
+        int64_t exp = 0;
+
+        constexpr Breakdown() = default;
+    };
+
+    static constexpr Breakdown breakdown() {
+        T x = ValConst::value();
+
+        Breakdown result;
+
+        result.is_positive = (x >= T{0});
+        if (!result.is_positive) {
+            x = -x;
+        }
+
+        while (x > static_cast<T>(std::numeric_limits<uint64_t>::max())) {
+            x /= T{2};
+            ++result.exp;
+        }
+        while (result.exp > 64 && static_cast<T>(static_cast<uint64_t>(x)) != x) {
+            x *= T{2};
+            --result.exp;
+        }
+
+        result.coeff = static_cast<uint64_t>(x);
+        return result;
+    }
+
+    static constexpr auto value() {
+        constexpr auto params = breakdown();
+        return mag_sign_if_positive_is<params.is_positive>() * mag<params.coeff>() *
+               pow<params.exp>(mag<2>());
+    }
+
+    using type = decltype(value());
+};
+
+template <typename Float>
+constexpr auto lowest_floating_point_as_mag() {
+    return MagFromFloatingPointConstantImpl<Float, ValueOfLowestInDestination<Float>>::value();
+}
+
+template <typename Float>
+constexpr auto highest_floating_point_as_mag() {
+    return MagFromFloatingPointConstantImpl<Float, ValueOfHighestInDestination<Float>>::value();
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `StaticCast` section:
@@ -633,6 +715,204 @@ TEST(StaticCast, MaxGoodForComplexOfTProvidesAnswerAsT) {
 
     EXPECT_THAT((MaxGood<StaticCast<std::complex<double>, std::complex<float>>>::value()),
                 SameTypeAndValue(static_cast<double>(std::numeric_limits<float>::max())));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `MultiplyTypeBy` section:
+
+//
+// `MinGood<MultiplyTypeBy>`:
+//
+
+TEST(MultiplyTypeBy, MinGoodForUnsignedIsAlwaysZero) {
+    EXPECT_THAT(min_good_value(multiply_type_by<uint8_t>(mag<1>())), SameTypeAndValue(uint8_t{0}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<uint16_t>(mag<123>())),
+                SameTypeAndValue(uint16_t{0}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<uint32_t>(mag<1>() / mag<234>())),
+                SameTypeAndValue(uint32_t{0}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<uint64_t>(-mag<1>())),
+                SameTypeAndValue(uint64_t{0}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<uint64_t>(-mag<543>())),
+                SameTypeAndValue(uint64_t{0}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<uint64_t>(-mag<1>() / mag<2>())),
+                SameTypeAndValue(uint64_t{0}));
+}
+
+TEST(MultiplyTypeBy, MinGoodForUnlimitedSignedTimesPosIntIsLowerLimitDivByMag) {
+    EXPECT_THAT(min_good_value(multiply_type_by<int8_t>(mag<1>())), SameTypeAndValue(int8_t{-128}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int8_t>(mag<64>())), SameTypeAndValue(int8_t{-2}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int8_t>(mag<65>())), SameTypeAndValue(int8_t{-1}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int8_t>(mag<127>())), SameTypeAndValue(int8_t{-1}));
+}
+
+TEST(MultiplyTypeBy, MinGoodForUnlimitedSignedTimesNegativeIntIsUpperLimitDivByMag) {
+    EXPECT_THAT(min_good_value(multiply_type_by<int8_t>(-mag<1>())),
+                SameTypeAndValue(int8_t{-127}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int8_t>(-mag<63>())), SameTypeAndValue(int8_t{-2}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int8_t>(-mag<64>())), SameTypeAndValue(int8_t{-1}));
+}
+
+TEST(MultiplyTypeBy, MinGoodForUnlimitedFloatTimesPosIrrationalBiggerThanOneIsLowerLimitDivByMag) {
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(PI)),
+                FloatEq(std::numeric_limits<float>::lowest() / get_value<float>(PI)));
+}
+
+TEST(MultiplyTypeBy, MinGoodForUnlimitedFloatTimesNegIrrationalBiggerThanOneIsUpperLimitDivByMag) {
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(-PI)),
+                FloatEq(std::numeric_limits<float>::max() / get_value<float>(-PI)));
+}
+
+TEST(MultiplyTypeBy, MinGoodForUnlimitedFloatTimesPosIrrationalSmallerThanOneIsLowerLimit) {
+    constexpr auto m = mag<1>() / PI;
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(m)),
+                SameTypeAndValue(std::numeric_limits<float>::lowest()));
+}
+
+TEST(MultiplyTypeBy, MinGoodForUnlimitedFloatTimesNegIrrationalSmallerThanOneIsNegUpperLimit) {
+    constexpr auto m = -mag<1>() / PI;
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(m)),
+                SameTypeAndValue(-std::numeric_limits<float>::max()));
+}
+
+TEST(MultiplyTypeBy, MinGoodForUnlimitedIntTimesPosIrrationalIsZeroAsAPlaceholder) {
+    // We can't even compute the overflow boundary for this kind of operation yet, so just return an
+    // extremely conservative result of 0.
+    EXPECT_THAT(min_good_value(multiply_type_by<int32_t>(PI)), SameTypeAndValue(int32_t{0}));
+}
+
+TEST(MultiplyTypeBy, MinGoodForSignedTimesPosIntIsLowerLimitDivByMag) {
+    struct I32LowerLimitMinus24 : NoUpperLimit<int32_t> {
+        static constexpr int32_t lower() { return -24; }
+    };
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int32_t>(mag<1>()), I32LowerLimitMinus24{}),
+                SameTypeAndValue(int32_t{-24}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int32_t>(mag<8>()), I32LowerLimitMinus24{}),
+                SameTypeAndValue(int32_t{-3}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int32_t>(mag<24>()), I32LowerLimitMinus24{}),
+                SameTypeAndValue(int32_t{-1}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int32_t>(mag<25>()), I32LowerLimitMinus24{}),
+                SameTypeAndValue(int32_t{0}));
+}
+
+TEST(MultiplyTypeBy, MinGoodForSignedTimesNegIntIsUpperLimitDivByMag) {
+    struct I32UpperLimit24 : NoLowerLimit<int32_t> {
+        static constexpr int32_t upper() { return 24; }
+    };
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int32_t>(-mag<1>()), I32UpperLimit24{}),
+                SameTypeAndValue(int32_t{-24}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int32_t>(-mag<8>()), I32UpperLimit24{}),
+                SameTypeAndValue(int32_t{-3}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int32_t>(-mag<24>()), I32UpperLimit24{}),
+                SameTypeAndValue(int32_t{-1}));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<int32_t>(-mag<25>()), I32UpperLimit24{}),
+                SameTypeAndValue(int32_t{0}));
+}
+
+TEST(MultiplyTypeBy, MinGoodForFloatTimesPosIntIsLowerLimitDivByMag) {
+    struct FloatLowerLimitMinus64 : NoUpperLimit<float> {
+        static constexpr float lower() { return -64.0f; }
+    };
+
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(mag<1>()), FloatLowerLimitMinus64{}),
+                SameTypeAndValue(-64.0f));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(mag<8>()), FloatLowerLimitMinus64{}),
+                SameTypeAndValue(-8.0f));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(mag<64>()), FloatLowerLimitMinus64{}),
+                SameTypeAndValue(-1.0f));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(mag<128>()), FloatLowerLimitMinus64{}),
+                SameTypeAndValue(-0.5f));
+}
+
+TEST(MultiplyTypeBy, MinGoodForFloatTimesNegIntIsUpperLimitDivByMag) {
+    struct FloatUpperLimit64 : NoLowerLimit<float> {
+        static constexpr float upper() { return 64.0f; }
+    };
+
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(-mag<1>()), FloatUpperLimit64{}),
+                SameTypeAndValue(-64.0f));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(-mag<8>()), FloatUpperLimit64{}),
+                SameTypeAndValue(-8.0f));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(-mag<64>()), FloatUpperLimit64{}),
+                SameTypeAndValue(-1.0f));
+
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(-mag<128>()), FloatUpperLimit64{}),
+                SameTypeAndValue(-0.5f));
+}
+
+TEST(MultiplyTypeBy, MinGoodForFloatTimesPosIrrationalBiggerThanOneIsLowerLimitDivByMag) {
+    struct FloatLowerLimitMinus64 : NoUpperLimit<float> {
+        static constexpr float lower() { return -64.0f; }
+    };
+
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(PI), FloatLowerLimitMinus64{}),
+                FloatEq(-64.0f / get_value<float>(PI)));
+}
+
+TEST(MultiplyTypeBy, MinGoodForFloatTimesNegIrrationalBiggerThanOneIsUpperLimitDivByMag) {
+    struct FloatUpperLimit64 : NoLowerLimit<float> {
+        static constexpr float upper() { return 64.0f; }
+    };
+
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(-PI), FloatUpperLimit64{}),
+                FloatEq(64.0f / get_value<float>(-PI)));
+}
+
+TEST(MultiplyTypeBy, MinGoodForFloatTimesPosIrrationalSmallerThanOneIsClampedLowerLimit) {
+    struct FloatLowerLimitMinus64 : NoUpperLimit<float> {
+        static constexpr float lower() { return -64.0f; }
+    };
+
+    constexpr auto m_no_clamping = mag<1>() / PI;
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(m_no_clamping), FloatLowerLimitMinus64{}),
+                FloatEq(-64.0f / get_value<float>(m_no_clamping)));
+
+    constexpr auto m_clamping = mag<16>() * PI / highest_floating_point_as_mag<float>();
+    ASSERT_THAT(is_positive(m_clamping), IsTrue());
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(m_clamping), FloatLowerLimitMinus64{}),
+                SameTypeAndValue(std::numeric_limits<float>::lowest()));
+}
+
+TEST(MultiplyTypeBy, MinGoodForFloatTimesNegIrrationalSmallerThanOneIsClampedUpperLimit) {
+    struct FloatUpperLimit64 : NoLowerLimit<float> {
+        static constexpr float upper() { return 64.0f; }
+    };
+
+    constexpr auto m_no_clamping = -mag<1>() / PI;
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(m_no_clamping), FloatUpperLimit64{}),
+                FloatEq(64.0f / get_value<float>(m_no_clamping)));
+
+    constexpr auto m_clamping = mag<16>() * PI / lowest_floating_point_as_mag<float>();
+    ASSERT_THAT(is_positive(m_clamping), IsFalse());
+    EXPECT_THAT(min_good_value(multiply_type_by<float>(m_clamping), FloatUpperLimit64{}),
+                SameTypeAndValue(-std::numeric_limits<float>::max()));
+}
+
+TEST(MultiplyTypeBy, MinGoodForComplexOfTProvidesAnswerAsT) {
+    EXPECT_THAT(min_good_value(multiply_type_by<std::complex<int32_t>>(mag<12>())),
+                SameTypeAndValue(min_good_value(multiply_type_by<int32_t>(mag<12>()))));
 }
 
 }  // namespace


### PR DESCRIPTION
If `T` is unsigned, this should always be 0 (because 0 is the minimum
_possible_, and 0 is _always_ "good").  Otherwise, we check whether `M`
is "the sort of thing" that can be represented in `T`.  If not, well, we
just return 0 as a placeholder.  If it _is_ compatible, we _divide_ the
limits by the magnitude, and take whichever is lower --- unless the
result would be lower than the minimum value of the type, in which case
we clamp it.

Helps #349.