### PR TITLE
Support risk policy argument in `as_raw_number()`

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -105,9 +105,9 @@ constexpr auto as_quantity(T &&x) -> CorrespondingQuantityT<T> {
 // Only works for dimensionless `Quantities`; will return a compile-time error otherwise.
 //
 // Identity for non-`Quantity` types.
-template <typename U, typename R>
-constexpr R as_raw_number(Quantity<U, R> q) {
-    return q.as(UnitProductT<>{});
+template <typename U, typename R, typename RiskPolicyT = decltype(check(ALL_RISKS))>
+constexpr R as_raw_number(Quantity<U, R> q, RiskPolicyT policy = RiskPolicyT{}) {
+    return q.in(UnitProductT<>{}, policy);
 }
 template <typename T>
 constexpr T as_raw_number(T x) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -904,6 +904,13 @@ TEST(AsRawNumber, PerformsConversionsWherePermissible) {
     EXPECT_THAT(as_raw_number(kilo(hertz)(7) * seconds(3)), SameTypeAndValue(21'000));
 }
 
+TEST(AsRawNumber, CanProvideConversionRiskPolicyAsSecondArgument) {
+    EXPECT_THAT(as_raw_number(percent(234), ignore(TRUNCATION_RISK)), SameTypeAndValue(2));
+
+    EXPECT_THAT(as_raw_number((giga(hertz) / hertz)(uint32_t{8}), ignore(OVERFLOW_RISK)),
+                SameTypeAndValue(static_cast<uint32_t>(8'000'000'000u % (uint64_t{1u} << 32u))));
+}
+
 TEST(AsRawNumber, IdentityForBuiltInNumericTypes) {
     EXPECT_THAT(as_raw_number(3), SameTypeAndValue(3));
     EXPECT_THAT(as_raw_number(3u), SameTypeAndValue(3u));


### PR DESCRIPTION
I still haven't fully figured out the updates for `Constant`, but at
least `as_raw_number()` is pretty straightforward and easy to knock out!

Helps #387.