### PR TITLE
Support risk policy argument for `QuantityPoint`

### DIFF
--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -119,6 +119,10 @@ TEST(QuantityPoint, CanCreateAndRetrieveValue) {
     EXPECT_THAT(p.in(Celsius{}), SameTypeAndValue(3));
 }
 
+TEST(QuantityPoint, CanRetrieveInSameUnitEvenForVerySmallRep) {
+    EXPECT_THAT(celsius_pt(int8_t{20}).in(celsius_pt), SameTypeAndValue(int8_t{20}));
+}
+
 TEST(QuantityPoint, CanGetValueInDifferentUnits) {
     constexpr auto p = meters_pt(3);
     EXPECT_THAT(p.in(centi(meters_pt)), SameTypeAndValue(300));
@@ -227,6 +231,29 @@ TEST(QuantityPoint, CanCastToUnitWithDifferentMagnitude) {
 TEST(QuantityPoint, CanCastToUnitWithDifferentOrigin) {
     EXPECT_THAT(celsius_pt(10.).as(kelvins_pt), IsNear(kelvins_pt(283.15), nano(kelvins)(1)));
     EXPECT_THAT(celsius_pt(10).coerce_as(Kelvins{}), SameTypeAndValue(kelvins_pt(283)));
+}
+
+TEST(QuantityPoint, AsCanProvideConversionPolicy) {
+    EXPECT_THAT(celsius_pt(10).as(kelvins_pt, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue(kelvins_pt(283)));
+    EXPECT_THAT(deci(celsius_pt)(10'9).as(kelvins_pt, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue(kelvins_pt(284)));
+}
+
+TEST(QuantityPoint, AsWithExplicitRepCanProvideConversionPolicy) {
+    EXPECT_THAT(celsius_pt(10.86).as<int>(kelvins_pt, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue(kelvins_pt(284)));
+}
+
+TEST(QuantityPoint, InCanProvideConversionPolicy) {
+    EXPECT_THAT(celsius_pt(10).in(kelvins_pt, ignore(TRUNCATION_RISK)), SameTypeAndValue(283));
+    EXPECT_THAT(deci(celsius_pt)(10'9).in(kelvins_pt, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue(284));
+}
+
+TEST(QuantityPoint, InWithExplicitRepCanProvideConversionPolicy) {
+    EXPECT_THAT(celsius_pt(10.86).in<int>(kelvins_pt, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue(284));
 }
 
 TEST(QuantityPoint, HandlesConversionWithSignedSourceAndUnsignedDestination) {


### PR DESCRIPTION
This lets us unify and simplify all of our `in` and `as` variants in
terms of an `in_impl` helper, as with `Quantity`.

This was conceptually tricky, because we were using the
`coerce_as_quantity` utility to shoehorn any uncooperative `Constant`
instances into the right type.  You might _think_ the right approach
would be to support policy arguments in `Constant`, and then just
passing the policy argument along.  But policies are about conversion
_risks_, whereas `Constant` has a _perfect_ conversion policy that
protects against _actual_ overflow and truncation.  Using the policy
would probably prevent some valid use cases and allow some invalid ones.

The solution was to tweak the computation so that we can take advantage
of that perfect conversion policy, and finally use the "shapeshifter
type" properties of the constant in _all_ cases.  To do this, we perform
all intermediate computations in the common unit of _all 3 units_:
initial, final, and "origin displacement unit".  This means the
`Constant` conversion can never truncate: it can only fail to convert if
it overflows the type, and I'm assuming we want to prevent _actual_
overflow even in cases where we're OK with overflow _risks_.

With that out of the way, all that's left is to forward the input
`policy` to all of the `Quantity` operations.

This new implementation isn't just simpler and more uniform, but it also
lets us get rid of that awkward `coerce_as_quantity` machinery right
now!

Helps #387.  We'll consider this done when every "coerce word" API has a
policy-based replacement, and so does `as_raw_number`.