### PR TITLE
Try format string approach

### DIFF
--- a/au/fmt_test.cc
+++ b/au/fmt_test.cc
@@ -21,8 +21,16 @@
 #include "gtest/gtest.h"
 
 namespace fmt {
+struct FmtFormatterImpl {
+    template <typename OutIter, typename... Args>
+    static auto format_to(OutIter out, const char *fmt_str, Args &&...args) {
+        return fmt::format_to(out, fmt_str, std::forward<Args>(args)...);
+    }
+};
+
 template <typename U, typename R>
-struct formatter<::au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, ::fmt::formatter> {};
+struct formatter<::au::Quantity<U, R>>
+    : ::au::QuantityFormatter<U, R, ::fmt::formatter, FmtFormatterImpl> {};
 }  // namespace fmt
 
 namespace au {


### PR DESCRIPTION
This uses only public API elements.  It does complicate the user setup,
because they need to add two boilerplate entities instead of one, and
the new one is more complicated, but this could be forgiven if it
actually works.

It doesn't.  The main config CI passes, but the C++20 tests fail:

```sh
bazel test --copt=-std=c++20 //au:fmt_test
```

The problem appears to be that C++20 introduces `consteval`, and `{fmt}`
uses it, and our `constexpr` `const char*` population is no longer good
enough.  If we can get a C++14 compatible solution that passes our CI,
we could consider landing this.

Helps #149.