### PR TITLE
Replace external `UnitAvoidance` with new trait

### DIFF
--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -438,6 +438,13 @@ constexpr auto pow(SingularNameFor<Unit>) {
     return SingularNameFor<UnitPowerT<Unit, Exp>>{};
 }
 
+//
+// Specialize `UnitOrderTiebreaker<YourCustomUnit>` as below, but with a different constant, in
+// order to reduce the chance of hitting "distinct input types compare equal" errors.
+//
+template <typename U>
+struct UnitOrderTiebreaker;
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Implementation details below
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1134,44 +1141,56 @@ struct OrderByOrigin
 // relative ordering among these built-in template types is probably less important than the fact
 // that there _is_ a relative ordering among them (because we need to have a strict total ordering).
 template <typename T>
-struct UnitAvoidance : std::integral_constant<int, 0> {};
+struct CoarseUnitOrdering : std::integral_constant<int, 0> {};
 
 template <typename A, typename B>
-struct OrderByUnitAvoidance
-    : stdx::bool_constant<(UnitAvoidance<A>::value < UnitAvoidance<B>::value)> {};
+struct OrderByCoarseUnitOrdering
+    : stdx::bool_constant<(CoarseUnitOrdering<A>::value < CoarseUnitOrdering<B>::value)> {};
 
 template <typename... Ts>
-struct UnitAvoidance<UnitProduct<Ts...>> : std::integral_constant<int, 1> {};
+struct CoarseUnitOrdering<UnitProduct<Ts...>> : std::integral_constant<int, 1> {};
 
 template <typename... Ts>
-struct UnitAvoidance<UnitImpl<Ts...>> : std::integral_constant<int, 2> {};
+struct CoarseUnitOrdering<UnitImpl<Ts...>> : std::integral_constant<int, 2> {};
 
 template <typename... Ts>
-struct UnitAvoidance<ScaledUnit<Ts...>> : std::integral_constant<int, 3> {};
+struct CoarseUnitOrdering<ScaledUnit<Ts...>> : std::integral_constant<int, 3> {};
 
 template <typename B, std::intmax_t N>
-struct UnitAvoidance<Pow<B, N>> : std::integral_constant<int, 4> {};
+struct CoarseUnitOrdering<Pow<B, N>> : std::integral_constant<int, 4> {};
 
 template <typename B, std::intmax_t N, std::intmax_t D>
-struct UnitAvoidance<RatioPow<B, N, D>> : std::integral_constant<int, 5> {};
+struct CoarseUnitOrdering<RatioPow<B, N, D>> : std::integral_constant<int, 5> {};
 
 template <typename... Us>
-struct UnitAvoidance<CommonUnit<Us...>> : std::integral_constant<int, 6> {};
+struct CoarseUnitOrdering<CommonUnit<Us...>> : std::integral_constant<int, 6> {};
 
 template <typename... Us>
-struct UnitAvoidance<CommonPointUnit<Us...>> : std::integral_constant<int, 7> {};
+struct CoarseUnitOrdering<CommonPointUnit<Us...>> : std::integral_constant<int, 7> {};
+
+template <typename A, typename B>
+struct OrderByUnitOrderTiebreaker
+    : stdx::bool_constant<(UnitOrderTiebreaker<A>::value < UnitOrderTiebreaker<B>::value)> {};
+
+template <typename U>
+struct UnitAvoidance : std::integral_constant<int, 0> {};
+
 }  // namespace detail
+
+template <typename U>
+struct UnitOrderTiebreaker : detail::UnitAvoidance<U> {};
 
 template <typename A, typename B>
 struct InOrderFor<UnitProduct, A, B>
     : LexicographicTotalOrdering<A,
                                  B,
-                                 detail::OrderByUnitAvoidance,
+                                 detail::OrderByCoarseUnitOrdering,
                                  detail::OrderByDim,
                                  detail::OrderByMag,
                                  detail::OrderByScaleFactor,
                                  detail::OrderByOrigin,
                                  detail::OrderAsUnitProduct,
-                                 detail::OrderAsOriginDisplacementUnit> {};
+                                 detail::OrderAsOriginDisplacementUnit,
+                                 detail::OrderByUnitOrderTiebreaker> {};
 
 }  // namespace au


### PR DESCRIPTION
We want to stop telling end users to specialize
`::au::detail::UnitAvoidance`, because it's in the `detail` namespace,
which they should never name.  Instead, we provide
`::au::UnitOrderTiebreaker`, which has _almost_ the same effect, but is
in the `::au` namespace and so we can support it.

The difference alluded to above is that, as the name suggests, this is a
_tiebreaker_.  Specializing (the old) `UnitAvoidance`, on the other
hand, affected the _coarse_ ordering of units.  So, we replaced _that_
role with `CoarseUnitOrdering`.

`UnitOrderTiebreaker` will default to `UnitAvoidance` for now, so as to
provide a smooth upgrade path.  In 0.6.0, `UnitAvoidance` will stop
working, and we'll add a deprecation warning to tell people what to do
instead.

Fixes #480.