### PR TITLE
Rename `check()` to `check_for()`

### DIFF
--- a/au/constant.hh
+++ b/au/constant.hh
@@ -57,7 +57,7 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     // Convert this constant to a Quantity of the given unit and rep.
     template <typename T, typename OtherUnit>
     constexpr auto as(OtherUnit u) const {
-        return as<T>(u, guard_against(ALL_RISKS));
+        return as<T>(u, check_for(ALL_RISKS));
     }
 
     // Convert this constant to a Quantity of the given unit and rep, following this risk policy.
@@ -87,7 +87,7 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     // Get the value of this constant in the given unit and rep.
     template <typename T, typename OtherUnit>
     constexpr auto in(OtherUnit u) const {
-        return in<T>(u, guard_against(ALL_RISKS));
+        return in<T>(u, check_for(ALL_RISKS));
     }
 
     // Get the value of this constant in the given unit and rep, following this risk policy.

--- a/au/constant.hh
+++ b/au/constant.hh
@@ -57,7 +57,7 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     // Convert this constant to a Quantity of the given unit and rep.
     template <typename T, typename OtherUnit>
     constexpr auto as(OtherUnit u) const {
-        return as<T>(u, check(ALL_RISKS));
+        return as<T>(u, guard_against(ALL_RISKS));
     }
 
     // Convert this constant to a Quantity of the given unit and rep, following this risk policy.
@@ -87,7 +87,7 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     // Get the value of this constant in the given unit and rep.
     template <typename T, typename OtherUnit>
     constexpr auto in(OtherUnit u) const {
-        return in<T>(u, check(ALL_RISKS));
+        return in<T>(u, guard_against(ALL_RISKS));
     }
 
     // Get the value of this constant in the given unit and rep, following this risk policy.

--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -31,9 +31,9 @@ namespace au {
 // Conversion risk section.
 //
 // End users can use the constants `OVERFLOW_RISK` and `TRUNCATION_RISK`.  They can combine them as
-// flags with `|`.  And they can pass either of these (or the result of `|`) to either `check()` or
-// `ignore()`.  The result of these functions is a risk _policy_, which can be passed as a second
-// argument to conversion functions to control which checks are performed.
+// flags with `|`.  And they can pass either of these (or the result of `|`) to either
+// `guard_against()` or `ignore()`.  The result of these functions is a risk _policy_, which can be
+// passed as a second argument to conversion functions to control which checks are performed.
 //
 
 namespace detail {
@@ -58,7 +58,7 @@ struct RiskSet {
 
     constexpr uint8_t flags() const { return RiskFlags; }
 
-    friend constexpr CheckTheseRisks<RiskSet<RiskFlags>> check(RiskSet) { return {}; }
+    friend constexpr CheckTheseRisks<RiskSet<RiskFlags>> guard_against(RiskSet) { return {}; }
     friend constexpr CheckTheseRisks<RiskSet<3u - RiskFlags>> ignore(RiskSet) { return {}; }
 };
 

--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -32,7 +32,7 @@ namespace au {
 //
 // End users can use the constants `OVERFLOW_RISK` and `TRUNCATION_RISK`.  They can combine them as
 // flags with `|`.  And they can pass either of these (or the result of `|`) to either
-// `guard_against()` or `ignore()`.  The result of these functions is a risk _policy_, which can be
+// `check_for()` or `ignore()`.  The result of these functions is a risk _policy_, which can be
 // passed as a second argument to conversion functions to control which checks are performed.
 //
 
@@ -58,7 +58,7 @@ struct RiskSet {
 
     constexpr uint8_t flags() const { return RiskFlags; }
 
-    friend constexpr CheckTheseRisks<RiskSet<RiskFlags>> guard_against(RiskSet) { return {}; }
+    friend constexpr CheckTheseRisks<RiskSet<RiskFlags>> check_for(RiskSet) { return {}; }
     friend constexpr CheckTheseRisks<RiskSet<3u - RiskFlags>> ignore(RiskSet) { return {}; }
 };
 

--- a/au/conversion_policy_test.cc
+++ b/au/conversion_policy_test.cc
@@ -58,19 +58,19 @@ TEST(ConversionRisk, IgnoreAllRisksChecksNeitherRisk) {
 }
 
 TEST(ConversionRisk, CheckOverflowRiskChecksOverflowRiskButNotTruncationRisk) {
-    constexpr auto policy = guard_against(OVERFLOW_RISK);
+    constexpr auto policy = check_for(OVERFLOW_RISK);
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsTrue());
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsFalse());
 }
 
 TEST(ConversionRisk, CheckTruncationRiskChecksTruncationRiskButNotOverflowRisk) {
-    constexpr auto policy = guard_against(TRUNCATION_RISK);
+    constexpr auto policy = check_for(TRUNCATION_RISK);
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsFalse());
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsTrue());
 }
 
 TEST(ConversionRisk, CheckAllRisksChecksBothRisks) {
-    constexpr auto policy = guard_against(ALL_RISKS);
+    constexpr auto policy = check_for(ALL_RISKS);
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsTrue());
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsTrue());
 }

