### PR TITLE
Update docs for common point unit

### DIFF
--- a/docs/reference/quantity_point.md
+++ b/docs/reference/quantity_point.md
@@ -440,7 +440,7 @@ As [required by the standard](https://en.cppreference.com/w/cpp/types/common_typ
 [SFINAE](https://en.cppreference.com/w/cpp/language/sfinae)-friendly: improper combinations will
 simply not be present, rather than producing a hard error.
 
-### AreQuantityPointTypesEquivalent
+### AreQuantityPointTypesEquivalent {#are-quantity-point-types-equivalent}
 
 **Result:** Indicates whether two `QuantityPoint` types are equivalent.  Equivalent types may be
 freely converted to each other, and no arithmetic operations will be performed in doing so.

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -657,7 +657,7 @@ To understand the precise definition of the common point unit, first assume that
 displacement" for any two units with different origins is itself a new unit, which we can create
 implicitly.  Then, the _common point unit_ is defined as the unit such that:
 
-- It is quantity-equivalent to the _common unit_ of **both** all input units, **and** of all "origin
+- It is quantity-equivalent to the _common unit_ of **both** all input units **and** of all "origin
   displacement units" created by any pairs of input units with different origins.
 
 - Its _origin_ is the _lowest_ of all input origins, because this is the _highest_ value that is

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -653,6 +653,16 @@ A specialization will only exist if the inputs are all units, and will exist but
 error if any two input units have different Dimensions.  We also strive to keep the result
 associative, and symmetric under interchange of any inputs.
 
+To understand the precise definition of the common point unit, first assume that the "origin
+displacement" for any two units with different origins is itself a new unit, which we can create
+implicitly.  Then, the _common point unit_ is defined as the unit such that:
+
+- It is quantity-equivalent to the _common unit_ of **both** all input units, **and** of all "origin
+  displacement units" created by any pairs of input units with different origins.
+
+- Its _origin_ is the _lowest_ of all input origins, because this is the _highest_ value that is
+  still "common" to all input units (in the sense that all additive offsets will be non-negative).
+
 ??? note "A note on inputs vs. outputs for the `common_point_unit(us...)` form"
     The return value of the instance version is a _unit_, while the input parameters are
     [unit _slots_](../discussion/idioms/unit-slots.md).  This means that the return value will often


### PR DESCRIPTION
The common point unit is simply the common _unit_ of both the input
units, and of the implicitly created "origin displacement" units as
appropriate.  Its origin is the lowest origin of all input units.

This PR fleshes out the description in the discussion page, and provides
a full definition in the reference page.  We also include a worked
example of how the GCD algorithm lets you compute what the common point
unit is.

Finally, I added some links for some usages I saw of "quantity
equivalent" and "point equivalent", because obviously we can't expect
users to just know what these mean.

Helps #470.