### PR TITLE
Add foundations for `:truncation_risk` target

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -627,6 +627,27 @@ cc_test(
 )
 
 cc_library(
+    name = "truncation_risk",
+    hdrs = ["truncation_risk.hh"],
+    deps = [
+        ":abstract_operations",
+        ":magnitude",
+    ],
+)
+
+cc_test(
+    name = "truncation_risk_test",
+    size = "small",
+    srcs = ["truncation_risk_test.cc"],
+    deps = [
+        ":magnitude",
+        ":testing",
+        ":truncation_risk",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "unit_of_measure",
     hdrs = ["unit_of_measure.hh"],
     deps = [

--- a/au/truncation_risk.hh
+++ b/au/truncation_risk.hh
@@ -1,0 +1,100 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/abstract_operations.hh"
+
+namespace au {
+namespace detail {
+
+template <typename T>
+struct NoTruncationRisk {
+    static constexpr bool would_value_truncate(const T &) { return false; }
+};
+
+template <typename T, typename M>
+struct ValueTimesRatioIsNotIntegerImpl;
+template <typename T, typename M>
+struct ValueTimesRatioIsNotInteger : ValueTimesRatioIsNotIntegerImpl<T, M> {};
+
+template <typename T>
+using ValueIsNotInteger = ValueTimesRatioIsNotInteger<T, Magnitude<>>;
+
+template <typename T>
+struct ValueIsNotZero {
+    static constexpr bool would_value_truncate(const T &x) { return x != T{0}; }
+};
+
+template <typename T>
+struct CannotAssessTruncationRiskFor {
+    static constexpr bool would_value_truncate(const T &) { return true; }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// IMPLEMENTATION DETAILS (`truncation_risk.hh`):
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `ValueTimesRatioIsNotInteger` section:
+
+template <typename T, typename M>
+struct ValueTimesRatioIsNotIntegerImplForIntWhereDenominatorDoesNotFit {
+    static constexpr bool would_value_truncate(const T &value) { return value != T{0}; }
+};
+
+template <typename T, typename M>
+struct ValueTimesRatioIsNotIntegerImplForIntWhereDenominatorFits {
+    static constexpr bool would_value_truncate(const T &value) {
+        return (value % get_value<RealPart<T>>(DenominatorT<M>{})) != T{0};
+    }
+};
+
+template <typename T, typename M>
+struct ValueTimesRatioIsNotIntegerImplForInt
+    : std::conditional_t<get_value_result<RealPart<T>>(DenominatorT<M>{}).outcome ==
+                             MagRepresentationOutcome::ERR_CANNOT_FIT,
+                         ValueTimesRatioIsNotIntegerImplForIntWhereDenominatorDoesNotFit<T, M>,
+                         ValueTimesRatioIsNotIntegerImplForIntWhereDenominatorFits<T, M>> {};
+
+template <typename T, typename M>
+struct ValueTimesRatioIsNotIntegerImplForFloatGeneric {
+    static constexpr bool would_value_truncate(const T &value) {
+        const auto result = value * get_value<RealPart<T>>(M{});
+        return std::trunc(result) != result;
+    }
+};
+
+template <typename T, typename M>
+struct ValueTimesRatioIsNotIntegerImplForFloatDivideByInteger {
+    static constexpr bool would_value_truncate(const T &value) {
+        const auto result = value / get_value<RealPart<T>>(MagInverseT<M>{});
+        return std::trunc(result) != result;
+    }
+};
+
+template <typename T, typename M>
+struct ValueTimesRatioIsNotIntegerImplForFloat
+    : std::conditional_t<IsInteger<MagInverseT<M>>::value,
+                         ValueTimesRatioIsNotIntegerImplForFloatDivideByInteger<T, M>,
+                         ValueTimesRatioIsNotIntegerImplForFloatGeneric<T, M>> {};
+
+template <typename T, typename M>
+struct ValueTimesRatioIsNotIntegerImpl
+    : std::conditional_t<std::is_integral<T>::value,
+                         ValueTimesRatioIsNotIntegerImplForInt<T, M>,
+                         ValueTimesRatioIsNotIntegerImplForFloat<T, M>> {};
+
+}  // namespace detail
+}  // namespace au

--- a/au/truncation_risk_test.cc
+++ b/au/truncation_risk_test.cc
@@ -43,11 +43,11 @@ TEST(WouldValueTruncate, AlwaysFalseForNoTruncationRisk) {
 
 TEST(WouldValueTruncate, OnlyFalseForZeroForValueIsNotZeroFloat) {
     EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(-1.23456e7f), IsTrue());
-    EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(-9.87e-12), IsTrue());
+    EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(-9.87e-12f), IsTrue());
 
     EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(0.0f), IsFalse());
 
-    EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(9.87e-12), IsTrue());
+    EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(9.87e-12f), IsTrue());
     EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(1.23456e7f), IsTrue());
 }
 

