### PR TITLE
Tweak code to appease gcc 5.3

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -541,8 +541,11 @@ class AlwaysDivisibleQuantity {
         return make_quantity<UnitInverseT<U>>(x / q.q_.in(U{}));
     }
 
-    friend constexpr AlwaysDivisibleQuantity<U, R> unblock_int_div<U, R>(Quantity<U, R> q);
-    friend constexpr AlwaysDivisibleQuantity<UnitProductT<>, R> unblock_int_div<R>(R x);
+    template <typename UU, typename RR>
+    friend constexpr AlwaysDivisibleQuantity<UU, RR> unblock_int_div(Quantity<UU, RR> q);
+
+    template <typename RR>
+    friend constexpr AlwaysDivisibleQuantity<UnitProductT<>, RR> unblock_int_div(RR x);
 
  private:
     constexpr AlwaysDivisibleQuantity(Quantity<U, R> q) : q_{q} {}

--- a/au/utility/probable_primes.hh
+++ b/au/utility/probable_primes.hh
@@ -141,7 +141,8 @@ constexpr int jacobi_symbol_positive_numerator(uint64_t a, uint64_t n, int start
 
     while (a != 0u) {
         // Handle even numbers in the "numerator".
-        const int sign_for_even = bool_sign(n % 8u == 1u || n % 8u == 7u);
+        const uint64_t rem_8 = n % 8u;
+        const int sign_for_even = bool_sign(rem_8 == 1u || rem_8 == 7u);
         while (a % 2u == 0u) {
             a /= 2u;
             result *= sign_for_even;

--- a/au/utility/string_constant.hh
+++ b/au/utility/string_constant.hh
@@ -255,11 +255,11 @@ constexpr StringConstant<UIToA<N>::length> UIToA<N>::value;
 
 template <bool IsPositive>
 struct SignIfPositiveIs {
-    static constexpr StringConstant<0> value() { return ""; }
+    static constexpr StringConstant<0> value() { return StringConstant<0>{""}; }
 };
 template <>
 struct SignIfPositiveIs<false> {
-    static constexpr StringConstant<1> value() { return "-"; }
+    static constexpr StringConstant<1> value() { return StringConstant<1>{"-"}; }
 };
 
 template <int64_t N>


### PR DESCRIPTION
This compiler isn't officially supported, but we'll make a "best effort"
to work around any issues it has, within reason.

- We need to explicitly convert a `const char*` to `StringConstant`.
- We need to make the _whole template_ of `unblock_int_div` a `friend`
  of `AlwaysDivisibleQuantity`.  This is more friendship than we want,
  but it's very hard to see how this would cause an actual problem.
- Shockingly, `(n % 8u == 1u || n % 8u == 7u)` appears to be able to
  give different results at runtime and `constexpr` time for some values
  of `n`.  This does not appear to happen when we use a stored value of
  `n % 8u`.

Helps #548, although to really fix it, we may have to consider some
release artifact options.