### PR TITLE
Add `-Wsign-conversion` coverage to `:fmt_test`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -149,9 +149,9 @@ http_archive(
         "Move-Item -Path support/bazel/MODULE.bazel -Destination MODULE.bazel",
         "Move-Item -Path support/bazel/WORKSPACE.bazel -Destination WORKSPACE.bazel",
     ],
-    sha256 = "203eb4e8aa0d746c62d8f903df58e0419e3751591bb53ff971096eaa0ebd4ec3",
-    strip_prefix = "fmt-11.2.0",
-    url = "https://github.com/fmtlib/fmt/releases/download/11.2.0/fmt-11.2.0.zip",
+    sha256 = "40fc58bebcf38c759e11a7bd8fdc163507d2423ef5058bba7f26280c5b9c5465",
+    strip_prefix = "fmt-11.0.2",
+    url = "https://github.com/fmtlib/fmt/releases/download/11.0.2/fmt-11.0.2.zip",
 )
 
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")

--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -84,8 +84,6 @@ cc_test(
     name = "fmt_test",
     size = "small",
     srcs = ["fmt_test.cc"],
-    copts = ["-Wno-sign-conversion"],
-    tags = ["no_wsign_conversion"],
     deps = [
         ":quantity",
         ":testing",

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -941,7 +941,7 @@ struct QuantityFormatter {
         if (is_unit_label) {
             ++it;
         }
-        FormatParseContext parse_ctx{it, static_cast<int>(next_end - it)};
+        FormatParseContext parse_ctx{{it, static_cast<std::size_t>(next_end - it)}, 0};
 
         if (is_unit_label) {
             unit_label_format.parse(parse_ctx);


### PR DESCRIPTION
We fix the problem by downgrading to 11.0.2, which was the last version
before the `-Wsign-conversion` errors were introduced (fmtlib/fmt#4268).

Helps #149.