### PR TITLE
Constrain policy parameter in 2-param constructor

### DIFF
--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -78,6 +78,17 @@ constexpr auto OVERFLOW_RISK = detail::OVERFLOW_RISK;
 constexpr auto TRUNCATION_RISK = detail::TRUNCATION_RISK;
 constexpr auto ALL_RISKS = OVERFLOW_RISK | TRUNCATION_RISK;
 
+// `IsConversionRiskPolicy<T>` checks whether `T` is a conversion risk policy type.  For now, this
+// boils down to being a specialization of `CheckTheseRisks` on some `RiskSet`.
+//
+// Although we have no such plans at present, it's conceivable that we could create more general
+// conversion risk policy types later.  If we do, this trait will still be authoritatively correct.
+template <typename T>
+struct IsConversionRiskPolicy : std::false_type {};
+template <uint8_t RiskFlags>
+struct IsConversionRiskPolicy<detail::CheckTheseRisks<detail::RiskSet<RiskFlags>>>
+    : std::true_type {};
+
 //
 // "Main" conversion policy section.
 //

--- a/au/conversion_policy_test.cc
+++ b/au/conversion_policy_test.cc
@@ -39,6 +39,30 @@ struct Degrees : UnitImpl<Angle> {};
 struct EquivalentToDegrees : Degrees {};
 struct NegativeDegrees : decltype(Degrees{} * (-mag<1>())) {};
 
+template <typename T>
+constexpr bool is_conversion_risk_policy(T) {
+    return IsConversionRiskPolicy<T>::value;
+}
+
+TEST(IsConversionRiskPolicy, TrueForConversionPolicy) {
+    EXPECT_THAT(is_conversion_risk_policy(ignore(ALL_RISKS)), IsTrue());
+    EXPECT_THAT(is_conversion_risk_policy(check_for(ALL_RISKS)), IsTrue());
+
+    EXPECT_THAT(is_conversion_risk_policy(ignore(OVERFLOW_RISK)), IsTrue());
+    EXPECT_THAT(is_conversion_risk_policy(check_for(OVERFLOW_RISK)), IsTrue());
+
+    EXPECT_THAT(is_conversion_risk_policy(ignore(TRUNCATION_RISK)), IsTrue());
+    EXPECT_THAT(is_conversion_risk_policy(check_for(TRUNCATION_RISK)), IsTrue());
+}
+
+TEST(IsConversionRiskPolicy, FalseForNonConversionPolicy) {
+    EXPECT_THAT(is_conversion_risk_policy(5), IsFalse());
+    EXPECT_THAT(is_conversion_risk_policy("hello"), IsFalse());
+    EXPECT_THAT(is_conversion_risk_policy(nullptr), IsFalse());
+    EXPECT_THAT(is_conversion_risk_policy(Degrees{}), IsFalse());
+    EXPECT_THAT(is_conversion_risk_policy(Grams{}), IsFalse());
+}
+
 TEST(ConversionRisk, IgnoreOverflowRiskChecksTruncationRiskButNotOverflowRisk) {
     constexpr auto policy = ignore(OVERFLOW_RISK);
     EXPECT_THAT(policy.should_check(detail::ConversionRisk::Overflow), IsFalse());

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -163,7 +163,10 @@ class Quantity {
     explicit constexpr Quantity(Quantity<OtherUnit, OtherRep> other) = delete;
 
     // Constructor for another Quantity with an explicit conversion risk policy.
-    template <typename OtherUnit, typename OtherRep, typename RiskPolicyT>
+    template <typename OtherUnit,
+              typename OtherRep,
+              typename RiskPolicyT,
+              std::enable_if_t<IsConversionRiskPolicy<RiskPolicyT>::value, int> = 0>
     constexpr Quantity(Quantity<OtherUnit, OtherRep> other, RiskPolicyT policy)
         : value_{other.template in<Rep>(UnitT{}, policy)} {}
 

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -119,7 +119,10 @@ class QuantityPoint {
     constexpr explicit QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other) = delete;
 
     // Construct from another QuantityPoint with an explicit conversion risk policy.
-    template <typename OtherUnit, typename OtherRep, typename RiskPolicyT>
+    template <typename OtherUnit,
+              typename OtherRep,
+              typename RiskPolicyT,
+              std::enable_if_t<IsConversionRiskPolicy<RiskPolicyT>::value, int> = 0>
     constexpr QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other, RiskPolicyT policy)
         : QuantityPoint{other.template as<Rep>(Unit{}, policy)} {}
 

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -119,6 +119,18 @@ TEST(QuantityPoint, CanProvidePolicyToConstructor) {
     EXPECT_THAT(temp, SameTypeAndValue(kelvins_pt(293)));
 }
 
+struct Combo {
+    QuantityPointD<Meters> x;
+    QuantityPointD<Centi<Meters>> y;
+};
+
+void overload_that_takes_a_quantity_point_or_a_combo(Combo) {}
+void overload_that_takes_a_quantity_point_or_a_combo(QuantityPointD<Meters>) {}
+
+TEST(QuantityPoint, PolicyConstructorDoesNotCreateAmbiguities) {
+    overload_that_takes_a_quantity_point_or_a_combo({meters_pt(1.0), centi(meters_pt)(1.0)});
+}
+
 TEST(QuantityPoint, CanCreateAndRetrieveValue) {
     constexpr auto p = celsius_pt(3);
     EXPECT_THAT(p.in(Celsius{}), SameTypeAndValue(3));

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -132,6 +132,18 @@ TEST(Quantity, CanProvidePolicyToConstructor) {
     EXPECT_THAT(length, SameTypeAndValue(feet(3)));
 }
 
+struct Combo {
+    QuantityD<Meters> x;
+    QuantityD<Seconds> t;
+};
+
+void overload_that_takes_a_quantity_or_a_combo(QuantityD<Meters>) {}
+void overload_that_takes_a_quantity_or_a_combo(Combo) {}
+
+TEST(Quantity, PolicyConstructorDoesNotCreateAmbiguities) {
+    overload_that_takes_a_quantity_or_a_combo({meters(5.0), seconds(10.0)});
+}
+
 TEST(Quantity, CanRequestOutputRepWhenCallingIn) { EXPECT_THAT(feet(3.14).in<int>(feet), Eq(3)); }
 
 TEST(MakeQuantity, MakesQuantityInGivenUnit) {


### PR DESCRIPTION
Matching "any two arguments" can create weird ambiguities when you have
a struct whose first argument is a `Quantity`, _and_ an overload set
that takes either that struct or a `Quantity`, _and_ when you pass an ad
hoc instance of that struct to this overload set that you created with a
two-argument braced initializer list.

Overall, this is pretty rare; we hit just a single instance in the
entire AV codebase when we upgraded to 0.5.0.  But it's still a problem
that we can and should fix.

This commit includes tests that failed for vanilla 0.5.0, and makes them
pass.  We introduce an authoritative trait, `IsConversionRiskPolicy<T>`,
to make this easier to write.

Compile time impact measurements showed no cause for concern.

Fixes #525.