### PR TITLE
Implement limits for `OpSequence`

### DIFF
--- a/au/overflow_boundary.hh
+++ b/au/overflow_boundary.hh
@@ -655,12 +655,11 @@ struct MaxGoodImpl<DivideTypeByInteger<T, M>, Limits>
 //
 
 template <typename OnlyOp, typename Limits>
-struct MinGoodImpl<OpSequenceImpl<OnlyOp>, Limits> : stdx::type_identity<MinGood<OnlyOp, Limits>> {
-};
+struct MinGoodImpl<OpSequenceImpl<OnlyOp>, Limits> : MinGoodImpl<OnlyOp, Limits> {};
 
 template <typename Op1, typename Op2, typename... Ops, typename Limits>
 struct MinGoodImpl<OpSequenceImpl<Op1, Op2, Ops...>, Limits>
-    : stdx::type_identity<MinGood<Op1, LimitsFor<OpSequenceImpl<Op2, Ops...>, Limits>>> {
+    : MinGoodImpl<Op1, LimitsFor<OpSequenceImpl<Op2, Ops...>, Limits>> {
     static_assert(std::is_same<OpOutput<Op1>, OpInput<Op2>>::value,
                   "Output of each op in sequence must match input of next op");
 };
@@ -670,12 +669,11 @@ struct MinGoodImpl<OpSequenceImpl<Op1, Op2, Ops...>, Limits>
 //
 
 template <typename OnlyOp, typename Limits>
-struct MaxGoodImpl<OpSequenceImpl<OnlyOp>, Limits> : stdx::type_identity<MaxGood<OnlyOp, Limits>> {
-};
+struct MaxGoodImpl<OpSequenceImpl<OnlyOp>, Limits> : MaxGoodImpl<OnlyOp, Limits> {};
 
 template <typename Op1, typename Op2, typename... Ops, typename Limits>
 struct MaxGoodImpl<OpSequenceImpl<Op1, Op2, Ops...>, Limits>
-    : stdx::type_identity<MaxGood<Op1, LimitsFor<OpSequenceImpl<Op2, Ops...>, Limits>>> {
+    : MaxGoodImpl<Op1, LimitsFor<OpSequenceImpl<Op2, Ops...>, Limits>> {
     static_assert(std::is_same<OpOutput<Op1>, OpInput<Op2>>::value,
                   "Output of each op in sequence must match input of next op");
 };

--- a/au/overflow_boundary_test.cc
+++ b/au/overflow_boundary_test.cc
@@ -1447,7 +1447,7 @@ TEST(OpSequence, MinGoodIsZeroIfUnsignedTypeFoundOnBothSidesOfNegativeMultiplica
 }
 
 //
-// `MinGood<OpSequence>`:
+// `MaxGood<OpSequence>`:
 //
 
 TEST(OpSequence, MaxGoodForSequenceOfSingleOpIsMaxGoodForThatOp) {


### PR DESCRIPTION
Now it all comes together.  We carefully designed the overflow checkers
for each individual operation so that they took a `Limits` parameter,
which might be different from the full limits for the type.  This PR
adds a `LimitsFor<Op, Limits>` helper, which takes an "output target"
limits type `Limits`, and an operation `Op`, and produces the _input
limits_ that will stay within that target.  And this object can be used
as the "limits" parameter _for the previous operation in the chain_!
And we're done.

Helps https://github.com/aurora-opensource/au/issues/349.