### PR TITLE
Support unit slots in `Quantity::data_in`

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -225,29 +225,19 @@ class Quantity {
 
     // Direct access to the underlying value member, with any Quantity-equivalent Unit.
     //
-    // Mutable access, QuantityMaker input.
-    template <typename U>
-    Rep &data_in(const QuantityMaker<U> &) {
-        static_assert(AreUnitsQuantityEquivalent<U, Unit>::value,
+    // Mutable access:
+    template <typename UnitSlot>
+    Rep &data_in(UnitSlot) {
+        static_assert(AreUnitsQuantityEquivalent<AssociatedUnitT<UnitSlot>, Unit>::value,
                       "Can only access value via Quantity-equivalent unit");
         return value_;
     }
-    // Mutable access, Unit input.
-    template <typename U>
-    Rep &data_in(const U &) {
-        return data_in(QuantityMaker<U>{});
-    }
-    // Const access, QuantityMaker input.
-    template <typename U>
-    const Rep &data_in(const QuantityMaker<U> &) const {
-        static_assert(AreUnitsQuantityEquivalent<U, Unit>::value,
+    // Const access:
+    template <typename UnitSlot>
+    const Rep &data_in(UnitSlot) const {
+        static_assert(AreUnitsQuantityEquivalent<AssociatedUnitT<UnitSlot>, Unit>::value,
                       "Can only access value via Quantity-equivalent unit");
         return value_;
-    }
-    // Const access, Unit input.
-    template <typename U>
-    const Rep &data_in(const U &) const {
-        return data_in(QuantityMaker<U>{});
     }
 
     // Permit this factory functor to access our private constructor.

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -40,6 +40,7 @@ struct Feet : UnitImpl<Length> {
 };
 constexpr const char Feet::label[];
 constexpr auto feet = QuantityMaker<Feet>{};
+constexpr auto ft = SymbolFor<Feet>{};
 
 struct Miles : decltype(Feet{} * mag<5'280>()) {
     static constexpr const char label[] = "mi";
@@ -220,6 +221,17 @@ TEST(Quantity, SupportsDirectAccessWithQuantityMakerOfSameUnit) {
 }
 
 TEST(Quantity, SupportsDirectConstAccessWithQuantityMakerOfSameUnit) {
+    const auto x = meters(3.5);
+    EXPECT_THAT(static_cast<const void *>(&x.data_in(meters)), Eq(static_cast<const void *>(&x)));
+}
+
+TEST(Quantity, SupportsDirectAccessWithUnitSymbol) {
+    auto x = feet(3);
+    ++(x.data_in(ft));
+    EXPECT_THAT(x, Eq(feet(4)));
+}
+
+TEST(Quantity, SupportsDirectConstAccessWithUnitSymbol) {
     const auto x = meters(3.5);
     EXPECT_THAT(static_cast<const void *>(&x.data_in(meters)), Eq(static_cast<const void *>(&x)));
 }


### PR DESCRIPTION
The old APIs predate the "unit slot" concept, so we had a separate
overload for each kind of thing we might have been passing.  This meant
that, e.g., `SymbolFor` would not work here.

This PR adds unit tests for unit symbol inputs, and makes sure all the
existing tests still pass.  We end up with more tests and fewer
overloads --- a nice win!

Fixes #489.