### PR TITLE
Support risk policy parameter in constructors

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -162,6 +162,11 @@ class Quantity {
     // Deleted: use `.as<NewRep>(new_unit)` to force a cast.
     explicit constexpr Quantity(Quantity<OtherUnit, OtherRep> other) = delete;
 
+    // Constructor for another Quantity with an explicit conversion risk policy.
+    template <typename OtherUnit, typename OtherRep, typename RiskPolicyT>
+    constexpr Quantity(Quantity<OtherUnit, OtherRep> other, RiskPolicyT policy)
+        : value_{other.template in<Rep>(UnitT{}, policy)} {}
+
     // Construct this Quantity with a value of exactly Zero.
     constexpr Quantity(Zero) : value_{0} {}
 

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -119,6 +119,11 @@ class QuantityPoint {
     // Deleted: use `.as<NewRep>(new_unit)` to force a cast.
     constexpr explicit QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other) = delete;
 
+    // Construct from another QuantityPoint with an explicit conversion risk policy.
+    template <typename OtherUnit, typename OtherRep, typename RiskPolicyT>
+    constexpr QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other, RiskPolicyT policy)
+        : QuantityPoint{other.template as<Rep>(Unit{}, policy)} {}
+
     // The notion of "0" is *not* unambiguous for point types, because different scales can make
     // different decisions about what point is labeled as "0".
     constexpr QuantityPoint(Zero) = delete;

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -114,6 +114,11 @@ TEST(QuantityPoint, ImplicitConstructionsAreCorrect) {
     EXPECT_THAT(zero_celsius_as_mK, SameTypeAndValue(milli(kelvins_pt)(273'150)));
 }
 
+TEST(QuantityPoint, CanProvidePolicyToConstructor) {
+    constexpr auto temp = QuantityPointI<Kelvins>{celsius_pt(20), ignore(TRUNCATION_RISK)};
+    EXPECT_THAT(temp, SameTypeAndValue(kelvins_pt(293)));
+}
+
 TEST(QuantityPoint, CanCreateAndRetrieveValue) {
     constexpr auto p = celsius_pt(3);
     EXPECT_THAT(p.in(Celsius{}), SameTypeAndValue(3));

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -127,6 +127,11 @@ TEST(Quantity, CanCreateAndReadValuesByNamingUnits) {
     EXPECT_THAT(output_value, Eq(3.14));
 }
 
+TEST(Quantity, CanProvidePolicyToConstructor) {
+    constexpr auto length = QuantityI<Feet>{inches(36), ignore(TRUNCATION_RISK)};
+    EXPECT_THAT(length, SameTypeAndValue(feet(3)));
+}
+
 TEST(Quantity, CanRequestOutputRepWhenCallingIn) { EXPECT_THAT(feet(3.14).in<int>(feet), Eq(3)); }
 
 TEST(MakeQuantity, MakesQuantityInGivenUnit) {


### PR DESCRIPTION
Sometimes, end users have aliases for `Quantity` or `QuantityPoint`
types.  In these cases, sticking exclusively to `.as` can be more
awkward than just using a constructor.  Therefore, we add new Q-to-Q
(and QP-to-QP) constructors to support a second policy argument.

Follow-on for #387.