### PR TITLE
Add support for {fmt}

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -134,6 +134,26 @@ http_archive(
     url = "https://github.com/nholthaus/units/archive/refs/tags/v2.3.3.tar.gz",
 )
 
+http_archive(
+    name = "fmt",
+    patch_cmds = [
+        "mv support/bazel/.bazelversion .bazelversion",
+        "mv support/bazel/BUILD.bazel BUILD.bazel",
+        "mv support/bazel/MODULE.bazel MODULE.bazel",
+        "mv support/bazel/WORKSPACE.bazel WORKSPACE.bazel",
+    ],
+    # Windows related patch commands are only needed in the case MSYS2 is not installed
+    patch_cmds_win = [
+        "Move-Item -Path support/bazel/.bazelversion -Destination .bazelversion",
+        "Move-Item -Path support/bazel/BUILD.bazel -Destination BUILD.bazel",
+        "Move-Item -Path support/bazel/MODULE.bazel -Destination MODULE.bazel",
+        "Move-Item -Path support/bazel/WORKSPACE.bazel -Destination WORKSPACE.bazel",
+    ],
+    sha256 = "203eb4e8aa0d746c62d8f903df58e0419e3751591bb53ff971096eaa0ebd4ec3",
+    strip_prefix = "fmt-11.2.0",
+    url = "https://github.com/fmtlib/fmt/releases/download/11.2.0/fmt-11.2.0.zip",
+)
+
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 python_register_toolchains(

--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -80,6 +80,19 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "fmt_test",
+    size = "small",
+    srcs = ["fmt_test.cc"],
+    deps = [
+        ":quantity",
+        ":testing",
+        ":units",
+        "@com_google_googletest//:gtest_main",
+        "@fmt",
+    ],
+)
+
 cc_library(
     name = "fwd",
     hdrs = ["fwd.hh"],

--- a/au/fmt_test.cc
+++ b/au/fmt_test.cc
@@ -1,0 +1,74 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/prefix.hh"
+#include "au/quantity.hh"
+#include "au/units/meters.hh"
+#include "au/units/seconds.hh"
+#include "fmt/format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace fmt {
+template <typename U, typename R>
+struct formatter<::au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, ::fmt::formatter> {};
+}  // namespace fmt
+
+namespace au {
+namespace {
+
+using symbols::m;
+using symbols::s;
+constexpr auto cm = centi(m);
+constexpr auto km = kilo(m);
+
+using ::testing::StrEq;
+
+TEST(Fmt, PrintsQuantityAndUnitLabelByDefault) {
+    EXPECT_THAT(fmt::format("{}", meters(8.5)), StrEq("8.5 m"));
+}
+
+TEST(Fmt, DefaultFormatAppliesToNumberPart) {
+    EXPECT_THAT(fmt::format("{:,<10}", meters(8.5)), StrEq("8.5,,,,,,, m"));
+    EXPECT_THAT(fmt::format("{:,>10}", meters(8.5)), StrEq(",,,,,,,8.5 m"));
+    EXPECT_THAT(fmt::format("{:,>8.2f}", meters(0.1234)), StrEq(",,,,0.12 m"));
+}
+
+TEST(Fmt, CanFormatUnitLabelWithUPrefix) {
+    EXPECT_THAT(fmt::format("{:U,^5}", meters(8.5)), StrEq("8.5 ,,m,,"));
+}
+
+TEST(Fmt, CanFormatBothParts) {
+    // Overall width of 20: 10 for the number, 10 for the label.
+
+    EXPECT_THAT(fmt::format("{:*>10.3f;U,<10}", 123.456789 * cm / s),
+                StrEq("***123.457 cm / s,,,,"));
+}
+
+TEST(Fmt, DocExamplesAreCorrect) {
+    EXPECT_THAT(fmt::format("{}", meters(123.456)), StrEq("123.456 m"));
+    EXPECT_THAT(fmt::format("{:~^10.2f}", meters(123.456)), StrEq("~~123.46~~ m"));
+    EXPECT_THAT(fmt::format("{:U.>5}", meters(123.456)), StrEq("123.456 ....m"));
+    EXPECT_THAT(fmt::format("{:~^10.2f;U.>5}", meters(123.456)), StrEq("~~123.46~~ ....m"));
+
+    constexpr auto speed = (centi(meters) / second)(987.654321);
+    EXPECT_THAT(fmt::format("{:.^31}", fmt::format("{:,<8.2f;U*>10}", speed)),
+                StrEq("......987.65,, ****cm / s......"));
+
+    constexpr auto c = 299'792.458 * km / s;
+    EXPECT_THAT(fmt::format("{:,<12.2f}", c.data_in(km / s)), StrEq("299792.46,,,"));
+}
+
+}  // namespace
+}  // namespace au

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -901,6 +901,78 @@ struct CommonQuantity<Quantity<U1, R1>,
                       Quantity<U2, R2>,
                       std::enable_if_t<HasSameDimension<U1, U2>::value>>
     : stdx::type_identity<Quantity<CommonUnitT<U1, U2>, std::common_type_t<R1, R2>>> {};
