### PR TITLE
In default `QuantityPoint` ctor, use default rep

### DIFF
--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -100,11 +100,10 @@ class QuantityPoint {
     static constexpr Unit unit{};
     using Diff = Quantity<Unit, Rep>;
 
-    // The default constructor produces a QuantityPoint in a valid but contractually unspecified
-    // state.  It exists to give you an object you can assign to.  The main motivating factor for
-    // including this is to support `std::atomic`, which requires its types to be
-    // default-constructible.
-    constexpr QuantityPoint() noexcept : x_{ZERO} {}
+    // The default constructor produces a QuantityPoint whose value is default constructed.  It
+    // exists to give you an object you can assign to.  The main motivating factor for including
+    // this is to support `std::atomic`, which requires its types to be default-constructible.
+    constexpr QuantityPoint() noexcept : x_{} {}
 
     template <typename OtherUnit,
               typename OtherRep,

--- a/docs/reference/quantity_point.md
+++ b/docs/reference/quantity_point.md
@@ -143,11 +143,14 @@ class QuantityPoint {
 };
 ```
 
-A default-constructed `QuantityPoint` is initialized to some value, which helps avoid certain kinds
-of memory safety bugs.  However, **the value is contractually unspecified**.  You can of course look
-up that value by reading the source code, but we may change it in the future, and **we would not
-consider this to be a breaking change**.  The only valid operation on a default-constructed
-`QuantityPoint` is to assign to it later on.
+A default-constructed `QuantityPoint` default-constructs the underlying type, which helps avoid
+certain kinds of memory safety bugs.  It will contain a default-constructed instance of the rep
+type.
+
+!!! warning
+    Avoid relying on the _specific value_ of a default-constructed `QuantityPoint`, because it
+    poorly communicates intent.  The only logically valid operation on a default-constructed
+    `Quantity` is to assign to it later on.
 
 ## Extracting the stored value
 


### PR DESCRIPTION
This makes us more consistent with `Quantity`, and lets us remove the
last of the excessively-scary language that precipitated #273.