### PR TITLE
Add RELEASE procedures for "problem" compilers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,24 @@ These are test cases that we can't test automatically, usually because the inten
 a compiler error.  Grep the codebase for `uncomment`, and test every such case individually to make
 sure they still display the desired behavior.
 
+### Check known "problem" compilers
+
+Some compilers in our "Assumed Support" tier (see [supported compilers]) are known to be prone to
+problems or errors.  We can't keep these passing on every _commit_, but if we check in on them at
+_release_ time, we can keep builds passing for more users.  To be added to this list, a compiler
+must (a) be requested by an actual user, and (b) fail in a way that we can't capture on our CI.
+
+For each link below, make sure the build completes successfully.  If it doesn't, fix the build if
+possible.
+
+- [gcc 5.3](https://godbolt.org/z/EoEaK3aWs)
+    - Issues seen:
+        - functions giving different results in `constexpr` vs. runtime
+        - incorrectly restricting `friend` template declarations
+        - incorrectly failing to apply an implicit constructor
+
+[supported compilers]: https://aurora-opensource.github.io/au/main/supported-compilers/
+
 ### Check Aurora's code
 
 Create a draft PR which updates Aurora's internal code to the candidate release.  Make sure all of

--- a/docs/supported-compilers.md
+++ b/docs/supported-compilers.md
@@ -14,6 +14,9 @@ Formally, we have three tiers of support.
 1. **Full Support.**  These configurations must be kept passing on every commit.
 2. **Best Effort Support.**  We measure _whether_ these configurations are passing on every commit,
    and strive to _keep_ them passing.  However, if we cannot do so, we may let them break.
+      - _**Note:** To be crystal clear, we have never yet let any such compiler "break", and we
+        expect that we never will.  For all intents and purposes, end users will experience these as
+        equivalent to "full support"._
 3. **Assumed Support.**  These include all other C++14-compatible configurations which we do not
    measure explicitly.
 
@@ -69,3 +72,21 @@ Here are the configurations that have Best Effort Support status.
 | Platform | Compiler | Status |
 |----------|----------|--------|
 | Windows Server 2022 | MSVC 2022 x64 | [![MSVC 2022 x64]( https://github.com/aurora-opensource/au/actions/workflows/msvc-2022-x64.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/msvc-2022-x64.yml) |
+
+### Assumed support
+
+This section only discusses compilers that we can't run in CI.  This means we have no way to keep
+them working on every commit.  However, some users may bring issues with specific compiler versions
+to our attention.  If it's feasible for us to fix them, we will.
+
+This section will discuss our experience with a few specific compiler versions.
+
+| Platform | Compiler | Status |
+|----------|----------|--------|
+| Ubuntu   | gcc 5.3  | Works on [0.3.5].  Broken on [0.4.0], [0.4.1], and [0.5.0], but expected to be fixed on [0.6.0]. |
+
+[0.3.5]: https://github.com/aurora-opensource/au/releases/tag/0.3.5
+[0.4.0]: https://github.com/aurora-opensource/au/releases/tag/0.4.0
+[0.4.1]: https://github.com/aurora-opensource/au/releases/tag/0.4.1
+[0.5.0]: https://github.com/aurora-opensource/au/releases/tag/0.5.0
+[0.6.0]: https://github.com/aurora-opensource/au/milestone/9


### PR DESCRIPTION
This should help us keep more compiler versions working for more
releases.

It's also a good opportunity to clean up our compiler support page.  Now
we can discuss specific compilers in the "assumed support" tier, where
appropriate.

Additionally, it's good to emphasize front and center that our "best
effort" tier is basically equivalent to the "full support" tier, based
both on past experience and future expectations.  All I was trying to
say here was that it's _conceivable_ that we could hit an un-debuggable
problem on a compiler that we can't iterate on locally, and give
ourselves an escape hatch for that.  This is something that did happen
to me on mp-units, although that was probably because we used more
bleeding edge features in that project.

Fixes #548.  If the user needs a specific release artifact, we can
simply attach it to that issue.