### PR TITLE
Update docs to reflect conversion risk policies

### DIFF
--- a/docs/discussion/concepts/conversion_risks.md
+++ b/docs/discussion/concepts/conversion_risks.md
@@ -66,8 +66,12 @@ from determining whether _a specific input value_ will be lossy.  For example:
 | Conversion | Policy | Result (if allowed) | Actually lossy? |
 |------------|--------|---------------------|-----------------|
 | `inches(24).as(feet)` | :x: Forbidden (truncation risk) | `feet(2)` | :thumbs_up: No |
-| `seconds(4u).as(nano(seconds))` | :x: Forbidden (overflow risk) | `nano(seconds(4'000'000'000u))` | :thumbs_up: No |
-| `seconds(9000u).as(micro(seconds))` | :thumbs_up: Allowed | `micro(seconds(410'065'408u))` | :x: Yes (overflow) |
+| `seconds(4u).as(nano(seconds))`[^1] | :x: Forbidden (overflow risk) | `nano(seconds(4'000'000'000u))` | :thumbs_up: No |
+| `seconds(9000u).as(micro(seconds))`[^1] | :thumbs_up: Allowed | `micro(seconds(410'065'408u))` | :x: Yes (overflow) |
+
+[^1]: In these docs, we assume that `unsigned int` values (such as `4u` and `9000u`) are 32 bits
+wide.  On architectures where this is not true, you could pattern-replace items such as `4u` with
+`uint32_t{4}` to reproduce the results in the tables.
 
 This shows that our default policy has two kinds of failure modes.
 
@@ -96,7 +100,7 @@ Let's look at some more examples to make this clear.
 | Conversion | Policy | Result | Actually lossy? |
 |------------|--------|--------|-----------------|
 | `inches(24).as(feet, ignore(TRUNCATION_RISK))` | :thumbs_up: Allowed (by policy override) | `feet(2)` | :thumbs_up: No |
-| `seconds(4u).as(nano(seconds), ignore(OVERFLOW_RISK))` | :thumbs_up: Allowed (by policy override) | `nano(seconds(4'000'000'000))` | :thumbs_up: No |
+| `seconds(4u).as(nano(seconds), ignore(OVERFLOW_RISK))`[^1] | :thumbs_up: Allowed (by policy override) | `nano(seconds(4'000'000'000))` | :thumbs_up: No |
 
 Here, we have revisited the examples from the previous table, but thanks to our policy override,
 they are no longer forbidden.  We see that they do produce the correct results.  However, we
@@ -106,7 +110,7 @@ could easily produce grossly incorrect results:
 | Conversion | Policy | Result | Actually lossy? |
 |------------|--------|--------|-----------------|
 | `inches(23).as(feet, ignore(TRUNCATION_RISK))` | :thumbs_up: Allowed (by policy override) | `feet(1)` | :x: Yes (truncation) |
-| `seconds(5u).as(nano(seconds), ignore(OVERFLOW_RISK))` | :thumbs_up: Allowed (by policy override) | `nano(seconds(705'032'704u))` | :x: Yes (overflow) |
+| `seconds(5u).as(nano(seconds), ignore(OVERFLOW_RISK))`[^1] | :thumbs_up: Allowed (by policy override) | `nano(seconds(705'032'704u))` | :x: Yes (overflow) |
 
 Use the opt-out tool wisely, and carefully consider whether it's the right solution for your use
 case.

