### PR TITLE
Tweak invalid construction policy tests

### DIFF
--- a/au/conversion_policy_test.cc
+++ b/au/conversion_policy_test.cc
@@ -159,18 +159,9 @@ TEST(ConstructionPolicy, PermitsImplicitFromIntegralTypesIffTargetScaleDividesSo
 }
 
 TEST(ConstructionPolicy, ComplexToRealPreventsImplicitConversion) {
-    // `complex<int>` -> `float`: forbid, although `int` -> `float` is allowed.
     using gigagrams_float_policy = ConstructionPolicy<Gigagrams, float>;
-    ASSERT_THAT((gigagrams_float_policy::PermitImplicitFrom<Grams, int>::value), IsTrue());
-    EXPECT_THAT((gigagrams_float_policy::PermitImplicitFrom<Grams, std::complex<int>>::value),
+    EXPECT_THAT((gigagrams_float_policy::PermitImplicitFrom<Grams, std::complex<float>>::value),
                 IsFalse());
-
-    // (`int` or `complex<int>`) -> `complex<float>`: both allowed.
-    using gigagrams_complex_float_policy = ConstructionPolicy<Gigagrams, std::complex<float>>;
-    EXPECT_THAT((gigagrams_complex_float_policy::PermitImplicitFrom<Grams, int>::value), IsTrue());
-    EXPECT_THAT(
-        (gigagrams_complex_float_policy::PermitImplicitFrom<Grams, std::complex<int>>::value),
-        IsTrue());
 }
 
 TEST(ConstructionPolicy, ForbidsImplicitConstructionOfIntegralTypeFromFloatingPtType) {
@@ -188,17 +179,17 @@ TEST(ConstructionPolicy, AlwaysOkForSameRepAndEquivalentUnit) {
 }
 
 TEST(ConstructionPolicy, NotOkForNegativeRatioAndUnsignedDestination) {
-    EXPECT_THAT(
-        (ConstructionPolicy<NegativeDegrees, uint8_t>::PermitImplicitFrom<Degrees, int8_t>::value),
-        IsFalse());
-    EXPECT_THAT(
-        (ConstructionPolicy<NegativeDegrees, uint8_t>::PermitImplicitFrom<Degrees, uint8_t>::value),
-        IsFalse());
+    EXPECT_THAT((ConstructionPolicy<NegativeDegrees, uint16_t>::PermitImplicitFrom<Degrees,
+                                                                                   int16_t>::value),
+                IsFalse());
+    EXPECT_THAT((ConstructionPolicy<NegativeDegrees,
+                                    uint16_t>::PermitImplicitFrom<Degrees, uint16_t>::value),
+                IsFalse());
 
     // Make sure it's explicitly the unsigned _destination_ that we were forbidding.
-    ASSERT_THAT(
-        (ConstructionPolicy<NegativeDegrees, int8_t>::PermitImplicitFrom<Degrees, uint8_t>::value),
-        IsTrue());
+    ASSERT_THAT((ConstructionPolicy<NegativeDegrees, int16_t>::PermitImplicitFrom<Degrees,
+                                                                                  uint16_t>::value),
+                IsTrue());
 }
 
 TEST(ConstructionPolicy, OkForIntegralRepAndEquivalentUnit) {


### PR DESCRIPTION
The "complex to real" test was based on some assumptions about how
`std::complex` worked which I had never verified.  It turns out that
whether or not we _permit_ certain conversions, they may not even be
_possible_.  For example: you can't actually construct a
`std::complex<float>` from a `std::complex<int>`, even though you can of
course construct a `float` from an `int`!

Therefore, we delete all irrelevant aspects of the test case, and focus
it down to its core: that `std::complex<float>` to `float` is forbidden.

The "negative ratio, unsigned destination" test will begin to fail for
an unrelated reason, with our new and more carefully designed
construction policy.  `uint8_t` has a max value of 255, and `int8_t` a
max value of 127.  We will now prevent assigning the former to the
latter because the risk of overflow is too high.  (The max
non-overflowing value is 127, which is smaller than our threshold of
2147.)

Here, the fix is to just use 16-bit integers.

Helps #349.