### PR TITLE
Handle `std::complex` types in conversion strategy

### DIFF
--- a/au/conversion_strategy.hh
+++ b/au/conversion_strategy.hh
@@ -68,31 +68,67 @@ struct ApplicationStrategyForImpl<T, Mag, MagKind::INTEGER_DIVIDE>
 template <typename T, typename Mag>
 struct ApplicationStrategyForImpl<T, Mag, MagKind::NONTRIVIAL_RATIONAL>
     : std::conditional<
-          std::is_integral<T>::value,
+          std::is_integral<RealPart<T>>::value,
           OpSequence<MultiplyTypeBy<T, NumeratorT<Mag>>, DivideTypeByInteger<T, DenominatorT<Mag>>>,
           MultiplyTypeBy<T, Mag>> {};
 
 //
-// `FullConversionImpl<OldRep, PromotedCommon, NewRep, Factor>` should resolve to the most efficient
-// sequence of operations for a conversion from `OldRep` to `NewRep`, with a magnitude `Factor`,
-// where `PromotedCommon` is the promoted type of the common type of `OldRep` and `NewRep`.
+// `RepForConversion<OldRep, NewRep>` is the rep we should use when applying the conversion factor.
+//
+template <typename OldRep, typename NewRep>
+struct ApplicationRepImpl;
+template <typename OldRep, typename NewRep>
+using RepForConversion = typename ApplicationRepImpl<OldRep, NewRep>::type;
+
+template <typename OldRep, typename NewRep>
+struct IsRealToComplex
+    : stdx::conjunction<std::is_same<OldRep, RealPart<OldRep>>,
+                        stdx::experimental::is_detected<TypeOfRealMember, NewRep>> {};
+
+template <typename OldRep, typename NewRep>
+struct ApplicationRepImpl
+    : std::conditional<IsRealToComplex<OldRep, NewRep>::value,
+                       PromotedType<std::common_type_t<RealPart<OldRep>, RealPart<NewRep>>>,
+                       PromotedType<std::common_type_t<OldRep, NewRep>>> {};
+
+//
+// `StaticCastSequence<T, U>` is the sequence of operations that gets us from `T` to `U`.
+//
+// Normally, of course, this is just `StaticCast<T, U>`.  But we have weird edge cases like going
+// from `double` to `std::complex<int>`, which require an intermediate step of static casting to
+// `int`.
 //
 
-template <typename OldRep, typename PromotedCommon, typename NewRep, typename Factor>
+template <typename T, typename U>
+struct StaticCastSequenceImpl
+    : std::conditional<stdx::conjunction<IsRealToComplex<T, U>,
+                                         stdx::negation<std::is_same<T, RealPart<U>>>>::value,
+                       OpSequence<StaticCast<T, RealPart<U>>, StaticCast<RealPart<U>, U>>,
+                       StaticCast<T, U>> {};
+template <typename T, typename U>
+using StaticCastSequence = typename StaticCastSequenceImpl<T, U>::type;
+
+//
+// `FullConversionImpl<OldRep, ApplicationRep, NewRep, Factor>` should resolve to the most efficient
+// sequence of operations for a conversion from `OldRep` to `NewRep`, with a magnitude `Factor`,
+// where `ApplicationRep` is the promoted type of the common type of `OldRep` and `NewRep`.
+//
+
+template <typename OldRep, typename ApplicationRep, typename NewRep, typename Factor>
 struct FullConversionImpl
-    : stdx::type_identity<OpSequence<StaticCast<OldRep, PromotedCommon>,
-                                     ApplicationStrategyFor<PromotedCommon, Factor>,
-                                     StaticCast<PromotedCommon, NewRep>>> {};
+    : stdx::type_identity<OpSequence<StaticCastSequence<OldRep, ApplicationRep>,
+                                     ApplicationStrategyFor<ApplicationRep, Factor>,
+                                     StaticCastSequence<ApplicationRep, NewRep>>> {};
 
-template <typename OldRepIsPromotedCommon, typename NewRep, typename Factor>
-struct FullConversionImpl<OldRepIsPromotedCommon, OldRepIsPromotedCommon, NewRep, Factor>
-    : stdx::type_identity<OpSequence<ApplicationStrategyFor<OldRepIsPromotedCommon, Factor>,
-                                     StaticCast<OldRepIsPromotedCommon, NewRep>>> {};
+template <typename OldRepIsApplicationRep, typename NewRep, typename Factor>
+struct FullConversionImpl<OldRepIsApplicationRep, OldRepIsApplicationRep, NewRep, Factor>
+    : stdx::type_identity<OpSequence<ApplicationStrategyFor<OldRepIsApplicationRep, Factor>,
+                                     StaticCastSequence<OldRepIsApplicationRep, NewRep>>> {};
 
-template <typename OldRep, typename NewRepIsPromotedCommon, typename Factor>
-struct FullConversionImpl<OldRep, NewRepIsPromotedCommon, NewRepIsPromotedCommon, Factor>
-    : stdx::type_identity<OpSequence<StaticCast<OldRep, NewRepIsPromotedCommon>,
-                                     ApplicationStrategyFor<NewRepIsPromotedCommon, Factor>>> {};
+template <typename OldRep, typename NewRepIsApplicationRep, typename Factor>
+struct FullConversionImpl<OldRep, NewRepIsApplicationRep, NewRepIsApplicationRep, Factor>
+    : stdx::type_identity<OpSequence<StaticCastSequence<OldRep, NewRepIsApplicationRep>,
+                                     ApplicationStrategyFor<NewRepIsApplicationRep, Factor>>> {};
 
 template <typename Rep, typename Factor>
 struct FullConversionImpl<Rep, Rep, Rep, Factor>
@@ -101,8 +137,7 @@ struct FullConversionImpl<Rep, Rep, Rep, Factor>
 // To implement `ConversionForRepsAndFactor`, delegate to `FullConversionImpl`.
 template <typename OldRep, typename NewRep, typename Factor>
 struct ConversionForRepsAndFactorImpl
-    : FullConversionImpl<OldRep, PromotedType<std::common_type_t<OldRep, NewRep>>, NewRep, Factor> {
-};
+    : FullConversionImpl<OldRep, RepForConversion<OldRep, NewRep>, NewRep, Factor> {};
 
 }  // namespace detail
 }  // namespace au


### PR DESCRIPTION
Fundamentally, this is all about the tests.  We're just adding a few
more test cases, and making them pass.

What those tests showed us is interesting.

The first test is pretty straightforward.  It showed that we weren't
doing the same multiply-then-divide operation for `std::complex<int>`
that we would do for `int`.  That was very easy to fix.

The rest of the tests cover the tricky and subtle case that #445
handled.  In the parlance of our new `:abstract_operations` target, if
you try to `StaticCast<double, std::complex<int>>`, it will _compile_,
but you'll get a warning.  `std::complex<int>` has an `int` constructor,
and the `double` will get _implicitly_ converted to `int` --- even
though the static cast itself is an _explicit_ conversion!

To fix this, we need to add two abstractions into our strategy
generation.  First, instead of calling it the "promoted common" type
(which was always properly an implementation detail), we now call it
what it is: the _"application rep"_ --- that is, the rep we should use
for applying the conversion factor.  Next, we replace `StaticCast` with
`StaticCastSequence`, which allows us to detect problematic single-hop
conversions and replace them with a more manageable sequence.

For now, we're only handling the "real to complex" case, but these
abstractions feel like the right ones.  In general, we need to get our
initial type to the conversion type, perform the conversion, and then
get the result to the final type.

Helps #349.