### PR TITLE
Apply safety checks to explicit rep overloads

### DIFF
--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -127,7 +127,9 @@ class QuantityPoint {
     // different decisions about what point is labeled as "0".
     constexpr QuantityPoint(Zero) = delete;
 
-    template <typename NewRep, typename NewUnit, typename RiskPolicyT = decltype(ignore(ALL_RISKS))>
+    template <typename NewRep,
+              typename NewUnit,
+              typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
     constexpr auto as(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity_point<AssociatedUnitForPointsT<NewUnit>>(in_impl<NewRep>(u, policy));
     }
@@ -137,7 +139,9 @@ class QuantityPoint {
         return make_quantity_point<AssociatedUnitForPointsT<NewUnit>>(in_impl<Rep>(u, policy));
     }
 
-    template <typename NewRep, typename NewUnit, typename RiskPolicyT = decltype(ignore(ALL_RISKS))>
+    template <typename NewRep,
+              typename NewUnit,
+              typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
     constexpr NewRep in(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<NewRep>(u, policy);
     }
@@ -151,22 +155,22 @@ class QuantityPoint {
     template <typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {
         // Usage example: `p.coerce_as(new_units)`.
-        return as<Rep>(NewUnit{});
+        return as(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewRep, typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {
         // Usage example: `p.coerce_as<T>(new_units)`.
-        return as<NewRep>(NewUnit{});
+        return as<NewRep>(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewUnit>
     constexpr auto coerce_in(NewUnit) const {
         // Usage example: `p.coerce_in(new_units)`.
-        return in<Rep>(NewUnit{});
+        return in(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewRep, typename NewUnit>
     constexpr auto coerce_in(NewUnit) const {
         // Usage example: `p.coerce_in<T>(new_units)`.
-        return in<NewRep>(NewUnit{});
+        return in<NewRep>(NewUnit{}, ignore(ALL_RISKS));
     }
 
     // Direct access to the underlying value member, with any Point-equivalent Unit.
@@ -315,7 +319,7 @@ struct AreQuantityPointTypesEquivalent<QuantityPoint<U1, R1>, QuantityPoint<U2, 
 // Cast QuantityPoint to a different underlying type.
 template <typename NewRep, typename Unit, typename Rep>
 constexpr auto rep_cast(QuantityPoint<Unit, Rep> q) {
-    return q.template as<NewRep>(Unit{});
+    return q.template as<NewRep>(Unit{}, ignore(ALL_RISKS));
 }
 
 namespace detail {

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -134,7 +134,7 @@ TEST(QuantityPoint, CanGetValueInDifferentUnits) {
 }
 
 TEST(QuantityPoint, IntermediateTypeIsSignedIfExplicitRepIsSigned) {
-    EXPECT_THAT(milli(kelvins_pt)(0u).coerce_as<int>(celsius_pt),
+    EXPECT_THAT(milli(kelvins_pt)(0u).as<int>(celsius_pt, ignore(TRUNCATION_RISK)),
                 SameTypeAndValue(celsius_pt(-273)));
 }
 
@@ -224,18 +224,20 @@ TEST(QuantityPoint, InHandlesIntegerRepInUnitsWithNonzeroOffset) {
 }
 
 TEST(QuantityPoint, CanRequestOutputRepWhenCallingIn) {
-    EXPECT_THAT(celsius_pt(5.2).in<int>(Celsius{}), Eq(5));
+    EXPECT_THAT(celsius_pt(5.2).in<int>(Celsius{}, ignore(TRUNCATION_RISK)), Eq(5));
 }
 
 TEST(QuantityPoint, CanCastToUnitWithDifferentMagnitude) {
-    EXPECT_THAT(centi(meters_pt)(75).coerce_as(meters_pt), SameTypeAndValue(meters_pt(0)));
+    EXPECT_THAT(centi(meters_pt)(75).as(meters_pt, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue(meters_pt(0)));
 
     EXPECT_THAT(centi(meters_pt)(75.0).as(meters_pt), SameTypeAndValue(meters_pt(0.75)));
 }
 
 TEST(QuantityPoint, CanCastToUnitWithDifferentOrigin) {
     EXPECT_THAT(celsius_pt(10.).as(kelvins_pt), IsNear(kelvins_pt(283.15), nano(kelvins)(1)));
-    EXPECT_THAT(celsius_pt(10).coerce_as(Kelvins{}), SameTypeAndValue(kelvins_pt(283)));
+    EXPECT_THAT(celsius_pt(10).as(Kelvins{}, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue(kelvins_pt(283)));
 }
 
 TEST(QuantityPoint, AsCanProvideConversionPolicy) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -132,7 +132,9 @@ TEST(Quantity, CanProvidePolicyToConstructor) {
     EXPECT_THAT(length, SameTypeAndValue(feet(3)));
 }
 
-TEST(Quantity, CanRequestOutputRepWhenCallingIn) { EXPECT_THAT(feet(3.14).in<int>(feet), Eq(3)); }
+TEST(Quantity, CanRequestOutputRepWhenCallingIn) {
+    EXPECT_THAT(feet(3.14).in<int>(feet, ignore(TRUNCATION_RISK)), Eq(3));
+}
 
 TEST(MakeQuantity, MakesQuantityInGivenUnit) {
     EXPECT_THAT(make_quantity<Feet>(1.234), Eq(feet(1.234)));
@@ -536,7 +538,6 @@ TEST(Quantity, AsCanExplicitlyOptOutOfOverflowRiskCheck) {
 }
 
 TEST(Quantity, AsCanExplicitlyOptOutOfOverflowRiskCheckForExplicitRep) {
-    // In future versions (see #122), this would fail to compile without `ignore(OVERFLOW_RISK)`.
     constexpr auto q = seconds(2u).as<int32_t>(nano(seconds), ignore(OVERFLOW_RISK));
     EXPECT_THAT(q, SameTypeAndValue(nano(seconds)(int32_t{2'000'000'000})));
 }
@@ -548,7 +549,6 @@ TEST(Quantity, AsCanExplicitlyOptOutOfTruncationRiskCheck) {
 }
 
 TEST(Quantity, AsCanExplicitlyOptOutOfTruncationRiskCheckForExplicitRep) {
-    // In future versions (see #122), this would fail to compile without `ignore(TRUNCATION_RISK)`.
     constexpr auto q = inches(36u).as<int>(feet, ignore(TRUNCATION_RISK));
     EXPECT_THAT(q, SameTypeAndValue(feet(int{3})));
 }
@@ -560,7 +560,6 @@ TEST(Quantity, InCanExplicitlyOptOutOfOverflowRiskCheck) {
 }
 
 TEST(Quantity, InCanExplicitlyOptOutOfOverflowRiskCheckForExplicitRep) {
-    // In future versions (see #122), this would fail to compile without `ignore(OVERFLOW_RISK)`.
     constexpr auto q = seconds(2u).in<int32_t>(nano(seconds), ignore(OVERFLOW_RISK));
     EXPECT_THAT(q, SameTypeAndValue(int32_t{2'000'000'000}));
 }
@@ -572,7 +571,6 @@ TEST(Quantity, InCanExplicitlyOptOutOfTruncationRiskCheck) {
 }
 
 TEST(Quantity, InCanExplicitlyOptOutOfTruncationRiskCheckForExplicitRep) {
-    // In future versions (see #122), this would fail to compile without `ignore(TRUNCATION_RISK)`.
     constexpr auto q = inches(36u).in<int>(feet, ignore(TRUNCATION_RISK));
     EXPECT_THAT(q, SameTypeAndValue(3));
 }
@@ -599,7 +597,7 @@ TEST(Quantity, AddingNegativeAndPositiveUnitsGivesPositiveUnit) {
 
 TEST(Quantity, SupportsExplicitRepConversionToComplexRep) {
     constexpr auto a = feet(15'000.0);
-    const auto b = a.as<std::complex<int>>(miles);
+    const auto b = a.as<std::complex<int>>(miles, ignore(TRUNCATION_RISK));
     EXPECT_THAT(b, SameTypeAndValue(miles(std::complex<int>{2, 0})));
 }
 

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -289,28 +289,10 @@ the [unit slots](../discussion/idioms/unit-slots.md) discussion for valid choice
     type `Inches`, writing `length.as(Inches{})`.  The former is generally preferable; the latter is
     mainly useful in generic code where the unit type may be all you have.
 
-**Without** a template argument, `.as(unit)` obeys the same safety checks as for the [implicit
-constructors](#implicit-from-quantity): conversions at high risk for integer overflow or truncation
-are forbidden.  Additionally, the `Rep` of the output is identical to the `Rep` of the input.
+**Without** a template argument, `.as(unit)`, the output `Rep` is identical to the `Rep` of the
+input.
 
-**With** a template argument, `.as<T>(unit)` has two differences.
-
-1. The output `Rep` will be `T`.
-2. The conversion is considered "forcing", and will be permitted in spite of any overflow or
-   truncation risk.  The semantics are similar to `static_cast<T>`.
-
-However, note that we may change this second property in the future.  The version with the template
-arguments may be changed later so that it _does_ prevent lossy conversions.  If you want this
-"forcing" semantic, prefer to use a policy argument, and add the explicit template parameter only if
-you want to change the rep.  See [#122] to track progress on this change, and see the [policy
-argument section](#policy-argument) for an example of the _preferred_ way to force a conversion.
-
-!!! tip
-    Prefer to **omit** the template argument if possible, because you will get more safety checks.
-    The risks which the no-template-argument version warns about are real.
-
-    As of [0.6.0] and [#122], however, this advice will no longer apply.  At that point, the
-    explicit-rep versions will have the same safety checks as the implicit-rep versions.
+**With** a template argument, `.as<T>(unit)`, the output `Rep` will be `T`.
 
 ### `.in(unit)`, `.in<T>(unit)`
 
@@ -332,28 +314,10 @@ slots](../discussion/idioms/unit-slots.md) discussion for valid choices for `uni
     type `Inches`, writing `length.in(Inches{})`.  The former is generally preferable; the latter is
     mainly useful in generic code where the unit type may be all you have.
 
-**Without** a template argument, `.in(unit)` obeys the same safety checks as for the [implicit
-constructors](#implicit-from-quantity): conversions at high risk for integer overflow or truncation
-are forbidden.  Additionally, the `Rep` of the output is identical to the `Rep` of the input.
+**Without** a template argument, `.in(unit)`, the output type is identical to the `Rep` of the
+input.
 
-**With** a template argument, `.in<T>(unit)` has two differences.
-
-1. The output type will be `T`.
-2. The conversion is considered "forcing", and will be permitted in spite of any overflow or
-   truncation risk.  The semantics are similar to `static_cast<T>`.
-
-However, note that we may change this second property in the future.  The version with the template
-arguments may be changed later so that it _does_ prevent lossy conversions.  If you want this
-"forcing" semantic, prefer to use a policy argument, and add the explicit template parameter only if
-you want to change the rep.  See [#122] to track progress on this change, and see the [policy
-argument section](#policy-argument) for an example of the _preferred_ way to force a conversion.
-
-!!! tip
-    Prefer to **omit** the template argument if possible, because you will get more safety checks.
-    The risks which the no-template-argument version warns about are real.
-
-    As of [0.6.0] and [#122], however, this advice will no longer apply.  At that point, the
-    explicit-rep versions will have the same safety checks as the implicit-rep versions.
+**With** a template argument, `.in<T>(unit)`, the output type will be `T`.
 
 ### Skipping risk checks: the `policy` argument {#policy-argument}
 
@@ -944,7 +908,6 @@ the following conditions hold.
 - For _types_ `U1` and `U2`:
     - `AreQuantityTypesEquivalent<U1, U2>::value`
 
-[#122]: https://github.com/aurora-opensource/au/issues/122
 [#185]: https://github.com/aurora-opensource/au/issues/185
 [#481]: https://github.com/aurora-opensource/au/issues/481
 [0.6.0]: https://github.com/aurora-opensource/au/milestone/9

--- a/docs/reference/quantity_point.md
+++ b/docs/reference/quantity_point.md
@@ -213,28 +213,10 @@ See the [unit slots](../discussion/idioms/unit-slots.md) discussion for valid ch
     of the unit type `Centi<Meters>`, writing `point.as(Centi<Meters>{})`.  The former is generally
     preferable; the latter is mainly useful in generic code where the unit type may be all you have.
 
-**Without** a template argument, `.as(unit)` obeys the same safety checks as for the [implicit
-constructors](#implicit-from-quantity): conversions at high risk for integer overflow or truncation
-are forbidden.  Additionally, the `Rep` of the output is identical to the `Rep` of the input.
+**Without** a template argument, `.as(unit)`, the output `Rep` is identical to the `Rep` of the
+input.
 
-**With** a template argument, `.as<T>(unit)` has two differences.
-
-1. The output `Rep` will be `T`.
-2. The conversion is considered "forcing", and will be permitted in spite of any overflow or
-   truncation risk.  The semantics are similar to `static_cast<T>`.
-
-However, note that we may change this second property in the future.  The version with the template
-arguments may be changed later so that it _does_ prevent lossy conversions.  If you want this
-"forcing" semantic, prefer to use a policy argument, and add the explicit template parameter only if
-you want to change the rep.  See [#122] to track progress on this change, and see the [policy
-argument section](#policy-argument) for an example of the _preferred_ way to force a conversion.
-
-!!! tip
-    Prefer to **omit** the template argument if possible, because you will get more safety checks.
-    The risks which the no-template-argument version warns about are real.
-
-    As of [0.6.0] and [#122], however, this advice will no longer apply.  At that point, the
-    explicit-rep versions will have the same safety checks as the implicit-rep versions.
+**With** a template argument, `.as<T>(unit)`, the output `Rep` will be `T`.
 
 ### `.in(unit)`, `.in<T>(unit)`
 
@@ -256,28 +238,10 @@ be either a `QuantityPointMaker` for the quantity's unit, or an instance of the 
     of the unit type `Centi<Meters>`, writing `point.in(Centi<Meters>{})`.  The former is generally
     preferable; the latter is mainly useful in generic code where the unit type may be all you have.
 
-**Without** a template argument, `.in(unit)` obeys the same safety checks as for the [implicit
-constructors](#implicit-from-quantity): conversions at high risk for integer overflow or truncation
-are forbidden.  Additionally, the `Rep` of the output is identical to the `Rep` of the input.
+**Without** a template argument, `.in(unit)`, the output type is identical to the `Rep` of the
+input.
 
-**With** a template argument, `.in<T>(unit)` has two differences.
-
-1. The output type will be `T`.
-2. The conversion is considered "forcing", and will be permitted in spite of any overflow or
-   truncation risk.  The semantics are similar to `static_cast<T>`.
-
-However, note that we may change this second property in the future.  The version with the template
-arguments may be changed later so that it _does_ prevent lossy conversions.  If you want this
-"forcing" semantic, prefer to use a policy argument, and add the explicit template parameter only if
-you want to change the rep.  See [#122] to track progress on this change, and see the [policy
-argument section](#policy-argument) for an example of the _preferred_ way to force a conversion.
-
-!!! tip
-    Prefer to **omit** the template argument if possible, because you will get more safety checks.
-    The risks which the no-template-argument version warns about are real.
-
-    As of [0.6.0] and [#122], however, this advice will no longer apply.  At that point, the
-    explicit-rep versions will have the same safety checks as the implicit-rep versions.
+**With** a template argument, `.in<T>(unit)`, the output type will be `T`.
 
 ### Skipping risk checks: the `policy` argument {#policy-argument}
 
@@ -525,7 +489,6 @@ More precisely, `QuantityPoint<U1, R1>` and `QuantityPoint<U2, R2>` are equivale
 - For _types_ `U1` and `U2`:
     - `AreQuantityPointTypesEquivalent<U1, U2>::value`
 
-[#122]: https://github.com/aurora-opensource/au/issues/122
 [#352]: https://github.com/aurora-opensource/au/issues/352
 [#481]: https://github.com/aurora-opensource/au/issues/481
 [0.6.0]: https://github.com/aurora-opensource/au/milestone/9

--- a/fuzz/quantity_runtime_conversion_checkers_test.cc
+++ b/fuzz/quantity_runtime_conversion_checkers_test.cc
@@ -103,7 +103,8 @@ TYPED_TEST_P(QuantityRuntimeConversionChecker, RoundTripIsIdentityIffConversionN
 
         const bool expect_loss = is_conversion_lossy(value, destination_unit);
 
-        const auto round_trip = value.coerce_as(destination_unit).coerce_as(meters);
+        const auto round_trip =
+            value.as(destination_unit, ignore(ALL_RISKS)).as(meters, ignore(ALL_RISKS));
         const bool actual_loss = (value != round_trip);
 
         EXPECT_THAT(expect_loss, Eq(actual_loss))


### PR DESCRIPTION
This is the future proof release for #122 for 0.5.0, paving the way for
the 0.6.0 release.