### PR TITLE
Fix up the fuzz helper tool

### DIFF
--- a/fuzz/BUILD.bazel
+++ b/fuzz/BUILD.bazel
@@ -18,11 +18,11 @@ cc_binary(
     name = "quantity_runtime_conversion_check",
     testonly = True,
     srcs = ["quantity_runtime_conversion_check.cc"],
+    tags = ["manual"],
     deps = [
         ":quantity_runtime_conversion_checkers",
         "//au:conversion_strategy",
         "//au:testing",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/fuzz/quantity_runtime_conversion_check.cc
+++ b/fuzz/quantity_runtime_conversion_check.cc
@@ -185,7 +185,7 @@ constexpr TestCategory categorize_testing_scenario() {
         return std::is_integral<DestRepT>::value ? TestCategory::INTEGRAL_TO_INTEGRAL
                                                  : TestCategory::INTEGRAL_TO_FLOAT;
     }
-    
+
     return std::is_integral<DestRepT>::value ? TestCategory::FLOAT_TO_INTEGRAL
                                              : TestCategory::FLOAT_TO_FLOAT;
 }
@@ -288,8 +288,7 @@ struct LossChecker<RepT, UnitT, DestRepT, DestUnitT, TestCategory::FLOAT_TO_FLOA
         const auto max_ok = next_higher_quantity(value, 2u);
 
         std::ostringstream oss;
-        oss << "Breakdown:" << std::setprecision(std::numeric_limits<RepT>::digits10 + 1u)
-            << '\n'
+        oss << "Breakdown:" << std::setprecision(std::numeric_limits<RepT>::digits10 + 1u) << '\n'
             << "  Initial:    " << value << '\n'
             << "  Min OK:     " << min_ok << '\n'
             << "  Round trip: " << round_trip << '\n'
@@ -498,7 +497,7 @@ struct TestBody : TestBodyImpl<RepT,
                                DestUnitT,
                                categorize_testing_scenario<RepT, UnitT, DestRepT, DestUnitT>()> {};
 
-TEST(RuntimeConversionCheckers, Fuzz) {
+int main() {
     GeneratorFor<Reps> generators{9876543210u};
     constexpr auto for_each_params = ForEach<CartesianProduct<std::tuple, Reps, Units>>{};
     auto print_if_equals = 1u;
@@ -525,7 +524,11 @@ TEST(RuntimeConversionCheckers, Fuzz) {
             });
         });
     }
+
+    return 0;
 }
 
 }  // namespace detail
 }  // namespace au
+
+int main(int, char **) { return ::au::detail::main(); }


### PR DESCRIPTION
The most pressing issue is that right now, it makes `//...:all`
nightmarishly slow.  It basically adds about a minute or two _after_ all
the tests finish running, just to build (and not even run) this target.
(This utility is extremely compiler intensive!)  The easy fix is to add
a `manual` tag.

While I'm at it, I might as well stop using gtest as a shortcut to get
an executable.  This was never really that much of a shortcut to begin
with --- it's just a lazy decision I made N months ago when I started
working on this, and I never felt like writing a `main` function.  I was
going to add the comments as [suggested] in #461 to explain why we're
using gtest, but it was easier to just stop using gtest.

[suggested]: https://github.com/aurora-opensource/au/pull/461#discussion_r2217955375