--- a/au/truncation_risk_test.cc
+++ b/au/truncation_risk_test.cc
@@ -1,0 +1,107 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/truncation_risk.hh"
+
+#include <complex>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::IsFalse;
+using ::testing::IsTrue;
+using ::testing::StaticAssertTypeEq;
+
+namespace au {
+namespace detail {
+namespace {
+
+template <typename T, typename M>
+using ValueTimesIntIsNotInteger = ValueTimesRatioIsNotInteger<T, M>;
+
+template <typename T, typename M>
+using ValueDivIntIsNotInteger = ValueTimesRatioIsNotInteger<T, MagInverseT<M>>;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `WouldValueTruncate` section:
+
+TEST(WouldValueTruncate, AlwaysFalseForNoTruncationRisk) {
+    EXPECT_THAT(NoTruncationRisk<float>::would_value_truncate(3.1415f), IsFalse());
+    EXPECT_THAT(NoTruncationRisk<int8_t>::would_value_truncate(int8_t{-128}), IsFalse());
+}
+
+TEST(WouldValueTruncate, OnlyFalseForZeroForValueIsNotZeroFloat) {
+    EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(-1.23456e7f), IsTrue());
+    EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(-9.87e-12), IsTrue());
+
+    EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(0.0f), IsFalse());
+
+    EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(9.87e-12), IsTrue());
+    EXPECT_THAT(ValueIsNotZero<float>::would_value_truncate(1.23456e7f), IsTrue());
+}
+
+TEST(WouldValueTruncate, OnlyFalseForZeroForValueIsNotZeroInt) {
+    EXPECT_THAT(ValueIsNotZero<int8_t>::would_value_truncate(int8_t{-128}), IsTrue());
+    EXPECT_THAT(ValueIsNotZero<int8_t>::would_value_truncate(int8_t{-1}), IsTrue());
+
+    EXPECT_THAT(ValueIsNotZero<int8_t>::would_value_truncate(int8_t{0}), IsFalse());
+
+    EXPECT_THAT(ValueIsNotZero<int8_t>::would_value_truncate(int8_t{1}), IsTrue());
+    EXPECT_THAT(ValueIsNotZero<int8_t>::would_value_truncate(int8_t{127}), IsTrue());
+}
+
+TEST(WouldValueTruncate, ValueTimesRatioIsNotIntegerUsesModOfDenominatorForIntegerTypes) {
+    using IntDiv3IsNotInteger = ValueTimesRatioIsNotInteger<int, decltype(mag<2>() / mag<3>())>;
+
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(-1000000), IsTrue());
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(-999999), IsFalse());
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(-999998), IsTrue());
+
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(-1), IsTrue());
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(0), IsFalse());
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(1), IsTrue());
+
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(2), IsTrue());
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(3), IsFalse());
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(4), IsTrue());
+
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(299), IsTrue());
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(300), IsFalse());
+    EXPECT_THAT(IntDiv3IsNotInteger::would_value_truncate(301), IsTrue());
+}
+
+TEST(WouldValueTruncate, ValueTimesRatioIsNotIntegerDividesByDenominatorForFloatTypes) {
+    using FloatTimesOneSeventhIsNotInteger =
+        ValueTimesRatioIsNotInteger<float, decltype(mag<1>() / mag<7>())>;
+    for (int i = 0; i < 1000; ++i) {
+        const auto f = static_cast<float>(i) * 7.f;
+        EXPECT_THAT(FloatTimesOneSeventhIsNotInteger::would_value_truncate(f), IsFalse())
+            << "i = " << i << ", f = " << f;
+
+        EXPECT_THAT(FloatTimesOneSeventhIsNotInteger::would_value_truncate(f - 1.f), IsTrue());
+        EXPECT_THAT(FloatTimesOneSeventhIsNotInteger::would_value_truncate(f + 1.f), IsTrue());
+    }
+}
+
+TEST(WouldValueTruncate, AssumedAlwaysTrueIfCannotAssessTruncationRisk) {
+    using CannotAssessRisk = CannotAssessTruncationRiskFor<int>;
+
+    EXPECT_THAT(CannotAssessRisk::would_value_truncate(0), IsTrue());
+    EXPECT_THAT(CannotAssessRisk::would_value_truncate(1), IsTrue());
+    EXPECT_THAT(CannotAssessRisk::would_value_truncate(-1), IsTrue());
+}
+
+}  // namespace
+}  // namespace detail
+}  // namespace au


### PR DESCRIPTION
This adds one (templated) type for each of various kinds of truncation
risk that we might have.  Each type has a `would_value_truncate(T)`
member, which assesses _any individual value_ of type `T` to see if it
would truncate.  Future PRs will associate each operation with one of
these.

This set isn't perfect.  In particular, I'm pretty suspicious as to
whether `ValueTimesRatioIsNotInteger` is the right solution.  But in my
local client, this suite seems to be able to handle all the cases I
checked.  I think **the most important thing is the structure**.  If we
land a suite that passes all known test cases, then we can clean up the
particular details later on, and trust in our expanding set of test
cases to be sure we end up in a better place.

Helps https://github.com/aurora-opensource/au/issues/349.  Technically, that's only about overflow, but we can't
actually _use_ the new overflow implementations without moving to this
operation based approach, which means we need to be able to handle
truncation too.  Besides, this will ultimately lead to more efficient
truncation checkers as well.