### PR TITLE
Implement `MaxGood<MultiplyTypeBy<T, M>>`

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -435,6 +435,7 @@ cc_library(
     deps = [
         ":abstract_operations",
         ":magnitude",
+        ":operators",
         ":stdx",
     ],
 )

--- a/au/overflow_boundary.hh
+++ b/au/overflow_boundary.hh
@@ -19,6 +19,7 @@
 
 #include "au/abstract_operations.hh"
 #include "au/magnitude.hh"
+#include "au/operators.hh"
 #include "au/stdx/type_traits.hh"
 
 // These utilities help assess overflow risk for an operation `Op` by finding the minimum and
@@ -133,6 +134,17 @@ struct LowerLimit<T, void> {
     static constexpr T value() { return std::numeric_limits<T>::lowest(); }
 };
 
+template <typename T>
+constexpr T clamped_negate(T x) {
+    if (Less{}(x, T{0}) && Less{}(x, -std::numeric_limits<T>::max())) {
+        return std::numeric_limits<T>::max();
+    }
+    if (Greater{}(x, T{0}) && Greater{}(x, clamped_negate(std::numeric_limits<T>::lowest()))) {
+        return std::numeric_limits<T>::lowest();
+    }
+    return -x;
+}
+
 // Inherit from this struct to produce a compiler error in case we try to use a combination of types
 // that isn't yet supported.
 template <typename T>
