### PR TITLE
Support `{fmt}` and `std::format`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,13 @@
 # 2022, and is our newest officially supported compiler.  The next CMake release was v3.23.0, on
 # March 29, 2022.  Therefore, our minimum version must be at least CMake 3.23.
 #
-# We also use the `CMAKE_VERIFY_INTERFACE_HEADER_SETS`, which was added in CMake
-# 3.24, which means the minimum must also be at least 3.24.
+# We also use the `SKIP_LINTING` property, which was added in CMake 3.27, which means the minimum
+# must also be at least 3.27.
 #
 # The maximum version should be the latest version we've tested the project with.
 #
 # [1]: https://cliutils.gitlab.io/modern-cmake/chapters/intro/dodonot.html
-cmake_minimum_required(VERSION 3.24...3.29)
+cmake_minimum_required(VERSION 3.27...3.29)
 
 project(
    Au

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -134,6 +134,26 @@ http_archive(
     url = "https://github.com/nholthaus/units/archive/refs/tags/v2.3.3.tar.gz",
 )
 
+http_archive(
+    name = "fmt",
+    patch_cmds = [
+        "mv support/bazel/.bazelversion .bazelversion",
+        "mv support/bazel/BUILD.bazel BUILD.bazel",
+        "mv support/bazel/MODULE.bazel MODULE.bazel",
+        "mv support/bazel/WORKSPACE.bazel WORKSPACE.bazel",
+    ],
+    # Windows related patch commands are only needed in the case MSYS2 is not installed
+    patch_cmds_win = [
+        "Move-Item -Path support/bazel/.bazelversion -Destination .bazelversion",
+        "Move-Item -Path support/bazel/BUILD.bazel -Destination BUILD.bazel",
+        "Move-Item -Path support/bazel/MODULE.bazel -Destination MODULE.bazel",
+        "Move-Item -Path support/bazel/WORKSPACE.bazel -Destination WORKSPACE.bazel",
+    ],
+    sha256 = "40fc58bebcf38c759e11a7bd8fdc163507d2423ef5058bba7f26280c5b9c5465",
+    strip_prefix = "fmt-11.0.2",
+    url = "https://github.com/fmtlib/fmt/releases/download/11.0.2/fmt-11.0.2.zip",
+)
+
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 python_register_toolchains(

--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -143,6 +143,15 @@ cc_test(
 )
 
 cc_library(
+    name = "std_format",
+    hdrs = ["std_format.hh"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":quantity",
+    ],
+)
+
+cc_library(
     name = "testing",
     testonly = True,
     hdrs = ["testing.hh"],

--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -80,6 +80,19 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "fmt_test",
+    size = "small",
+    srcs = ["fmt_test.cc"],
+    deps = [
+        ":quantity",
+        ":testing",
+        ":units",
+        "@com_google_googletest//:gtest_main",
+        "@fmt",
+    ],
+)
+
 cc_library(
     name = "fwd",
     hdrs = ["fwd.hh"],

--- a/au/CMakeLists.txt
+++ b/au/CMakeLists.txt
@@ -181,6 +181,10 @@ header_only_library(
     utility/string_constant.hh
     utility/type_traits.hh
 )
+
+# Skip the header verification for `std_format.hh`, since we don't expect it to
+# work on all configurations.  Users are responsible for only including it in
+# configurations that fully support `std::format`.
 set_source_files_properties(
   std_format.hh
   PROPERTIES SKIP_LINTING TRUE

--- a/au/CMakeLists.txt
+++ b/au/CMakeLists.txt
@@ -198,7 +198,7 @@ cmake_pop_check_state()
 # Conditionally add `std_format.hh` to the `au` target.
 if (AU_HAS_STD_FORMAT)
   message(STATUS "<format> is available; providing \"au/std_format.hh\" in `au`.")
-  list(APPEND AU_MAIN_HEADERS au/std_format.hh)
+  list(APPEND AU_MAIN_HEADERS std_format.hh)
 else()
   message(STATUS "<format> is NOT available; excluding \"au/std_format.hh\" from `au`.")
 endif()

--- a/au/CMakeLists.txt
+++ b/au/CMakeLists.txt
@@ -14,12 +14,13 @@
 
 include("${PROJECT_SOURCE_DIR}/cmake/HeaderOnlyLibrary.cmake")
 
-# Build up the authoritative list of headers for our main target, `au`.
 #
-# Making a separate list variable will let us conditionally include files based
-# on the toolchain support, most notably `"au/std_format.hh"`, which requires
-# support for the `<format>` header.
-set(AU_MAIN_HEADERS
+# Publicly exported targets
+#
+
+header_only_library(
+  NAME au
+  HEADERS
     abstract_operations.hh
     au.hh
     chrono_interop.hh
@@ -39,6 +40,7 @@ set(AU_MAIN_HEADERS
     quantity.hh
     quantity_point.hh
     rep.hh
+    std_format.hh
     truncation_risk.hh
     unit_of_measure.hh
     unit_symbol.hh
@@ -179,37 +181,9 @@ set(AU_MAIN_HEADERS
     utility/string_constant.hh
     utility/type_traits.hh
 )
-
-# Check whether `<format>` is available, storing in `AU_HAS_STD_FORMAT`.
-include(CheckCXXSourceCompiles)
-include(CMakePushCheckState)
-cmake_push_check_state()
-set(CMAKE_REQUIRED_QUIET ${AU_HAS_STD_FORMAT_QUIET})
-message(STATUS "Checking for <format> support")
-check_cxx_source_compiles(
-  "
-  #include <format>
-  int main() { return 0; }
-  "
-  AU_HAS_STD_FORMAT
-)
-cmake_pop_check_state()
-
-# Conditionally add `std_format.hh` to the `au` target.
-if (AU_HAS_STD_FORMAT)
-  message(STATUS "<format> is available; providing \"au/std_format.hh\" in `au`.")
-  list(APPEND AU_MAIN_HEADERS std_format.hh)
-else()
-  message(STATUS "<format> is NOT available; excluding \"au/std_format.hh\" from `au`.")
-endif()
-
-#
-# Publicly exported targets
-#
-
-header_only_library(
-  NAME au
-  HEADERS ${AU_MAIN_HEADERS}
+set_source_files_properties(
+  std_format.hh
+  PROPERTIES SKIP_LINTING TRUE
 )
 
 if (NOT AU_EXCLUDE_GTEST_DEPENDENCY)

--- a/au/CMakeLists.txt
+++ b/au/CMakeLists.txt
@@ -14,13 +14,12 @@
 
 include("${PROJECT_SOURCE_DIR}/cmake/HeaderOnlyLibrary.cmake")
 
+# Build up the authoritative list of headers for our main target, `au`.
 #
-# Publicly exported targets
-#
-
-header_only_library(
-  NAME au
-  HEADERS
+# Making a separate list variable will let us conditionally include files based
+# on the toolchain support, most notably `"au/std_format.hh"`, which requires
+# support for the `<format>` header.
+set(AU_MAIN_HEADERS
     abstract_operations.hh
     au.hh
     chrono_interop.hh
@@ -40,7 +39,6 @@ header_only_library(
     quantity.hh
     quantity_point.hh
     rep.hh
-    std_format.hh
     truncation_risk.hh
     unit_of_measure.hh
     unit_symbol.hh
@@ -180,6 +178,38 @@ header_only_library(
     utility/probable_primes.hh
     utility/string_constant.hh
     utility/type_traits.hh
+)
+
+# Check whether `<format>` is available, storing in `AU_HAS_STD_FORMAT`.
+include(CheckCXXSourceCompiles)
+include(CMakePushCheckState)
+cmake_push_check_state()
+set(CMAKE_REQUIRED_QUIET ${AU_HAS_STD_FORMAT_QUIET})
+message(STATUS "Checking for <format> support")
+check_cxx_source_compiles(
+  "
+  #include <format>
+  int main() { return 0; }
+  "
+  AU_HAS_STD_FORMAT
+)
+cmake_pop_check_state()
+
+# Conditionally add `std_format.hh` to the `au` target.
+if (AU_HAS_STD_FORMAT)
+  message(STATUS "<format> is available; providing \"au/std_format.hh\" in `au`.")
+  list(APPEND AU_MAIN_HEADERS au/std_format.hh)
+else()
+  message(STATUS "<format> is NOT available; excluding \"au/std_format.hh\" from `au`.")
+endif()
+
+#
+# Publicly exported targets
+#
+
+header_only_library(
+  NAME au
+  HEADERS ${AU_MAIN_HEADERS}
 )
 
 if (NOT AU_EXCLUDE_GTEST_DEPENDENCY)

--- a/au/CMakeLists.txt
+++ b/au/CMakeLists.txt
@@ -40,6 +40,7 @@ header_only_library(
     quantity.hh
     quantity_point.hh
     rep.hh
+    std_format.hh
     truncation_risk.hh
     unit_of_measure.hh
     unit_symbol.hh

--- a/au/fmt_test.cc
+++ b/au/fmt_test.cc
@@ -1,0 +1,76 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/prefix.hh"
+#include "au/quantity.hh"
+#include "au/units/meters.hh"
+#include "au/units/seconds.hh"
+#include "fmt/format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace fmt {
+template <typename U, typename R>
+struct formatter<::au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, ::fmt::formatter> {};
+}  // namespace fmt
+
+namespace au {
+namespace {
+
+using symbols::m;
+using symbols::s;
+constexpr auto cm = centi(m);
+constexpr auto km = kilo(m);
+
+using ::testing::StrEq;
+
+TEST(Fmt, PrintsQuantityAndUnitLabelByDefault) {
+    EXPECT_THAT(fmt::format("{}", meters(8.5)), StrEq("8.5 m"));
+}
+
+TEST(Fmt, DefaultFormatAppliesToNumberPart) {
+    EXPECT_THAT(fmt::format("{:,<10}", meters(8.5)), StrEq("8.5,,,,,,, m"));
+    EXPECT_THAT(fmt::format("{:,>10}", meters(8.5)), StrEq(",,,,,,,8.5 m"));
+    EXPECT_THAT(fmt::format("{:,>8.2f}", meters(0.1234)), StrEq(",,,,0.12 m"));
+}
+
+TEST(Fmt, CanFormatUnitLabelWithUPrefix) {
+    EXPECT_THAT(fmt::format("{:U4}", meters(8.5)), StrEq("8.5 m   "));
+    //                                             alignment: 1234
+}
+
+TEST(Fmt, CanFormatBothParts) {
+    // Overall width of 23: 10 for the number, 1 for the space, 12 for the label.
+
+    EXPECT_THAT(fmt::format("{:U12;*>10.3f}", 123.456789 * cm / s),
+                StrEq("***123.457 cm / s      "));
+    //                 alignment: 123456789012
+}
+
+TEST(Fmt, DocExamplesAreCorrect) {
+    EXPECT_THAT(fmt::format("{}", meters(123.456)), StrEq("123.456 m"));
+    EXPECT_THAT(fmt::format("{:~^10.2f}", meters(123.456)), StrEq("~~123.46~~ m"));
+    EXPECT_THAT(fmt::format("{:U5}", meters(123.456)), StrEq("123.456 m    "));
+    EXPECT_THAT(fmt::format("{:U5;~^10.2f}", meters(123.456)), StrEq("~~123.46~~ m    "));
+
+    constexpr auto speed = (centi(meters) / second)(987.654321);
+    EXPECT_THAT(fmt::format("{:.^31}", fmt::format("{:U10;,<8.2f}", speed)),
+                StrEq("......987.65,, cm / s    ......"));
+
+    constexpr auto c = 299'792.458 * km / s;
+    EXPECT_THAT(fmt::format("{:,<12.2f}", c.data_in(km / s)), StrEq("299792.46,,,"));
+}
+
+}  // namespace
+}  // namespace au

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -957,16 +957,6 @@ struct QuantityFormatter {
 
 }  // namespace au
 
-// We want the `std::formatter` specialization to be defined if and only if `std::format` is
-// supported.  Putting it in the same file helps avoid ODR violations.
-#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
-#include <format>
-namespace std {
-template <typename U, typename R>
-struct formatter<au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, ::std::formatter> {};
-}  // namespace std
-#endif
-
 namespace std {
 // Note: we would prefer not to reopen `namespace std` [1].  However, some older compilers (which we
 // still want to support) incorrectly treat the preferred syntax recommended in [1] as an error.

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -879,7 +879,91 @@ struct CommonQuantity<Quantity<U1, R1>,
                       Quantity<U2, R2>,
                       std::enable_if_t<HasSameDimension<U1, U2>::value>>
     : stdx::type_identity<Quantity<CommonUnitT<U1, U2>, std::common_type_t<R1, R2>>> {};
+
+//
+// Formatter implementation for fmtlib or `std::format`.
+//
+// To use with fmtlib, add this template specialization to a file that includes both
+// `"au/quantity.hh"`, and `"fmt/format.h"`:
+//
+//    namespace fmt {
+//    template <typename U, typename R>
+//    struct formatter<::au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, ::fmt::formatter> {};
+//    }  // namespace fmt
+//
+// Then, include that file any time you want to format a `Quantity`.
+//
+template <typename U, typename R, template <class...> class Formatter>
+struct QuantityFormatter {
+    template <typename FormatParseContext>
+    constexpr auto parse_unit_label_part(FormatParseContext &ctx) {
+        auto it = ctx.begin();
+
+        if (it != ctx.end() && *it == 'U') {
+            // Consume the 'U'.
+            ++it;
+
+            // Parse the total width.
+            while (it != ctx.end() && *it >= '0' && *it <= '9') {
+                min_label_width_ = (min_label_width_ * 10) + static_cast<std::size_t>(*it++ - '0');
+            }
+
+            if (it != ctx.end()) {
+                if (*it == '}') {
+                    return it;
+                }
+
+                if (*it++ != ';') {
+                    // Cause an error condition in further parsing.
+                    it = ctx.end();
+                }
+            }
+        }
+
+        return it;
+    }
+
+    template <typename FormatParseContext>
+    constexpr auto parse(FormatParseContext &ctx) {
+        ctx.advance_to(parse_unit_label_part(ctx));
+        return value_format.parse(ctx);
+    }
+
+    template <typename FormatContext>
+    constexpr auto format(const au::Quantity<U, R> &q, FormatContext &ctx) const {
+        value_format.format(q.data_in(U{}), ctx);
+        *ctx.out()++ = ' ';
+        return write_and_pad(unit_label(U{}), sizeof(unit_label(U{})), ctx);
+    }
+
+    template <typename FormatContext>
+    constexpr auto write_and_pad(const char *data,
+                                 std::size_t data_size,
+                                 FormatContext &ctx) const {
+        Formatter<const char *> unit_label_formatter{};
+        unit_label_formatter.format(data, ctx);
+        while (data_size <= min_label_width_) {
+            *ctx.out()++ = ' ';
+            ++data_size;
+        }
+        return ctx.out();
+    }
+
+    Formatter<R> value_format{};
+    std::size_t min_label_width_{0};
+};
+
 }  // namespace au
+
+// We want the `std::formatter` specialization to be defined if and only if `std::format` is
+// supported.  Putting it in the same file helps avoid ODR violations.
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
+#include <format>
+namespace std {
+template <typename U, typename R>
+struct formatter<au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, ::std::formatter> {};
+}  // namespace std
+#endif
 
 namespace std {
 // Note: we would prefer not to reopen `namespace std` [1].  However, some older compilers (which we

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -899,7 +899,13 @@ struct QuantityFormatter {
     constexpr auto parse_unit_label_part(FormatParseContext &ctx) {
         auto it = ctx.begin();
 
-        if (it != ctx.end() && *it == 'U') {
+        if (it == ctx.end()) {
+            return it;
+        }
+        
+        if (*it != 'U') {
+            return it;
+        }
             // Consume the 'U'.
             ++it;
 
@@ -908,15 +914,17 @@ struct QuantityFormatter {
                 min_label_width_ = (min_label_width_ * 10) + static_cast<std::size_t>(*it++ - '0');
             }
 
-            if (it != ctx.end()) {
-                if (*it == '}') {
-                    return it;
-                }
+            if (it == ctx.end()) {
+                return it;
+            }
 
-                if (*it++ != ';') {
-                    // Cause an error condition in further parsing.
-                    it = ctx.end();
-                }
+            if (*it == '}') {
+                return it;
+            }
+
+            if (*it++ != ';') {
+                // Cause an error condition in further parsing.
+                it = ctx.end();
             }
         }
 

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -902,32 +902,26 @@ struct QuantityFormatter {
         if (it == ctx.end()) {
             return it;
         }
-        
+
         if (*it != 'U') {
             return it;
         }
-            // Consume the 'U'.
-            ++it;
+        // Consume the 'U'.
+        ++it;
 
-            // Parse the total width.
-            while (it != ctx.end() && *it >= '0' && *it <= '9') {
-                min_label_width_ = (min_label_width_ * 10) + static_cast<std::size_t>(*it++ - '0');
-            }
-
-            if (it == ctx.end()) {
-                return it;
-            }
-
-            if (*it == '}') {
-                return it;
-            }
-
-            if (*it++ != ';') {
-                // Cause an error condition in further parsing.
-                it = ctx.end();
-            }
+        // Parse the total width.
+        while (it != ctx.end() && *it >= '0' && *it <= '9') {
+            min_label_width_ = (min_label_width_ * 10) + static_cast<std::size_t>(*it++ - '0');
         }
 
+        if (it == ctx.end() || *it == '}') {
+            return it;
+        }
+
+        if (*it++ != ';') {
+            // Cause an error condition in further parsing.
+            it = ctx.end();
+        }
         return it;
     }
 

--- a/au/std_format.hh
+++ b/au/std_format.hh
@@ -1,0 +1,24 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <format>
+
+#include "au/quantity.hh"
+
+namespace std {
+template <typename U, typename R>
+struct formatter<au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, ::std::formatter> {};
+}  // namespace std

--- a/docs/install.md
+++ b/docs/install.md
@@ -122,6 +122,7 @@ to your `deps` attribute, and include the appropriate files.
 |------------|------------------|-------|
 | `@au//au` | `"au/au.hh"`<br>`"au/fwd.hh"`<br>`"au/units/*.hh"`<br>`"au/units/*_fwd.hh"`<br>`"au/constants/*.hh"` | Core library functionality.  See [all available units](https://github.com/aurora-opensource/au/tree/main/au/units) and [constants](./reference/constant.md#built-in) |
 | `@au//au:io` | `"au/io.hh"` | `operator<<` support |
+| `@au//au:std_format` | `"au/std_format.hh"` | `std::format` support[^1] |
 | `@au//au:testing` | `"au/testing.hh"` | Utilities for writing googletest tests<br>_Note:_ `testonly = True` |
 
 #### CMake
@@ -141,8 +142,12 @@ In either case, here are the main targets and include files provided by the Au l
 
 | Target | Headers provided | Notes |
 |--------|------------------|-------|
-| `Au::au` | `"au/au.hh"`<br>`"au/fwd.hh"`<br>`"au/io.hh"`<br>`"au/units/*.hh"`<br>`"au/units/*_fwd.hh"`<br>`"au/constants/*.hh"` | Core library functionality.  See [all available units](https://github.com/aurora-opensource/au/tree/main/au/units) |
+| `Au::au` | `"au/au.hh"`<br>`"au/fwd.hh"`<br>`"au/io.hh"`<br>`"au/std_format.hh"`[^1]<br>`"au/units/*.hh"`<br>`"au/units/*_fwd.hh"`<br>`"au/constants/*.hh"` | Core library functionality.  See [all available units](https://github.com/aurora-opensource/au/tree/main/au/units) |
 | `Au::testing` | `"au/testing.hh"` | Utilities for writing googletest tests |
+
+[^1]: Do not include `"au/std_format.hh"` unless you know that both your compiler and your build
+configuration fully supports `std::format`.  This requires at least C++20, but many compilers with
+nominal C++20 support do not actually support `std::format`.
 
 !!! note
     These instructions are for adding Au to a _project_ that uses CMake, not building Au itself

--- a/docs/reference/format.md
+++ b/docs/reference/format.md
@@ -1,0 +1,138 @@
+# Format
+
+Au supports string formatting using either the [{fmt}] library, or else [std::format] (available
+in C++20 or later).
+
+??? warning "Warning: if using {fmt}, ensure version is at least 9.0"
+    If you are using the [{fmt}] library, **make sure that it is at least [version 9.0]** (July 5,
+    2022).
+
+    All earlier versions provide automatic specializations for `formatter<T>` for any type `T` that
+    supports streaming output.  While this is convenient, it also makes it extremely easy to violate
+    the One Definition Rule (ODR): if anyone calls `format` in a file without Au's specialization,
+    then both definitions will exist.  This makes the program "ill-formed, no diagnostic required"
+    (IFNDR), which means that it has **silently** failed to be a valid C++ program, and all
+    guarantees are out the window.
+
+    Version 9.0 was the first release to make the default specialization cause a hard compiler
+    error.  This mitigates the risk of having two definitions, undetected.
+
+    As for `std::format`, it has always required explicit specializations, so it is not subject to
+    this vulnerability.
+
+We can't provide fully seamless support out of the box without adding an external dependency --- and
+Au is committed to being a zero-dependency library.  What we _can_ do is to define the format string
+specification, and take the hard work out of implementing it.  To use it in your project, you'll
+create a single file, and write a single line of code.  Then, you'll include that file anywhere you
+want to format a `Quantity`.
+
+## Setup
+
+The setup depends on whether you are using the [{fmt}] library, or `std::format`.
+
+### Using `{fmt}`
+
+There are two steps to support formatting in your project:
+
+1. Create a file to hold the authoritative formatter definition.
+
+2. Include this file anywhere you want to format a `Quantity`.
+
+Here are the contents of the file to create:
+
+```cpp
+#pragma once
+
+#include "au/au.hh"
+#include "fmt/format.h"
+
+namespace fmt {
+template <typename U, typename R>
+struct formatter<::au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, ::fmt::formatter> {};
+}  // namespace fmt
+```
+
+!!! tip "Tip: finding the file in your project"
+    It's very important to have _only one_ definition of `formatter<Quantity<U, R>>` in your
+    project.  This means you need a way to tell whether someone has created this file already, and
+    find it if it exists.
+
+    Fortunately, the string `QuantityFormatter` is very greppable.  In most cases, it should only
+    occur once in your project --- even if there are a few stray mentions, it should be easy to find
+    the authoritative definition.  Start by grepping your project for this string.  If you find it,
+    you can just use the file.  If not, you know you need to create it.
+
+### Using `std::format`
+
+Au automatically supports `Quantity` formatting on any configuration that includes `std::format`.
+No setup is necessary.
+
+## Syntax
+
+Printing a `Quantity<U, R>` means printing its numeric value, followed by its unit label.  Au offers
+some degree of formatting control for each of these.
+
+- For the **numeric part**, the syntax is exactly the same as for formatting the underlying
+  representation type `R`.  For example, if `R` is `double`, you can use any of the standard format
+  specifiers for `double`.
+- For the **unit label**, we offer very limited control: only a minimum label string width.  If the
+  label is shorter than this, we will pad it on the right with spaces.  The syntax is a `U` (for
+  "unit label") followed by digits representing the minimum width.
+- If both are present, then the unit label format string must come first, and they must be separated
+  by a `;`.
+
+It may be easier to understand with several examples.
+
+| Specialize format for | Pattern | Example | Output |
+|-----------------------|---------|---------|--------|
+| Neither | `{}` | `fmt::format("{}", meters(123.456))` | `"123.456 m"` |
+| Numeric value | `{:~^10.2f}` | `fmt::format("{:~^10.2f}", meters(123.456))` | `"~~123.46~~ m"` |
+| Unit label | `{:U5}` | `fmt::format("{:U5}", meters(123.456))` | `"123.456 m____"`<br>(Each `'_'` char represents a space `' '`; see footnote[^1]) |
+| Both | `{:U5;~^10.2f}` | `fmt::format("{:U5;~^10.2f}", meters(123.456))` | `"~~123.46~~ m____"`<br>(Each `'_'` char represents a space `' '`; see footnote[^1]) |
+
+[^1]: Our documentation website cannot properly render multiple consecutive space characters in
+a monospaced block.  Therefore, we replaced the space characters `' '` with underscore characters
+`'_'`.  The real string does not have any `'_'` characters in any of these examples, so we hope that
+this does not cause too much confusion.
+
+To target a specific and consistent overall width --- say, for aligning columnar output --- provide
+formatters for both the unit label and the numeric value, and choose a specific width for each.  The
+overall width will be the sum of the widths of the two pieces, plus one space in between.
+
+### Specialized use cases
+
+The core support provides a formatted numeric value, then a space `' '`, the unit label, and
+optional padding.  There may be other use cases, but we don't support them directly, and we don't
+plan to. Fortunately, these tend to have straightforward workarounds.
+
+Here are some examples.
+
+Besides the separate formatters for the numeric value and unit label, some users may wish to format
+the "overall result".  For example, they may want the whole quantity (unit and label) to be centered
+in a width of, say, 25 characters.  We cannot support this directly without excessive complexity ---
+both in the implementation, and in the formatter syntax.  The simple workaround is to format your
+quantity as desired using the existing syntax, and then format the result using simple `std::string`
+formatting, like so:
+
+```cpp
+constexpr auto speed = (centi(meters) / second)(987.654321);
+std::cout << fmt::format("{:.^31}", fmt::format("{:U10;,<8.2f}", speed));
+// Output: "......987.65,, cm / s    ......"
+```
+
+Some users may want a format that prints _only_ the numeric value, or _only_ the unit label.  We
+don't provide a direct way to do this, because neither of these pieces is meaningful on its own.  If
+you do have a use case for formatting only one of these, the workaround is straightforward.  Simply
+retrieve the numeric value or unit label by the library's standard methods, and pass the result to
+a formatter for that numeric type, like so:
+
+```cpp
+constexpr auto c = 299'792.458 * km / s;
+std::cout << fmt::format("{:,<12.2f}", c.data_in(km / s));
+// Output: "299792.46,,,"
+```
+
+[{fmt}]: https://github.com/fmtlib/fmt
+[std::format]: https://en.cppreference.com/w/cpp/utility/format/format.html
+[version 9.0]: https://github.com/fmtlib/fmt/releases/tag/9.0.0
+[standard format syntax]: https://hackingcpp.com/cpp/libs/fmt.html

--- a/docs/reference/format.md
+++ b/docs/reference/format.md
@@ -87,13 +87,8 @@ It may be easier to understand with several examples.
 |-----------------------|---------|---------|--------|
 | Neither | `{}` | `fmt::format("{}", meters(123.456))` | `"123.456 m"` |
 | Numeric value | `{:~^10.2f}` | `fmt::format("{:~^10.2f}", meters(123.456))` | `"~~123.46~~ m"` |
-| Unit label | `{:U5}` | `fmt::format("{:U5}", meters(123.456))` | `"123.456 m____"`<br>(Each `'_'` char represents a space `' '`; see footnote[^1]) |
-| Both | `{:U5;~^10.2f}` | `fmt::format("{:U5;~^10.2f}", meters(123.456))` | `"~~123.46~~ m____"`<br>(Each `'_'` char represents a space `' '`; see footnote[^1]) |
-
-[^1]: Our documentation website cannot properly render multiple consecutive space characters in
-a monospaced block.  Therefore, we replaced the space characters `' '` with underscore characters
-`'_'`.  The real string does not have any `'_'` characters in any of these examples, so we hope that
-this does not cause too much confusion.
+| Unit label | `{:U5}` | `fmt::format("{:U5}", meters(123.456))` | `"123.456 m    "` |
+| Both | `{:U5;~^10.2f}` | `fmt::format("{:U5;~^10.2f}", meters(123.456))` | `"~~123.46~~ m    "` |
 
 To target a specific and consistent overall width --- say, for aligning columnar output --- provide
 formatters for both the unit label and the numeric value, and choose a specific width for each.  The

--- a/docs/reference/format.md
+++ b/docs/reference/format.md
@@ -28,7 +28,14 @@ want to format a `Quantity`.
 
 ## Setup
 
-The setup depends on whether you are using the [{fmt}] library, or `std::format`.
+The setup depends on whether you are using `std::format`, or the [{fmt}] library.
+
+### Using `std::format`
+
+Include `"au/std_format.hh"`.
+
+Note that this will not work unless you are building on a toolchain that fully supports
+`std::format` and the `<format>` header.
 
 ### Using `{fmt}`
 
@@ -61,11 +68,6 @@ struct formatter<::au::Quantity<U, R>> : ::au::QuantityFormatter<U, R, ::fmt::fo
     occur once in your project --- even if there are a few stray mentions, it should be easy to find
     the authoritative definition.  Start by grepping your project for this string.  If you find it,
     you can just use the file.  If not, you know you need to create it.
-
-### Using `std::format`
-
-Au automatically supports `Quantity` formatting on any configuration that includes `std::format`.
-No setup is necessary.
 
 ## Syntax
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -31,6 +31,11 @@ Here's a guide to the main reference pages.
   unit with a specified _relative size_.  For example, `centi` is a prefix whose relative magnitude
   is $1/100$, and a `centi(meter)` is a new unit which is one one-hundredth of a `meter`.
 
-- **[`Math functions`](./math.md).**  We provide many common mathematical functions out of the box.
+- **[Math functions](./math.md).**  We provide many common mathematical functions out of the box.
+
+- **[Format support](./format.md).**  Exercise fine-grained control over formatting quantities to
+  strings, using either the popular [{fmt}] library, or C++20's `std::format`.
 
 See the sidebar for the complete list of pages.
+
+[{fmt}]: https://github.com/fmtlib/fmt

--- a/tools/bin/check-cmake-headers
+++ b/tools/bin/check-cmake-headers
@@ -18,12 +18,6 @@ import subprocess
 import sys
 
 
-# These headers will be included or excluded based on the CMake configuration.  The point of this
-# script is to make sure we're not _accidentally_ excluding them.  Explicitly putting a header in
-# this list is a good indication that we haven't neglected it.
-OPTIONAL_CMAKE_HEADERS = ["std_format.hh"]
-
-
 def main(argv=None):
     cmake_headers = _get_cmake_headers()
     bazel_headers = _get_bazel_headers()
@@ -83,7 +77,7 @@ def _get_bazel_headers():
 def _check_equality_and_print_any_differences(cmake_headers, bazel_headers):
     cmake = (cmake_headers, "CMake")
     bazel = (bazel_headers, "bazel")
-    result = (set.union(cmake_headers, OPTIONAL_CMAKE_HEADERS) == bazel_headers)
+    result = (cmake_headers == bazel_headers)
 
     if not result:
         print("\n** ERROR **: Headers in CMake and bazel are not identical.")
@@ -128,7 +122,7 @@ def _print_any_only_in_first(first, second):
     if extras:
         print(f"\nHeaders in {first_name} but not {second_name}:")
         for header in extras:
-            print(f"  {header}{' (ok; optional)' if header in OPTIONAL_CMAKE_HEADERS else ''}")
+            print(f"  {header}")
 
 
 if __name__ == "__main__":

--- a/tools/bin/check-cmake-headers
+++ b/tools/bin/check-cmake-headers
@@ -18,6 +18,12 @@ import subprocess
 import sys
 
 
+# These headers will be included or excluded based on the CMake configuration.  The point of this
+# script is to make sure we're not _accidentally_ excluding them.  Explicitly putting a header in
+# this list is a good indication that we haven't neglected it.
+OPTIONAL_CMAKE_HEADERS = ["std_format.hh"]
+
+
 def main(argv=None):
     cmake_headers = _get_cmake_headers()
     bazel_headers = _get_bazel_headers()
@@ -77,7 +83,7 @@ def _get_bazel_headers():
 def _check_equality_and_print_any_differences(cmake_headers, bazel_headers):
     cmake = (cmake_headers, "CMake")
     bazel = (bazel_headers, "bazel")
-    result = (cmake_headers == bazel_headers)
+    result = (set.union(cmake_headers, OPTIONAL_CMAKE_HEADERS) == bazel_headers)
 
     if not result:
         print("\n** ERROR **: Headers in CMake and bazel are not identical.")
@@ -122,7 +128,7 @@ def _print_any_only_in_first(first, second):
     if extras:
         print(f"\nHeaders in {first_name} but not {second_name}:")
         for header in extras:
-            print(f"  {header}")
+            print(f"  {header}{' (ok; optional)' if header in OPTIONAL_CMAKE_HEADERS else ''}")
 
 
 if __name__ == "__main__":

--- a/tools/bin/check-cmake-headers
+++ b/tools/bin/check-cmake-headers
@@ -60,11 +60,12 @@ def _get_cmake_headers():
 
 
 def _get_bazel_headers():
+    deps_str = ' union '.join(f'deps(//au{target})' for target in ['', ':io', ':std_format'])
     raw_output = subprocess.run(
         [
             "bazel",
             "query",
-            "kind(source, filter(//au, deps(//au) union deps(//au:io)))",
+            f"kind(source, filter(//au, {deps_str}))",
         ],
         stdout=subprocess.PIPE,
         check=True,

--- a/tools/bin/make-single-file
+++ b/tools/bin/make-single-file
@@ -53,6 +53,7 @@ def main(argv=None):
             units=args.units,
             constants=args.constants,
             include_io=args.include_io,
+            include_std_format=args.std_format,
         )
     )
     print_unified_file(files, args=args)
@@ -60,7 +61,7 @@ def main(argv=None):
     return 0
 
 
-def filenames(main_files, units, constants, include_io):
+def filenames(main_files, units, constants, include_io, include_std_format):
     """Construct the list of project filenames to include.
 
     The script will be sure to include all of these, and will also include any
@@ -74,6 +75,8 @@ def filenames(main_files, units, constants, include_io):
     )
     if include_io:
         names.append("au/io.hh")
+    if include_std_format:
+        names.append("au/std_format.hh")
     return names
 
 
@@ -114,6 +117,13 @@ def parse_command_line_args(argv):
         action="store_false",
         dest="include_io",
         help="Exclude I/O capabilities",
+    )
+
+    parser.add_argument(
+        "--std-format",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Include support for `std::format` (C++20)",
     )
 
     return parser.parse_args()
@@ -282,6 +292,7 @@ def manifest(args):
         [
             f"Version identifier: {args.version_id}",
             f'<iostream> support: {"INCLUDED" if args.include_io else "EXCLUDED"}',
+            f'<format> support: {"INCLUDED" if args.std_format else "EXCLUDED"}',
             "List of included units:",
         ]
         + [f"  {u}" for u in sorted(args.units)]
@@ -293,7 +304,8 @@ def manifest(args):
         lines.append("Extra files included:")
         lines.extend(f"  {f}" for f in sorted(args.main_files))
 
-    assert args.are_all_used()
+    unused_args = args.unused_args()
+    assert not unused_args, f"Arguments not used: {unused_args}"
     return lines
 
 
@@ -302,8 +314,8 @@ class CheckArgs(dict):
         self.vars = vars(args)
         self.used = set()
 
-    def are_all_used(self):
-        return not set(self.vars.keys()).difference(self.used)
+    def unused_args(self):
+        return set(self.vars.keys()).difference(self.used)
 
     def __getattr__(self, k):
         self.used.add(k)


### PR DESCRIPTION
We tried this earlier (#491), but then reverted it (#495).  That was
just a few short weeks ago: what changed?

We learned that our old format string syntax wasn't just _hard_ to
implement; it was actually [impossible].  This led naturally to a [new
idea] that may not be as flexible, but actually still supports the most
important use cases.  Happily, this new idea is very easy to implement
without using any internal implementation details of the formatting
libraries.  It even gives us a little (_very_ little) room for evolving
more options for formatting the unit label, such as setting the fill
character, although we don't currently expect to ever need or want them.

I was also able to verify support for `std::format` by generating a
single file, and uploading it to [godbolt].  This shows that on a
compiler version and setup that includes `std::format`, Au supports it
via the `"au/std_format.hh"` header.  I also updated the single-file
script to have `--no-std-format` (which is the default) and
`--std-format` options.  A future PR will add versions with/without
`std::format` support to our automatically generated single-file
options.

On the CMake side, we need to skip linting for `std_format.hh`.  It's
too hard and too complicated to set up reliable rules for when we should
and shouldn't make it available.  Therefore, we _always_ make it
available, but we trust that users will only include it if they know
they can support it.  That's the point of the opt-in header strategy.
Note, though, that this required us to bump the minimum CMake version
from 3.24 to 3.27.

Fixes #149.

[impossible]: fmtlib/fmt#4508 (comment)
[new idea]: fmtlib/fmt#4508 (comment)
[godbolt]: https://godbolt.org/z/f6Pvz9Mzb