### PR TITLE
Support `mean()` for `Quantity` and `QuantityPoint`

### DIFF
--- a/au/math.hh
+++ b/au/math.hh
@@ -399,6 +399,32 @@ constexpr auto min(QuantityPoint<U, R> a, QuantityPoint<U, R> b) {
     return std::min(a, b);
 }
 
+template <typename U0, typename R0, typename... Us, typename... Rs>
+constexpr auto mean(Quantity<U0, R0> q0, Quantity<Us, Rs>... qs) {
+    using R = std::common_type_t<R0, Rs...>;
+    using Common = Quantity<CommonUnitT<U0, Us...>, R>;
+    const auto base = Common{q0};
+    Common diffs[] = {(Common{qs} - base)...};
+    Common sum_diffs = ZERO;
+    for (const auto &d : diffs) {
+        sum_diffs += d;
+    }
+    return base + (sum_diffs / static_cast<R>(1u + sizeof...(qs)));
+}
+
+template <typename U0, typename R0, typename... Us, typename... Rs>
+constexpr auto mean(QuantityPoint<U0, R0> p0, QuantityPoint<Us, Rs>... ps) {
+    using U = CommonPointUnitT<U0, Us...>;
+    using R = std::common_type_t<R0, Rs...>;
+    const auto base = QuantityPoint<U, R>{p0};
+    Quantity<U, R> diffs[] = {(QuantityPoint<U, R>{ps} - base)...};
+    Quantity<U, R> sum_diffs = ZERO;
+    for (const auto &d : diffs) {
+        sum_diffs += d;
+    }
+    return base + (sum_diffs / static_cast<R>(1u + sizeof...(ps)));
+}
+
 // The (zero-centered) floating point remainder of two values of the same dimension.
 template <typename U1, typename R1, typename U2, typename R2>
 auto remainder(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -562,6 +562,15 @@ TEST(sin, GivesCorrectAnswersForInputsInDegrees) {
     EXPECT_THAT(sin(degrees(90)), DoubleNear(1.0, TOL));
 }
 
+TEST(mean, QuantityMeanGivesCommonUnit) {
+    EXPECT_THAT(mean(feet(1), inches(12), yards(2)), SameTypeAndValue(inches(32)));
+}
+
+TEST(mean, QuantityPointMeanGivesCommonUnit) {
+    EXPECT_THAT(mean(meters_pt(2), centi(meters_pt)(150), milli(meters_pt)(2500)),
+                SameTypeAndValue(milli(meters_pt)(2000)));
+}
+
 TEST(sqrt, OutputRepDependsOnInputRep) {
     EXPECT_THAT(sqrt(squared(meters)(4)), QuantityEquivalent(meters(2.)));
     EXPECT_THAT(sqrt(squared(meters)(4.)), QuantityEquivalent(meters(2.)));

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -199,7 +199,9 @@ expand the note below for further details.
 #### `lerp` (C++20) {#lerp}
 
 !!! warning
-    `lerp`, based on [std::lerp], is only available for C++20 and later.  For the special case where `t = 0.5`, see [`mean`](#mean) below.
+    `lerp`, based on [std::lerp], is only available for C++20 and later.
+
+    For the special case where `t = 0.5`, [`mean`](#mean) (see below) presents an alternative.
 
 Linearly interpolate between two `Quantity` or `QuantityPoint` values, based on a parameter `t`,
 such that `t=0` corresponds to the first argument, and `t=1` corresponds to the second argument.

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -199,8 +199,7 @@ expand the note below for further details.
 #### `lerp` (C++20) {#lerp}
 
 !!! warning
-    `lerp`, based on [std::lerp], is only available for C++20 and later.  For a pre-C++20 solution
-    for the special case where `t = 0.5`, see [`mean`](#mean) below.
+    `lerp`, based on [std::lerp], is only available for C++20 and later.  For the special case where `t = 0.5`, see [`mean`](#mean) below.
 
 Linearly interpolate between two `Quantity` or `QuantityPoint` values, based on a parameter `t`,
 such that `t=0` corresponds to the first argument, and `t=1` corresponds to the second argument.

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -196,10 +196,11 @@ expand the note below for further details.
 
 ### Interpolating functions
 
-#### `lerp` (C++20)
+#### `lerp` (C++20) {#lerp}
 
 !!! warning
-    `lerp`, based on [std::lerp], is only available for C++20 and later.
+    `lerp`, based on [std::lerp], is only available for C++20 and later.  For a pre-C++20 solution
+    for the special case where `t = 0.5`, see [`mean`](#mean) below.
 
 Linearly interpolate between two `Quantity` or `QuantityPoint` values, based on a parameter `t`,
 such that `t=0` corresponds to the first argument, and `t=1` corresponds to the second argument.
@@ -223,6 +224,37 @@ handling outlined in [std::lerp].  The return value will be expressed in the com
 units of the inputs `a` and `b`.
 
 [std::lerp]: https://en.cppreference.com/w/cpp/numeric/lerp
+
+#### `mean` {#mean}
+
+Produce the arithmetic mean of two or more `Quantity` or `QuantityPoint` values.
+
+**Signatures:**
+
+```cpp
+// 1. `Quantity` inputs
+template <typename U0, typename R0, typename... Us, typename... Rs>
+constexpr auto mean(Quantity<U0, R0> q0, Quantity<Us, Rs>... qs);
+
+// 2. `QuantityPoint` inputs
+template <typename U0, typename R0, typename... Us, typename... Rs>
+constexpr auto mean(QuantityPoint<U0, R0> p0, QuantityPoint<Us, Rs>... ps);
+```
+
+**Returns:** The arithmetic mean of all inputs.  The return value will be expressed in the common
+unit of the units of the inputs, and the rep will be the common type of the reps of all inputs.
+
+!!! note
+    `mean` has overlap with `lerp`: `mean(a, b)` is similar to `lerp(a, b, 0.5)`.  Here is
+    a comparison table to help you decide which to use.
+
+    | Criterion | `mean` | `lerp` |
+    |-----------|--------|--------|
+    | Number of inputs | 2 or more | Exactly 2 |
+    | Weights | All equal | Arbitrary |
+    | Special case handling | Avoids overflows | Delegates to [std::lerp], which handles many special cases |
+    | Approach to integer types | Use integer arithmetic | Delegates to [std::lerp], which always converts to floating point |
+    | C++ version compatibility | All versions of Au (C++14 and later) | C++20 and later |
 
 ### Exponentiation
 


### PR DESCRIPTION
This should enable end users to write more intent-based code.

Fixes #506.