### PR TITLE
Support conversion risk policy with `Constant`

### DIFF
--- a/au/constant.hh
+++ b/au/constant.hh
@@ -62,20 +62,20 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
 
     // Convert this constant to a Quantity of the given unit and rep, following this risk policy.
     template <typename T, typename OtherUnit, typename RiskPolicyT>
-    constexpr auto as(OtherUnit u, RiskPolicyT policy) const {
+    constexpr auto as(OtherUnit, RiskPolicyT) const {
         constexpr auto this_value = make_quantity<Unit>(static_cast<T>(1));
 
         constexpr bool has_unacceptable_overflow =
-            policy.should_check(detail::ConversionRisk::Overflow) &&
-            will_conversion_overflow(this_value, u);
+            RiskPolicyT{}.should_check(detail::ConversionRisk::Overflow) &&
+            will_conversion_overflow(this_value, OtherUnit{});
         static_assert(!has_unacceptable_overflow, "Constant conversion known to overflow");
 
         constexpr bool has_unacceptable_truncation =
-            policy.should_check(detail::ConversionRisk::Truncation) &&
-            will_conversion_truncate(this_value, u);
+            RiskPolicyT{}.should_check(detail::ConversionRisk::Truncation) &&
+            will_conversion_truncate(this_value, OtherUnit{});
         static_assert(!has_unacceptable_truncation, "Constant conversion known to truncate");
 
-        return this_value.as(u, ignore(ALL_RISKS));
+        return this_value.as(OtherUnit{}, ignore(ALL_RISKS));
     }
 
     // Get the value of this constant in the given unit and rep, ignoring safety checks.

--- a/au/constant.hh
+++ b/au/constant.hh
@@ -57,9 +57,25 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     // Convert this constant to a Quantity of the given unit and rep.
     template <typename T, typename OtherUnit>
     constexpr auto as(OtherUnit u) const {
-        static_assert(can_store_value_in<T>(OtherUnit{}),
-                      "Cannot represent constant in this unit/rep");
-        return coerce_as<T>(u);
+        return as<T>(u, check(ALL_RISKS));
+    }
+
+    // Convert this constant to a Quantity of the given unit and rep, following this risk policy.
+    template <typename T, typename OtherUnit, typename RiskPolicyT>
+    constexpr auto as(OtherUnit u, RiskPolicyT policy) const {
+        constexpr auto this_value = make_quantity<Unit>(static_cast<T>(1));
+
+        constexpr bool has_unacceptable_overflow =
+            policy.should_check(detail::ConversionRisk::Overflow) &&
+            will_conversion_overflow(this_value, u);
+        static_assert(!has_unacceptable_overflow, "Constant conversion known to overflow");
+
+        constexpr bool has_unacceptable_truncation =
+            policy.should_check(detail::ConversionRisk::Truncation) &&
+            will_conversion_truncate(this_value, u);
+        static_assert(!has_unacceptable_truncation, "Constant conversion known to truncate");
+
+        return this_value.as(u, ignore(ALL_RISKS));
     }
 
     // Get the value of this constant in the given unit and rep, ignoring safety checks.
@@ -71,9 +87,13 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     // Get the value of this constant in the given unit and rep.
     template <typename T, typename OtherUnit>
     constexpr auto in(OtherUnit u) const {
-        static_assert(can_store_value_in<T>(OtherUnit{}),
-                      "Cannot represent constant in this unit/rep");
-        return coerce_in<T>(u);
+        return in<T>(u, check(ALL_RISKS));
+    }
+
+    // Get the value of this constant in the given unit and rep, following this risk policy.
+    template <typename T, typename OtherUnit, typename RiskPolicyT>
+    constexpr auto in(OtherUnit u, RiskPolicyT policy) const {
+        return as<T>(u, policy).in(u);
     }
 
     // Implicitly convert to any quantity type which passes safety checks.

--- a/au/constant_test.cc
+++ b/au/constant_test.cc
@@ -120,6 +120,13 @@ TEST(Constant, CanCoerce) {
                 SameTypeAndValue((kilo(meters) / second)(299'792)));
 }
 
+TEST(Constant, CanProvidePolicy) {
+    EXPECT_THAT(c.in<int>(kilo(meters) / second, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue(299'792));
+    EXPECT_THAT(c.as<int>(kilo(meters) / second, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue((kilo(meters) / second)(299'792)));
+}
+
 TEST(Constant, CanNegate) {
     constexpr auto neg_c = -c;
     EXPECT_THAT(neg_c, Eq(-299'792'458 * m / s));
@@ -135,7 +142,7 @@ TEST(Constant, MakesQuantityWhenPostMultiplyingNumericValue) {
 }
 
 TEST(Constant, MakesQuantityWhenPreMultiplyingNumericValue) {
-    EXPECT_THAT((c * 2).coerce_as(meters / second),
+    EXPECT_THAT((c * 2).as(meters / second, ignore(OVERFLOW_RISK)),
                 SameTypeAndValue((meters / second)(get_value<int>(mag<2>() * C_MPS))));
 }
 


### PR DESCRIPTION
`Constant` is a really interesting case for conversion risks, because it
has a perfect conversion policy: we always know at compile time whether
the _actual value_ will be lossy in any way.  Unfortunately, this seems
to make it hard to explicitly opt out of _individual_ risks.

For example, consider getting the speed of light in km/s.  Obviously,
we'll need to provide `ignore(TRUNCATION_RISK)` as a second parameter,
and we would expect this to produce a value of `299'792`.  However, this
won't work, because the overflow risk (which we retained) will be
checking _generic_ values (measured in `c`!), and forbidding any
operation where a value of `2'147` would overflow.  Indeed, it turns out
that `2'147 * c` _would_ overflow `int` in units of km/s!

The solution is amusing: use the _runtime_ conversion checkers, at
_compile_ time!  After all, they are `constexpr` compatible, and here we
know our value at compile time.  This seems like it works really well so
far.  We are able to explicitly specify individual kinds of lossiness
that we're OK with.

Fixes #387.