### PR TITLE
Support policy argument for `Quantity` `in`, `as`

### DIFF
--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -37,8 +37,10 @@ namespace au {
 //
 
 enum class ConversionRisk : uint8_t {
-    OVERFLOW = 1u << 0u,
-    TRUNCATION = 1u << 1u,
+    // We use CamelCase instead of UPPER_SNAKE_CASE because `OVERFLOW` causes compiler errors on gcc
+    // and MSVC.
+    Overflow = 1u,
+    Truncation = 2u,
 };
 
 template <typename T>
@@ -66,8 +68,8 @@ struct CheckTheseRisks<RiskSet<RiskFlags>> {
     }
 };
 
-constexpr auto OVERFLOW_RISK = RiskSet<static_cast<uint8_t>(ConversionRisk::OVERFLOW)>{};
-constexpr auto TRUNCATION_RISK = RiskSet<static_cast<uint8_t>(ConversionRisk::TRUNCATION)>{};
+constexpr auto OVERFLOW_RISK = RiskSet<static_cast<uint8_t>(ConversionRisk::Overflow)>{};
+constexpr auto TRUNCATION_RISK = RiskSet<static_cast<uint8_t>(ConversionRisk::Truncation)>{};
 constexpr auto ALL_RISKS = OVERFLOW_RISK | TRUNCATION_RISK;
 
 //
@@ -125,7 +127,7 @@ struct OverflowAboveRiskAcceptablyLow
 // That said, the _runtime_ overflow checkers _do_ check both above and below.
 template <typename Op, typename Policy>
 struct OverflowRiskAcceptablyLow
-    : std::conditional_t<Policy{}.should_check(ConversionRisk::OVERFLOW),
+    : std::conditional_t<Policy{}.should_check(ConversionRisk::Overflow),
                          OverflowAboveRiskAcceptablyLow<Op>,
                          std::true_type> {};
 
@@ -133,7 +135,7 @@ struct OverflowRiskAcceptablyLow
 template <typename Op, typename Policy>
 struct TruncationRiskAcceptablyLow
     : std::conditional_t<
-          Policy{}.should_check(ConversionRisk::TRUNCATION),
+          Policy{}.should_check(ConversionRisk::Truncation),
           std::is_same<TruncationRiskFor<Op>, NoTruncationRisk<RealPart<OpInput<Op>>>>,
           std::true_type> {};
 

