### PR TITLE
Re-enable safety checks in convert-and-compare

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -732,8 +732,9 @@ constexpr auto convert_and_compare(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     using U = CommonUnitT<U1, U2>;
     using ComRep1 = detail::CommonTypeButPreserveIntSignedness<R1, R2>;
     using ComRep2 = detail::CommonTypeButPreserveIntSignedness<R2, R1>;
-    return detail::SignAwareComparison<UnitSign<U>, Op>{}(q1.template in<ComRep1>(U{}),
-                                                          q2.template in<ComRep2>(U{}));
+    return detail::SignAwareComparison<UnitSign<U>, Op>{}(
+        q1.template in<ComRep1>(U{}, check_for(ALL_RISKS)),
+        q2.template in<ComRep2>(U{}, check_for(ALL_RISKS)));
 }
 }  // namespace detail
 

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -331,8 +331,9 @@ constexpr auto convert_and_compare(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R
     using U = CommonPointUnitT<U1, U2>;
     using ComRep1 = detail::CommonTypeButPreserveIntSignedness<R1, R2>;
     using ComRep2 = detail::CommonTypeButPreserveIntSignedness<R2, R1>;
-    return detail::SignAwareComparison<UnitSign<U>, Op>{}(p1.template in<ComRep1>(U{}),
-                                                          p2.template in<ComRep2>(U{}));
+    return detail::SignAwareComparison<UnitSign<U>, Op>{}(
+        p1.template in<ComRep1>(U{}, check_for(ALL_RISKS)),
+        p2.template in<ComRep2>(U{}, check_for(ALL_RISKS)));
 }
 }  // namespace detail
 


### PR DESCRIPTION
We did not mean to disable these in #432.  Maybe my excuse is that my
brain was already living in the glorious future where #122 is landed.
At any rate, thank goodness for those policy argument overloads!  This
would have been a much more complicated fix without them.

I tested this by uncommenting the "feeters" test case, and verifying
that it now produces a compiler error, as it should.  I also uncommented
the quantity point test case where we check inheriting the overflow
safety surface.

Fixes #516.