### PR TITLE
Bump CMake versions for 0.5.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,9 @@ cmake_minimum_required(VERSION 3.27...3.29)
 
 project(
    Au
-   VERSION 0.4.1
+   VERSION 0.5.0
    DESCRIPTION "A C++ quantities and units library, by Aurora Innovation"
-   HOMEPAGE_URL "https://aurora-opensource.github.io/au/0.4.1/"
+   HOMEPAGE_URL "https://aurora-opensource.github.io/au/0.5.0/"
    LANGUAGES CXX
 )
 


### PR DESCRIPTION
We are following the release guide.