### PR TITLE
Simplify `detail::MakeSigned<T>`

### DIFF
--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -417,12 +417,8 @@ constexpr auto operator<=>(const QuantityPoint<U1, R1> &lhs, const QuantityPoint
 namespace detail {
 
 // We simply want a version of `std::make_signed_t` that won't choke on non-integral types.
-template <typename T, bool IsInt = std::is_integral<T>::value>
-struct MakeSigned;
 template <typename T>
-struct MakeSigned<T, false> : stdx::type_identity<T> {};
-template <typename T>
-struct MakeSigned<T, true> : stdx::type_identity<std::make_signed_t<T>> {};
+struct MakeSigned : std::conditional<std::is_integral<T>::value, std::make_signed_t<T>, T> {};
 
 // If the destination is a signed integer, we want to ensure we do our
 // computations in a signed type.  Otherwise, just use the common type for our


### PR DESCRIPTION
The current implementation is goofy and embarrassing, and I cannot
account for what I was thinking at the time.

This also lets us get rid of a `bool` template parameter!