### PR TITLE
Add `UpdateRisk<Op, Risk>` helper

### DIFF
--- a/au/truncation_risk_test.cc
+++ b/au/truncation_risk_test.cc
@@ -203,6 +203,246 @@ TEST(WouldValueTruncate, AssumedAlwaysTrueIfCannotAssessTruncationRisk) {
     EXPECT_THAT(CannotAssessRisk::would_value_truncate(-1), IsTrue());
 }
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `UpdateRisk` section:
+
+TEST(UpdateRisk, StaticCastFloatToFloatPreservesRiskButChangesInputType) {
+    StaticAssertTypeEq<UpdateRisk<StaticCast<float, double>, NoTruncationRisk<double>>,
+                       NoTruncationRisk<float>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<double, float>, ValueIsNotInteger<float>>,
+                       ValueIsNotInteger<double>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<long double, float>, ValueIsNotZero<float>>,
+                       ValueIsNotZero<long double>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<float, long double>,
+                                  ValueDivIntIsNotInteger<long double, decltype(mag<3>())>>,
+                       ValueDivIntIsNotInteger<float, decltype(mag<3>())>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<long double, double>,
+                                  ValueTimesIntIsNotInteger<double, decltype(mag<4>())>>,
+                       ValueTimesIntIsNotInteger<long double, decltype(mag<4>())>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<StaticCast<float, double>,
+                   ValueTimesRatioIsNotInteger<double, decltype(mag<3>() / mag<4>())>>,
+        ValueTimesRatioIsNotInteger<float, decltype(mag<3>() / mag<4>())>>();
+}
+
+TEST(UpdateRisk, AnyOpBeforeCannotAssessTruncationRiskUpdatesInputType) {
+    StaticAssertTypeEq<UpdateRisk<StaticCast<float, int>, CannotAssessTruncationRiskFor<int>>,
+                       CannotAssessTruncationRiskFor<float>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<int, decltype(mag<2>())>, CannotAssessTruncationRiskFor<int>>,
+        CannotAssessTruncationRiskFor<int>>();
+
+    StaticAssertTypeEq<UpdateRisk<DivideTypeByInteger<float, decltype(mag<3>())>,
+                                  CannotAssessTruncationRiskFor<float>>,
+                       CannotAssessTruncationRiskFor<float>>();
+}
+
+TEST(UpdateRisk, AnyOpBeforeValueIsNotZeroIsValueIsNotZero) {
+    StaticAssertTypeEq<UpdateRisk<StaticCast<float, int>, ValueIsNotZero<int>>,
+                       ValueIsNotZero<float>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<int16_t, double>, ValueIsNotZero<double>>,
+                       ValueIsNotZero<int16_t>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<uint16_t, int32_t>, ValueIsNotZero<int32_t>>,
+                       ValueIsNotZero<uint16_t>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<double, float>, ValueIsNotZero<float>>,
+                       ValueIsNotZero<double>>();
+
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<int, decltype(mag<2>())>, ValueIsNotZero<int>>,
+                       ValueIsNotZero<int>>();
+
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<float, decltype(mag<2>())>, ValueIsNotZero<float>>,
+                       ValueIsNotZero<float>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<int, decltype(mag<1>() / mag<4>())>, ValueIsNotZero<int>>,
+        ValueIsNotZero<int>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<float, decltype(mag<1>() / mag<4>())>, ValueIsNotZero<float>>,
+        ValueIsNotZero<float>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<int, decltype(PI / mag<180>())>, ValueIsNotZero<int>>,
+        ValueIsNotZero<int>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<float, decltype(PI / mag<180>())>, ValueIsNotZero<float>>,
+        ValueIsNotZero<float>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<DivideTypeByInteger<int, decltype(mag<2>())>, ValueIsNotZero<int>>,
+        ValueIsNotZero<int>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<DivideTypeByInteger<float, decltype(mag<2>())>, ValueIsNotZero<float>>,
+        ValueIsNotZero<float>>();
+}
+
+TEST(UpdateRisk, AnyOpBeforeNoTruncationRiskIsNoTruncationRisk) {
+    StaticAssertTypeEq<UpdateRisk<StaticCast<float, int>, NoTruncationRisk<int>>,
+                       NoTruncationRisk<float>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<int16_t, double>, NoTruncationRisk<double>>,
+                       NoTruncationRisk<int16_t>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<uint16_t, int32_t>, NoTruncationRisk<int32_t>>,
+                       NoTruncationRisk<uint16_t>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<double, float>, NoTruncationRisk<float>>,
+                       NoTruncationRisk<double>>();
+
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<int, decltype(mag<2>())>, NoTruncationRisk<int>>,
+                       NoTruncationRisk<int>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<float, decltype(mag<2>())>, NoTruncationRisk<float>>,
+        NoTruncationRisk<float>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<int, decltype(mag<1>() / mag<4>())>, NoTruncationRisk<int>>,
+        NoTruncationRisk<int>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<float, decltype(mag<1>() / mag<4>())>, NoTruncationRisk<float>>,
+        NoTruncationRisk<float>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<int, decltype(PI / mag<180>())>, NoTruncationRisk<int>>,
+        NoTruncationRisk<int>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<float, decltype(PI / mag<180>())>, NoTruncationRisk<float>>,
+        NoTruncationRisk<float>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<DivideTypeByInteger<int, decltype(mag<2>())>, NoTruncationRisk<int>>,
+        NoTruncationRisk<int>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<DivideTypeByInteger<float, decltype(mag<2>())>, NoTruncationRisk<float>>,
+        NoTruncationRisk<float>>();
+}
+
+TEST(UpdateRisk, StaticCastIntToFloatBeforeValueIsNotIntegerIsNoTruncationRisk) {
+    StaticAssertTypeEq<UpdateRisk<StaticCast<int16_t, float>, ValueIsNotInteger<float>>,
+                       NoTruncationRisk<int16_t>>();
+}
+
+TEST(UpdateRisk, MultiplyFloatByIntBeforeValueIsNotIntegerIsValuesNotSomeIntegerDividedBy) {
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<float, decltype(mag<6>())>, ValueIsNotInteger<float>>,
+        ValueTimesIntIsNotInteger<float, decltype(mag<6>())>>();
+}
+
+TEST(UpdateRisk, DivideFloatByIntBeforeValueIsNotIntegerIsValuesNotSomeIntegerTimes) {
+    StaticAssertTypeEq<
+        UpdateRisk<DivideTypeByInteger<float, decltype(mag<6>())>, ValueIsNotInteger<float>>,
+        ValueDivIntIsNotInteger<float, decltype(mag<6>())>>();
+}
+
+TEST(UpdateRisk, MultiplyFloatByIrrationalBeforeValueTimesRatioIsNotIntegerIsValueIsNotZero) {
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<float, decltype(PI / mag<180>())>, ValueIsNotInteger<float>>,
+        ValueIsNotZero<float>>();
+
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<double, decltype(sqrt(mag<2>()))>,
+                                  ValueTimesIntIsNotInteger<double, decltype(mag<8>())>>,
+                       ValueIsNotZero<double>>();
+
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<long double, decltype(PI / mag<180>())>,
+                                  ValueDivIntIsNotInteger<long double, decltype(mag<123>())>>,
+                       ValueIsNotZero<long double>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<MultiplyTypeBy<double, decltype(sqrt(mag<2>()))>,
+                   ValueTimesRatioIsNotInteger<double, decltype(mag<3>() / mag<5>())>>,
+        ValueIsNotZero<double>>();
+}
+
+TEST(UpdateRisk, StaticCastIntToFloatBeforeValueTimesIntIsNotIntegerIsNoTruncationRisk) {
+    StaticAssertTypeEq<UpdateRisk<StaticCast<int16_t, float>,
+                                  ValueTimesIntIsNotInteger<float, decltype(mag<23>())>>,
+                       NoTruncationRisk<int16_t>>();
+}
+
+TEST(UpdateRisk, MultiplyFloatByIntBeforeValueTimesIntIsNotIntegerMultipliesFactor) {
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<float, decltype(mag<6>())>,
+                                  ValueTimesIntIsNotInteger<float, decltype(mag<9>())>>,
+                       ValueTimesIntIsNotInteger<float, decltype(mag<54>())>>();
+}
+
+TEST(UpdateRisk, DivideFloatByIntBeforeValueTimesIntIsNotIntegerMakesFraction) {
+    StaticAssertTypeEq<UpdateRisk<DivideTypeByInteger<float, decltype(mag<6>())>,
+                                  ValueTimesIntIsNotInteger<float, decltype(mag<7>())>>,
+                       ValueTimesRatioIsNotInteger<float, decltype(mag<7>() / mag<6>())>>();
+}
+
+TEST(UpdateRisk, StaticCastBeforeValueDivIntIsNotIntegerGivesSame) {
+    StaticAssertTypeEq<
+        UpdateRisk<StaticCast<int16_t, float>, ValueDivIntIsNotInteger<float, decltype(mag<23>())>>,
+        ValueDivIntIsNotInteger<int16_t, decltype(mag<23>())>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<uint32_t, int64_t>,
+                                  ValueDivIntIsNotInteger<int64_t, decltype(mag<123>())>>,
+                       ValueDivIntIsNotInteger<uint32_t, decltype(mag<123>())>>();
+
+    StaticAssertTypeEq<
+        UpdateRisk<StaticCast<double, float>, ValueDivIntIsNotInteger<float, decltype(mag<456>())>>,
+        ValueDivIntIsNotInteger<double, decltype(mag<456>())>>();
+
+    StaticAssertTypeEq<UpdateRisk<StaticCast<float, int16_t>,
+                                  ValueDivIntIsNotInteger<int16_t, decltype(mag<789>())>>,
+                       ValueDivIntIsNotInteger<float, decltype(mag<789>())>>();
+}
+
+TEST(UpdateRisk, MultiplyIntByIntBeforeValueDivIntIsNotIntegerUpdatesRatio) {
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<int16_t, decltype(mag<3>())>,
+                                  ValueDivIntIsNotInteger<int16_t, decltype(mag<5>())>>,
+                       ValueTimesRatioIsNotInteger<int16_t, decltype(mag<3>() / mag<5>())>>();
+
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<uint32_t, decltype(mag<8>())>,
+                                  ValueDivIntIsNotInteger<uint32_t, decltype(mag<12>())>>,
+                       ValueTimesRatioIsNotInteger<uint32_t, decltype(mag<2>() / mag<3>())>>();
+}
+
+TEST(UpdateRisk,
+     MultiplyIntByExactMultipleOfDivisorBeforeValueDivIntIsNotIntegerIsNoTruncationRisk) {
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<uint64_t, decltype(mag<7>())>,
+                                  ValueDivIntIsNotInteger<uint64_t, decltype(mag<7>())>>,
+                       NoTruncationRisk<uint64_t>>();
+
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<int, decltype(mag<10>())>,
+                                  ValueDivIntIsNotInteger<int, decltype(mag<2>())>>,
+                       NoTruncationRisk<int>>();
+}
+
+TEST(UpdateRisk, MultiplyFloatByIntBeforeValueDivIntIsNotIntegerUpdatesRatio) {
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<float, decltype(mag<3>())>,
+                                  ValueDivIntIsNotInteger<float, decltype(mag<5>())>>,
+                       ValueTimesRatioIsNotInteger<float, decltype(mag<3>() / mag<5>())>>();
+
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<double, decltype(mag<8>())>,
+                                  ValueDivIntIsNotInteger<double, decltype(mag<12>())>>,
+                       ValueTimesRatioIsNotInteger<double, decltype(mag<2>() / mag<3>())>>();
+
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<long double, decltype(mag<7>())>,
+                                  ValueDivIntIsNotInteger<long double, decltype(mag<7>())>>,
+                       ValueIsNotInteger<long double>>();
+
+    StaticAssertTypeEq<UpdateRisk<MultiplyTypeBy<float, decltype(mag<10>())>,
+                                  ValueDivIntIsNotInteger<float, decltype(mag<2>())>>,
+                       ValueTimesIntIsNotInteger<float, decltype(mag<5>())>>();
+}
+
 }  // namespace
 }  // namespace detail
 }  // namespace au