--- a/au/conversion_policy_test.cc
+++ b/au/conversion_policy_test.cc
@@ -58,19 +58,19 @@ TEST(ConversionRisk, IgnoreAllRisksChecksNeitherRisk) {
 }
 
 TEST(ConversionRisk, CheckOverflowRiskChecksOverflowRiskButNotTruncationRisk) {
-    constexpr auto policy = check(OVERFLOW_RISK);
+    constexpr auto policy = guard_against(OVERFLOW_RISK);
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsTrue());
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsFalse());
 }
 
 TEST(ConversionRisk, CheckTruncationRiskChecksTruncationRiskButNotOverflowRisk) {
-    constexpr auto policy = check(TRUNCATION_RISK);
+    constexpr auto policy = guard_against(TRUNCATION_RISK);
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsFalse());
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsTrue());
 }
 
 TEST(ConversionRisk, CheckAllRisksChecksBothRisks) {
-    constexpr auto policy = check(ALL_RISKS);
+    constexpr auto policy = guard_against(ALL_RISKS);
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsTrue());
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Truncation), IsTrue());
 }

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -105,7 +105,7 @@ constexpr auto as_quantity(T &&x) -> CorrespondingQuantityT<T> {
 // Only works for dimensionless `Quantities`; will return a compile-time error otherwise.
 //
 // Identity for non-`Quantity` types.
-template <typename U, typename R, typename RiskPolicyT = decltype(check(ALL_RISKS))>
+template <typename U, typename R, typename RiskPolicyT = decltype(guard_against(ALL_RISKS))>
 constexpr R as_raw_number(Quantity<U, R> q, RiskPolicyT policy = RiskPolicyT{}) {
     return q.in(UnitProductT<>{}, policy);
 }
@@ -182,7 +182,7 @@ class Quantity {
     }
 
     // `q.as(new_unit)`, or `q.as(new_unit, risk_policy)`
-    template <typename NewUnitSlot, typename RiskPolicyT = decltype(check(ALL_RISKS))>
+    template <typename NewUnitSlot, typename RiskPolicyT = decltype(guard_against(ALL_RISKS))>
     constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity<AssociatedUnitT<NewUnitSlot>>(in_impl<Rep>(u, policy));
     }
@@ -196,7 +196,7 @@ class Quantity {
     }
 
     // `q.in(new_unit)`, or `q.in(new_unit, risk_policy)`
-    template <typename NewUnitSlot, typename RiskPolicyT = decltype(check(ALL_RISKS))>
+    template <typename NewUnitSlot, typename RiskPolicyT = decltype(guard_against(ALL_RISKS))>
     constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<Rep>(u, policy);
     }

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -105,7 +105,7 @@ constexpr auto as_quantity(T &&x) -> CorrespondingQuantityT<T> {
 // Only works for dimensionless `Quantities`; will return a compile-time error otherwise.
 //
 // Identity for non-`Quantity` types.
-template <typename U, typename R, typename RiskPolicyT = decltype(guard_against(ALL_RISKS))>
+template <typename U, typename R, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
 constexpr R as_raw_number(Quantity<U, R> q, RiskPolicyT policy = RiskPolicyT{}) {
     return q.in(UnitProductT<>{}, policy);
 }
@@ -182,7 +182,7 @@ class Quantity {
     }
 
     // `q.as(new_unit)`, or `q.as(new_unit, risk_policy)`
-    template <typename NewUnitSlot, typename RiskPolicyT = decltype(guard_against(ALL_RISKS))>
+    template <typename NewUnitSlot, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
     constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity<AssociatedUnitT<NewUnitSlot>>(in_impl<Rep>(u, policy));
     }
@@ -196,7 +196,7 @@ class Quantity {
     }
 
     // `q.in(new_unit)`, or `q.in(new_unit, risk_policy)`
-    template <typename NewUnitSlot, typename RiskPolicyT = decltype(guard_against(ALL_RISKS))>
+    template <typename NewUnitSlot, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
     constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<Rep>(u, policy);
     }

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -128,7 +128,7 @@ class QuantityPoint {
         return make_quantity_point<AssociatedUnitForPointsT<NewUnit>>(in_impl<NewRep>(u, policy));
     }
 
-    template <typename NewUnit, typename RiskPolicyT = decltype(check(ALL_RISKS))>
+    template <typename NewUnit, typename RiskPolicyT = decltype(guard_against(ALL_RISKS))>
     constexpr auto as(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity_point<AssociatedUnitForPointsT<NewUnit>>(in_impl<Rep>(u, policy));
     }
@@ -138,7 +138,7 @@ class QuantityPoint {
         return in_impl<NewRep>(u, policy);
     }
 
-    template <typename NewUnit, typename RiskPolicyT = decltype(check(ALL_RISKS))>
+    template <typename NewUnit, typename RiskPolicyT = decltype(guard_against(ALL_RISKS))>
     constexpr Rep in(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<Rep>(u, policy);
     }

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -128,7 +128,7 @@ class QuantityPoint {
         return make_quantity_point<AssociatedUnitForPointsT<NewUnit>>(in_impl<NewRep>(u, policy));
     }
 
-    template <typename NewUnit, typename RiskPolicyT = decltype(guard_against(ALL_RISKS))>
+    template <typename NewUnit, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
     constexpr auto as(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity_point<AssociatedUnitForPointsT<NewUnit>>(in_impl<Rep>(u, policy));
     }
@@ -138,7 +138,7 @@ class QuantityPoint {
         return in_impl<NewRep>(u, policy);
     }
 
-    template <typename NewUnit, typename RiskPolicyT = decltype(guard_against(ALL_RISKS))>
+    template <typename NewUnit, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
     constexpr Rep in(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<Rep>(u, policy);
     }


### PR DESCRIPTION
Bad news: `check(TRUNCATION_RISK)` won't work if the user's namespace
has a `check` namespace.  Aurora does; that's how I found out.

Not a huge deal: we can rename `check()` to `check_for()`.  This isn't
quite as concise, but it reads very nicely, and is extremely unlikely to
be a namespace anywhere out in the wild (which I think is also true of
`ignore`.

Follow-up to #387.