### PR TITLE
Improve efficiency of `mean` implementations

### DIFF
--- a/au/math.hh
+++ b/au/math.hh
@@ -401,26 +401,28 @@ constexpr auto min(QuantityPoint<U, R> a, QuantityPoint<U, R> b) {
 
 template <typename U0, typename R0, typename... Us, typename... Rs>
 constexpr auto mean(Quantity<U0, R0> q0, Quantity<Us, Rs>... qs) {
+    static_assert(sizeof...(qs) > 0, "mean() requires at least two inputs");
     using R = std::common_type_t<R0, Rs...>;
     using Common = Quantity<CommonUnitT<U0, Us...>, R>;
     const auto base = Common{q0};
     Common diffs[] = {(Common{qs} - base)...};
-    Common sum_diffs = ZERO;
-    for (const auto &d : diffs) {
-        sum_diffs += d;
+    Common sum_diffs = diffs[0];
+    for (auto i = 1u; i < sizeof...(qs); ++i) {
+        sum_diffs += diffs[i];
     }
     return base + (sum_diffs / static_cast<R>(1u + sizeof...(qs)));
 }
 
 template <typename U0, typename R0, typename... Us, typename... Rs>
 constexpr auto mean(QuantityPoint<U0, R0> p0, QuantityPoint<Us, Rs>... ps) {
+    static_assert(sizeof...(ps) > 0, "mean() requires at least two inputs");
     using U = CommonPointUnitT<U0, Us...>;
     using R = std::common_type_t<R0, Rs...>;
     const auto base = QuantityPoint<U, R>{p0};
     Quantity<U, R> diffs[] = {(QuantityPoint<U, R>{ps} - base)...};
-    Quantity<U, R> sum_diffs = ZERO;
-    for (const auto &d : diffs) {
-        sum_diffs += d;
+    Quantity<U, R> sum_diffs = diffs[0];
+    for (auto i = 1u; i < sizeof...(ps); ++i) {
+        sum_diffs += diffs[i];
     }
     return base + (sum_diffs / static_cast<R>(1u + sizeof...(ps)));
 }


### PR DESCRIPTION
Turns out, the first version we launched has some extra assembly
instructions, because our sum starts at 0 instead of starting at the
first element.  If we could require C++17, of course we'd just use a
fold expression.  Instead, we'll switch to an indexed loop, and start at
`1`.

This also seems like a good opportunity to tighten up the assumption of
"at least two inputs", with a `static_assert`.  This makes it crystal
clear that starting with the 0th element is OK, as is starting the index
at `1` (because if we only _have_ one element, the loop will not
execute).

Fixes #526.