### PR TITLE
Make `parse_ctx` constructor call more precise

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -941,7 +941,7 @@ struct QuantityFormatter {
         if (is_unit_label) {
             ++it;
         }
-        FormatParseContext parse_ctx({it, static_cast<std::size_t>(next_end - it)});
+        FormatParseContext parse_ctx{{it, static_cast<std::size_t>(next_end - it)}, 0};
 
         if (is_unit_label) {
             unit_label_format.parse(parse_ctx);

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -941,7 +941,7 @@ struct QuantityFormatter {
         if (is_unit_label) {
             ++it;
         }
-        FormatParseContext parse_ctx{it, static_cast<int>(next_end - it)};
+        FormatParseContext parse_ctx({it, static_cast<std::size_t>(next_end - it)});
 
         if (is_unit_label) {
             unit_label_format.parse(parse_ctx);


### PR DESCRIPTION
Here is the first attempt to test `std::format` support:
<https://godbolt.org/z/fYbarPdvG>.

The error complains about our `static_cast<int>` needing to _then_
become a `size_t` in the `std::format` implementation.  So I decided to
look into the constructors in more detail.  It turns out that for
`{fmt}`, the constructor takes a `fmt::string_view` and optional `int`
argument count, while the `std::format` takes a `std::string_view` and a
`size_t` argument count.

So this makes it seem like the constructor was spelled wrongly, and we
were actually providing an argument count, not a second argument to the
`xyz::string_view`.  Oops!

The fix is to construct it with a _nested_ braced list whose second
argument is the `size_t` difference.  To disambiguate the constructor,
we also need to pass something for the argument count.  `0` should work
in all cases.  It's pretty rare for the format parse context argument to
actually _need_ the argument count, and is mostly used for, e.g.,
getting part of a formatting string from a _different numbered
argument_.

Helps #149.  After this, we will try again with the godbolt link ---
unfortunately, we can't easily test the `std::format` directly just yet.