### PR TITLE
Clarify how-to docs for new units

### DIFF
--- a/docs/howto/forward-declarations.md
+++ b/docs/howto/forward-declarations.md
@@ -9,6 +9,11 @@ forward declarations.  This page explains how to use them.
     configurations.  Most users won't need to forward declare Au's types.  However, for situations
     where you really do need every bit of speed, these forward declarations can help.
 
+!!! note
+    We are omitting the `au::` namespace in the text of this how-to guide, for conciseness and
+    readability.  However, all code samples will include the `au::` namespace qualification wherever
+    appropriate.
+
 ## How to use {#how-to-use}
 
 First, identify the file in your project that could benefit from forward declarations.  _This is
@@ -96,7 +101,7 @@ Here is a series of steps to follow to forward declare compound units.
     like this:
 
     ```cpp
-    using InverseYourUnitsCubedFwd = ForwardDeclareUnitPow<YourUnits, -3>;
+    using InverseYourUnitsCubedFwd = au::ForwardDeclareUnitPow<YourUnits, -3>;
     using InverseYourUnitsCubed = YourUnitsCubedFwd::unit_type;
     ```
 
@@ -110,7 +115,7 @@ Here is a series of steps to follow to forward declare compound units.
     existing `InverseYourUnitsCubed` that you would have defined in step 2):
 
     ```cpp
-    using OtherUnitsPerYourUnitsCubedFwd = ForwardDeclareUnitProduct<OtherUnits, InverseYourUnitsCubed>;
+    using OtherUnitsPerYourUnitsCubedFwd = au::ForwardDeclareUnitProduct<OtherUnits, InverseYourUnitsCubed>;
     using OtherUnitsPerYourUnitsCubed = OtherUnitsPerYourUnitsCubedFwd::unit_type;
     ```
 
@@ -121,15 +126,11 @@ Here is a series of steps to follow to forward declare compound units.
 
     ```cpp
     // In whatever file _corresponds to_ the one with the forward declarations:
-    static_assert(is_forward_declared_unit_valid(InverseYourUnitsCubedFwd{}));
-    static_assert(is_forward_declared_unit_valid(OtherUnitsPerYourUnitsCubedFwd{}));
+    static_assert(au::is_forward_declared_unit_valid(InverseYourUnitsCubedFwd{}));
+    static_assert(au::is_forward_declared_unit_valid(OtherUnitsPerYourUnitsCubedFwd{}));
     ```
 
 ## Full worked example
-
-!!! note
-    We are omitting the `au::` namespace in the text of this example, for conciseness and
-    readability.
 
 Suppose we want to make a library target that can print a speed, in km/h, to a `std::string`.
 Suppose, too, that we want our library to be as lightweight as possible: maybe some client targets