@@ -240,6 +252,7 @@ struct ValueOfMaxFloatNotExceedingMaxInt {
 
 template <typename T, typename MagT, MagRepresentationOutcome Outcome>
 struct MagHelper {
+    static constexpr bool equal(const T &, const T &) { return false; }
     static constexpr T div(const T &, const T &) {
         static_assert(Outcome == MagRepresentationOutcome::ERR_CANNOT_FIT,
                       "Internal library error");
@@ -251,6 +264,7 @@ struct MagHelper {
 
 template <typename T, typename MagT>
 struct MagHelper<T, MagT, MagRepresentationOutcome::OK> {
+    static constexpr bool equal(const T &x, const T &value) { return x == value; }
     static constexpr T div(const T &a, const T &b) { return a / b; }
 };
 
@@ -288,12 +302,14 @@ struct ClampLowestOfLimitsTimesInverseValue {
     static constexpr T value() {
         constexpr auto ABS_DIVISOR = MagInverseT<Abs<M>>{};
 
-        constexpr T RELEVANT_LIMIT =
-            IsPositive<M>::value ? LowerLimit<T, Limits>::value() : -UpperLimit<T, Limits>::value();
+        constexpr T RELEVANT_LIMIT = IsPositive<M>::value
+                                         ? LowerLimit<T, Limits>::value()
+                                         : clamped_negate(UpperLimit<T, Limits>::value());
 
         constexpr T RELEVANT_BOUND =
-            IsPositive<M>::value ? divide_by_mag(std::numeric_limits<T>::lowest(), ABS_DIVISOR)
-                                 : -divide_by_mag(std::numeric_limits<T>::max(), ABS_DIVISOR);
+            IsPositive<M>::value
+                ? divide_by_mag(std::numeric_limits<T>::lowest(), ABS_DIVISOR)
+                : clamped_negate(divide_by_mag(std::numeric_limits<T>::max(), ABS_DIVISOR));
         constexpr bool SHOULD_CLAMP = RELEVANT_BOUND >= RELEVANT_LIMIT;
 
         // This value will be meaningless if `get_value_result<T>(ABS_DIVISOR).outcome` is not `OK`,
@@ -301,6 +317,53 @@ struct ClampLowestOfLimitsTimesInverseValue {
         constexpr auto ABS_DIVISOR_AS_T = get_value_result<T>(ABS_DIVISOR).value;
 
         return SHOULD_CLAMP ? std::numeric_limits<T>::lowest() : RELEVANT_LIMIT * ABS_DIVISOR_AS_T;
+    }
+};
+
+template <typename T, typename... BPs>
+constexpr bool mag_representation_equals(const T &x, Magnitude<BPs...> m) {
+    constexpr auto result = get_value_result<T>(m);
+    return MagHelper<T, Magnitude<BPs...>, result.outcome>::equal(x, result.value);
+}
+
+// Name reads as "highest of (limits divided by value)".  Remember that the value can be negative,
+// so we just take whichever limit is larger _after_ dividing.  And since `Abs<M>` can be assumed to
+// be greater than one, we know that dividing by `M` will shrink values, so we don't risk overflow.
+template <typename T, typename M, typename Limits>
+struct HighestOfLimitsDividedByValue {
+    static constexpr T value() {
+        if (mag_representation_equals(LowerLimit<T, Limits>::value(), M{})) {
+            return T{1};
+        }
+
+        return (IsPositive<M>::value)
+                   ? divide_by_mag(UpperLimit<T, Limits>::value(), M{})
+                   : clamped_negate(divide_by_mag(LowerLimit<T, Limits>::value(), Abs<M>{}));
+    }
+};
+
+// Name reads as "clamp highest of (limits times inverse value)".  See comments for
+// `ClampLowestOfLimitsTimesInverseValue` for more details on the motivation and logic.
+template <typename T, typename M, typename Limits>
+struct ClampHighestOfLimitsTimesInverseValue {
+    static constexpr T value() {
+        constexpr auto ABS_DIVISOR = MagInverseT<Abs<M>>{};
+
+        constexpr T RELEVANT_LIMIT = IsPositive<M>::value
+                                         ? UpperLimit<T, Limits>::value()
+                                         : clamped_negate(LowerLimit<T, Limits>::value());
+
+        constexpr T RELEVANT_BOUND =
+            IsPositive<M>::value
+                ? divide_by_mag(std::numeric_limits<T>::max(), ABS_DIVISOR)
+                : clamped_negate(divide_by_mag(std::numeric_limits<T>::lowest(), ABS_DIVISOR));
+        constexpr bool SHOULD_CLAMP = RELEVANT_BOUND <= RELEVANT_LIMIT;
+
+        // This value will be meaningless if `get_value_result<T>(ABS_DIVISOR).outcome` is not `OK`,
+        // but we won't end up actually using the value in those cases.
+        constexpr auto ABS_DIVISOR_AS_T = get_value_result<T>(ABS_DIVISOR).value;
+
+        return SHOULD_CLAMP ? std::numeric_limits<T>::max() : RELEVANT_LIMIT * ABS_DIVISOR_AS_T;
     }
 };
 
@@ -506,6 +569,33 @@ struct MinGoodImplForMultiplyTypeByUsingRealPart
 template <typename T, typename M, typename Limits>
 struct MinGoodImpl<MultiplyTypeBy<T, M>, Limits>
     : MinGoodImplForMultiplyTypeByUsingRealPart<RealPart<T>, M, Limits> {};
+
+//
+// `MaxGood<MultiplyTypeBy<T, M>>` implementation cluster.
+//
+
+template <typename T, typename M, typename Limits>
+struct MaxGoodImplForMultiplyCompatibleTypeBy
+    : std::conditional<IsClampingRequired<T, M>::value,
+                       ClampHighestOfLimitsTimesInverseValue<T, M, Limits>,
+                       HighestOfLimitsDividedByValue<T, M, Limits>> {};
+
+template <typename T, typename M, typename Limits>
+struct MaxGoodImplForMultiplyTypeByAssumingSignedTypeOrPositiveFactor
+    : std::conditional_t<IsCompatibleApartFromMaybeOverflow<T, M>::value,
+                         MaxGoodImplForMultiplyCompatibleTypeBy<T, M, Limits>,
+                         stdx::type_identity<ValueOfZero<T>>> {};
+
+template <typename T, typename M, typename Limits>
+struct MaxGoodImplForMultiplyTypeByUsingRealPart
+    : std::conditional_t<
+          stdx::conjunction<IsDefinitelyUnsigned<T>, stdx::negation<IsPositive<M>>>::value,
+          stdx::type_identity<ValueOfZero<T>>,
+          MaxGoodImplForMultiplyTypeByAssumingSignedTypeOrPositiveFactor<T, M, Limits>> {};
+
+template <typename T, typename M, typename Limits>
+struct MaxGoodImpl<MultiplyTypeBy<T, M>, Limits>
+    : MaxGoodImplForMultiplyTypeByUsingRealPart<RealPart<T>, M, Limits> {};
 
 }  // namespace detail
 }  // namespace au

--- a/au/overflow_boundary_test.cc
+++ b/au/overflow_boundary_test.cc
@@ -69,6 +69,16 @@ auto min_good_value(Op, Limits) {
     return MinGood<Op, Limits>::value();
 }
 
+template <typename Op>
+auto max_good_value(Op) {
+    return MaxGood<Op>::value();
+}
+
+template <typename Op, typename Limits>
+auto max_good_value(Op, Limits) {
+    return MaxGood<Op, Limits>::value();
+}
+
 template <bool IsPositive>
 struct MagSignIfPositiveIs : stdx::type_identity<Magnitude<>> {};
 template <>
@@ -913,6 +923,255 @@ TEST(MultiplyTypeBy, MinGoodForFloatTimesNegIrrationalSmallerThanOneIsClampedUpp
 TEST(MultiplyTypeBy, MinGoodForComplexOfTProvidesAnswerAsT) {
     EXPECT_THAT(min_good_value(multiply_type_by<std::complex<int32_t>>(mag<12>())),
                 SameTypeAndValue(min_good_value(multiply_type_by<int32_t>(mag<12>()))));
+}
+
+//
+// `MaxGood<MultiplyTypeBy>`:
+//
+
+TEST(MultiplyTypeBy, MaxGoodForUnsignedIsAlwaysZeroIfMagIsNegative) {
+    EXPECT_THAT(max_good_value(multiply_type_by<uint8_t>(-mag<1>())), SameTypeAndValue(uint8_t{0}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<uint16_t>(-mag<123>())),
+                SameTypeAndValue(uint16_t{0}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<uint32_t>(-mag<1>() / mag<234>())),
+                SameTypeAndValue(uint32_t{0}));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForUnlimitedUnsignedTimesPosIntIsUpperLimitDivByMag) {
+    EXPECT_THAT(max_good_value(multiply_type_by<uint8_t>(mag<1>())),
+                SameTypeAndValue(uint8_t{255}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<uint8_t>(mag<127>())),
+                SameTypeAndValue(uint8_t{2}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<uint8_t>(mag<128>())),
+                SameTypeAndValue(uint8_t{1}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<uint8_t>(mag<255>())),
+                SameTypeAndValue(uint8_t{1}));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForUnlimitedSignedTimesPosIntIsUpperLimitDivByMag) {
+    EXPECT_THAT(max_good_value(multiply_type_by<int8_t>(mag<1>())), SameTypeAndValue(int8_t{127}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int8_t>(mag<63>())), SameTypeAndValue(int8_t{2}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int8_t>(mag<64>())), SameTypeAndValue(int8_t{1}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int8_t>(mag<127>())), SameTypeAndValue(int8_t{1}));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForUnlimitedSignedTimesNegIntIsLowerLimitDivByMag) {
+    EXPECT_THAT(max_good_value(multiply_type_by<int8_t>(-mag<1>())), SameTypeAndValue(int8_t{127}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int8_t>(-mag<2>())), SameTypeAndValue(int8_t{64}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int8_t>(-mag<64>())), SameTypeAndValue(int8_t{2}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int8_t>(-mag<65>())), SameTypeAndValue(int8_t{1}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int8_t>(-mag<127>())), SameTypeAndValue(int8_t{1}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int8_t>(-mag<128>())), SameTypeAndValue(int8_t{1}));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForUnlimitedFloatTimesPosIrrationalBiggerThanOneIsUpperLimitDivByMag) {
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(PI)),
+                FloatEq(std::numeric_limits<float>::max() / get_value<float>(PI)));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForUnlimitedFloatTimesNegIrrationalBiggerThanOneIsLowerLimitDivByMag) {
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(-PI)),
+                FloatEq(std::numeric_limits<float>::lowest() / get_value<float>(-PI)));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForUnlimitedFloatTimesPosIrrationalSmallerThanOneIsUpperLimit) {
+    constexpr auto m = mag<1>() / PI;
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(m)),
+                SameTypeAndValue(std::numeric_limits<float>::max()));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForUnlimitedFloatTimesNegIrrationalSmallerThanOneIsNegLowerLimit) {
+    constexpr auto m = -mag<1>() / PI;
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(m)),
+                SameTypeAndValue(-std::numeric_limits<float>::lowest()));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForSignedTimesPosIntIsUpperLimitDivByMag) {
+    struct I32UpperLimit24 : NoLowerLimit<int32_t> {
+        static constexpr int32_t upper() { return 24; }
+    };
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int32_t>(mag<1>()), I32UpperLimit24{}),
+                SameTypeAndValue(int32_t{24}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int32_t>(mag<8>()), I32UpperLimit24{}),
+                SameTypeAndValue(int32_t{3}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int32_t>(mag<24>()), I32UpperLimit24{}),
+                SameTypeAndValue(int32_t{1}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int32_t>(mag<25>()), I32UpperLimit24{}),
+                SameTypeAndValue(int32_t{0}));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForSignedTimesNegIntIsLowerLimitDivByMag) {
+    struct I32LowerLimitMinus24 : NoUpperLimit<int32_t> {
+        static constexpr int32_t lower() { return -24; }
+    };
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int32_t>(-mag<1>()), I32LowerLimitMinus24{}),
+                SameTypeAndValue(int32_t{24}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int32_t>(-mag<8>()), I32LowerLimitMinus24{}),
+                SameTypeAndValue(int32_t{3}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int32_t>(-mag<24>()), I32LowerLimitMinus24{}),
+                SameTypeAndValue(int32_t{1}));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<int32_t>(-mag<25>()), I32LowerLimitMinus24{}),
+                SameTypeAndValue(int32_t{0}));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForSignedTimesNumericLimitsLowestIsZeroIfNontrivialLowerLimit) {
+    // Use the most liberal nontrivial lower limit imaginable.
+    struct I32LowerLimitOfNegativeUpperLimit : NoUpperLimit<int32_t> {
+        static constexpr int32_t lower() { return -std::numeric_limits<int32_t>::max(); }
+    };
+
+    constexpr auto I32_LOWEST =
+        -mag<static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) + 1u>();
+
+    // To ensure test validity, make sure we get a nonzero value if the limits are trivial.
+    ASSERT_THAT(max_good_value(multiply_type_by<int32_t>(I32_LOWEST)),
+                SameTypeAndValue(int32_t{1}));
+
+    EXPECT_THAT(
+        max_good_value(multiply_type_by<int32_t>(I32_LOWEST), I32LowerLimitOfNegativeUpperLimit{}),
+        SameTypeAndValue(int32_t{0}));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForUnlimitedIntTimesPosIrrationalIsZeroAsAPlaceholder) {
+    // We can't even compute the overflow boundary for this kind of operation yet, so just return an
+    // extremely conservative result of 0.
+    EXPECT_THAT(max_good_value(multiply_type_by<int32_t>(PI)), SameTypeAndValue(int32_t{0}));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForFloatTimesPosIntIsUpperLimitDivByMag) {
+    struct FloatUpperLimit64 : NoLowerLimit<float> {
+        static constexpr float upper() { return 64.0f; }
+    };
+
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(mag<1>()), FloatUpperLimit64{}),
+                SameTypeAndValue(64.0f));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(mag<8>()), FloatUpperLimit64{}),
+                SameTypeAndValue(8.0f));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(mag<64>()), FloatUpperLimit64{}),
+                SameTypeAndValue(1.0f));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(mag<128>()), FloatUpperLimit64{}),
+                SameTypeAndValue(0.5f));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForFloatTimesNegIntIsLowerLimitDivByMag) {
+    struct FloatLowerLimitMinus64 : NoUpperLimit<float> {
+        static constexpr float lower() { return -64.0f; }
+    };
+
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(-mag<1>()), FloatLowerLimitMinus64{}),
+                SameTypeAndValue(64.0f));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(-mag<8>()), FloatLowerLimitMinus64{}),
+                SameTypeAndValue(8.0f));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(-mag<64>()), FloatLowerLimitMinus64{}),
+                SameTypeAndValue(1.0f));
+
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(-mag<128>()), FloatLowerLimitMinus64{}),
+                SameTypeAndValue(0.5f));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForFloatTimesPosIrrationalBiggerThanOneIsUpperLimitDivByMag) {
+    struct FloatUpperLimit64 : NoLowerLimit<float> {
+        static constexpr float upper() { return 64.0f; }
+    };
+
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(PI), FloatUpperLimit64{}),
+                FloatEq(64.0f / get_value<float>(PI)));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForFloatTimesNegIrrationalBiggerThanOneIsLowerLimitDivByMag) {
+    struct FloatLowerLimitMinus64 : NoUpperLimit<float> {
+        static constexpr float lower() { return -64.0f; }
+    };
+
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(-PI), FloatLowerLimitMinus64{}),
+                FloatEq(-64.0f / get_value<float>(-PI)));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForFloatTimesPosIrrationalSmallerThanOneIsClampedUpperLimit) {
+    struct FloatUpperLimit64 : NoLowerLimit<float> {
+        static constexpr float upper() { return 64.0f; }
+    };
+
+    constexpr auto m_no_clamping = mag<1>() / PI;
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(m_no_clamping), FloatUpperLimit64{}),
+                FloatEq(64.0f / get_value<float>(m_no_clamping)));
+
+    constexpr auto m_clamping = mag<16>() * PI / highest_floating_point_as_mag<float>();
+    ASSERT_THAT(is_positive(m_clamping), IsTrue());
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(m_clamping), FloatUpperLimit64{}),
+                SameTypeAndValue(std::numeric_limits<float>::max()));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForFloatTimesNegIrrationalSmallerThanOneIsClampedLowerLimit) {
+    struct FloatLowerLimitMinus64 : NoUpperLimit<float> {
+        static constexpr float lower() { return -64.0f; }
+    };
+
+    constexpr auto m_no_clamping = -mag<1>() / PI;
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(m_no_clamping), FloatLowerLimitMinus64{}),
+                FloatEq(-64.0f / get_value<float>(m_no_clamping)));
+
+    constexpr auto m_clamping = mag<16>() * PI / lowest_floating_point_as_mag<float>();
+    ASSERT_THAT(is_positive(m_clamping), IsFalse());
+    EXPECT_THAT(max_good_value(multiply_type_by<float>(m_clamping), FloatLowerLimitMinus64{}),
+                SameTypeAndValue(-std::numeric_limits<float>::lowest()));
+}
+
+TEST(MultiplyTypeBy, MaxGoodForComplexOfTProvidesAnswerAsT) {
+    EXPECT_THAT(max_good_value(multiply_type_by<std::complex<int32_t>>(mag<12>())),
+                SameTypeAndValue(max_good_value(multiply_type_by<int32_t>(mag<12>()))));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `clamped_negate()` section
+
+TEST(ClampedNegate, SimplyNegatesWhenLimitsOfTypeAreNotRelevant) {
+    EXPECT_THAT(clamped_negate(15), SameTypeAndValue(-15));
+    EXPECT_THAT(clamped_negate(-15), SameTypeAndValue(15));
+}
+
+TEST(ClampedNegate, ClampsSignedIntMinToIntMax) {
+    EXPECT_THAT(clamped_negate(int8_t{-128}), SameTypeAndValue(int8_t{127}));
+
+    EXPECT_THAT(clamped_negate(int16_t{-32768}), SameTypeAndValue(int16_t{32767}));
+
+    EXPECT_THAT(clamped_negate(int32_t{-2147483648}), SameTypeAndValue(int32_t{2147483647}));
+}
+
+TEST(ClampedNegate, MapsAnyUnsignedInputToZero) {
+    EXPECT_THAT(clamped_negate(123u), SameTypeAndValue(0u));
+
+    EXPECT_THAT(clamped_negate(uint64_t{123'456'789'012'345'678u}), SameTypeAndValue(uint64_t{0}));
+}
+
+TEST(ClampedNegate, SupportsFloatingPointBySimplyNegating) {
+    EXPECT_THAT(clamped_negate(3.14f), FloatEq(-3.14f));
 }
 
 }  // namespace


### PR DESCRIPTION
The main hurdle here is that for signed integral types, the minimum
value is more negative than the max value is positive.  To deal with
this, we add a `clamped_negate(T)` function, which negates the input,
but saturates at the limits of the type.  We use it consistently in a
few other places where it makes sense.

We also add an `equal` function to the `MagHelper`, so that we can
seamlessly check whether a value in a given type happens to equal a
`Magnitude`.  This again helps us deal with this hurdle that we have
with signed integral types.

With these helpers in hand, we can implement `MaxGood` using a very
similar strategy as for `MinGood`.  The only substantive difference is
that `MinGood` automatically returns `0` for all unsigned types period,
but `MaxGood` only does this for an unsigned type _with a negative scale
factor_.

Helps #349.