### PR DESCRIPTION
Our goal is to assess truncation risk for `OpSequence<Ops...>`
instances.  Just like with overflow risk, we'll start from the last
operation, and work our way backwards.  But the substance is quite
different.

First: we are making the explicit assumption that we can always reduce
the risk for a compound operation to a single risk category.  This may
or may not always be strictly true.  However, it does seem like it's at
least good enough to get a working implementation that we can start
with.  And there's a good chance that it _is_ true if we restrict
ourselves to _the kinds of operation sequences that we will actually
use_ in unit conversions.

(For posterity: what would we do if we learned that this assumption is
wrong?  We would return a _list_ of risks, and assess all of them.  This
list should almost always turn out to have only one element anyway.)

Now: based on this truncation risk strategy, there are two sources of
risk to compare at each step:

1. The (simplified) risk from "all future operations in the sequence".

2. The "direct" risk from the current operation.

The problem is that steps 1 and 2 can't be compared, because in general
they operate on different types.  That's why we need the `UpdateRisk`
utility: to take a risk object, and "back-propagate" it using the
current operation.

Normally, this "back propagation" is very simple: it just updates the
input type.  But sometimes it can be more complex.  For example, if we
have a risk `ValueIsNotInteger<float>`, but it's preceded by a
`StaticCast<int, float>`, then it should become `NoTruncationRisk<int>`,
because we know the `int` input will always produce integral `float`
values.

Helps #349.