+
+//
+// Formatter implementation for fmtlib or `std::format`.
+//
+// Support for `std::format` is automatically included whenever `std::format` is present.
+//
+// To use with fmtlib, add this template specialization to a file that includes both
+// `"au/quantity.hh"`, and `"fmt/format.h"`:
+//
+//    namespace fmt {
+//    template <typename U, typename R>
+//    struct formatter<::au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, ::fmt::formatter> {};
+//    }  // namespace fmt
+//
+// Then, include that file any time you want to format a `Quantity`.
+//
+template <typename U, typename R, template <class...> class Formatter>
+struct QuantityFormatter {
+    template <typename FormatParseContext>
+    constexpr auto parse(FormatParseContext &ctx) {
+        auto it = ctx.begin();
+
+        while (it != ctx.end() && *it != '}') {
+            it = parse_section<FormatParseContext>(it, ctx.end());
+        }
+
+        return it;
+    }
+
+    template <typename FormatParseContext, typename Iter, typename End>
+    constexpr auto parse_section(Iter it, End end) {
+        const auto next_end = find_next_end(it, end);
+        const auto next_begin =
+            (next_end == end || *next_end == '}') ? next_end : std::next(next_end);
+
+        const bool is_unit_label = (*it == 'U');
+        if (is_unit_label) {
+            ++it;
+        }
+        FormatParseContext parse_ctx{it, static_cast<int>(next_end - it)};
+
+        if (is_unit_label) {
+            unit_label_format.parse(parse_ctx);
+        } else {
+            value_format.parse(parse_ctx);
+        }
+
+        return next_begin;
+    }
+
+    template <typename Iter, typename End>
+    constexpr auto find_next_end(Iter it, End end) {
+        auto next_end = std::find(it, end, ';');
+
+        if (next_end == end) {
+            next_end = std::find(it, end, '}');
+        }
+
+        return next_end;
+    }
+
+    template <typename FormatContext>
+    auto format(const au::Quantity<U, R> &q, FormatContext &ctx) const {
+        value_format.format(q.data_in(U{}), ctx);
+        ctx.out() = ' ';
+        return unit_label_format.format(unit_label(U{}), ctx);
+    }
+
+    Formatter<R> value_format{};
+    Formatter<const char *> unit_label_format{};
+};
+
 }  // namespace au
 
 namespace std {

--- a/docs/reference/format.md
+++ b/docs/reference/format.md
@@ -1,0 +1,136 @@
+# Format
+
+Au supports string formatting using either the [{fmt}] library, or else [std::format] (available
+in C++20 or later).
+
+??? warning "Warning: if using {fmt}, ensure version is at least 9.0"
+    If you are using the [{fmt}] library, **make sure that it is at least [version 9.0]** (July 5,
+    2022).
+
+    All earlier versions provide automatic specializations for `formatter<T>` for any type `T` that
+    supports streaming output.  While this is convenient, it also makes it extremely easy to violate
+    the One Definition Rule (ODR): if anyone calls `format` in a file without Au's specialization,
+    then both definitions will exist.  This makes the program "ill-formed, no diagnostic required"
+    (IFNDR), which means that it has **silently** failed to be a valid C++ program, and all
+    guarantees are out the window.
+
+    Version 9.0 was the first release to make the default specialization cause a hard compiler
+    error.  This mitigates the risk of having two definitions, undetected.
+
+    As for `std::format`, it has always required explicit specializations, so it is not subject to
+    this vulnerability.
+
+We can't provide fully seamless support out of the box without adding an external dependency --- and
+Au is committed to being a zero-dependency library.  What we _can_ do is to define the format string
+specification, and take the hard work out of implementing it.  To use it in your project, you'll
+create a single file, and write a single line of code.  Then, you'll include that file anywhere you
+want to format a `Quantity`.
+
+## Setup
+
+There are two steps to support formatting in your project:
+
+1. Create a file to hold the authoritative formatter definition.
+
+2. Include this file anywhere you want to format a `Quantity`.
+
+Here are the contents of the file to create:
+
+=== "Using {fmt}"
+
+    ```cpp
+    #pragma once
+
+    #include "au/au.hh"
+    #include "fmt/format.h"
+
+    namespace fmt {
+    template <typename U, typename R>
+    struct formatter<::au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, ::fmt::formatter> {};
+    }  // namespace fmt
+    ```
+
+=== "Using std::format"
+
+    !!! warning
+        These instructions have not yet been tested, because the Au repo doesn't yet have an
+        official toolchain that supports `std::format`.
+
+    ```cpp
+    #pragma once
+
+    #include <format>
+
+    #include "au/au.hh"
+
+    template <typename U, typename R>
+    struct std::formatter<::au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, std::formatter> {};
+    ```
+
+!!! tip "Tip: finding the file in your project"
+    It's very important to have _only one_ definition of `formatter<Quantity<U, R>>` in your
+    project.  This means you need a way to tell whether someone has created this file already, and
+    find it if it exists.
+
+    Fortunately, the string `QuantityFormatter` is very greppable.  In most cases, it should only
+    occur once in your project --- even if there are a few stray mentions, it should be easy to find
+    the authoritative definition.  Start by grepping your project for this string.  If you find it,
+    you can just use the file, and if not, you know you need to create it.
+
+## Syntax
+
+Printing a quantity means printing its numeric value, followed by its unit label.  Au lets you
+provide format strings for either or both of these.  If you add a format string for the unit label,
+you need to prefix it with a `U`.  If you add format strings for both, separate them with a `;`.  In
+both cases, the syntax delegates to the [standard format syntax] for each piece.
+
+It may be easier to understand with several examples.
+
+| Specialize format for | Pattern | Example | Output |
+|-----------------------|---------|---------|--------|
+| Neither | `{}` | `std::format("{}", meters(123.456))` | `"123.456 m"` |
+| Numeric value | `{:~^10.2f}` | `std::format("{:~^10.2f}", meters(123.456))` | `"~~123.46~~ m"` |
+| Unit label | `{:U.>5}` | `std::format("{:U.>5}", meters(123.456))` | `"123.456 ....m"` |
+| Both | `{:~^10.2f;U.>5}` | `std::format("{:~^10.2f;U.>5}", meters(123.456))` | `"~~123.46~~ ....m"` |
+
+To target a specific and consistent overall width --- say, for aligning columnar output --- provide
+formatters for both the numeric value and the unit label, and choose a specific width for each.  The
+overall width will be the sum of the widths of the two pieces, plus one space in between.
+
+### Specialized use cases
+
+The core support provides a formatted numeric value, then a space `' '`, then a formatted unit
+label.  There may be other use cases, but we don't support them directly, and we don't plan to.
+Fortunately, these tend to have straightforward workarounds.
+
+Here are some examples.
+
+Besides the separate formatters for the numeric value and unit label, some users may wish to format
+the "overall result".  For example, they may want the whole quantity (unit and label) to be centered
+in a width of, say, 25 characters.  We cannot support this directly without excessive complexity, in
+both the implementation, and the formatter syntax.  The simple workaround is to format your quantity
+as desired using the existing syntax, and then format the result using simple `std::string`
+formatting, like so:
+
+```cpp
+constexpr auto speed = (centi(meters) / second)(987.654321);
+std::cout << fmt::format("{:.^31}", fmt::format("{:,<8.2f;U*>10}", speed));
+// Output: "......987.65,, ****cm / s......"
+```
+
+Some users may want a format that prints _only_ the numeric value, or _only_ the unit label.  We
+don't provide a direct way to do this, because neither of these pieces is meaningful on its own.  If
+you do have a use case for formatting only one of these, the workaround is straightforward.  Simply
+retrieve the numeric value or unit label by the library's standard methods, and pass the result to
+a formatter for that numeric type, like so:
+
+```cpp
+constexpr auto c = 299'792.458 * km / s;
+std::cout << fmt::format("{:,<12.2f}", c.data_in(km / s));
+// Output: "299792.46,,,"
+```
+
+[{fmt}]: https://github.com/fmtlib/fmt
+[std::format]: https://en.cppreference.com/w/cpp/utility/format/format.html
+[version 9.0]: https://github.com/fmtlib/fmt/releases/tag/9.0.0
+[standard format syntax]: https://hackingcpp.com/cpp/libs/fmt.html

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -31,6 +31,11 @@ Here's a guide to the main reference pages.
   unit with a specified _relative size_.  For example, `centi` is a prefix whose relative magnitude
   is $1/100$, and a `centi(meter)` is a new unit which is one one-hundredth of a `meter`.
 
-- **[`Math functions`](./math.md).**  We provide many common mathematical functions out of the box.
+- **[Math functions](./math.md).**  We provide many common mathematical functions out of the box.
+
+- **[Format support](./format.md).**  Exercise fine-grained control over formatting quantities to
+  strings, using either the popular [{fmt}] library, or C++20's `std::format`.
 
 See the sidebar for the complete list of pages.
+
+[{fmt}]: https://github.com/fmtlib/fmt


### PR DESCRIPTION
The structure of this support was much more challenging than I had
anticipated.  I _wanted_ to get out-of-the-box support for anyone who
included `"fmt/format.h"`, by forward declaring `fmt::formatter`, and
then specializing it.  This doesn't work because `fmt::formatter` is
actually `fmt::v11::formatter` (currently), where `v11` is an inline
namespace, and `fmt::v10::formatter`, `fmt::v9::formatter`, and so on
are also out in the wild.

The next best thing is to write a class that has _all of the logic_ of
what would be `fmt::formatter<Quantity<U, R>>`, without actually taking
a physical dependency on the fmt library.  This actually does work, and
this is what we do.  End users will need to make their own file which
depends on Au, depends on fmt, and specializes `fmt::formatter` by just
inheriting from `au::QuantityFormatter`.

Now for the actual syntax.  I ended up going with two optional parts:
one for the numeric value, and one for the unit label.  The unit label
gets a `U` prefix, and we use a `;` to separate them if they're both
there, but otherwise the syntax is simply "whatever syntax you would use
for the underlying types".  This gives a lot of flexibility without a
lot of complexity!

I also added documentation explaining how to use the formatting support.

Helps #149.  Really, this does _almost all_ of the work, but we can't
actually test the `std::format` support with our current toolchains (as
we're blocked on #485, #486, and #487).  So the plan is to land the
support for `{fmt}`, and then play around on godbolt to validate our
support for `std::format`.