### PR TITLE
Add Alternatives section for ongoing maintenance

### DIFF
--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -165,7 +165,7 @@ experience.
 
 2. You will get **more compiler errors** that developers will need to understand and fix.
 
-These costs can bring significant benefits, but we still want them to be as small as possible.
+These costs purchase significant benefits, but we still want them to be as small as possible.
 
 <table>
     <tr>
@@ -244,13 +244,148 @@ These costs can bring significant benefits, but we still want them to be as smal
     </tr>
 </table>
 
+### Ongoing maintenance
+
+The last thing to consider before diving into features is how the library will evolve over time.
+There are two extremes that a production-worthy library must avoid:
+
+- _Changing too much_, especially when a new version forces a monolithic, codebase-wide change.
+- _Changing too little_, especially when the library becomes unmaintained or abandoned.
+
+These opposite extremes have the same effect: they lock you into an old and ever-aging version of
+the code, depriving you of bugfixes and improvements.  The ideal library would be one that is
+actively maintained, but that respects its production users and makes upgrades as smooth and
+incremental as possible.
+
+<table>
+    <tr>
+        <th></th>
+        <th>Boost</th>
+        <th>nholthaus</th>
+        <th>bernedom/SI</th>
+        <th>mp-units</th>
+        <th class="highlight">Au</th>
+    </tr>
+    <tr>
+        <td>
+            <details class="criterion">
+                <summary>Actively Maintained</summary>
+                <p>
+                    Does the library respond to issues?  Is it continuing to receive regular
+                    commits?  Does it put out new releases, ideally at least once per year?
+                </p>
+            </details>
+        </td>
+        <td class="poor">
+            <p>Long unmaintained.</p>
+            <ul>
+                <li class="x">
+                    No <a
+                    href="https://www.boost.org/doc/libs/latest/doc/html/boost_units/ReleaseNotes.html">releases</a>
+                    since 2010; no <i>significant</i> releases since March 2007
+                </li>
+                <li class="x">
+                    Most <a href="https://github.com/boostorg/units/issues">issues</a> are open and
+                    unanswered
+                </li>
+            </ul>
+        </td>
+        <td class="fair">
+            <ul>
+                <li class="check">Still putting out feature releases on 3.x branch as of 2025</li>
+                <li class="x">Many open issues; some unresponded for years</li>
+            </ul>
+        </td>
+        <td class="fair">
+            <ul>
+                <li>Still receiving commits, but no release since 2022</li>
+                <li>
+                    Most issues closed/addressed, but some issues have gone multiple years with no
+                    response
+                </li>
+            </ul>
+        </td>
+        <td class="good">
+            <ul>
+                <li class="check">Regular commits and releases</li>
+                <li class="check">
+                    <a href="https://github.com/mpusz/mp-units/issues">Issues</a> responded to and
+                    closed over time
+                </li>
+            </ul>
+        </td>
+        <td class="good">
+            <ul>
+                <li class="check">Regular commits and releases</li>
+                <li class="check">
+                    <a
+                    href="https://github.com/aurora-opensource/au/issues?q=is%3Aissue%20state%3Aopen%20-author%3Achiphogg%20-author%3Ahoffbrinkle%20-author%3Ageoffviola%20-author%3Atobin">External
+                    issues</a> always promptly responded, usually closed
+                </li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <details class="criterion">
+                <summary>Smooth Upgrades</summary>
+                <p>
+                    The ideal library...
+                    <ul>
+                        <li>enables incremental upgrades (no "megadiff" required)</li>
+                        <li>clearly calls out each breaking change, and explains how to adapt</li>
+                    </ul>
+                </p>
+            </details>
+        </td>
+        <td class="invalid"><p><b>Not Applicable:</b><br>No new releases to judge</p></td>
+        <td class="good">
+            <ul>
+                <li class="check">Updates within 2.x family usually smooth</li>
+                <li class="x">2.x to 3.x <a
+                    href="https://github.com/nholthaus/units/issues/313">expected</a> to require
+                    monolithic change, but 2.x still receives backports
+                </li>
+            </ul>
+        </td>
+        <td class="good">
+            No evidence of user-reported issues with upgrades
+        </td>
+        <td class="fair">
+            <ul>
+                <li class="check">
+                    Good quality release notes, with breaking changes clearly called out
+                </li>
+                <li class="x">
+                    Upgrade from 0.8 to 2.0 badly broke many users who were treating it as
+                    production software
+                </li>
+            </ul>
+        </td>
+        <td class="best">
+            <p>As incremental as possible:</p>
+            <ul>
+                <li class="check">
+                    Every breaking change provides a syntax that works in both old and new versions
+                </li>
+                <li class="check">
+                    Starting from 0.5.0, <a
+                    href="https://aurora-opensource.github.io/au/main/howto/upgrade/#future-proof-releases">future-proof
+                    releases</a> let you tackle breaking changes one at a time
+                </li>
+            </ul>
+        </td>
+    </tr>
+</table>
+
 ### Library features
 
 At this point, you've assessed:
 
 - whether you can use each library at all;
 - how hard it will be to add to your project;
