### PR TITLE
Indicate specific blocking risks in conversions

### DIFF
--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -131,23 +131,17 @@ struct OverflowAboveRiskAcceptablyLow
 // --- we simply cannot afford to break that many _valid_ use cases to catch those invalid ones.
 //
 // That said, the _runtime_ overflow checkers _do_ check both above and below.
-template <typename Op, typename Policy>
-struct OverflowRiskAcceptablyLow
-    : std::conditional_t<Policy{}.should_check(detail::ConversionRisk::Overflow),
-                         OverflowAboveRiskAcceptablyLow<Op>,
-                         std::true_type> {};
+template <typename Op>
+struct OverflowRiskAcceptablyLow : OverflowAboveRiskAcceptablyLow<Op> {};
 
 // Check truncation risk.
-template <typename Op, typename Policy>
+template <typename Op>
 struct TruncationRiskAcceptablyLow
-    : std::conditional_t<
-          Policy{}.should_check(detail::ConversionRisk::Truncation),
-          std::is_same<TruncationRiskFor<Op>, NoTruncationRisk<RealPart<OpInput<Op>>>>,
-          std::true_type> {};
+    : std::is_same<TruncationRiskFor<Op>, NoTruncationRisk<RealPart<OpInput<Op>>>> {};
 
-template <typename Op, typename Policy = decltype(check(ALL_RISKS))>
-struct ConversionRiskAcceptablyLow : stdx::conjunction<OverflowRiskAcceptablyLow<Op, Policy>,
-                                                       TruncationRiskAcceptablyLow<Op, Policy>> {};
+template <typename Op>
+struct ConversionRiskAcceptablyLow
+    : stdx::conjunction<OverflowRiskAcceptablyLow<Op>, TruncationRiskAcceptablyLow<Op>> {};
 
 template <typename Rep, typename ScaleFactor, typename SourceRep>
 struct PermitAsCarveOutForIntegerPromotion

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -449,8 +449,36 @@ class Quantity {
         static_assert(IsUnit<OtherUnit>::value, "Invalid type passed to unit slot");
 
         using Op = detail::ConversionForRepsAndFactor<Rep, OtherRep, UnitRatioT<Unit, OtherUnit>>;
-        static_assert(detail::ConversionRiskAcceptablyLow<Op, RiskPolicyT>::value,
-                      "Conversion risks too high for policy");
+
+        constexpr bool should_check_overflow =
+            RiskPolicyT{}.should_check(detail::ConversionRisk::Overflow);
+        constexpr bool is_overflow_risk_ok = detail::OverflowRiskAcceptablyLow<Op>::value;
+
+        constexpr bool should_check_truncation =
+            RiskPolicyT{}.should_check(detail::ConversionRisk::Truncation);
+        constexpr bool is_truncation_risk_ok = detail::TruncationRiskAcceptablyLow<Op>::value;
+
+        constexpr bool is_overflow_only_unacceptable_risk =
+            (should_check_overflow && !is_overflow_risk_ok && is_truncation_risk_ok);
+        static_assert(!is_overflow_only_unacceptable_risk,
+                      "Overflow risk too high.  "
+                      "Can silence by passing `ignore(OVERFLOW_RISK)` as second argument, "
+                      "but first CAREFULLY CONSIDER whether this is really what you mean to do.");
+
+        constexpr bool is_truncation_only_unacceptable_risk =
+            (should_check_truncation && !is_truncation_risk_ok && is_overflow_risk_ok);
+        static_assert(!is_truncation_only_unacceptable_risk,
+                      "Truncation risk too high.  "
+                      "Can silence by passing `ignore(TRUNCATION_RISK)` as second argument, "
+                      "but first CAREFULLY CONSIDER whether this is really what you mean to do.");
+
+        constexpr bool are_both_overflow_and_truncation_unacceptably_risky =
+            (should_check_overflow || should_check_truncation) && !is_overflow_risk_ok &&
+            !is_truncation_risk_ok;
+        static_assert(!are_both_overflow_and_truncation_unacceptably_risky,
+                      "Both truncation and overflow risk too high.  "
+                      "Can silence by passing `ignore(ALL_RISKS)` as second argument, "
+                      "but first CAREFULLY CONSIDER whether this is really what you mean to do.");
 
         return Op::apply_to(value_);
     }


### PR DESCRIPTION
Right now, conversion failures are somewhat inscrutable.  Consider these
unsafe conversions:

```cpp
seconds(2).as(nano(seconds));                      // OVERFLOW_RISK
nano(seconds)(2).as(seconds);                      // TRUNCATION_RISK
(giga(hertz) * mag<2>() / mag<3>())(1).as(hertz);  // ALL_RISKS
```

I've annotated each one with the risk that prevents the conversion ---
but remember that an end user won't know a priori which one this is!
And the error messages are no help:

<img width="1117" height="829" alt="image"
src="https://github.com/user-attachments/assets/8f0315be-dd03-44d8-876d-ba71577633f9" />

This just basically says "some risk is too high".  It doesn't say which
risk(s), and it doesn't say what to do about it.

We can do better by checking the risks individually, and splitting the
error message across three mutually exclusive and exhasutive error
conditions.  First, if a conversion is blocked, then it would either
fail the overflow risk check, truncation risk check, or else both (those
are the 3 possibilities).  Second, if _any_ non-skipped risk check
fails, then we want to check _all_ risk checks, _regardless_ of skip
status.  After all, if a conversion is "double risked", and the user has
passed `ignore(OVERFLOW_RISK)`, we don't want to tell them to pass
`ignore(TRUNCATION_RISK)`, because that will just re-activate the
overflow risk failure!  We want to tell them to use `ignore(ALL_RISKS)`.

<img width="1117" height="814" alt="image"
src="https://github.com/user-attachments/assets/8a9ac4a4-5eeb-4b0b-aac1-7af6e98bac84" />

These error messages are much more clear and actionable.  We can
bikeshed the wording, but it seems clear that this will be a much better
experience for our users.

Follow-on to #387.