### PR TITLE
Move nholthaus units to MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,3 +36,15 @@ pip.parse(
     requirements_lock = "//:requirements_lock.txt",
 )
 use_repo(pip, "au_pip_deps")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "nholthaus_units",
+    add_prefix = "nholthaus_units",
+    build_file = "@//third_party/nholthaus_units:BUILD.bazel",
+    dev_dependency = True,
+    sha256 = "b1f3c1dd11afa2710a179563845ce79f13ebf0c8c090d6aa68465b18bd8bd5fc",
+    strip_prefix = "units-2.3.3/include/",
+    url = "https://github.com/nholthaus/units/archive/refs/tags/v2.3.3.tar.gz",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,15 +97,6 @@ gcc_register_toolchain(
 )
 
 http_archive(
-    name = "nholthaus_units",
-    add_prefix = "nholthaus_units",
-    build_file = "@//third_party/nholthaus_units:BUILD.bazel",
-    sha256 = "b1f3c1dd11afa2710a179563845ce79f13ebf0c8c090d6aa68465b18bd8bd5fc",
-    strip_prefix = "units-2.3.3/include/",
-    url = "https://github.com/nholthaus/units/archive/refs/tags/v2.3.3.tar.gz",
-)
-
-http_archive(
     name = "fmt",
     patch_cmds = [
         "mv support/bazel/.bazelversion .bazelversion",


### PR DESCRIPTION
Given that nholthaus/units isn't available in the BCR, we pull it in using the
http_archive rule.

Helps #485.
