### PR TITLE
Add `:conversion_strategy` target

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -332,6 +332,27 @@ cc_test(
 )
 
 cc_library(
+    name = "conversion_strategy",
+    hdrs = ["conversion_strategy.hh"],
+    deps = [
+        ":abstract_operations",
+        ":magnitude",
+        ":stdx",
+    ],
+)
+
+cc_test(
+    name = "conversion_strategy_test",
+    size = "small",
+    srcs = ["conversion_strategy_test.cc"],
+    deps = [
+        ":conversion_strategy",
+        ":testing",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "dimension",
     hdrs = ["dimension.hh"],
     deps = [

--- a/au/conversion_strategy.hh
+++ b/au/conversion_strategy.hh
@@ -1,0 +1,108 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/abstract_operations.hh"
+#include "au/magnitude.hh"
+#include "au/stdx/type_traits.hh"
+
+namespace au {
+namespace detail {
+
+//
+// `ConversionForRepsAndFactor<OldRep, NewRep, Factor>` is the operation that takes a value of
+// `OldRep`, and produces the product of that value with magnitude `Factor` in the type `NewRep`.
+//
+template <typename OldRep, typename NewRep, typename Factor>
+struct ConversionForRepsAndFactorImpl;
+template <typename OldRep, typename NewRep, typename Factor>
+using ConversionForRepsAndFactor =
+    typename ConversionForRepsAndFactorImpl<OldRep, NewRep, Factor>::type;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Implementation details (`conversion_strategy.hh`):
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//
+// `ApplicationStrategyFor<T, Mag>` tells us how we should apply a magnitude `Mag` to a type `T`.
+//
+
+enum class MagKind {
+    DEFAULT,
+    INTEGER_DIVIDE,
+    NONTRIVIAL_RATIONAL,
+};
+
+template <typename M>
+constexpr MagKind mag_kind_for(M) {
+    if (stdx::conjunction<IsRational<M>,
+                          stdx::negation<std::is_same<DenominatorT<M>, Magnitude<>>>>::value) {
+        return std::is_same<Abs<NumeratorT<M>>, Magnitude<>>::value ? MagKind::INTEGER_DIVIDE
+                                                                    : MagKind::NONTRIVIAL_RATIONAL;
+    }
+    return MagKind::DEFAULT;
+}
+
+template <typename T, typename Mag, MagKind>
+struct ApplicationStrategyForImpl : stdx::type_identity<MultiplyTypeBy<T, Mag>> {};
+template <typename T, typename Mag>
+using ApplicationStrategyFor =
+    typename ApplicationStrategyForImpl<T, Mag, mag_kind_for(Mag{})>::type;
+
+template <typename T, typename Mag>
+struct ApplicationStrategyForImpl<T, Mag, MagKind::INTEGER_DIVIDE>
+    : stdx::type_identity<DivideTypeByInteger<T, MagProductT<Sign<Mag>, DenominatorT<Mag>>>> {};
+
+template <typename T, typename Mag>
+struct ApplicationStrategyForImpl<T, Mag, MagKind::NONTRIVIAL_RATIONAL>
+    : std::conditional<
+          std::is_integral<T>::value,
+          OpSequence<MultiplyTypeBy<T, NumeratorT<Mag>>, DivideTypeByInteger<T, DenominatorT<Mag>>>,
+          MultiplyTypeBy<T, Mag>> {};
+
+//
+// `FullConversionImpl<OldRep, PromotedCommon, NewRep, Factor>` should resolve to the most efficient
+// sequence of operations for a conversion from `OldRep` to `NewRep`, with a magnitude `Factor`,
+// where `PromotedCommon` is the promoted type of the common type of `OldRep` and `NewRep`.
+//
+
+template <typename OldRep, typename PromotedCommon, typename NewRep, typename Factor>
+struct FullConversionImpl
+    : stdx::type_identity<OpSequence<StaticCast<OldRep, PromotedCommon>,
+                                     ApplicationStrategyFor<PromotedCommon, Factor>,
+                                     StaticCast<PromotedCommon, NewRep>>> {};
+
+template <typename OldRepIsPromotedCommon, typename NewRep, typename Factor>
+struct FullConversionImpl<OldRepIsPromotedCommon, OldRepIsPromotedCommon, NewRep, Factor>
+    : stdx::type_identity<OpSequence<ApplicationStrategyFor<OldRepIsPromotedCommon, Factor>,
+                                     StaticCast<OldRepIsPromotedCommon, NewRep>>> {};
+
+template <typename OldRep, typename NewRepIsPromotedCommon, typename Factor>
+struct FullConversionImpl<OldRep, NewRepIsPromotedCommon, NewRepIsPromotedCommon, Factor>
+    : stdx::type_identity<OpSequence<StaticCast<OldRep, NewRepIsPromotedCommon>,
+                                     ApplicationStrategyFor<NewRepIsPromotedCommon, Factor>>> {};
+
+template <typename Rep, typename Factor>
+struct FullConversionImpl<Rep, Rep, Rep, Factor>
+    : stdx::type_identity<ApplicationStrategyFor<Rep, Factor>> {};
+
+// To implement `ConversionForRepsAndFactor`, delegate to `FullConversionImpl`.
+template <typename OldRep, typename NewRep, typename Factor>
+struct ConversionForRepsAndFactorImpl
+    : FullConversionImpl<OldRep, PromotedType<std::common_type_t<OldRep, NewRep>>, NewRep, Factor> {
+};
+
+}  // namespace detail
+}  // namespace au

--- a/au/conversion_strategy_test.cc
+++ b/au/conversion_strategy_test.cc
@@ -1,0 +1,79 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/conversion_strategy.hh"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace au {
+namespace detail {
+
+using ::testing::IsFalse;
+using ::testing::StaticAssertTypeEq;
+
+TEST(ConversionForRepsAndFactor, SameRepAndNonPromotingTypeIsJustMultiplyByDefault) {
+    StaticAssertTypeEq<ConversionForRepsAndFactor<int32_t, int32_t, decltype(mag<15>())>,
+                       MultiplyTypeBy<int32_t, decltype(mag<15>())>>();
+}
+
+TEST(ConversionForRepsAndFactor, SameRepAndNonPromotingTypeWithInverseIntegerIsJustDivideBy) {
+    StaticAssertTypeEq<ConversionForRepsAndFactor<int32_t, int32_t, decltype(mag<1>() / mag<16>())>,
+                       DivideTypeByInteger<int32_t, decltype(mag<16>())>>();
+
+    StaticAssertTypeEq<ConversionForRepsAndFactor<double, double, decltype(mag<1>() / mag<3456>())>,
+                       DivideTypeByInteger<double, decltype(mag<3456>())>>();
+}
+
+TEST(ConversionForRepsAndFactor, SameRepForPromotingTypeHasStaticCastAtBeginningAndEnd) {
+    using T = uint16_t;
+    using Promoted = PromotedType<T>;
+    ASSERT_THAT((std::is_same<T, Promoted>::value), IsFalse());
+
+    StaticAssertTypeEq<ConversionForRepsAndFactor<T, T, decltype(mag<15>())>,
+                       OpSequence<StaticCast<T, Promoted>,
+                                  MultiplyTypeBy<Promoted, decltype(mag<15>())>,
+                                  StaticCast<Promoted, T>>>();
+}
+
+TEST(ConversionForRepsAndFactor, ApplyingNontrivialRationalToIntegralTypeIsMultiplyThenDivide) {
+    StaticAssertTypeEq<
+        ConversionForRepsAndFactor<uint64_t, uint64_t, decltype(mag<3>() / mag<4>())>,
+        OpSequence<MultiplyTypeBy<uint64_t, decltype(mag<3>())>,
+                   DivideTypeByInteger<uint64_t, decltype(mag<4>())>>>();
+}
+
+TEST(ConversionForRepsAndFactor, ApplyingNontrivialRationalToFloatingPointIsSingleMultiply) {
+    StaticAssertTypeEq<ConversionForRepsAndFactor<double, double, decltype(mag<3>() / mag<4>())>,
+                       MultiplyTypeBy<double, decltype(mag<3>() / mag<4>())>>();
+}
+
+TEST(ConversionForRepsAndFactor, WhenTargetIsPromotedTypeSkipFinalStaticCast) {
+    using T = uint16_t;
+    using Promoted = PromotedType<T>;
+    ASSERT_THAT((std::is_same<T, Promoted>::value), IsFalse());
+
+    StaticAssertTypeEq<
+        ConversionForRepsAndFactor<T, Promoted, decltype(mag<15>())>,
+        OpSequence<StaticCast<T, Promoted>, MultiplyTypeBy<Promoted, decltype(mag<15>())>>>();
+}
+
+TEST(ConversionForRepsAndFactor, WhenOldRepIsPromotedCommonSkipInitialStaticCast) {
+    StaticAssertTypeEq<ConversionForRepsAndFactor<float, int, decltype(mag<13>() / mag<15>())>,
+                       OpSequence<MultiplyTypeBy<float, decltype(mag<13>() / mag<15>())>,
+                                  StaticCast<float, int>>>();
+}
+
+}  // namespace detail
+}  // namespace au


### PR DESCRIPTION
This new target is the One True Home for choosing each unit conversion
implementation.  It depends only on the initial rep, final rep, and
conversion factor.  The output is a tailor-made and trimmed sequence of
operations for that conversion.  It will automatically take care of:

- Type promotion
- Using division for pure-inverse-integer factors
- Using multiply-then-divide for applying a rational to an integral type

When all is said and done for #349, each conversion implementation will
be able to simply ask for the right conversion for the reps and factor,
and just apply it blindly.  And when we want to reason about overflow
and/or truncation risk for those conversions, we can do so by checking
this sequence of operations!