### PR TITLE
Add fuzz-style explorer for conversion lossiness

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -182,6 +182,7 @@ cc_test(
 cc_library(
     name = "abstract_operations",
     hdrs = ["abstract_operations.hh"],
+    visibility = ["//fuzz:__subpackages__"],
     deps = [":magnitude"],
 )
 
@@ -334,6 +335,7 @@ cc_test(
 cc_library(
     name = "conversion_strategy",
     hdrs = ["conversion_strategy.hh"],
+    visibility = ["//fuzz:__subpackages__"],
     deps = [
         ":abstract_operations",
         ":magnitude",

--- a/fuzz/BUILD.bazel
+++ b/fuzz/BUILD.bazel
@@ -1,0 +1,51 @@
+# Copyright 2025 Aurora Operations, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
+cc_binary(
+    name = "quantity_runtime_conversion_check",
+    testonly = True,
+    srcs = ["quantity_runtime_conversion_check.cc"],
+    deps = [
+        ":quantity_runtime_conversion_checkers",
+        "//au:conversion_strategy",
+        "//au:testing",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "quantity_runtime_conversion_checkers",
+    testonly = True,
+    hdrs = ["quantity_runtime_conversion_checkers.hh"],
+    deps = [
+        "//au",
+        "//au:abstract_operations",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "quantity_runtime_conversion_checkers_test",
+    size = "small",
+    srcs = ["quantity_runtime_conversion_checkers_test.cc"],
+    deps = [
+        ":quantity_runtime_conversion_checkers",
+        "//au",
+        "//au:conversion_strategy",
+        "//au:testing",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/fuzz/quantity_runtime_conversion_check.cc
+++ b/fuzz/quantity_runtime_conversion_check.cc
@@ -184,12 +184,10 @@ constexpr TestCategory categorize_testing_scenario() {
     if (std::is_integral<RepT>::value) {
         return std::is_integral<DestRepT>::value ? TestCategory::INTEGRAL_TO_INTEGRAL
                                                  : TestCategory::INTEGRAL_TO_FLOAT;
-    } else {
-        return std::is_integral<DestRepT>::value ? TestCategory::FLOAT_TO_INTEGRAL
-                                                 : TestCategory::FLOAT_TO_FLOAT;
     }
-
-    return TestCategory::UNSUPPORTED;
+    
+    return std::is_integral<DestRepT>::value ? TestCategory::FLOAT_TO_INTEGRAL
+                                             : TestCategory::FLOAT_TO_FLOAT;
 }
 
 template <typename RepT,

--- a/fuzz/quantity_runtime_conversion_check.cc
+++ b/fuzz/quantity_runtime_conversion_check.cc
@@ -278,11 +278,11 @@ struct LossChecker<RepT, UnitT, DestRepT, DestUnitT, TestCategory::FLOAT_TO_FLOA
 
         std::ostringstream oss;
         oss << "Breakdown:" << std::setprecision(std::numeric_limits<RepT>::digits10 + 1u)
-            << std::endl
-            << "  Initial:    " << value << std::endl
-            << "  Min OK:     " << min_ok << std::endl
-            << "  Round trip: " << round_trip << std::endl
-            << "  Max OK:     " << max_ok << std::endl;
+            << '\n'
+            << "  Initial:    " << value << '\n'
+            << "  Min OK:     " << min_ok << '\n'
+            << "  Round trip: " << round_trip << '\n'
+            << "  Max OK:     " << max_ok << '\n';
 
         const auto result =
             ((round_trip == value)                          ? RoundTripResult::IDENTICAL

--- a/fuzz/quantity_runtime_conversion_check.cc
+++ b/fuzz/quantity_runtime_conversion_check.cc
@@ -1,0 +1,523 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <string>
+
+#include "au/conversion_strategy.hh"
+#include "au/math.hh"
+#include "au/testing.hh"
+#include "au/units/inches.hh"
+#include "au/units/meters.hh"
+#include "au/units/miles.hh"
+#include "au/units/yards.hh"
+#include "fuzz/quantity_runtime_conversion_checkers.hh"
+#include "gtest/gtest.h"
+
+namespace au {
+namespace detail {
+
+enum class RoundTripResult {
+    IDENTICAL,
+    SIGNIFICANT_LOSS,
+    MINOR_LOSS,
+    IGNORE_SUBNORMALS,
+    CAST_NON_INT_TO_INT_IS_DEFINITELY_LOSSY,
+};
+
+std::string print(RoundTripResult result) {
+    switch (result) {
+        case RoundTripResult::IDENTICAL:
+            return "IDENTICAL";
+        case RoundTripResult::SIGNIFICANT_LOSS:
+            return "SIGNIFICANT_LOSS";
+        case RoundTripResult::MINOR_LOSS:
+            return "MINOR_LOSS";
+        case RoundTripResult::IGNORE_SUBNORMALS:
+            return "IGNORE_SUBNORMALS";
+        case RoundTripResult::CAST_NON_INT_TO_INT_IS_DEFINITELY_LOSSY:
+            return "CAST_NON_INT_TO_INT_IS_DEFINITELY_LOSSY";
+    }
+    return "UNKNOWN";
+}
+
+template <typename T>
+T next_higher(T x, std::size_t n = 1u) {
+    static_assert(std::is_floating_point<T>::value, "");
+    while (n-- > 0u) {
+        x = std::nextafter(x, std::numeric_limits<T>::infinity());
+    }
+    return x;
+}
+
+template <typename T>
+T next_lower(T x, std::size_t n = 1u) {
+    static_assert(std::is_floating_point<T>::value, "");
+    while (n-- > 0u) {
+        x = std::nextafter(x, -std::numeric_limits<T>::infinity());
+    }
+    return x;
+}
+
+template <typename U, typename R>
+Quantity<U, R> next_higher_quantity(Quantity<U, R> q, std::size_t n = 1u) {
+    return make_quantity<U>(next_higher(q.in(U{}), n));
+}
+
+template <typename U, typename R>
+Quantity<U, R> next_lower_quantity(Quantity<U, R> q, std::size_t n = 1u) {
+    return make_quantity<U>(next_lower(q.in(U{}), n));
+}
+
+constexpr std::size_t MAX_DIST = 1000u;
+
+template <typename T>
+std::size_t distance(T a, T b) {
+    std::size_t dist = 0u;
+    while (a != b) {
+        ++dist;
+        a = std::nextafter(a, b);
+        if (dist >= MAX_DIST) {
+            break;
+        }
+    }
+    return dist;
+}
+
+template <typename T>
+struct Tag {};
+
+template <typename T, typename U>
+constexpr bool operator==(Tag<T>, Tag<U>) {
+    return std::is_same<T, U>::value;
+}
+
+template <typename T>
+T type_of(const Tag<T> &);
+
+template <typename T>
+struct UnwrapTagImpl : stdx::type_identity<T> {};
+template <typename T>
+using UnwrapTag = typename UnwrapTagImpl<T>::type;
+template <typename T>
+struct UnwrapTagImpl<Tag<T>> : stdx::type_identity<T> {};
+
+template <typename... Ts>
+struct ListImpl;
+template <typename... Ts>
+using List = typename ListImpl<Ts...>::type;
+template <typename... Ts>
+struct ListImpl : stdx::type_identity<std::tuple<Tag<Ts>...>> {};
+
+using Reps = List<uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float>;
+using Units = List<Inches, Feet, Meters, Miles, Yards, Centi<Meters>, Nano<Meters>>;
+
+template <typename PackT>
+struct GeneratorForImpl;
+template <typename PackT>
+using GeneratorFor = typename GeneratorForImpl<PackT>::type;
+template <template <class...> class Pack, typename... Ts>
+struct GeneratorForImpl<Pack<Ts...>>
+    : stdx::type_identity<RandomValueGenerators<UnwrapTag<Ts>...>> {};
+
+template <typename ListT>
+struct ForEach;
+template <>
+struct ForEach<std::tuple<>> {
+    template <typename Func>
+    void operator()(const Func &) {}
+};
+template <typename T, typename... Ts>
+struct ForEach<std::tuple<T, Ts...>> {
+    template <typename Func>
+    void operator()(const Func &f) const {
+        f(T{});
+        ForEach<std::tuple<Ts...>>{}(f);
+    }
+};
+
+enum class TestCategory {
+    INTEGRAL_TO_INTEGRAL,
+    INTEGRAL_TO_FLOAT,
+    FLOAT_TO_INTEGRAL,
+    FLOAT_TO_FLOAT,
+    TRIVIAL,
+    IMPOSSIBLE,
+    UNSUPPORTED,
+};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+constexpr TestCategory categorize_testing_scenario() {
+    if (std::is_same<RepT, DestRepT>::value && std::is_same<UnitT, DestUnitT>::value) {
+        return TestCategory::TRIVIAL;
+    }
+
+    using Common = std::common_type_t<RepT, DestRepT>;
+    constexpr auto conversion_factor = UnitRatioT<UnitT, DestUnitT>{};
+
+    if (is_integer(conversion_factor) &&
+        (get_value_result<Common>(conversion_factor).outcome != MagRepresentationOutcome::OK)) {
+        return TestCategory::IMPOSSIBLE;
+    }
+
+    if (is_integer(mag<1>() / conversion_factor) &&
+        (get_value_result<Common>(mag<1>() / conversion_factor).outcome !=
+         MagRepresentationOutcome::OK)) {
+        return TestCategory::IMPOSSIBLE;
+    }
+
+    static_assert(std::is_integral<RepT>::value || std::is_floating_point<RepT>::value, "");
+    static_assert(std::is_integral<DestRepT>::value || std::is_floating_point<DestRepT>::value, "");
+    if (std::is_integral<RepT>::value) {
+        return std::is_integral<DestRepT>::value ? TestCategory::INTEGRAL_TO_INTEGRAL
+                                                 : TestCategory::INTEGRAL_TO_FLOAT;
+    } else {
+        return std::is_integral<DestRepT>::value ? TestCategory::FLOAT_TO_INTEGRAL
+                                                 : TestCategory::FLOAT_TO_FLOAT;
+    }
+
+    return TestCategory::UNSUPPORTED;
+}
+
+template <typename RepT,
+          typename UnitT,
+          typename DestRepT,
+          typename DestUnitT,
+          TestCategory Category>
+struct TestBodyImpl;
+
+template <bool R1Unsigned, bool R2Unsigned>
+struct SignFlipImpl;
+template <>
+struct SignFlipImpl<true, true> {
+    template <typename U1, typename R1, typename U2, typename R2>
+    static constexpr bool assess(const Quantity<U1, R1> &, const Quantity<U2, R2> &) {
+        return false;
+    }
+};
+template <>
+struct SignFlipImpl<true, false> {
+    template <typename U1, typename R1, typename U2, typename R2>
+    static constexpr bool assess(const Quantity<U1, R1> &, const Quantity<U2, R2> &b) {
+        return b < ZERO;
+    }
+};
+template <>
+struct SignFlipImpl<false, true> {
+    template <typename U1, typename R1, typename U2, typename R2>
+    static constexpr bool assess(const Quantity<U1, R1> &a, const Quantity<U2, R2> &) {
+        return a < ZERO;
+    }
+};
+template <>
+struct SignFlipImpl<false, false> {
+    template <typename U1, typename R1, typename U2, typename R2>
+    static constexpr bool assess(const Quantity<U1, R1> &a, const Quantity<U2, R2> &b) {
+        return (a < ZERO) != (b < ZERO);
+    }
+};
+template <typename U1, typename R1, typename U2, typename R2>
+constexpr bool sign_flip(const Quantity<U1, R1> &a, const Quantity<U2, R2> &b) {
+    return SignFlipImpl<std::is_unsigned<R1>::value, std::is_unsigned<R2>::value>::assess(a, b);
+}
+
+struct LossCheck {
+    RoundTripResult result;
+    std::string comment = "";
+};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT, TestCategory Cat>
+struct LossChecker {
+    static LossCheck check_for_loss(const Quantity<UnitT, RepT> &value,
+                                    const Quantity<DestUnitT, DestRepT> &,
+                                    const Quantity<UnitT, RepT> &round_trip) {
+        // Default implementation.
+        return {value == round_trip ? RoundTripResult::IDENTICAL
+                                    : RoundTripResult::SIGNIFICANT_LOSS};
+    }
+};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+struct LossChecker<RepT, UnitT, DestRepT, DestUnitT, TestCategory::INTEGRAL_TO_INTEGRAL> {
+    static LossCheck check_for_loss(const Quantity<UnitT, RepT> &value,
+                                    const Quantity<DestUnitT, DestRepT> &destination,
+                                    const Quantity<UnitT, RepT> &round_trip) {
+        const bool expect_sign_flip =
+            std::is_same<Sign<UnitRatioT<UnitT, DestUnitT>>, Magnitude<Negative>>::value;
+        const bool wrong_sign = (sign_flip(value, destination) != expect_sign_flip);
+
+        const bool actual_loss = (value != round_trip) || wrong_sign;
+        return {
+            actual_loss ? RoundTripResult::SIGNIFICANT_LOSS : RoundTripResult::IDENTICAL,
+            wrong_sign ? "Sign was wrong" : "",
+        };
+    }
+};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+struct LossChecker<RepT, UnitT, DestRepT, DestUnitT, TestCategory::FLOAT_TO_FLOAT> {
+    static LossCheck check_for_loss(const Quantity<UnitT, RepT> &value,
+                                    const Quantity<DestUnitT, DestRepT> &destination,
+                                    const Quantity<UnitT, RepT> &round_trip) {
+        if (!std::isnormal(value.in(UnitT{})) || !std::isnormal(destination.in(DestUnitT{}))) {
+            return {RoundTripResult::IGNORE_SUBNORMALS, "Subnormal value"};
+        }
+        const auto min_ok = next_lower_quantity(value, 2u);
+        const auto max_ok = next_higher_quantity(value, 2u);
+
+        std::ostringstream oss;
+        oss << "Breakdown:" << std::setprecision(std::numeric_limits<RepT>::digits10 + 1u)
+            << std::endl
+            << "  Initial:    " << value << std::endl
+            << "  Min OK:     " << min_ok << std::endl
+            << "  Round trip: " << round_trip << std::endl
+            << "  Max OK:     " << max_ok << std::endl;
+
+        const auto result =
+            ((round_trip == value)                          ? RoundTripResult::IDENTICAL
+             : (round_trip < min_ok || round_trip > max_ok) ? RoundTripResult::SIGNIFICANT_LOSS
+                                                            : RoundTripResult::MINOR_LOSS);
+
+        return {result, oss.str()};
+    }
+};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+struct LossChecker<RepT, UnitT, DestRepT, DestUnitT, TestCategory::INTEGRAL_TO_FLOAT> {
+    static LossCheck check_for_loss(const Quantity<UnitT, RepT> &value,
+                                    const Quantity<DestUnitT, DestRepT> &destination,
+                                    const Quantity<UnitT, RepT> &round_trip) {
+        auto fraction = value / 100'000;
+        if (std::is_signed<RepT>::value && value < ZERO) {
+            fraction = -fraction;
+        }
+        const auto dx = max(fraction, make_quantity<UnitT>(RepT{1}));
+
+        constexpr auto lowest = std::numeric_limits<Quantity<UnitT, RepT>>::lowest();
+        const auto min_ok = (lowest + dx > value) ? lowest : rep_cast<RepT>(value - dx);
+
+        constexpr auto highest = std::numeric_limits<Quantity<UnitT, RepT>>::max();
+        const auto max_ok = (highest - dx < value) ? highest : rep_cast<RepT>(value + dx);
+
+        const bool ignore_because_subnormal = !std::isnormal(destination.in(DestUnitT{}));
+
+        std::ostringstream oss;
+        oss << "We went through floating point; so, taking a very liberal margin.  Breakdown:"
+            << std::endl
+            << "  Initial:    " << value << std::endl
+            << "  Destination: " << destination << (ignore_because_subnormal ? " (subnormal)" : "")
+            << std::endl
+            << "  Min OK:     " << min_ok << std::endl
+            << "  Round trip: " << round_trip << std::endl
+            << "  Max OK:     " << max_ok << std::endl;
+
+        const auto result = ignore_because_subnormal
+                                ? RoundTripResult::IGNORE_SUBNORMALS
+                                : ((round_trip == value) ? RoundTripResult::IDENTICAL
+                                   : (round_trip < min_ok || round_trip > max_ok)
+                                       ? RoundTripResult::SIGNIFICANT_LOSS
+                                       : RoundTripResult::MINOR_LOSS);
+
+        return {result, oss.str()};
+    }
+};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+struct LossChecker<RepT, UnitT, DestRepT, DestUnitT, TestCategory::FLOAT_TO_INTEGRAL> {
+    static LossCheck check_for_loss(const Quantity<UnitT, RepT> &value,
+                                    const Quantity<DestUnitT, DestRepT> &,
+                                    const Quantity<UnitT, RepT> &round_trip) {
+        constexpr auto MIN_GOOD_VALUE =
+            max(std::numeric_limits<Quantity<DestUnitT, RepT>>::min().as(UnitT{}),
+                std::numeric_limits<Quantity<UnitT, RepT>>::min());
+        if (abs(value) < MIN_GOOD_VALUE) {
+            return {RoundTripResult::IGNORE_SUBNORMALS, "Subnormal value"};
+        }
+
+        if (round_trip == value) {
+            using Op = ConversionForRepsAndFactor<RepT, DestRepT, UnitRatioT<UnitT, DestUnitT>>;
+            const auto dest_value = FloatingPointPrefixPart<Op>::apply_to(value.in(UnitT{}));
+            const bool definitely_truncates = (std::trunc(dest_value) != dest_value);
+            std::ostringstream oss;
+            if (definitely_truncates) {
+                oss << "Floating point portion of converting " << value << " to <"
+                    << type_name<DestRepT>() << ">(" << unit_label(DestUnitT{}) << ") produced "
+                    << dest_value << ", which differs from the truncated int by "
+                    << std::abs(dest_value - std::trunc(dest_value));
+            } else {
+                oss << "Seems fine: floating point part produces " << dest_value
+                    << ", which is an integer";
+            }
+
+            return {
+                definitely_truncates ? RoundTripResult::CAST_NON_INT_TO_INT_IS_DEFINITELY_LOSSY
+                                     : RoundTripResult::IDENTICAL,
+                oss.str(),
+            };
+        }
+
+        const auto dist = distance(value.in(UnitT{}), round_trip.in(UnitT{}));
+
+        std::ostringstream oss;
+        oss << "Distance was " << dist << " steps" << (dist >= MAX_DIST ? " (truncated)" : "");
+
+        if (std::is_same<Abs<UnitRatioT<UnitT, DestUnitT>>, Magnitude<>>::value) {
+            oss << ".  Saw round trip error on conversion factor whose absolute value was 1.";
+            return {
+                RoundTripResult::SIGNIFICANT_LOSS,
+                oss.str(),
+            };
+        }
+
+        return {
+            (dist > 2u) ? RoundTripResult::SIGNIFICANT_LOSS : RoundTripResult::MINOR_LOSS,
+            oss.str(),
+        };
+    }
+};
+
+template <typename T>
+struct RepForImpl : stdx::type_identity<T> {};
+template <typename T>
+using RepFor = typename RepForImpl<T>::type;
+template <typename U, typename R>
+struct RepForImpl<Quantity<U, R>> : stdx::type_identity<R> {};
+
+template <typename T>
+std::string print_to_string(const T &value) {
+    std::ostringstream oss;
+    oss << std::setprecision(std::numeric_limits<RepFor<T>>::digits10 + 3u) << value;
+    return oss.str();
+}
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT, TestCategory Cat>
+struct NominalTestBodyImpl : LossChecker<RepT, UnitT, DestRepT, DestUnitT, Cat> {
+    using LossChecker<RepT, UnitT, DestRepT, DestUnitT, Cat>::check_for_loss;
+
+    using Op = ConversionForRepsAndFactor<RepT, DestRepT, UnitRatioT<UnitT, DestUnitT>>;
+
+    static void test(const Quantity<UnitT, RepT> &value) {
+        const bool expect_loss = is_conversion_lossy<DestRepT>(value, DestUnitT{});
+        const bool expect_trunc = will_conversion_truncate<DestRepT>(value, DestUnitT{});
+        const bool expect_overflow = will_conversion_overflow<DestRepT>(value, DestUnitT{});
+
+        const auto destination = value.template coerce_as<DestRepT>(DestUnitT{});
+        const auto dest_from_op = Op::apply_to(value.in(UnitT{}));
+        if (!std::isnan(dest_from_op) && dest_from_op != destination.in(DestUnitT{})) {
+            std::cerr << "Programming error: either `Op` is wrong, or it was applied wrong.\n"
+                      << "<" << type_name<RepT>() << ">(" << unit_label(UnitT{}) << ") -> <"
+                      << type_name<DestRepT>() << ">(" << unit_label(DestUnitT{}) << ")\n"
+                      << "Initial value: " << print_to_string(value) << "\n"
+                      << "Destination:   " << print_to_string(destination) << "\n"
+                      << "Op applied:    " << print_to_string(Op::apply_to(value.in(UnitT{})))
+                      << "\n"
+                      << "Diff:          "
+                      << print_to_string(destination.in(DestUnitT{}) - dest_from_op) << "\n";
+            std::terminate();
+        }
+
+        const auto round_trip = destination.template coerce_as<RepT>(UnitT{});
+
+        const auto loss_check = check_for_loss(value, destination, round_trip);
+        const auto actual_loss = loss_check.result;
+
+        const bool mismatch = (expect_loss && (actual_loss == RoundTripResult::IDENTICAL)) ||
+                              (!expect_loss && (actual_loss == RoundTripResult::SIGNIFICANT_LOSS));
+
+        if (mismatch) {
+            std::cout << "Error found for <" << type_name<RepT>() << ">(" << unit_label(UnitT{})
+                      << ") -> <" << type_name<DestRepT>() << ">(" << unit_label(DestUnitT{})
+                      << ")! " << std::endl
+                      << "Initial value: " << print_to_string(value) << std::endl
+                      << "Destination:   " << print_to_string(destination) << std::endl
+                      << "Round trip:    " << print_to_string(round_trip) << std::endl
+                      << "Expect loss: " << (expect_loss ? "true" : "false") << std::endl
+                      << "     (trunc: " << (expect_trunc ? "true" : "false") << std::endl
+                      << "     (overf: " << (expect_overflow ? "true" : "false") << ")" << std::endl
+                      << "Actual loss: " << print(actual_loss) << std::endl
+                      << "Extra comments: " << loss_check.comment << std::endl;
+            std::terminate();
+        }
+    }
+};
+
+template <typename U, typename R>
+struct NoOpTestImpl {
+    static void test(const Quantity<U, R> &) {}
+};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+struct TestBodyImpl<RepT, UnitT, DestRepT, DestUnitT, TestCategory::INTEGRAL_TO_INTEGRAL>
+    : NominalTestBodyImpl<RepT, UnitT, DestRepT, DestUnitT, TestCategory::INTEGRAL_TO_INTEGRAL> {};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+struct TestBodyImpl<RepT, UnitT, DestRepT, DestUnitT, TestCategory::INTEGRAL_TO_FLOAT>
+    : NominalTestBodyImpl<RepT, UnitT, DestRepT, DestUnitT, TestCategory::INTEGRAL_TO_FLOAT> {};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+struct TestBodyImpl<RepT, UnitT, DestRepT, DestUnitT, TestCategory::FLOAT_TO_FLOAT>
+    : NominalTestBodyImpl<RepT, UnitT, DestRepT, DestUnitT, TestCategory::FLOAT_TO_FLOAT> {};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+struct TestBodyImpl<RepT, UnitT, DestRepT, DestUnitT, TestCategory::FLOAT_TO_INTEGRAL>
+    : NominalTestBodyImpl<RepT, UnitT, DestRepT, DestUnitT, TestCategory::FLOAT_TO_INTEGRAL> {};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+struct TestBodyImpl<RepT, UnitT, DestRepT, DestUnitT, TestCategory::TRIVIAL>
+    : NoOpTestImpl<UnitT, RepT> {};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+struct TestBodyImpl<RepT, UnitT, DestRepT, DestUnitT, TestCategory::IMPOSSIBLE>
+    : NoOpTestImpl<UnitT, RepT> {};
+
+template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT>
+struct TestBody : TestBodyImpl<RepT,
+                               UnitT,
+                               DestRepT,
+                               DestUnitT,
+                               categorize_testing_scenario<RepT, UnitT, DestRepT, DestUnitT>()> {};
+
+TEST(RuntimeConversionCheckers, Fuzz) {
+    GeneratorFor<Reps> generators{9876543210u};
+    constexpr auto for_each_params = ForEach<CartesianProduct<std::tuple, Reps, Units>>{};
+    auto print_if_equals = 1u;
+    for (auto i = 0u; i < 100'000u; ++i) {
+        if (i == print_if_equals) {
+            std::cout << "Iteration: " << i << std::endl;
+            if (print_if_equals > 1'000u) {
+                print_if_equals += 10'000u;
+            } else {
+                print_if_equals *= 10u;
+            }
+        }
+        for_each_params([&](auto source_params) {
+            using RepT = decltype(type_of(std::get<0>(source_params)));
+            using UnitT = decltype(type_of(std::get<1>(source_params)));
+
+            const auto value = make_quantity<UnitT>(generators.template next_value<RepT>());
+
+            for_each_params([&](auto dest_params) {
+                using DestRepT = decltype(type_of(std::get<0>(dest_params)));
+                using DestUnitT = decltype(type_of(std::get<1>(dest_params)));
+
+                ::au::detail::TestBody<RepT, UnitT, DestRepT, DestUnitT>::test(value);
+            });
+        });
+    }
+}
+
+}  // namespace detail
+}  // namespace au

--- a/fuzz/quantity_runtime_conversion_checkers.hh
+++ b/fuzz/quantity_runtime_conversion_checkers.hh
@@ -1,0 +1,156 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cxxabi.h>
+
+#include <cstdint>
+#include <random>
+
+#include "au/abstract_operations.hh"
+#include "au/stdx/type_traits.hh"
+#include "au/utility/type_traits.hh"
+
+namespace au {
+
+template <typename T>
+std::string type_name() {
+    return abi::__cxa_demangle(typeid(T).name(), nullptr, nullptr, nullptr);
+}
+
+enum class GeneratorStrategy {
+    INTEGRAL,
+    FLOAT,
+    UNSUPPORTED,
+};
+
+template <typename T>
+constexpr GeneratorStrategy get_generator_strategy() {
+    if (std::is_integral<T>::value) {
+        return GeneratorStrategy::INTEGRAL;
+    }
+    if (std::is_floating_point<T>::value) {
+        return GeneratorStrategy::FLOAT;
+    }
+    return GeneratorStrategy::UNSUPPORTED;
+}
+
+template <typename T, GeneratorStrategy Strategy>
+struct RandomValueGeneratorImpl;
+
+template <typename T>
+struct RandomValueGeneratorImpl<T, GeneratorStrategy::INTEGRAL> {
+    T next_value(std::mt19937_64 &engine) {
+        static std::uniform_int_distribution<std::uint64_t> uniform{};
+        return static_cast<T>(uniform(engine));
+    }
+};
+
+template <typename T>
+struct RandomValueGeneratorImpl<T, GeneratorStrategy::FLOAT> {
+    T next_value(std::mt19937_64 &engine) {
+        static std::uniform_int_distribution<std::uint8_t> uniform{};
+        std::uint8_t bytes[sizeof(T)];
+        for (auto i = 0u; i < sizeof(T); ++i) {
+            bytes[i] = uniform(engine);
+        }
+
+        T result{};
+        memcpy(&result, bytes, sizeof(T));
+        return result;
+    }
+};
+
+template <typename T>
+class RandomValueGenerator {
+ public:
+    RandomValueGenerator(std::uint64_t seed) : engine_{seed} {}
+
+    T next_value() {
+        return RandomValueGeneratorImpl<T, get_generator_strategy<T>()>{}.next_value(engine_);
+    }
+
+ private:
+    std::mt19937_64 engine_;
+};
+
+template <typename... Ts>
+class RandomValueGenerators {
+ public:
+    RandomValueGenerators(std::uint64_t seed) : generators_{RandomValueGenerator<Ts>{seed}...} {}
+
+    template <typename T>
+    T next_value() {
+        return std::get<RandomValueGenerator<T>>(generators_).next_value();
+    }
+
+ private:
+    std::tuple<RandomValueGenerator<Ts>...> generators_;
+};
+
+template <template <class...> class Tuple, typename... Packs>
+struct CartesianProductImpl;
+template <template <class...> class Tuple, typename... Packs>
+using CartesianProduct = typename CartesianProductImpl<Tuple, Packs...>::type;
+template <template <class...> class Tuple, template <class...> class Pack, typename... Ts>
+struct CartesianProductImpl<Tuple, Pack<Ts...>> : stdx::type_identity<Pack<Tuple<Ts>...>> {};
+
+template <typename... Packs>
+struct FlattenImpl;
+template <typename... Packs>
+using Flatten = typename FlattenImpl<Packs...>::type;
+template <template <class...> class Pack, typename... Ts>
+struct FlattenImpl<Pack<Ts...>> : stdx::type_identity<Pack<Ts...>> {};
+template <template <class...> class Pack, typename... Ts, typename... Us, typename... Packs>
+struct FlattenImpl<Pack<Ts...>, Pack<Us...>, Packs...>
+    : stdx::type_identity<Flatten<Pack<Ts..., Us...>, Packs...>> {};
+
+template <typename T, typename... Packs>
+struct PrependToEachImpl;
+template <typename T, typename... Packs>
+using PrependToEach = typename PrependToEachImpl<T, Packs...>::type;
+template <template <class...> class Pack, typename T, typename... Ts>
+struct PrependToEachImpl<T, Pack<Ts...>> {
+    using type = Pack<detail::PrependT<Ts, T>...>;
+};
+
+template <template <class...> class Tuple,
+          template <class...>
+          class Pack,
+          typename... Ts,
+          typename... Packs>
+struct CartesianProductImpl<Tuple, Pack<Ts...>, Packs...> {
+    using type = Flatten<PrependToEach<Ts, CartesianProduct<Tuple, Packs...>>...>;
+};
+
+namespace detail {
+
+template <typename OpSeq>
+struct FloatingPointPrefixPartImpl;
+template <typename OpSeq>
+using FloatingPointPrefixPart = typename FloatingPointPrefixPartImpl<OpSeq>::type;
+
+template <typename Op, typename... Ops>
+struct FloatingPointPrefixPartImpl<OpSequenceImpl<Op, Ops...>>
+    : std::conditional<stdx::conjunction<std::is_floating_point<RealPart<OpInput<Op>>>,
+                                         std::is_floating_point<RealPart<OpOutput<Op>>>>::value,
+                       OpSequence<Op, FloatingPointPrefixPart<OpSequence<Ops...>>>,
+                       OpSequence<>> {};
+
+template <>
+struct FloatingPointPrefixPartImpl<OpSequenceImpl<>> : stdx::type_identity<OpSequence<>> {};
+
+}  // namespace detail
+}  // namespace au

--- a/fuzz/quantity_runtime_conversion_checkers_test.cc
+++ b/fuzz/quantity_runtime_conversion_checkers_test.cc
@@ -97,7 +97,7 @@ TYPED_TEST_P(QuantityRuntimeConversionChecker, RoundTripIsIdentityIffConversionN
     using Rep = std::tuple_element_t<0, TypeParam>;
     constexpr auto destination_unit = std::tuple_element_t<1, TypeParam>{};
     RandomValueGenerator<Rep> generator{9876543210u};
-    for (auto i = 0u; i < 1'000'000u; ++i) {
+    for (auto _ = 1'000'000u; --_;) {
         const auto value = meters(generator.next_value());
 
         const bool expect_loss = is_conversion_lossy(value, destination_unit);

--- a/fuzz/quantity_runtime_conversion_checkers_test.cc
+++ b/fuzz/quantity_runtime_conversion_checkers_test.cc
@@ -29,6 +29,7 @@
 namespace au {
 namespace {
 
+using ::testing::Eq;
 using ::testing::StaticAssertTypeEq;
 
 using ::au::detail::FloatingPointPrefixPart;
@@ -105,7 +106,8 @@ TYPED_TEST_P(QuantityRuntimeConversionChecker, RoundTripIsIdentityIffConversionN
         const auto round_trip = value.coerce_as(destination_unit).coerce_as(meters);
         const bool actual_loss = (value != round_trip);
 
-        EXPECT_EQ(expect_loss, actual_loss) << "Value: " << value << " Round trip: " << round_trip;
+        EXPECT_THAT(expect_loss, Eq(actual_loss))
+            << "Value: " << value << " Round trip: " << round_trip;
     }
 }
 

--- a/fuzz/quantity_runtime_conversion_checkers_test.cc
+++ b/fuzz/quantity_runtime_conversion_checkers_test.cc
@@ -1,0 +1,137 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fuzz/quantity_runtime_conversion_checkers.hh"
+
+#include <tuple>
+#include <type_traits>
+
+#include "au/conversion_strategy.hh"
+#include "au/quantity.hh"
+#include "au/testing.hh"
+#include "au/units/inches.hh"
+#include "au/units/meters.hh"
+#include "au/units/miles.hh"
+#include "au/units/yards.hh"
+#include "gtest/gtest.h"
+
+namespace au {
+namespace {
+
+using ::testing::StaticAssertTypeEq;
+
+using ::au::detail::FloatingPointPrefixPart;
+using ::au::detail::MultiplyTypeBy;
+using ::au::detail::OpSequence;
+using ::au::detail::StaticCast;
+
+TEST(PrependToEach, PrependsElementToEachPack) {
+    StaticAssertTypeEq<PrependToEach<int, ::testing::Types<>>, ::testing::Types<>>();
+    StaticAssertTypeEq<
+        PrependToEach<int, ::testing::Types<std::tuple<char>, std::tuple<double, float>>>,
+        ::testing::Types<std::tuple<int, char>, std::tuple<int, double, float>>>();
+}
+
+TEST(Flatten, ConcatenatesPacksOfSameType) {
+    StaticAssertTypeEq<Flatten<::testing::Types<>>, ::testing::Types<>>();
+    StaticAssertTypeEq<Flatten<::testing::Types<>, ::testing::Types<>>, ::testing::Types<>>();
+}
+
+TEST(CartesianProduct, AppliesPackToEachElementOfSinglePack) {
+    StaticAssertTypeEq<CartesianProduct<std::tuple, ::testing::Types<int, double, float>>,
+                       ::testing::Types<std::tuple<int>, std::tuple<double>, std::tuple<float>>>();
+}
+
+TEST(CartesianProduct, CombinesMultiplePacksIntoASinglePackWithAllCombinations) {
+    StaticAssertTypeEq<
+        CartesianProduct<std::tuple, ::testing::Types<int, double>, ::testing::Types<float, char>>,
+        ::testing::Types<std::tuple<int, float>,
+                         std::tuple<int, char>,
+                         std::tuple<double, float>,
+                         std::tuple<double, char>>>();
+}
+
+TEST(CartesianProduct, CanHandleMultipleLayers) {
+    struct A_1;
+    struct A_2;
+
+    struct B_1;
+    struct B_2;
+
+    struct C_1;
+    struct C_2;
+
+    StaticAssertTypeEq<CartesianProduct<std::tuple,
+
+                                        ::testing::Types<A_1, A_2>,
+                                        ::testing::Types<B_1, B_2>,
+                                        ::testing::Types<C_1, C_2>>,
+
+                       ::testing::Types<std::tuple<A_1, B_1, C_1>,
+                                        std::tuple<A_1, B_1, C_2>,
+                                        std::tuple<A_1, B_2, C_1>,
+                                        std::tuple<A_1, B_2, C_2>,
+                                        std::tuple<A_2, B_1, C_1>,
+                                        std::tuple<A_2, B_1, C_2>,
+                                        std::tuple<A_2, B_2, C_1>,
+                                        std::tuple<A_2, B_2, C_2>>>();
+}
+
+template <typename T>
+class QuantityRuntimeConversionChecker : public ::testing::Test {};
+
+TYPED_TEST_SUITE_P(QuantityRuntimeConversionChecker);
+
+TYPED_TEST_P(QuantityRuntimeConversionChecker, RoundTripIsIdentityIffConversionNotLossy) {
+    using Rep = std::tuple_element_t<0, TypeParam>;
+    constexpr auto destination_unit = std::tuple_element_t<1, TypeParam>{};
+    RandomValueGenerator<Rep> generator{9876543210u};
+    for (auto i = 0u; i < 1'000'000u; ++i) {
+        const auto value = meters(generator.next_value());
+
+        const bool expect_loss = is_conversion_lossy(value, destination_unit);
+
+        const auto round_trip = value.coerce_as(destination_unit).coerce_as(meters);
+        const bool actual_loss = (value != round_trip);
+
+        EXPECT_EQ(expect_loss, actual_loss) << "Value: " << value << " Round trip: " << round_trip;
+    }
+}
+
+REGISTER_TYPED_TEST_SUITE_P(QuantityRuntimeConversionChecker,
+                            RoundTripIsIdentityIffConversionNotLossy);
+
+using IntTypes =
+    ::testing::Types<uint64_t, int64_t, uint32_t, int32_t, uint16_t, int16_t, uint8_t, int8_t>;
+using DestinationUnits = ::testing::Types<Inches, Yards, Miles>;
+
+using TypesToTest = CartesianProduct<std::tuple, IntTypes, DestinationUnits>;
+INSTANTIATE_TYPED_TEST_SUITE_P(X, QuantityRuntimeConversionChecker, TypesToTest, );
+
+TEST(FloatingPointPrefixPart, EmptyForSequenceThatStartsAsIntegral) {
+    StaticAssertTypeEq<FloatingPointPrefixPart<OpSequence<StaticCast<int, double>>>,
+                       OpSequence<>>();
+}
+
+TEST(FloatingPointPrefixPart, DiscardsFromFirstOperationThatExitsFloatingPoint) {
+    StaticAssertTypeEq<
+        FloatingPointPrefixPart<OpSequence<StaticCast<float, double>,
+                                           MultiplyTypeBy<double, decltype(mag<2>())>,
+                                           StaticCast<double, int>,
+                                           MultiplyTypeBy<int, decltype(mag<3>())>>>,
+        OpSequence<StaticCast<float, double>, MultiplyTypeBy<double, decltype(mag<2>())>>>();
+}
+
+}  // namespace
+}  // namespace au


### PR DESCRIPTION
This is a simple tool to randomly generate values in a wide variety of
types, and try applying a bunch of unit conversions.  We make sure that
the round trip value changes if and only if we expect the conversion to
be lossy.

Of course, there are a variety of edge case ways for this to be
mismatched that we deem to be OK.  For example, floating point values
can be "subnormal", and we want to consider those out of scope.
Additionally, we assume that a floating point conversion can differ from
the best value by up to 1 ULP, so a round trip can be off by up to 2
ULP.  There are a few other carveouts of this nature.

If we find a mismatch, we terminate and immediately print out details
about the specific test case.  The expectation is that we will either
add a test case to the library and fix the implementation, or else add a
carveout to this utility.  The goal is to get to a state where we can
run continuously and not find any unaccepted anomalies.

Overall, this tool should greatly increase our confidence that our
runtime overflow and truncation checkers are working correctly.

Usage:

```sh
bazel run //fuzz:quantity_runtime_conversion_check
```

Helps #349.