-- and, what costs you'll pay in developer experience if you do.
+- what costs you'll pay in developer experience if you do;
+- and, how you can expect it to evolve over time.
 
 Now we're ready to compare the libraries "as units libraries" --- that is, in terms of their core
 features.

--- a/docs/tweaks.css
+++ b/docs/tweaks.css
@@ -35,7 +35,7 @@ td.best, td.best * {
     color: white;
 }
 
-td.na {
+td.na, td.invalid {
     background-color: #d9d9d9;
 }
 


### PR DESCRIPTION
This is a key strength and competitive advantage of Au, so it's time we
started giving ourselves credit for it!

The new section speaks for itself: a good library both _has_ bugfixes
and improvements, and makes it easy to _get_ them.  As for the
assessments, here's my reasoning:

- On "active maintenance":
    - Boost units should get the lowest rating here, and it should be
      "poor": no releases since 2010, and no substantive releases since
      2007 (!).  There are issues on GitHub, and even some commits, but
      they seem to be scattered and sporadic.
    - nholthaus and SI are "fair" because they're a mixed bag.
      nholthaus had a new release this year, but gets dinged for having
      a lot of unresponded issues.  SI has responded to _most_ issues,
      but has also now gone several years without a release.
    - IMO both mp-units and Au are doing a great job here.  Very active
      development, and solid responsiveness to issues.

- On "smooth upgrades":
    - mp-units is an interesting case...
        - The 0.8.0-to-2.x breakage was _necessary_ in order to get all
          the improved interfaces, because they were so radically
          different from what came before.  But it was a huge deal for
          users, many of whom were caught off guard by this, and had
          been treating it as "production" software: I saw a lot of
          complaints.
        - Still, their release notes are excellent, and I do believe
          this was a one-time thing, so this should be "fair" and not
          "poor".
    - SI is "good by default": I don't see any reason to ding them for
      anything here.
    - On nholthaus, I got direct clarification from the author in the
      linked issue.  I give them credit as "good" because even though
      2.x to 3.x requires a megadiff, 2.x still gets backports.
    - No sense assessing boost when they don't have any upgrades.
    - Au is outstanding here.  We always provide "bridging" syntax that
      works for both old and new versions, and our future proof releases
      are something I haven't seen anywhere else.  Basically, we bend
      over backwards to enable every upgrade to be as incremental as
      possible; yet, we still avoid stagnation, and even routinely make
      major interface changes.

Ultimately, the reason Au shines here is because it is very widely used
in production in a large codebase (Aurora's), and the lead "units
maintainer" in that codebase (i.e., me) is fanatical about avoiding
megadiffs.

These rankings pass the smell test for me.  On active maintenance: boost
is clearly the most stale by a wide margin; Au and mp-units are both
exemplary; and nholthaus and SI are more current than boost but have
significant issues.  And on ease of upgrade, Au is a clear "best", boost
a clear "not applicable", and mp-units caused the most significant
breakage of the remaining 3 options.

Fixes #532.