--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -26,8 +26,55 @@
 #include "au/unit_of_measure.hh"
 
 namespace au {
-namespace detail {
 
+//
+// Conversion risk section.
+//
+// End users can use the constants `OVERFLOW_RISK` and `TRUNCATION_RISK`.  They can combine them as
+// flags with `|`.  And they can pass either of these (or the result of `|`) to either `check()` or
+// `ignore()`.  The result of these functions is a risk _policy_, which can be passed as a second
+// argument to conversion functions to control which checks are performed.
+//
+
+enum class ConversionRisk : uint8_t {
+    OVERFLOW = 1u << 0u,
+    TRUNCATION = 1u << 1u,
+};
+
+template <typename T>
+struct CheckTheseRisks;
+
+template <uint8_t RiskFlags>
+struct RiskSet {
+    static_assert(RiskFlags <= 3u, "Invalid risk flags");
+
+    template <uint8_t OtherFlags>
+    constexpr RiskSet<RiskFlags | OtherFlags> operator|(RiskSet<OtherFlags>) const {
+        return {};
+    }
+
+    constexpr uint8_t flags() const { return RiskFlags; }
+
+    friend constexpr CheckTheseRisks<RiskSet<RiskFlags>> check(RiskSet) { return {}; }
+    friend constexpr CheckTheseRisks<RiskSet<3u - RiskFlags>> ignore(RiskSet) { return {}; }
+};
+
+template <uint8_t RiskFlags>
+struct CheckTheseRisks<RiskSet<RiskFlags>> {
+    constexpr bool should_check(ConversionRisk risk) const {
+        return (RiskFlags & static_cast<uint8_t>(risk)) != 0u;
+    }
+};
+
+constexpr auto OVERFLOW_RISK = RiskSet<static_cast<uint8_t>(ConversionRisk::OVERFLOW)>{};
+constexpr auto TRUNCATION_RISK = RiskSet<static_cast<uint8_t>(ConversionRisk::TRUNCATION)>{};
+constexpr auto ALL_RISKS = OVERFLOW_RISK | TRUNCATION_RISK;
+
+//
+// "Main" conversion policy section.
+//
+
+namespace detail {
 // Chosen so as to allow populating a `QuantityI32<Hertz>` with an input in MHz.
 constexpr auto OVERFLOW_THRESHOLD = mag<2'147>();
 
@@ -76,17 +123,23 @@ struct OverflowAboveRiskAcceptablyLow
 // --- we simply cannot afford to break that many _valid_ use cases to catch those invalid ones.
 //
 // That said, the _runtime_ overflow checkers _do_ check both above and below.
-template <typename Op>
-struct OverflowRiskAcceptablyLow : OverflowAboveRiskAcceptablyLow<Op> {};
+template <typename Op, typename Policy>
+struct OverflowRiskAcceptablyLow
+    : std::conditional_t<Policy{}.should_check(ConversionRisk::OVERFLOW),
+                         OverflowAboveRiskAcceptablyLow<Op>,
+                         std::true_type> {};
 
 // Check truncation risk.
-template <typename Op>
+template <typename Op, typename Policy>
 struct TruncationRiskAcceptablyLow
-    : std::is_same<TruncationRiskFor<Op>, NoTruncationRisk<RealPart<OpInput<Op>>>> {};
+    : std::conditional_t<
+          Policy{}.should_check(ConversionRisk::TRUNCATION),
+          std::is_same<TruncationRiskFor<Op>, NoTruncationRisk<RealPart<OpInput<Op>>>>,
+          std::true_type> {};
 
-template <typename Op>
-struct ConversionRiskAcceptablyLow
-    : stdx::conjunction<OverflowRiskAcceptablyLow<Op>, TruncationRiskAcceptablyLow<Op>> {};
+template <typename Op, typename Policy = decltype(check(ALL_RISKS))>
+struct ConversionRiskAcceptablyLow : stdx::conjunction<OverflowRiskAcceptablyLow<Op, Policy>,
+                                                       TruncationRiskAcceptablyLow<Op, Policy>> {};
 
 template <typename Rep, typename ScaleFactor, typename SourceRep>
 struct PermitAsCarveOutForIntegerPromotion

--- a/au/conversion_policy_test.cc
+++ b/au/conversion_policy_test.cc
@@ -40,38 +40,38 @@ struct NegativeDegrees : decltype(Degrees{} * (-mag<1>())) {};
 
 TEST(ConversionRisk, IgnoreOverflowRiskChecksTruncationRiskButNotOverflowRisk) {
     constexpr auto policy = ignore(OVERFLOW_RISK);
-    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsFalse());
-    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsTrue());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsFalse());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsTrue());
 }
 
 TEST(ConversionRisk, IgnoreTruncationRiskChecksOverflowRiskButNotTruncationRisk) {
     constexpr auto policy = ignore(TRUNCATION_RISK);
-    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsTrue());
-    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsFalse());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsTrue());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsFalse());
 }
 
 TEST(ConversionRisk, IgnoreAllRisksChecksNeitherRisk) {
     constexpr auto policy = ignore(ALL_RISKS);
-    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsFalse());
-    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsFalse());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsFalse());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsFalse());
 }
 
 TEST(ConversionRisk, CheckOverflowRiskChecksOverflowRiskButNotTruncationRisk) {
     constexpr auto policy = check(OVERFLOW_RISK);
-    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsTrue());
-    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsFalse());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsTrue());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsFalse());
 }
 
 TEST(ConversionRisk, CheckTruncationRiskChecksTruncationRiskButNotOverflowRisk) {
     constexpr auto policy = check(TRUNCATION_RISK);
-    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsFalse());
-    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsTrue());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsFalse());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsTrue());
 }
 
 TEST(ConversionRisk, CheckAllRisksChecksBothRisks) {
     constexpr auto policy = check(ALL_RISKS);
-    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsTrue());
-    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsTrue());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsTrue());
+    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsTrue());
 }
 
 TEST(ImplicitRepPermitted, TrueForIdentityMagnitude) {

--- a/au/conversion_policy_test.cc
+++ b/au/conversion_policy_test.cc
@@ -38,6 +38,42 @@ struct Degrees : UnitImpl<Angle> {};
 struct EquivalentToDegrees : Degrees {};
 struct NegativeDegrees : decltype(Degrees{} * (-mag<1>())) {};
 
+TEST(ConversionRisk, IgnoreOverflowRiskChecksTruncationRiskButNotOverflowRisk) {
+    constexpr auto policy = ignore(OVERFLOW_RISK);
+    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsFalse());
+    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsTrue());
+}
+
+TEST(ConversionRisk, IgnoreTruncationRiskChecksOverflowRiskButNotTruncationRisk) {
+    constexpr auto policy = ignore(TRUNCATION_RISK);
+    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsTrue());
+    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsFalse());
+}
+
+TEST(ConversionRisk, IgnoreAllRisksChecksNeitherRisk) {
+    constexpr auto policy = ignore(ALL_RISKS);
+    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsFalse());
+    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsFalse());
+}
+
+TEST(ConversionRisk, CheckOverflowRiskChecksOverflowRiskButNotTruncationRisk) {
+    constexpr auto policy = check(OVERFLOW_RISK);
+    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsTrue());
+    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsFalse());
+}
+
+TEST(ConversionRisk, CheckTruncationRiskChecksTruncationRiskButNotOverflowRisk) {
+    constexpr auto policy = check(TRUNCATION_RISK);
+    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsFalse());
+    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsTrue());
+}
+
+TEST(ConversionRisk, CheckAllRisksChecksBothRisks) {
+    constexpr auto policy = check(ALL_RISKS);
+    EXPECT_THAT(policy.should_check(ConversionRisk::OVERFLOW), IsTrue());
+    EXPECT_THAT(policy.should_check(ConversionRisk::TRUNCATION), IsTrue());
+}
+
 TEST(ImplicitRepPermitted, TrueForIdentityMagnitude) {
     EXPECT_THAT((ImplicitRepPermitted<long double, Magnitude<>>::value), IsTrue());
     EXPECT_THAT((ImplicitRepPermitted<double, Magnitude<>>::value), IsTrue());

--- a/au/conversion_policy_test.cc
+++ b/au/conversion_policy_test.cc
@@ -41,38 +41,38 @@ struct NegativeDegrees : decltype(Degrees{} * (-mag<1>())) {};
 
 TEST(ConversionRisk, IgnoreOverflowRiskChecksTruncationRiskButNotOverflowRisk) {
     constexpr auto policy = ignore(OVERFLOW_RISK);
-    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsFalse());
-    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsTrue());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsFalse());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsTrue());
 }
 
 TEST(ConversionRisk, IgnoreTruncationRiskChecksOverflowRiskButNotTruncationRisk) {
     constexpr auto policy = ignore(TRUNCATION_RISK);
-    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsTrue());
-    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsFalse());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsTrue());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsFalse());
 }
 
 TEST(ConversionRisk, IgnoreAllRisksChecksNeitherRisk) {
     constexpr auto policy = ignore(ALL_RISKS);
-    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsFalse());
-    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsFalse());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsFalse());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsFalse());
 }
 
 TEST(ConversionRisk, CheckOverflowRiskChecksOverflowRiskButNotTruncationRisk) {
     constexpr auto policy = check(OVERFLOW_RISK);
-    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsTrue());
-    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsFalse());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsTrue());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsFalse());
 }
 
 TEST(ConversionRisk, CheckTruncationRiskChecksTruncationRiskButNotOverflowRisk) {
     constexpr auto policy = check(TRUNCATION_RISK);
-    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsFalse());
-    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsTrue());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsFalse());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsTrue());
 }
 
 TEST(ConversionRisk, CheckAllRisksChecksBothRisks) {
     constexpr auto policy = check(ALL_RISKS);
-    EXPECT_THAT(policy.should_check(ConversionRisk::Overflow), IsTrue());
-    EXPECT_THAT(policy.should_check(ConversionRisk::Truncation), IsTrue());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsTrue());
+    EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsTrue());
 }
 
 TEST(ImplicitRepPermitted, TrueForIdentityMagnitude) {

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -173,7 +173,7 @@ class Quantity {
         std::enable_if_t<std::is_convertible<CorrespondingQuantityT<T>, Quantity>::value, int> = 0>
     constexpr Quantity(T &&x) : Quantity{as_quantity(std::forward<T>(x))} {}
 
-    // `q.as<R>(new_unit)`, or `q.as<R>(new_unit, risk_policy)`
+    // `q.as<Rep>(new_unit)`, or `q.as<Rep>(new_unit, risk_policy)`
     template <typename NewRep,
               typename NewUnitSlot,
               typename RiskPolicyT = decltype(ignore(ALL_RISKS))>

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -173,58 +173,32 @@ class Quantity {
         std::enable_if_t<std::is_convertible<CorrespondingQuantityT<T>, Quantity>::value, int> = 0>
     constexpr Quantity(T &&x) : Quantity{as_quantity(std::forward<T>(x))} {}
 
+    // q.as<R>(new_unit, risk_policy)
     template <typename NewRep,
-              typename NewUnit,
-              typename = std::enable_if_t<IsUnit<AssociatedUnitT<NewUnit>>::value>>
-    constexpr auto as(NewUnit) const {
-        return make_quantity<AssociatedUnitT<NewUnit>>(
-            detail::ConversionForRepsAndFactor<
-                Rep,
-                NewRep,
-                UnitRatioT<AssociatedUnitT<Unit>, AssociatedUnitT<NewUnit>>>::apply_to(value_));
+              typename NewUnitSlot,
+              typename RiskPolicyT = decltype(ignore(ALL_RISKS))>
+    constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
+        return make_quantity<AssociatedUnitT<NewUnitSlot>>(in_impl<NewRep>(u, policy));
     }
 
-    template <typename NewUnit,
-              typename = std::enable_if_t<IsUnit<AssociatedUnitT<NewUnit>>::value>>
-    constexpr auto as(NewUnit) const {
-        constexpr bool IMPLICIT_OK =
-            implicit_rep_permitted_from_source_to_target<Rep>(unit, NewUnit{});
-        constexpr bool INTEGRAL_REP = std::is_integral<Rep>::value;
-        static_assert(
-            IMPLICIT_OK || INTEGRAL_REP,
-            "Should never occur.  In the following static_assert, we assume that IMPLICIT_OK "
-            "can never fail unless INTEGRAL_REP is true.");
-        static_assert(
-            IMPLICIT_OK,
-            "Dangerous conversion for integer Rep!  See: "
-            "https://aurora-opensource.github.io/au/main/troubleshooting/#dangerous-conversion");
-        return make_quantity<AssociatedUnitT<NewUnit>>(
-            detail::ConversionForRepsAndFactor<
-                Rep,
-                Rep,
-                UnitRatioT<AssociatedUnitT<Unit>, AssociatedUnitT<NewUnit>>>::apply_to(value_));
+    // q.as(new_unit, risk_policy)
+    template <typename NewUnitSlot, typename RiskPolicyT = decltype(check(ALL_RISKS))>
+    constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
+        return make_quantity<AssociatedUnitT<NewUnitSlot>>(in_impl<Rep>(u, policy));
     }
 
+    // q.in<R>(new_unit, risk_policy)
     template <typename NewRep,
-              typename NewUnit,
-              typename = std::enable_if_t<IsUnit<AssociatedUnitT<NewUnit>>::value>>
-    constexpr NewRep in(NewUnit u) const {
-        if (are_units_quantity_equivalent(unit, u) && std::is_same<Rep, NewRep>::value) {
-            return static_cast<NewRep>(value_);
-        } else {
-            return as<NewRep>(u).in(u);
-        }
+              typename NewUnitSlot,
+              typename RiskPolicyT = decltype(ignore(ALL_RISKS))>
+    constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
+        return in_impl<NewRep>(u, policy);
     }
 
-    template <typename NewUnit,
-              typename = std::enable_if_t<IsUnit<AssociatedUnitT<NewUnit>>::value>>
-    constexpr Rep in(NewUnit u) const {
-        if (are_units_quantity_equivalent(unit, u)) {
-            return value_;
-        } else {
-            // Since Rep was requested _implicitly_, delegate to `.as()` for its safety checks.
-            return as(u).in(u);
-        }
+    // q.in(new_unit, risk_policy)
+    template <typename NewUnitSlot, typename RiskPolicyT = decltype(check(ALL_RISKS))>
+    constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
+        return in_impl<Rep>(u, policy);
     }
 
     // "Forcing" conversions, which explicitly ignore safety checks for overflow and truncation.
@@ -467,6 +441,18 @@ class Quantity {
         static_assert(are_units_quantity_equivalent || !uses_integer_division,
                       "Integer division forbidden: wrap denominator in `unblock_int_div()` if you "
                       "really want it");
+    }
+
+    template <typename OtherRep, typename OtherUnitSlot, typename RiskPolicyT>
+    constexpr OtherRep in_impl(OtherUnitSlot, RiskPolicyT) const {
+        using OtherUnit = AssociatedUnitT<OtherUnitSlot>;
+        static_assert(IsUnit<OtherUnit>::value, "Invalid type passed to unit slot");
+
+        using Op = detail::ConversionForRepsAndFactor<Rep, OtherRep, UnitRatioT<Unit, OtherUnit>>;
+        static_assert(detail::ConversionRiskAcceptablyLow<Op, RiskPolicyT>::value,
+                      "Conversion risks too high for policy");
+
+        return Op::apply_to(value_);
     }
 
     constexpr Quantity(Rep value) : value_{value} {}

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -173,7 +173,7 @@ class Quantity {
         std::enable_if_t<std::is_convertible<CorrespondingQuantityT<T>, Quantity>::value, int> = 0>
     constexpr Quantity(T &&x) : Quantity{as_quantity(std::forward<T>(x))} {}
 
-    // q.as<R>(new_unit, risk_policy)
+    // `q.as<R>(new_unit)`, or `q.as<R>(new_unit, risk_policy)`
     template <typename NewRep,
               typename NewUnitSlot,
               typename RiskPolicyT = decltype(ignore(ALL_RISKS))>
@@ -181,13 +181,13 @@ class Quantity {
         return make_quantity<AssociatedUnitT<NewUnitSlot>>(in_impl<NewRep>(u, policy));
     }
 
-    // q.as(new_unit, risk_policy)
+    // `q.as<Rep>(new_unit)`, or `q.as<Rep>(new_unit, risk_policy)`
     template <typename NewUnitSlot, typename RiskPolicyT = decltype(check(ALL_RISKS))>
     constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity<AssociatedUnitT<NewUnitSlot>>(in_impl<Rep>(u, policy));
     }
 
-    // q.in<R>(new_unit, risk_policy)
+    // `q.in(new_unit)`, or `q.in(new_unit, risk_policy)`
     template <typename NewRep,
               typename NewUnitSlot,
               typename RiskPolicyT = decltype(ignore(ALL_RISKS))>
@@ -195,7 +195,7 @@ class Quantity {
         return in_impl<NewRep>(u, policy);
     }
 
-    // q.in(new_unit, risk_policy)
+    // `q.in(new_unit)`, or `q.in(new_unit, risk_policy)`
     template <typename NewUnitSlot, typename RiskPolicyT = decltype(check(ALL_RISKS))>
     constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<Rep>(u, policy);

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -181,13 +181,13 @@ class Quantity {
         return make_quantity<AssociatedUnitT<NewUnitSlot>>(in_impl<NewRep>(u, policy));
     }
 
-    // `q.as<Rep>(new_unit)`, or `q.as<Rep>(new_unit, risk_policy)`
+    // `q.as(new_unit)`, or `q.as(new_unit, risk_policy)`
     template <typename NewUnitSlot, typename RiskPolicyT = decltype(check(ALL_RISKS))>
     constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity<AssociatedUnitT<NewUnitSlot>>(in_impl<Rep>(u, policy));
     }
 
-    // `q.in(new_unit)`, or `q.in(new_unit, risk_policy)`
+    // `q.in<Rep>(new_unit)`, or `q.in<Rep>(new_unit, risk_policy)`
     template <typename NewRep,
               typename NewUnitSlot,
               typename RiskPolicyT = decltype(ignore(ALL_RISKS))>

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -512,6 +512,63 @@ TEST(Quantity, ConvertingByNegativeOneCanBeDoneImplicitly) {
     EXPECT_THAT(q.as(neginches), SameTypeAndValue(neginches(int8_t{10})));
 }
 
+TEST(Quantity, AsCanExplicitlyOptOutOfOverflowRiskCheck) {
+    // This line would fail to compile without the `ignore(OVERFLOW_RISK)` argument.
+    constexpr auto q = seconds(int32_t{2}).as(nano(seconds), ignore(OVERFLOW_RISK));
+    EXPECT_THAT(q, SameTypeAndValue(nano(seconds)(int32_t{2'000'000'000})));
+}
+
+TEST(Quantity, AsCanExplicitlyOptOutOfOverflowRiskCheckForExplicitRep) {
+    // In future versions (see #122), this would fail to compile without `ignore(OVERFLOW_RISK)`.
+    constexpr auto q = seconds(2u).as<int32_t>(nano(seconds), ignore(OVERFLOW_RISK));
+    EXPECT_THAT(q, SameTypeAndValue(nano(seconds)(int32_t{2'000'000'000})));
+}
+
+TEST(Quantity, AsCanExplicitlyOptOutOfTruncationRiskCheck) {
+    // This line would fail to compile without the `ignore(TRUNCATION_RISK)` argument.
+    constexpr auto q = inches(36).as(feet, ignore(TRUNCATION_RISK));
+    EXPECT_THAT(q, SameTypeAndValue(feet(3)));
+}
+
+TEST(Quantity, AsCanExplicitlyOptOutOfTruncationRiskCheckForExplicitRep) {
+    // In future versions (see #122), this would fail to compile without `ignore(TRUNCATION_RISK)`.
+    constexpr auto q = inches(36u).as<int>(feet, ignore(TRUNCATION_RISK));
+    EXPECT_THAT(q, SameTypeAndValue(feet(int{3})));
+}
+
+TEST(Quantity, InCanExplicitlyOptOutOfOverflowRiskCheck) {
+    // This line would fail to compile without the `ignore(OVERFLOW_RISK)` argument.
+    constexpr auto q = seconds(int32_t{2}).in(nano(seconds), ignore(OVERFLOW_RISK));
+    EXPECT_THAT(q, SameTypeAndValue(int32_t{2'000'000'000}));
+}
+
+TEST(Quantity, InCanExplicitlyOptOutOfOverflowRiskCheckForExplicitRep) {
+    // In future versions (see #122), this would fail to compile without `ignore(OVERFLOW_RISK)`.
+    constexpr auto q = seconds(2u).in<int32_t>(nano(seconds), ignore(OVERFLOW_RISK));
+    EXPECT_THAT(q, SameTypeAndValue(int32_t{2'000'000'000}));
+}
+
+TEST(Quantity, InCanExplicitlyOptOutOfTruncationRiskCheck) {
+    // This line would fail to compile without the `ignore(TRUNCATION_RISK)` argument.
+    constexpr auto q = inches(36).in(feet, ignore(TRUNCATION_RISK));
+    EXPECT_THAT(q, SameTypeAndValue(3));
+}
+
+TEST(Quantity, InCanExplicitlyOptOutOfTruncationRiskCheckForExplicitRep) {
+    // In future versions (see #122), this would fail to compile without `ignore(TRUNCATION_RISK)`.
+    constexpr auto q = inches(36u).in<int>(feet, ignore(TRUNCATION_RISK));
+    EXPECT_THAT(q, SameTypeAndValue(3));
+}
+
+TEST(Quantity, IgnoringOverflowRiskCanProduceOverflow) {
+    EXPECT_THAT(seconds(uint8_t{1}).as(milli(seconds), ignore(OVERFLOW_RISK)),
+                SameTypeAndValue(milli(seconds)(uint8_t{1'000 % 256})));
+}
+
+TEST(Quantity, IgnoringTruncationRiskCanProduceTruncation) {
+    EXPECT_THAT(inches(35).as(feet, ignore(TRUNCATION_RISK)), SameTypeAndValue(feet(2)));
+}
+
 TEST(Quantity, ComparisonsAreReversedForNegativeUnits) {
     constexpr auto neginches = inches * (-mag<1>());
     EXPECT_THAT(neginches(10), Gt(neginches(20)));


### PR DESCRIPTION
This policy will indicate, _at compile time_, which conversion risks we
should guard against.  To implement this, we add a user-facing "risk
set" idea, with constants `OVERFLOW_RISK`, `TRUNCATION_RISK`, and
`ALL_RISKS` (which is `OVERFLOW_RISK | TRUNCATION_RISK`).  Users can
create a _policy_ by passing any of these to either `check()` or
`ignore()`.

So, for example, `inches(36).as(feet, ignore(TRUNCATION_RISK))` will now
produce `feet(3)`.

This gives us a more intent based interface for circumventing safety
checks, as compared to `coerce_as` and `coerce_in`.  We plan to provide
replacements for the other instances of the "coerce" word, which can be
found in `:quantity_point` and `:constant`.  Then, if real-world
experience with these new APIs is encouraging, we plan to formally
deprecate all "coerce" word APIs in 0.6.0, and delete them in 0.7.0.

Incidentally, we're also switching from SFINAE to a hard error if
somebody tries to call `.in` or `.as` without a valid unit, but this was
always a poor use of SFINAE anyway.

Helps #387.