@@ -193,8 +194,8 @@ Now, the implementation file:
 
 namespace my_library {
 
-static_assert(is_forward_declared_unit_valid(InverseHoursFwd{}));
-static_assert(is_forward_declared_unit_valid(KilometersPerHourFwd{}));
+static_assert(au::is_forward_declared_unit_valid(InverseHoursFwd{}));
+static_assert(au::is_forward_declared_unit_valid(KilometersPerHourFwd{}));
 
 std::string print_to_string(const au::QuantityD<KilometersPerHour>& speed) {
     std::ostringstream oss;

--- a/docs/howto/new-constants.md
+++ b/docs/howto/new-constants.md
@@ -30,7 +30,7 @@ will simply be cumbersome.
     Here's how to create a constant for the speed of light, without giving it a special symbol.
 
     ```cpp
-    constexpr auto c = au::make_constant(au::meters / au::second * au::mag<299'792'458>());
+    constexpr auto c = make_constant(au::meters / au::second * au::mag<299'792'458>());
     ```
 
     Here's an example use case, in user code:

--- a/docs/howto/new-constants.md
+++ b/docs/howto/new-constants.md
@@ -30,7 +30,7 @@ will simply be cumbersome.
     Here's how to create a constant for the speed of light, without giving it a special symbol.
 
     ```cpp
-    constexpr auto c = make_constant(meters / second * mag<299'792'458>());
+    constexpr auto c = au::make_constant(au::meters / au::second * au::mag<299'792'458>());
     ```
 
     Here's an example use case, in user code:
@@ -55,23 +55,23 @@ Next, pass an instance of this custom unit to `make_constant`.
 
     === "C++14"
         ```cpp
-        // In `.hh` file:
-        struct SpeedOfLightUnit : decltype(Meters{} / Seconds{} * mag<299'792'458>()) {
+        // In `.hh` file, in your project's namespace:
+        struct SpeedOfLightUnit : decltype(au::Meters{} / au::Seconds{} * au::mag<299'792'458>()) {
             static constexpr const char label[] = "c";
         };
-        constexpr auto c = make_constant(SpeedOfLightUnit{});
+        constexpr auto c = au::make_constant(SpeedOfLightUnit{});
 
-        // In `.cc` file:
+        // In `.cc` file, in your project's namespace:
         constexpr const char SpeedOfLightUnit::label[];
         ```
 
     === "C++17"
         ```cpp
-        // In `.hh` file:
-        struct SpeedOfLightUnit : decltype(Meters{} / Seconds{} * mag<299'792'458>()) {
+        // In `.hh` file, in your project's namespace:
+        struct SpeedOfLightUnit : decltype(au::Meters{} / au::Seconds{} * au::mag<299'792'458>()) {
             static constexpr inline const char label[] = "c";
         };
-        constexpr auto c = make_constant(SpeedOfLightUnit{});
+        constexpr auto c = au::make_constant(SpeedOfLightUnit{});
         ```
 
     Here's an example use case, in user code:

--- a/docs/howto/new-dimensions.md
+++ b/docs/howto/new-dimensions.md
@@ -76,8 +76,8 @@ unit label, quantity maker, and singular name.
     struct Pixels : au::UnitImpl<au::Dimension<PixelBaseDim>> {
         static constexpr const char label[] = "px";
     };
-    constexpr auto pixel  = SingularNameFor<Pixels>{};
-    constexpr auto pixels = QuantityMaker<Pixels>{};
+    constexpr auto pixel  = au::SingularNameFor<Pixels>{};
+    constexpr auto pixels = au::QuantityMaker<Pixels>{};
 
     // In .cc file:
     constexpr const char Pixels::label[];
@@ -90,8 +90,8 @@ unit label, quantity maker, and singular name.
     struct Pixels : au::UnitImpl<au::Dimension<PixelBaseDim>> {
         static constexpr inline const char label[] = "px";
     };
-    constexpr auto pixel  = SingularNameFor<Pixels>{};
-    constexpr auto pixels = QuantityMaker<Pixels>{};
+    constexpr auto pixel  = au::SingularNameFor<Pixels>{};
+    constexpr auto pixels = au::QuantityMaker<Pixels>{};
     ```
 
 ## Usage example
@@ -101,8 +101,8 @@ This new unit will compose with other units in all of the usual ways.
 Here's an example test case:
 
 ```cpp
-constexpr auto resolution = (pixels / inch)(300);
-EXPECT_THAT(resolution * inches(6), SameTypeAndValue(pixels(1800)));
+constexpr auto resolution = (pixels / au::inch)(300);
+EXPECT_THAT(resolution * au::inches(6), SameTypeAndValue(pixels(1800)));
 ```
 
 If we followed the instructions in the previous section, this test should pass --- and you can use

--- a/docs/howto/new-units.md
+++ b/docs/howto/new-units.md
@@ -28,20 +28,20 @@ a complete sample definition of a new Unit, with these features annotated and ex
     //
     // Items labeled with `*` are _required_; everything else is optional.
 
-    // In .hh file:
-    struct Fathoms : decltype(Inches{} * mag<72>()) {           // *[1]
-        static constexpr const char label[] = "ftm";            //  [2a]
+    // In .hh file, in your project's namespace:
+    struct Fathoms : decltype(au::Inches{} * au::mag<72>()) {       // *[1]
+        static constexpr const char label[] = "ftm";                //  [2a]
     };
-    constexpr auto fathom  = SingularNameFor<Fathoms>{};        //  [3]
-    constexpr auto fathoms = QuantityMaker<Fathoms>{};          // *[4]
-    constexpr auto fathoms_pt = QuantityPointMaker<Fathoms>{};  //  [5; less common]
+    constexpr auto fathom  = au::SingularNameFor<Fathoms>{};        //  [3]
+    constexpr auto fathoms = au::QuantityMaker<Fathoms>{};          // *[4]
+    constexpr auto fathoms_pt = au::QuantityPointMaker<Fathoms>{};  //  [5; less common]
 
     namespace symbols {
-    constexpr auto ftm = SymbolFor<Fathoms>{};                  //  [6]
+    constexpr auto ftm = au::SymbolFor<Fathoms>{};                  //  [6]
     }
 
-    // In .cc file:
-    constexpr const char Fathoms::label[];                      //  [2b]
+    // In .cc file, in your project's namespace:
+    constexpr const char Fathoms::label[];                          //  [2b]
     ```
 
 === "C++17 or later"
@@ -51,16 +51,16 @@ a complete sample definition of a new Unit, with these features annotated and ex
     //
     // Items labeled with `*` are _required_; everything else is optional.
 
-    // In .hh file:
-    struct Fathoms : decltype(Inches{} * mag<72>()) {           // *[1]
-        static constexpr inline const char label[] = "ftm";     //  [2]
+    // In .hh file, in your project's namespace:
+    struct Fathoms : decltype(au::Inches{} * au::mag<72>()) {       // *[1]
+        static constexpr inline const char label[] = "ftm";         //  [2]
     };
-    constexpr auto fathom  = SingularNameFor<Fathoms>{};        //  [3]
-    constexpr auto fathoms = QuantityMaker<Fathoms>{};          // *[4]
-    constexpr auto fathoms_pt = QuantityPointMaker<Fathoms>{};  //  [5; less common]
+    constexpr auto fathom  = au::SingularNameFor<Fathoms>{};        //  [3]
+    constexpr auto fathoms = au::QuantityMaker<Fathoms>{};          // *[4]
+    constexpr auto fathoms_pt = au::QuantityPointMaker<Fathoms>{};  //  [5; less common]
 
     namespace symbols {
-    constexpr auto ftm = SymbolFor<Fathoms>{};                  //  [6]
+    constexpr auto ftm = au::SymbolFor<Fathoms>{};                  //  [6]
     }
     ```
 
@@ -129,8 +129,8 @@ Above, we said to inherit your unit's strong type from the `decltype` of a [unit
 expression](../discussion/idioms/unit-slots.md#unit-expression). Recall the line from above:
 
 ```cpp
-struct Fathoms : decltype(Inches{} * mag<72>()) {
-//        Unit Expression ^^^^^^^^^^^^^^^^^^^^
+struct Fathoms : decltype(au::Inches{} * au::mag<72>()) {
+//        Unit Expression ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ```
 
 Some users may be surprised that we recommend using `decltype` and instances, instead of just naming
@@ -154,8 +154,8 @@ Here are some example unit expressions we might reach for to define various comm
 A shorter method of defining units is as _aliases_ for a compound unit.  For example:
 
 ```cpp
-using MilesPerHour = decltype(Miles{} / Hours{});
-constexpr auto miles_per_hour = miles / hour;
+using MilesPerHour = decltype(au::Miles{} / au::Hours{});
+constexpr auto miles_per_hour = au::miles / au::hour;
 ```
 
 We can use the alias, `MilesPerHour`, anywhere we'd use a unit type.  And we can call the

--- a/docs/howto/quantity-template-parameters.md
+++ b/docs/howto/quantity-template-parameters.md
@@ -60,10 +60,10 @@ Here's how we'd define that template.
 
 ```cpp
 // Step (1): use the NTTP type as the template parameter.
-template <QuantityU64<Hertz>::NTTP ClockFreq>
+template <au::QuantityU64<au::Hertz>::NTTP ClockFreq>
 class Processor {
  public:
-    static constexpr QuantityD<Giga<Hertz>> clock_freq() {
+    static constexpr au::QuantityD<au::Giga<au::Hertz>> clock_freq() {
 
         // Step (3): use `from_nttp()` to make it a `Quantity`.
         //
@@ -78,7 +78,7 @@ And here's how we'd use it.
 
 ```cpp
 // Step (2): when instantiating, convert to the exact right `Quantity` type.
-using Proc = Processor<mega(hertz)(1'200).as<uint64_t>(hertz)>;
+using Proc = Processor<au::mega(au::hertz)(1'200).as<uint64_t>(au::hertz)>;
 
 std::cout << Proc::clock_freq() << std::endl;
 ```


### PR DESCRIPTION
Some users have found some aspects of these docs confusing.  This PR
fixes them up to make the guide easier to use.  Here are the problems
and how we handled them.

- **Problem:** It was unclear which namespace should contain the
  definitions of new units.
    - **Solution:** Append `, in your project's namespace` to the
      comments in the guide.

- **Problem:** It was unclear which namespace the `symbols` namespace
  should go in.
    - **Solution:** The above change should automatically clarify this
      as well.

- **Problem:** The `au::` namespace was omitted from Au library
  constructs, making it unclear whether we had elided a `using` clause,
  or whether we wanted users to define the units in the `au` namespace.
    - **Solution:** The desired namespace should no longer be unclear.
      We had been writing the docs by omitting the `au` namespace to
      reduce visual clutter, but this is less appropriate for a how-to
      guide.  We have added the namespace.

Of course, this last point applies with equal force to every other
how-to guide.  It's OK to eliminate the `au::` namespace qualifier in
the _text_, but we should keep the _code samples_ as usable as possible.
Therefore, we apply this approach more consistently.

Fixes #504.