### PR TITLE
Update Au's release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -126,7 +126,7 @@ and push to GitHub.
 
 ```sh
 # Remember to update the version number!
-git switch --checkout release-0.3.1
+git switch --create release-0.3.1
 git push origin release-0.3.1
 ```
 


### PR DESCRIPTION
First, we add a section that contains everything we expect to be
relevant for upgrading from the last "minor or larger" release, which we
will name.

Next, we add a "release branch" strategy.  Why?  Well, the direct
motivation is that we have a lot of URLs in our C++ code that point to
`/main/`, whereas this content can change in ways that we can't predict.
We will want it to point to `/0.5.0/` instead.  But I don't want our
history to contain a bunch of PRs that go updating tons of URLs.  It
makes sense for `main` to always point to `/main/`.  So I came up with a
release branch strategy.

The other thing this ties into is the "future proofing" releases.  I am
currently planning to have each future-proofing commit be a PR against
the release **tag** on the release branch.  When the PR lands, its final
commit will get tagged with `0.5.0-future-122`, `0.5.0-future-185`, etc.
When all PRs have landed, the HEAD _of the release branch_ gets tagged
with `0.5.0-future`.  This will let us download tarballs in the exact
same way as for the main release, so everything will be consistent.

We still need a "how-to guide" for upgrading in general, and using
future-proof releases in particular.  But the point of this PR is to
give the team a vehicle to discuss updating our release policies.

Helps #470.