### PR TITLE
Add `std::format`-supporting single-file headers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -33,6 +33,10 @@ py_binary(
         ":au_all_units_noio_hh",
         ":au_hh",
         ":au_noio_hh",
+        ":au_stdformat_hh",
+        ":au_stdformat_noio_hh",
+        ":au_all_units_stdformat_hh",
+        ":au_all_units_stdformat_noio_hh",
     ] + glob(["docs/**"]),
     deps = [
         requirement("mkdocs"),
@@ -49,6 +53,10 @@ py_binary(
         ":au_all_units_noio_hh",
         ":au_hh",
         ":au_noio_hh",
+        ":au_stdformat_hh",
+        ":au_stdformat_noio_hh",
+        ":au_all_units_stdformat_hh",
+        ":au_all_units_stdformat_noio_hh",
     ] + glob(["docs/**"]),
     main = "mike_bin.py",
     deps = [
@@ -93,6 +101,7 @@ genrule(
     ),
     stamp = True,
     tools = ["tools/bin/make-single-file"],
+    visibility = ["//release:__pkg__"],
 )
 
 cc_library(
@@ -140,6 +149,7 @@ genrule(
     ),
     stamp = True,
     tools = ["tools/bin/make-single-file"],
+    visibility = ["//release:__pkg__"],
 )
 
 cc_library(
@@ -171,3 +181,83 @@ cc_library(
     hdrs = ["docs/au_all_units_noio.hh"],
     visibility = ["//release:__pkg__"],
 )
+
+################################################################################
+# Release single-file package `au_stdformat.hh`
+
+genrule(
+    name = "au_stdformat_hh",
+    srcs = ["//au:headers"],
+    outs = ["docs/au_stdformat.hh"],
+    cmd = CMD_ROOT.format(
+        all_constants = "",
+        extra_opts = "--std-format",
+        id_cmd = GIT_ID_CMD,
+        units = "--units " + BASE_UNIT_STRING,
+    ),
+    stamp = True,
+    tools = ["tools/bin/make-single-file"],
+    visibility = ["//release:__pkg__"],
+)
+
+# TODO(#508): no `cc_library`, because we don't yet have a toolchain that supports `std::format`.
+
+################################################################################
+# Release single-file package `au_stdformat_noio.hh`
+
+genrule(
+    name = "au_stdformat_noio_hh",
+    srcs = ["//au:headers"],
+    outs = ["docs/au_stdformat_noio.hh"],
+    cmd = CMD_ROOT.format(
+        all_constants = "",
+        extra_opts = "--std-format --noio",
+        id_cmd = GIT_ID_CMD,
+        units = "--units " + BASE_UNIT_STRING,
+    ),
+    stamp = True,
+    tools = ["tools/bin/make-single-file"],
+    visibility = ["//release:__pkg__"],
+)
+
+# TODO(#508): no `cc_library`, because we don't yet have a toolchain that supports `std::format`.
+
+################################################################################
+# Release single-file package `au_all_units_stdformat.hh`
+
+genrule(
+    name = "au_all_units_stdformat_hh",
+    srcs = ["//au:headers"],
+    outs = ["docs/au_all_units_stdformat.hh"],
+    cmd = CMD_ROOT.format(
+        all_constants = "--all-constants",
+        extra_opts = "--std-format",
+        id_cmd = GIT_ID_CMD,
+        units = "--all-units",
+    ),
+    stamp = True,
+    tools = ["tools/bin/make-single-file"],
+    visibility = ["//release:__pkg__"],
+)
+
+# TODO(#508): no `cc_library`, because we don't yet have a toolchain that supports `std::format`.
+
+################################################################################
+# Release single-file package `au_all_units_stdformat_noio.hh`
+
+genrule(
+    name = "au_all_units_stdformat_noio_hh",
+    srcs = ["//au:headers"],
+    outs = ["docs/au_all_units_stdformat_noio.hh"],
+    cmd = CMD_ROOT.format(
+        all_constants = "--all-constants",
+        extra_opts = "--std-format --noio",
+        id_cmd = GIT_ID_CMD,
+        units = "--all-units",
+    ),
+    stamp = True,
+    tools = ["tools/bin/make-single-file"],
+    visibility = ["//release:__pkg__"],
+)
+
+# TODO(#508): no `cc_library`, because we don't yet have a toolchain that supports `std::format`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -275,9 +275,33 @@ Here are the two ways to get a single-file packaging of the library.
 We provide pre-generated single-file versions of the library, automatically generated from the
 latest commit in the repo:
 
-- [`au.hh`](./au.hh)
-- [`au_noio.hh`](./au_noio.hh)
-  (Same as above, but with `<iostream>` support stripped out)
+<table>
+  <tr>
+    <th>Includes <code>std::format</code>?</th>
+    <th>Includes <code>&lt;iostream&gt;</code>?</th>
+    <th>Filename</th>
+  </tr>
+  <tr>
+    <td class="poor">No</td>
+    <td class="good">Yes</td>
+    <td><a href="../au.hh">au.hh</a></td>
+  </tr>
+  <tr>
+    <td class="poor">No</td>
+    <td class="poor">No</td>
+    <td><a href="../au_noio.hh">au_noio.hh</a></td>
+  </tr>
+  <tr>
+    <td class="good">Yes</td>
+    <td class="good">Yes</td>
+    <td><a href="../au_stdformat.hh">au_stdformat.hh</a></td>
+  </tr>
+  <tr>
+    <td class="good">Yes</td>
+    <td class="poor">No</td>
+    <td><a href="../au_stdformat_noio.hh">au_stdformat_noio.hh</a></td>
+  </tr>
+</table>
 
 These include very few units (to keep compile times short).  However, _combinations_ of these units
 should get you any other unit you're likely to want.  The units we include are:
@@ -322,10 +346,33 @@ should get you any other unit you're likely to want.  The units we include are:
 
     **If you don't care about compile times**, here are the files:
 
-    - [`au_all_units.hh`](./au_all_units.hh)
-    - [`au_all_units_noio.hh`](./au_all_units_noio.hh)
-      (Same as above, but with `<iostream>` support stripped out)
-
+    <table>
+      <tr>
+        <th>Includes <code>std::format</code>?</th>
+        <th>Includes <code>&lt;iostream&gt;</code>?</th>
+        <th>Filename</th>
+      </tr>
+      <tr>
+        <td class="poor">No</td>
+        <td class="good">Yes</td>
+        <td><a href="../au_all_units.hh">au_all_units.hh</a></td>
+      </tr>
+      <tr>
+        <td class="poor">No</td>
+        <td class="poor">No</td>
+        <td><a href="../au_all_units_noio.hh">au_all_units_noio.hh</a></td>
+      </tr>
+      <tr>
+        <td class="good">Yes</td>
+        <td class="good">Yes</td>
+        <td><a href="../au_all_units_stdformat.hh">au_all_units_stdformat.hh</a></td>
+      </tr>
+      <tr>
+        <td class="good">Yes</td>
+        <td class="poor">No</td>
+        <td><a href="../au_all_units_stdformat_noio.hh">au_all_units_stdformat_noio.hh</a></td>
+      </tr>
+    </table>
 
 #### Custom single file
 


### PR DESCRIPTION
These will now be automatically generated and included in the
installation guide.  This effectively makes each "group" a 2x2 matrix,
instead of just having 2 values (yes/no for `<iostream>`).  So I changed
the display to a matrix format to be more visual.

Yes, this does double the number of single-file versions that we
publish.  The increase in flexibility far outweighs the miniscule added
cost to generate and host these, IMO.  That said, we probably cannot
support _too_ many more doublings. :sweat_smile:

Also, I noticed that the visibility settings were inconsistent, so I
fixed them up.

Tested with `au-docs-serve`.  Note that the relative paths change from
`./` to `../`.  Formerly, we were using markdown syntax, and "relative"
meant "relative to `install.md`".  Now, in HTML, it means "relative to
`install/` on the output website": `install` becomes a _directory_, so
we need `../` to go up a level and find the files.

Helps #470.