--- a/docs/discussion/concepts/conversion_risks.md
+++ b/docs/discussion/concepts/conversion_risks.md
@@ -1,0 +1,204 @@
+# Conversion Risks
+
+Unit conversions turn one `Quantity` into another, where both the unit and the representation type
+(the "rep") might change.  Think of a "unit conversion" as being defined by three parameters:
+
+1. The _initial_ **rep**.
+2. The _target_ **rep**.
+3. The ratio between the _initial_ and _target_ **units**.
+
+Under the hood, we implement each conversion as a sequence of operations, including `static_cast`
+for changing the rep, and mathematical operations (mainly multiplying and dividing) for changing the
+value.  Each operation has an input type, and an output type (which might be the same as the input).
+
+## What can go wrong?
+
+On pen and paper, any unit conversion can be done exactly.  _In software_, this is not true.  Most
+representation types can only represent a limited range of numbers, and with only finite precision
+within that range.  This means that some conversions can produce grossly incorrect results!  In
+general, there are two main failure modes for an operation:
+
+- **[Overflow](./overflow.md)**: the result _exceeds the bounds_ of the output type.
+- **[Truncation](./truncation.md)**: the output type has _insufficient precision_ to represent the
+  result.
+
+Au accounts for these risks in our APIs.  For each conversion, we assess the overall risk in
+deciding whether to permit it _by default_.  We also let you opt out of individual named safety
+checks, for situations where you're confident it's okay.  Finally, we have efficient functions to
+check the lossiness of _individual values_ at runtime, for the most granular control possible.
+
+## Default policies
+
+Any conversion has a set of input values that are lossy, and a set that aren't.  For example,
+imagine that we had `int x`:
+
+- `inches(x).as(feet)` would be lossy for any number that isn't an exact multiple of 12 (due to
+  truncation).
+- `feet(x).as(inches)` would be lossy for any number greater than `357913941`, or less than
+  `-357913941` (due to overflow).
+
+Au's task is to decide which unit conversions to allow, and which to turn into compiler errors.
+Because we must make this decision at compile time, _we don't know the actual input value_. All we
+can do is to assess the risk across the values that we expect to see most often.
+
+Notice how the above two examples present very different risk profiles.  For `inches(x).as(feet)`,
+11 out of every 12 values will be significantly lossy.  For `feet(x).as(inches)`, it's another
+story.  In practice, users are unlikely to use values greater than 357 million feet in most
+applications, since that's over 1/4 of the way to the moon!  As you might expect, Au forbids the
+first conversion but permits the second.
+
+In more detail, Au has separate risk checks for overflow and truncation.
+
+- The **overflow check** is an [adaptive check](./overflow.md#adapt) based on a single number: the
+  smallest input that would exceed the output range.
+
+- The **truncation check** is based on whether truncation is possible for _any_ input value, with
+  the caveat that we treat [floating point as non-truncating](./truncation.md#float).
+
+Au only permits conversions by default if they pass _both_ checks.
+
+### Overall risk versus individual values
+
+It's critically important to understand that these policies are based on _risk_, which takes into
+account _all possible_ input values (and, crudely, their relative likelihoods).  This is different
+from determining whether _a specific input value_ will be lossy.  For example:
+
+| Conversion | Policy | Result (if allowed) | Actually lossy? |
+|------------|--------|---------------------|-----------------|
+| `inches(24).as(feet)` | :x: Forbidden (truncation risk) | `feet(2)` | :thumbs_up: No |
+| `seconds(4u).as(nano(seconds))` | :x: Forbidden (overflow risk) | `nano(seconds(4'000'000'000u))` | :thumbs_up: No |
+| `seconds(9000u).as(micro(seconds))` | :thumbs_up: Allowed | `micro(seconds(410'065'408u))` | :x: Yes (overflow) |
+
+This shows that our default policy has two kinds of failure modes.
+
+The first is that **allowed conversions can still be lossy** for some input values.  Granted, this
+can only happen for cases that Au assesses to be low risk.  While practical experience has largely
+validated these policies, some applications may not be able to tolerate _any_ risk of loss.  We'll
+explore the solution --- namely, _runtime checking_ --- later on in more detail.
+
+The second is that we forbid some conversions that are actually perfectly fine, at least for certain
+values.  Or, certain use cases --- for example, many embedded applications _expect and desire_ the
+truncating properties of integer division.  The solution for these cases is to opt out of individual
+safety checks.  We'll dive into it now.
+
+### Opting out of safety checks
+
+When a conversion fails to compile, the error message will tell you what risk Au was concerned
+about.  You can then pass `ignore(X)` as a _second parameter to the conversion function_, and it
+will ignore the risk `X`.  There are two reasons to prefer this more granular opt-out mechanism to
+a blanket approach that turns off all safety checks:
+
+1. It's more _intent-based_: readers will better understand what risk you are ignoring.
+2. It's _safer_: you still have coverage for the other risk.
+
+Let's look at some more examples to make this clear.
+
+| Conversion | Policy | Result | Actually lossy? |
+|------------|--------|--------|-----------------|
+| `inches(24).as(feet, ignore(TRUNCATION_RISK))` | :thumbs_up: Allowed (by policy override) | `feet(2)` | :thumbs_up: No |
+| `seconds(4u).as(nano(seconds), ignore(OVERFLOW_RISK))` | :thumbs_up: Allowed (by policy override) | `nano(seconds(4'000'000'000))` | :thumbs_up: No |
+
+Here, we have revisited the examples from the previous table, but thanks to our policy override,
+they are no longer forbidden.  We see that they do produce the correct results.  However, we
+emphasize that this is due to the _specific input values_ that we used.  Very similar input values
+could easily produce grossly incorrect results:
+
+| Conversion | Policy | Result | Actually lossy? |
+|------------|--------|--------|-----------------|
+| `inches(23).as(feet, ignore(TRUNCATION_RISK))` | :thumbs_up: Allowed (by policy override) | `feet(1)` | :x: Yes (truncation) |
+| `seconds(5u).as(nano(seconds), ignore(OVERFLOW_RISK))` | :thumbs_up: Allowed (by policy override) | `nano(seconds(705'032'704u))` | :x: Yes (overflow) |
+
+Use the opt-out tool wisely, and carefully consider whether it's the right solution for your use
+case.
+
+### Not all conversions are actually possible
+
+Opting out of safety checks is not sufficient to guarantee that Au will perform a conversion.  The
+opt-out removes one barrier.  If there are others, the conversion will still not happen.
+
+One common example is when users try to convert between two units with different dimensions.  This
+is a meaningless operation, and is always user error.  Au will not perform this conversion because
+it does not exist.
+
+Another example is when a conversion is meaningful in principle, but Au doesn't know how to
+implement it in the desired rep.  For example, `radians(1).as(degrees)` would require us to support
+irrational conversion factors in integral reps, which is very hard (although [#453] tracks one
+possible future solution).  In this case, if your architecture can tolerate floating point types
+such as `double`, you can write `radians(1.0).as<int>(degrees)` to obtain the answer.
+
+## Runtime checks
+
+Here, we address the second limitation: even conversions that Au considers low-risk can be lossy.
+If we tried to stick to compile time solutions, we would end up only allowing conversions where
+_no_ input value is lossy.  In practice, this is incredibly restrictive.
+
+The alternative is to provide _runtime checkers_, which can efficiently and accurately assess
+whether any individual value will be lossy.
+
+Unlike the compile time approach, we will pay a runtime cost.  However, this cost can be extremely
+low --- for example, the overflow checks simply compare to a single number that we compute for each
+conversion.  What's more, this cost doesn't usually _matter_, because unit conversions almost never
+occur in the performance-sensitive "hot loops" of well designed programs.
+
+A more serious issue is that you have to decide what to do if the check _fails_.  In general, there
+is no one-size-fits-all error handling mechanism that would be suitable for all clients of Au.  In
+general, you should use whatever error handling mechanism is appropriate for your project.
+
+### Provided checkers
+
+Au provides runtime checkers for overflow, truncation, and combined lossiness.  For a `Quantity q`,
+converting to a new unit `u`, we provide these signatures:
+
+| Risk | Target rep | Function |
+|------|------------|----------|
+| Overflow | same | `will_conversion_overflow(q, u)` |
+| Overflow | New rep `T` | `will_conversion_overflow<T>(q, u)` |
+| Truncation | same | `will_conversion_truncate(q, u)` |
+| Truncation | New rep `T` | `will_conversion_truncate<T>(q, u)` |
+| Any lossiness | same | `is_conversion_lossy(q, u)` |
+| Any lossiness | New rep `T` | `is_conversion_lossy<T>(q, u)` |
+
+In general, `is_conversion_lossy` will return true if either `will_conversion_overflow` or
+`will_conversion_truncate` returns true.
+
+### Creating checked helpers
+
+In general, effective runtime checker use has two steps.  First, call the checker you're interested
+in. Then, if it passed, call the conversion function while _opting out of the risk check you already
+validated_.
+
+It's even better to combine these in a utility function.  For example, using C++17's
+`std::optional`, here's a function that returns the correct result for non-truncating inputs, or
+`std::nullopt` otherwise:
+
+```cpp
+template <typename Target, typename U, typename R>
+std::optional<Quantity<TargetUnit, R>> checked_conversion(Quantity<U, R> q, Target u) {
+    return will_conversion_truncate(q, u)
+        ? std::nullopt
+        : std::make_optional(q.as(u, ignore(TRUNCATION_RISK)));
+}
+```
+
+`checked_conversion(inches(35), feet)` will produce `std::nullopt`, while
+`checked_conversion(inches(36), feet)` gives `std::make_optional(feet(3))`.
+
+## Takeaways
+
+By default, Au only permits a conversion if the risk is low, for both overflow and truncation.
+However, this is just a heuristic, based on _all inputs_ for a conversion.  Almost every conversion
+has _some_ inputs that go against this policy.
+
+If your conversion is forbidden, but you're confident it's OK for your inputs, you can _pass
+a second argument_ to opt out of that safety check: usually, `ignore(OVERFLOW_RISK)` or
+`ignore(TRUNCATION_RISK)`.  This tool does a good job of communicating your intent, but be wary of
+using it too widely.  The risk checks are there for good reason, so make sure your use case really
+is OK.
+
+By contrast, if you can't tolerate any lossiness, Au provides _runtime checkers_ that can quickly
+provide accurate answers for any individual value.  This adds runtime cost, but it's rarely
+important.  A harder problem is deciding what to do if the check fails.  We recommend using the
+runtime checkers as building blocks for a "checked conversion" utility, because this lets you use
+the error handling mechanism that's best for your project.
+
+[#453]: https://github.com/aurora-opensource/au/issues/453

--- a/docs/discussion/concepts/index.md
+++ b/docs/discussion/concepts/index.md
@@ -15,7 +15,7 @@ and help you use units libraries more effectively.
   teaches you what choice we make, and what advantages it has.
 
 - **[Conversion Risks](./conversion_risks.md)**.  Unit conversions can be lossy.  This page explains
-  how to think about conversoin lossiness: both for individual input values, and for the overall
+  how to think about conversion lossiness: both for individual input values, and for the overall
   conversion as a whole.  We'll learn about the safety checks built into Au's APIs, and how to
   circumvent them when necessary.
 

--- a/docs/discussion/concepts/index.md
+++ b/docs/discussion/concepts/index.md
@@ -14,6 +14,11 @@ and help you use units libraries more effectively.
   different units, the first step is to convert them to the same unit.  But which one?  This page
   teaches you what choice we make, and what advantages it has.
 
+- **[Conversion Risks](./conversion_risks.md)**.  Unit conversions can be lossy.  This page explains
+  how to think about conversoin lossiness: both for individual input values, and for the overall
+  conversion as a whole.  We'll learn about the safety checks built into Au's APIs, and how to
+  circumvent them when necessary.
+
 - **[Dimensionless Units and Quantities](./dimensionless.md)**.  "Dimensionless" isn't the same
   thing as "unitless"; we support dimensionless units, like `Percent`.  Here we explain how the
   library handles these situations, and avoids common pitfalls.
@@ -25,6 +30,10 @@ and help you use units libraries more effectively.
 
 - **[Quantity Point](./quantity_point.md)**.  An abstraction for "point types" that have units.
   Most use cases don't need this, but for a few --- including temperatures --- it's indispensable.
+
+- **[Truncation](./truncation.md)**.  Unit conversions truncate when the destination type can't hold
+  the result with acceptable precision.  This page will explain Au's approach to managing this risk,
+  both for individual values, and for the overall conversion.
 
 - **[Zero](./zero.md)**.  Switching to a units library can make some easy computations hard.  Learn
   how we make them easy again with a special constant, `ZERO`, that works with quantities of any

--- a/docs/discussion/concepts/overflow.md
+++ b/docs/discussion/concepts/overflow.md
@@ -83,7 +83,7 @@ are many dimensions, and new ones can be created on the fly, it's infeasible to 
 a "practical range" for _all_ of them.  Besides, users can still form arbitrary
 `std::chrono::duration` types, and they may not realize the safety they have given up in doing so.
 
-### Adapt to risk
+### Adapt to risk {#adapt}
 
 Fundamentally, there are two contributions to the level of overflow risk:
 

--- a/docs/discussion/concepts/truncation.md
+++ b/docs/discussion/concepts/truncation.md
@@ -1,0 +1,130 @@
+# Truncation
+
+_Truncation_ occurs when the result of a unit conversion lands _in-between_ representable values in
+the destination type.  Along with [overflow], it's one of the two main [conversion risks] in units
+libraries.
+
+## Au's approach
+
+Au implements unit conversions as _sequences of operations_.  Some operations multiply or divide by
+a particular number.  Others cast a value from one type to another.
+
+Au checks every operation in the sequence to see whether any input values might cause truncation.
+If we find _any_ risk, we forbid the conversion --- at least, by default.  There may be valid
+reasons to perform such a conversion anyway.  If users are confident this is what they want, they
+can pass `ignore(TRUNCATION_RISK)` as a second argument to any conversion operator.
+
+Usually, even conversions with truncation risk will truncate for only some values, and not for
+others.  Users can check _individual values_ at runtime to see if that particular value is safe.
+`will_conversion_truncate(q, u)` examines converting the _specific_ `Quantity` value `q` to the new
+unit `u`.  If the conversion being checked also changes the representation type (the "rep"), to
+a new type `T`, `will_conversion_truncate<T>(q, u)` is the right form to use.
+
+These tools complement each other.  A common pattern is to check an individual value at runtime, and
+then call the actual conversion function with `ignore(TRUNCATION_RISK)` if the check passes.
+Remember, the `TRUNCATION_RISK` flag refers to the risk of the _conversion as a whole_.  If you've
+just proved that _your particular value_ is safe, then ignoring that _general_ risk is clearly fine.
+
+## Truncation in mathematical operations
+
+By "mathematical operations", we mainly mean multiplying or dividing by numerical constants.  To
+understand the truncation risk, we first put the rep into one of several categories, because the
+risk profile strongly depends on the category.
+
+The main categories are the arithmetic[^1] types: integral, and floating point.  We'll also briefly
+discuss how to think about other numeric types that we hope to support more fully in the future
+([#52]).
+
+[^1]: "Arithmetic" types are C++'s built-in numeric types: `int`, `double`, `uint64_t`, and so on.
+
+### Integral types
+
+Integral types are considered _exact_.  To see the implications for truncation, we need to consider
+various [types of conversion factors](../implementation/applying_magnitudes.md).
+
+First, we have multiplying by an integer.  This is easy: it stays within the domain of the integers,
+so it can never truncate.
+
+Next, we have multiplication by a non-integer rational (including reciprocal integers).  This will
+truncate for any input that isn't an exact integer multiple of the denominator, so the _conversion
+as a whole_ clearly has truncation risk.  When checking _individual values_, we can use the built-in
+`%` operator.
+
+Finally, we have multiplication by an irrational number.  For integral types, this truncates for
+every nonzero input, because integers are exact types, and the only integer that produces an integer
+when multiplied by an irrational is zero.
+
+### Floating point types {#float}
+
+Mathematical operations on floating point types are governed by a very simple philosophy: _floating
+point never truncates_.
+
+This may surprise the reader: after all, truncation means the result falls in-between representable
+values, and floating point types certainly have gaps!  But consider the design philosophy of
+floating point.  The goal is to _emulate_ a continuous real line.  Floating point values implicitly
+come with a _relative tolerance_: one that is small, but _not_ zero.  Each representable value
+effectively stands in for a small range of real values around it, and the exact size of that range
+depends on the precise calculations.
+
+Or, more simply: floating point types are considered _inexact_.
+
+Now, we return to the problem of truncation in units libraries.  The very act of choosing a floating
+point representation is a statement, by the user, that _exact values do not matter_ for their
+application.  It would be inappropriate for us to raise warnings about perfectly routine properties
+of the user's chosen type.  Hence: _floating point never truncates_.
+
+### Other types
+
+Currently, Au has only limited support for non-arithmetic rep types (full support is tracked in
+[#52]). As a stopgap, Au treats any non-arithmetic type conservatively, and assumes that it can
+truncate.  We hope to refine this approach when we strengthen our support for more rep types.
+
+## Truncation in casting
+
+Besides mathematical operations, the other main operation in unit conversions is casting from one
+type to another.  We assess truncation risk for these operations as well.
+
+### Arithmetic to arithmetic
+
+Casting from one _arithmetic_ type to another is governed by simple rules.
+
+If the source and destination types are in the same _category_ --- that is, either both integral, or
+both floating point --- then the cast never truncates.  The reason for integral types is
+straightforward: clearly, the source can't hold a non-integer value.  As for floating point types,
+they are governed by the [philsophy explained above](#float).
+
+Casting from a floating point type to an integral type does have truncation risk: we would truncate
+for any non-integer input.  We can check this for individual values by discarding the fractional
+part, and checking whether this changes the value.
+
+Casting from an integral type to a floating point type is an interesting case.  As floating point
+values get larger, they grow farther apart.  At some point, consecutive representable values can
+differ by _multiple_ integers.  If we cast an input integer in this range, it may seem that we
+should consider this to truncate.  But recall the [philosophy above](#float): floating point types
+are all about _relative_ position.  For this reason, we consider casting from integral to floating
+point as a **non-truncating** operation.
+
+### Non-arithmetic types
+
+Here, too, our support for non-arithmetic rep types is limited (see [#52]), and we take
+a conservative approach.  Any cast involving a non-arithmetic type, either as source or destination,
+is considered to have truncation risk, and will not be allowed by default: users must pass
+`ignore(TRUNCATION_RISK)` as a second argument to override this.  We hope to have better default
+behavior once we support non-arithmetic types more fully.
+
+## Summary
+
+Truncation happens when the result of an operation falls in-between representable values in the
+numeric type where we're storing it.  If any input values for a unit conversion can truncate --- or,
+if we _don't know_ whether any can --- then we forbid the conversion.  Users can override this
+behavior by passing `ignore(TRUNCATION_RISK)` as a second argument.  Users can also check
+whether _individual values_ truncate using the `will_conversion_truncate` function.
+
+Truncation risk depends strongly on the types involved.  Integral types are vulnerable to truncation
+for non-integer scale factors.  On the other hand, we treat floating point types as though they
+never "truncate", because they're already inexact.  Finally, since we don't yet fully support
+non-arithmetic types, we treat them conservatively and assume that they carry truncation risk.
+
+[overflow]: ./overflow.md
+[conversion risks]: ./conversion_risks.md
+[#52]: https://github.com/aurora-opensource/au/issues/52

--- a/docs/reference/constant.md
+++ b/docs/reference/constant.md
@@ -197,7 +197,38 @@ the requested unit can be exactly represented in the type `T`.
 The argument `unit` is a [unit slot](../discussion/idioms/unit-slots.md) API, so it accepts a unit
 instance, quantity maker instance, or any other instance compatible with a unit slot.
 
+### `.as<T>(unit, policy)`
+
+This function expresses the constant as a `Quantity` in the requested unit, using a rep of `T`.  As
+usual, `Constant` has perfect knowledge at compile time about whether the conversion will cause
+overflow or truncation.  However, if the `policy` argument instructs it to ignore either of these
+problems, then it will not perform the corresponding safety check.
+
+The argument `unit` is a [unit slot](../discussion/idioms/unit-slots.md) API, so it accepts a unit
+instance, quantity maker instance, or any other instance compatible with a unit slot.
+
+The argument `policy` is a [conversion risk policy](./conversion_risk_policies.md).  In this
+context, instead of applying to the _risk_ of a problem, it applies to the _actual existence_ of
+that problem.  For example: you would **not** need to provide `ignore(TRUNCATION_RISK)` unless the
+specific conversion will _actually cause truncation_.
+
+!!! tip
+    This overload is typically only useful when you know that a specific conversion is _actually
+    lossy_, but you want it anyway.  Any non-lossy conversion would already be allowed with the
+    [simpler overload](#as-T-unit), which should be preferred.
+
+    Additionally, the conversion risks are not equally useful.  Use cases for
+    `ignore(TRUNCATION_RISK)` are straightforward to imagine: for example, you may simply want
+    a less precise version of the context.  Use cases for `ignore(OVERFLOW_RISK)` are very hard to
+    imagine, as they will produce a grossly incorrect result with no physical relationship to the
+    actual value.
+
 ### `.coerce_as<T>(unit)`
+
+!!! warning
+    We plan to deprecate APIs with `coerce` in their name in the [0.6.0] release ([#481]).  For
+    a `Constant` `c`, instead of `c.coerce_as<T>(unit)`, prefer `c.as<T>(unit, policy)`, where
+    `policy` is the desired [conversion risk policy](./conversion_risk_policies.md).
 
 This function expresses the constant as a `Quantity` in the requested unit, using a rep of `T`.  It
 is similar to [`.as<T>(unit)`](#as-T-unit), except that it will ignore the safety checks that
@@ -218,7 +249,38 @@ constant's value in the requested unit can be exactly represented in the type `T
 The argument `unit` is a [unit slot](../discussion/idioms/unit-slots.md) API, so it accepts a unit
 instance, quantity maker instance, or any other instance compatible with a unit slot.
 
+### `.in<T>(unit, policy)`
+
+This function produces a raw numeric value, of type `T`, holding the value of the constant in the
+requested unit.  As usual, `Constant` has perfect knowledge at compile time about whether the
+conversion will cause overflow or truncation.  However, if the `policy` argument instructs it to
+ignore either of these problems, then it will not perform the corresponding safety check.
+
+The argument `unit` is a [unit slot](../discussion/idioms/unit-slots.md) API, so it accepts a unit
+instance, quantity maker instance, or any other instance compatible with a unit slot.
+
+The argument `policy` is a [conversion risk policy](./conversion_risk_policies.md).  In this
+context, instead of applying to the _risk_ of a problem, it applies to the _actual existence_ of
+that problem.  For example: you would **not** need to provide `ignore(TRUNCATION_RISK)` unless the
+specific conversion will _actually cause truncation_.
+
+!!! tip
+    This overload is typically only useful when you know that a specific conversion is _actually
+    lossy_, but you want it anyway.  Any non-lossy conversion would already be allowed with the
+    [simpler overload](#in-T-unit), which should be preferred.
+
+    Additionally, the conversion risks are not equally useful.  Use cases for
+    `ignore(TRUNCATION_RISK)` are straightforward to imagine: for example, you may simply want
+    a less precise version of the context.  Use cases for `ignore(OVERFLOW_RISK)` are very hard to
+    imagine, as they will produce a grossly incorrect result with no physical relationship to the
+    actual value.
+
 ### `.coerce_in<T>(unit)`
+
+!!! warning
+    We plan to deprecate APIs with `coerce` in their name in the [0.6.0] release ([#481]).  For
+    a `Constant` `c`, instead of `c.coerce_in<T>(unit)`, prefer `c.in<T>(unit, policy)`, where
+    `policy` is the desired [conversion risk policy](./conversion_risk_policies.md).
 
 This function produces a raw numeric value, of type `T`, holding the value of the constant in the
 requested unit.  It is similar to [`.in<T>(unit)`](#in-T-unit), except that it will ignore the
@@ -346,3 +408,6 @@ because quantity points do not support multiplication.
 
 Multiplying or dividing `Constant<Unit>` with a `QuantityPoint<U, R>` is explicitly deleted,
 because quantity points do not support multiplication.
+
+[0.6.0]: https://github.com/aurora-opensource/au/milestone/9
+[#481]: https://github.com/aurora-opensource/au/issues/481

--- a/docs/reference/conversion_risk_policies.md
+++ b/docs/reference/conversion_risk_policies.md
@@ -1,0 +1,36 @@
+# Conversion Risk Policies
+
+A conversion risk policy is a [monovalue type](./detail/monovalue_types.md) that indicates how
+a unit conversion function should handle [conversion
+risks](../discussion/concepts/conversion_risks.md).  Au tracks two kinds of conversion risk:
+overflow, and truncation.  Each conversion risk policy will either enable or disable checking for
+each of these risks.
+
+## Conversion Risk Sets
+
+A _conversion risk set_ represents a set of risks.  It may be empty, refer to an individual risk, or
+refer to multiple risks.  The only supported way to form a risk set is to use a built-in risk set
+constant, or else to combine such constants using the bitwise-or operator (`|`).  Here are the risk
+set constants:
+
+- `OVERFLOW_RISK`
+- `TRUNCATION_RISK`
+- `ALL_RISKS`
+    - Currently, this is equivalent to `OVERFLOW_RISK | TRUNCATION_RISK`.  However, if we later
+      discover new conversion risks to guard against, then this constant would change to include
+      them too.
+
+## Forming Policies From Sets
+
+To turn a conversion risk _set_, `RISK_SET`, into a _conversion risk policy_, use one of two
+functions:
+
+- `ignore(RISK_SET)`
+    - This produces a policy that _ignores_ all the risks in `RISK_SET`, and _checks for_ all other
+      risks.
+- `check_for(RISK_SET)`
+    - This produces a policy that _checks for_ all the risks in `RISK_SET`, and _ignores_ all other
+      risks.
+
+In practice, `ignore()` is used very commonly, and `check_for()` is used very rarely, mostly
+internally to the library.

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -391,7 +391,7 @@ To be concrete, here are the signatures of the functions that support the policy
     safety checks.  The risks which the "base" versions warn about are real.
 
     However, one place where it's _very safe_ to use the "coercing versions" is right after running
-    a _runtime conversion checker_.  These provde _exact_ conversion checks, even more accurate than
+    a _runtime conversion checker_.  These provide _exact_ conversion checks, even more accurate than
     the default compile-time safety surface (although at the cost of runtime operations).  See the
     [subsequent section](#runtime-conversion-checkers) for more details.
 

--- a/docs/reference/quantity_point.md
+++ b/docs/reference/quantity_point.md
@@ -73,22 +73,22 @@ fail to exist in several ways.
 1. If the input quantity has a **different dimension**, then the operation is intrinsically
    meaningless and we forbid it.
 
-2. If the _constructed_ quantity's rep (that is, `Rep` in the code snippet above) is **not floating
-   point**, then we forbid any conversion that might produce a non-integer value.  Examples include:
+2. If the unit conversion has what we consider to be **unacceptable risk**, then we also forbid it.
+   Common examples include:
 
-    a. When `OtherRep` _is floating point_, we forbid this conversion.
+    a. When `OtherRep` is _floating point_, but `Rep` is _integral_, we forbid this conversion for
+       excessive truncation risk.
 
-    b. When `UnitRatioT<OtherUnit, Unit>` is _not an integer_, we forbid this conversion.
+    b. If the conversion factor is large, and `Rep` is small, such that _even very small values_ in
+       `OtherRep` would exceed the bounds of `Rep`, we forbid this conversion for excessive overflow
+       risk.  See the [overflow safety surface](../discussion/concepts/overflow.md#adapt) docs for
+       more details.
 
     c. When the origin of `OtherUnit` is _additively offset_ from the origin of `Unit` by an amount
        that can't be represented as an integer in the target units, `Unit`, we forbid this
-       conversion.
+       conversion if `Rep` is an integral type.
 
 Note that case `c` doesn't occur for `Quantity`; it is unique to `QuantityPoint`.
-
-We also inherit the "overflow safety surface" from the `Quantity` member inside of `QuantityPoint`
-(discussed as point 3 of the [`Quantity` constructor docs](./quantity.md#implicit-from-quantity)).
-This can prevent certain quantity point conversions which have excessive overflow risk.
 
 Here are several examples to illustrate the conditions under which implicit conversions are allowed.
 
@@ -111,6 +111,26 @@ Note that every case in the above table is _physically_ meaningful (because the 
 have the same dimension), but some conversions are forbidden due to the risk of larger-than-usual
 errors.  The library can still perform these conversions, but not via this constructor, and it must
 be "forced" to do so. See [`.coerce_as(unit)`](#coerce) for more details.
+
+### Constructing from another `QuantityPoint`, with explicit risk policy
+
+This constructor also performs a unit conversion, but the user selects which conversion risks are
+actively checked for.  This is done by passing an explicit [conversion risk
+policy](./conversion_risk_policies.md) as a second argument.
+
+Here is the signature.  We've simplified it slightly for illustration purposes, and enclosed it
+inside the class definition for context.
+
+```cpp
+template <typename Unit, typename Rep>
+class QuantityPoint {
+    template <typename OtherUnit, typename OtherRep, typename Policy>
+    QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other, Policy policy);
+};
+```
+
+A common example for `policy` is `ignore(TRUNCATION_RISK)`.  This can be used when truncation is
+actually desired, or when you independently know that the specific input value will not truncate.
 
 ### Default constructor
 
@@ -202,25 +222,16 @@ are forbidden.  Additionally, the `Rep` of the output is identical to the `Rep` 
 
 However, note that we may change this second property in the future.  The version with the template
 arguments may be changed later so that it _does_ prevent lossy conversions.  If you want this
-"forcing" semantic, prefer to use [`.coerce_as(unit)`](#coerce), and add the explicit template
-parameter only if you want to change the rep.  See
-[#122](https://github.com/aurora-opensource/au/issues/122) for more details.
-
-??? example "Example: forcing a conversion from centimeters to meters"
-    `centi(meters_pt)(200).as(meters_pt)` is not allowed.  This conversion will divide the
-    underlying value, `200`, by `100`.  Now, it so happens that this _particular_ value _would_
-    produce an integer result. However, the compiler must decide whether to permit this operation
-    _at compile time_, which means we don't yet know the value.  Since most `int` values would _not_
-    produce integer results, we forbid this.
-
-    `centi(meters_pt)(200).as<int>(meters_pt)` _is_ allowed.  The "explicit rep" template parameter
-    has "forcing" semantics.  This would produce `meters_pt(2)`. However, note that this operation
-    uses integer division, which truncates: so, for example,
-    `centi(meters_pt)(199).as<int>(meters_pt)` would produce `meters_pt(1)`.
+"forcing" semantic, prefer to use a policy argument, and add the explicit template parameter only if
+you want to change the rep.  See [#122] to track progress on this change, and see the [policy
+argument section](#policy-argument) for an example of the _preferred_ way to force a conversion.
 
 !!! tip
     Prefer to **omit** the template argument if possible, because you will get more safety checks.
     The risks which the no-template-argument version warns about are real.
+
+    As of [0.6.0] and [#122], however, this advice will no longer apply.  At that point, the
+    explicit-rep versions will have the same safety checks as the implicit-rep versions.
 
 ### `.in(unit)`, `.in<T>(unit)`
 
@@ -254,28 +265,82 @@ are forbidden.  Additionally, the `Rep` of the output is identical to the `Rep` 
 
 However, note that we may change this second property in the future.  The version with the template
 arguments may be changed later so that it _does_ prevent lossy conversions.  If you want this
-"forcing" semantic, prefer to use [`.coerce_in(unit)`](#coerce), and add the explicit template
-parameter only if you want to change the rep.  See
-[#122](https://github.com/aurora-opensource/au/issues/122) for more details.
-
-??? example "Example: forcing a conversion from centimeters to meters"
-    `centi(meters_pt)(200).in(meters_pt)` is not allowed.  This conversion will divide the
-    underlying value, `200`, by `100`.  Now, it so happens that this _particular_ value _would_
-    produce an integer result. However, the compiler must decide whether to permit this operation
-    _at compile time_, which means we don't yet know the value.  Since most `int` values would _not_
-    produce integer results, we forbid this.
-
-    `centi(meters_pt)(200).in<int>(meters_pt)` _is_ allowed.  The "explicit rep" template parameter
-    has "forcing" semantics (at least for now; see
-    [#122](https://github.com/aurora-opensource/au/issues/122)).  This would produce `2`. However,
-    note that this operation uses integer division, which truncates: so, for example,
-    `centi(meters_pt)(199).in<int>(meters_pt)` would produce `1`.
+"forcing" semantic, prefer to use a policy argument, and add the explicit template parameter only if
+you want to change the rep.  See [#122] to track progress on this change, and see the [policy
+argument section](#policy-argument) for an example of the _preferred_ way to force a conversion.
 
 !!! tip
     Prefer to **omit** the template argument if possible, because you will get more safety checks.
     The risks which the no-template-argument version warns about are real.
 
+    As of [0.6.0] and [#122], however, this advice will no longer apply.  At that point, the
+    explicit-rep versions will have the same safety checks as the implicit-rep versions.
+
+### Skipping risk checks: the `policy` argument {#policy-argument}
+
+Some unit conversions have too much [conversion risk](../discussion/concepts/conversion_risks.md) to
+permit by default.  When that happens, the compiler will tell you which risk (overflow or
+truncation) it deemed too high.  You can still perform the conversion, but you must explicitly turn
+off the corresponding safety check, by passing a [policy argument](./conversion_risk_policies.md).
+Every variant of `as` and `in` mentioned above supports such an argument.  If you pass a policy, it
+will control the set of conversion risks that we check for.
+
+To be concrete, here are the signatures of the functions that support the policy argument:
+
+| Usual form | With policy argument |
+|------------|----------------------|
+| `.as(unit)` | `.as(unit, policy)` |
+| `.as<T>(unit)` | `.as<T>(unit, policy)` |
+| `.in(unit)` | `.in(unit, policy)` |
+| `.in<T>(unit)` | `.in<T>(unit, policy)` |
+
+??? example "Example: forcing a conversion from degrees Celsius to Kelvins"
+    `celsius_pt(20).as(kelvins_pt)` is not allowed.  This conversion would add the non-integer value
+    `273.15` to the underlying value, `20`, which is an `int`.  Clearly, this would truncate, so we
+    forbid it.
+
+    `celsius_pt(20).as(kelvins_pt, ignore(TRUNCATION_RISK))` _is_ allowed.  The second argument
+    turns off the truncation risk check.  In this case, there is more than just a _risk_ of
+    truncation; there is _actual_ truncation.  The result would be `kelvins_pt(293)`, where the
+    underlying value has discarded the fractional part of the exact answer, $293.15 \,\text{K}$.
+
+??? example "Example: simultaneous unit and type conversion"
+    `celsius_pt(20.86).as<int>(kelvins_pt, ignore(TRUNCATION_RISK))` will return `kelvins_pt(294)`.
+
+!!! tip
+    In most cases, prefer **not** to use the policy versions if possible, because you will get more
+    safety checks.  The risks which the "base" versions warn about are real.
+
+    However, once we provide runtime conversion checkers for `QuantityPoint` (see [#352]), then it
+    will always be safe to provide a policy argument that ignores a risk that you have just verified
+    to be absent.
+
 ### Forcing lossy conversions: `.coerce_as(unit)`, `.coerce_in(unit)` {#coerce}
+
+!!! warning
+    We are planning to deprecate these functions in the [0.6.0] release.  See [#481] to track the
+    progress.
+
+    In the meantime, here is how you convert.
+
+    First, figure out which conversion risks you are trying to override: **overflow**, or
+    **truncation**, or **both**.  (If you don't have an explicit `<Rep>` argument, you can simply
+    delete the `"coerce_"` word and compile, and the error message will tell you which one is
+    relevant.  Otherwise, you will need to use your knowledge of the types and units involved to
+    figure this out.)
+
+    Then, follow this table to rewrite your conversion, using the conversion risk you identified
+    above.
+
+    | "Coerce" version (dis-preferred; will be deprecated) | "Policy" version (preferred) |
+    |------------------------------------------------------|------------------------------|
+    | `q.coerce_as(unit)` | One of:<br>`q.as(unit, ignore(OVERFLOW_RISK))`<br>`q.as(unit, ignore(TRUNCATION_RISK))`<br>`q.as(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
+    | `q.coerce_as<T>(unit)` | One of:<br>`q.as<T>(unit, ignore(OVERFLOW_RISK))`<br>`q.as<T>(unit, ignore(TRUNCATION_RISK))`<br>`q.as<T>(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
+    | `q.coerce_in(unit)` | One of:<br>`q.in(unit, ignore(OVERFLOW_RISK))`<br>`q.in(unit, ignore(TRUNCATION_RISK))`<br>`q.in(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
+    | `q.coerce_in<T>(unit)` | One of:<br>`q.in<T>(unit, ignore(OVERFLOW_RISK))`<br>`q.in<T>(unit, ignore(TRUNCATION_RISK))`<br>`q.in<T>(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
+
+    These new versions are both more clear about their intent, and safer (because they only turn off
+    the safety checks that they need to).
 
 This function performs the exact same kind of unit conversion as if the string `coerce_` were
 removed.  However, it will ignore any safety checks for overflow or truncation.
@@ -456,3 +521,8 @@ More precisely, `QuantityPoint<U1, R1>` and `QuantityPoint<U2, R2>` are equivale
 
 - For _types_ `U1` and `U2`:
     - `AreQuantityPointTypesEquivalent<U1, U2>::value`
+
+[#122]: https://github.com/aurora-opensource/au/issues/122
+[#352]: https://github.com/aurora-opensource/au/issues/352
+[#481]: https://github.com/aurora-opensource/au/issues/481
+[0.6.0]: https://github.com/aurora-opensource/au/milestone/9

--- a/docs/tutorial/103-unit-conversions.md
+++ b/docs/tutorial/103-unit-conversions.md
@@ -197,40 +197,43 @@ types.
         have _different dimensions_ (namely, _length_ and _temperature_).  For both **integral** and
         **floating point** Rep, we **forbid** this operation.
 
-## Forcing lossy conversions: `.coerce_as(...)` and `.coerce_in(...)`
+## Forcing lossy conversions: the `policy` argument
 
 Sometimes, you may want to perform a conversion even though you know it's usually lossy.  For
 example, maybe you know that _your particular_ value will give an exact result (like converting
 6 feet into yards).  Or perhaps the truncation is desired.
 
-Whatever the reason, you can simply add the word "coerce" before your conversion function to make it
-"forcing".  Consider this example.
+Whatever the reason, you can simply add an explicit
+[policy](../reference/conversion_risk_policies.md) as a second argument to turn off a given risk
+check.  Consider this example.
 
 ```cpp
-feet(6.0).as(yards);       // yards(2.0)
+feet(6.0).as(yards);                         // yards(2.0)
 
 // Compiler error!
 // feet(6).as(yards);
 
-feet(6).coerce_as(yards);  // yards(2)
+feet(6).as(yards, ignore(TRUNCATION_RISK));  // yards(2)
 ```
 
-These "coercing" versions work similarly to `static_cast`, in that they will truncate if necessary.
-For example:
+These versions work similarly to `static_cast`, in that they will truncate if necessary. For
+example:
 
 ```cpp
-feet(5).coerce_as(yards);  // yards(1) --- a truncation of (5/3 = 1.6666...) yards
+feet(5).as(yards, ignore(TRUNCATION_RISK));
+// Gives `yards(1)` --- a truncation of (5/3 = 1.666...) yards
 ```
 
-You can use this to "overrule" Au when we prevent a _physically meaningful_ conversion because we
-think it's too risky.
+Besides `TRUNCATION_RISK`, you can also pass `OVERFLOW_RISK`, or even `ALL_RISKS`.  These versions
+can "overrule" Au when we prevent a _physically meaningful_ conversion because we think it's too
+risky.
 
 !!! tip
-    Prefer **not** to use the coercing versions unless you have a good reason.  If you do, consider
-    adding a comment to explain why your specific use case is OK.
+    Prefer **not** to use these policy-override versions unless you have a good reason.  If you do,
+    consider adding a comment to explain why your specific use case is OK.
 
-    As a code reviewer, if you see a coercing version that doesn't seem necessary or justified, ask
-    about it!
+    As a code reviewer, if you see a risk check being ignored, and it doesn't seem necessary or
+    justified, ask about it!
 
 At this point, we've seen several examples of conversions which Au forbids.  We've also seen how
 some of them can be forced anyway.  Here's a chance to test your understanding: what will happen if
@@ -243,12 +246,12 @@ you try to force that _final_ example --- the one where the _dimensions_ differ?
 
     === "Conversion"
         ```cpp
-        feet(6).coerce_as(kelvins);
+        feet(6).as(kelvins, ignore(ALL_RISKS));
         ```
 
     === "Results and Discussion"
         ```cpp
-        feet(6).coerce_as(kelvins);  // Compiler error!
+        feet(6).as(kelvins, ignore(ALL_RISKS));  // Compiler error!
         ```
 
         Converting units with different dimensions isn't merely "unsafe"; it's completely
@@ -273,14 +276,14 @@ storage types.
   <tr>
     <td><code>length.as(yards)</code></td>
     <td class="fair">
-        <b>Forbidden</b>: not guaranteed to be integral<br>(can be forced with coercing version)
+        <b>Forbidden</b>: not guaranteed to be integral<br>(can be forced with <code>ignore(TRUNCATION_RISK)</code>)
     </td>
     <td class="good"><code>yards(2.0)</code></td>
   </tr>
   <tr>
     <td><code>length.as(nano(meters))</code></td>
     <td class="fair">
-        <b>Forbidden</b>: excessive overflow risk<br>(can be forced with coercing version)
+        <b>Forbidden</b>: excessive overflow risk<br>(can be forced with <code>ignore(OVERFLOW_RISK)</code>)
     </td>
     <td class="good"><code>nano(meters)(1'828'800'000.0)</code></td>
   </tr>
@@ -371,11 +374,13 @@ Check out the [Au 103: Unit Conversions Exercise](./exercise/103-unit-conversion
       library](https://en.cppreference.com/w/cpp/chrono/duration/duration)), _and_ we **don't have
       excessive overflow risk** (an Au-original feature!).
 
-4. You can **force** a conversion that is **meaningful, but considered dangerous** by preceding your
-   function name with **`coerce_`**.
+4. You can **force** a conversion that is **meaningful, but considered dangerous** by passing
+   a [conversion risk policy argument](../reference/conversion_risk_policies.md) as a second
+   parameter.
 
-    - For example: `seconds(200).as(minutes)` won't compile, but `seconds(200).coerce_as(minutes)`
-      gives `minutes(3)`, because we forced this lossy conversion by using the word "coerce".
+    - For example: `seconds(200).as(minutes)` won't compile, but
+      `seconds(200).as(minutes, ignore(TRUNCATION_RISK))` gives `minutes(3)`, because the second
+      argument turned off the truncation risk check.
 
     - **Use this sparingly,** since the safety checks are there for a reason, and consider **adding
       a comment** to explain why your usage is safe.

--- a/docs/tutorial/exercise/103-unit-conversions.md
+++ b/docs/tutorial/exercise/103-unit-conversions.md
@@ -165,7 +165,7 @@ You may find it useful to use the explicit-Rep overload to force a conversion th
 risky, but in _this_ instance is known to be OK.  You should not need to use floating point
 numbers at all.
 
-!!! example "Exercise 1(b)"
+!!! example "Exercise 2"
     === "Task"
         Replace `PLACEHOLDER` instances with correct expressions.
 
@@ -188,7 +188,7 @@ numbers at all.
         // inches.  For example, `inches(17)` would be decomposed into `Height{feet(1), inches(5)}`.
         Height decompose_height(QuantityU32<Inches> total_height) {
             Height h;
-            h.feet = total_height.coerce_as(feet);  // NOTE: truncation is intended.
+            h.feet = total_height.as(feet, ignore(TRUNCATION_RISK)); // Truncation desired.
             h.inches = total_height - h.feet.as(inches);
             return h;
         }
@@ -210,7 +210,7 @@ numbers at all.
 
 This exercise gave a few worked examples of unit conversions.  We saw how Au can immediately replace
 crufty, error-prone manual conversions, making code more readable.  We also saw a practical example
-of quantity-to-quantity conversion using `.as(...)`, including one example where the forcing
-"explicit-Rep" form is clearly safe and correct to use.
+of quantity-to-quantity conversion using `.as(...)`, including one example where explicitly turning
+off the truncation risk check was clearly safe and correct to use.
 
 Return to the [main tutorial page](../103-unit-conversions.md).


### PR DESCRIPTION
We add three new documents: two discussion docs on truncation risk and
conversion risks generally, and one reference doc for the conversion
risk policy objects.

Then we go through and update all of the affected docs.  The main types
of changes are:

- Update new APIs (constructors, conversion functions) that can take a
  policy argument.
- Mark the "coerce" APIs as "to be deprecated", and tell people to use
  the policy arguments instead.
- If we find outdated language around permitted/forbidden conversions,
  or around "explicit Rep" APIs, clean it up

This should get the Au docs into a good state with respect to our modern
approach to conversion safety.

Helps #470.