### PR TITLE
Narrow the policy carveout for integer promotion

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -313,6 +313,7 @@ cc_test(
     deps = [
         ":conversion_policy",
         ":unit_of_measure",
+        ":utility",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -91,6 +91,7 @@ struct ConversionRiskAcceptablyLow
 template <typename Rep, typename ScaleFactor, typename SourceRep>
 struct PermitAsCarveOutForIntegerPromotion
     : stdx::conjunction<std::is_same<Abs<ScaleFactor>, Magnitude<>>,
+                        std::is_same<SourceRep, PromotedType<Rep>>,
                         stdx::disjunction<IsPositive<ScaleFactor>, std::is_signed<Rep>>,
                         std::is_integral<Rep>,
                         std::is_integral<SourceRep>,

--- a/au/conversion_policy_test.cc
+++ b/au/conversion_policy_test.cc
@@ -17,6 +17,7 @@
 #include <complex>
 
 #include "au/unit_of_measure.hh"
+#include "au/utility/type_traits.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -195,6 +196,15 @@ TEST(ConstructionPolicy, OkForSignedIntegralToUnsignedIntegral) {
     EXPECT_THAT(
         (ConstructionPolicy<Grams, uint64_t>::PermitImplicitFrom<Kilograms, int64_t>::value),
         IsTrue());
+}
+
+TEST(ConstructionPolicy, OkForExactlyPromotedType) {
+    ASSERT_THAT((std::is_same<int, detail::PromotedType<int8_t>>::value), IsTrue());
+
+    EXPECT_THAT((ConstructionPolicy<Grams, int8_t>::PermitImplicitFrom<Grams, int>::value),
+                IsTrue());
+    EXPECT_THAT((ConstructionPolicy<Grams, int8_t>::PermitImplicitFrom<Grams, uint16_t>::value),
+                IsFalse());
 }
 
 }  // namespace


### PR DESCRIPTION
Right now, we permit assigning to a promotable integral type from _any
other integral type_.  This is way more permissive than we need to be.
We really only need this loophole for the exact promoted type.  This
closes the loophole.