### PR TITLE
Support `constexpr` in `data_in`

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -235,14 +235,14 @@ class Quantity {
     //
     // Mutable access:
     template <typename UnitSlot>
-    Rep &data_in(UnitSlot) {
+    constexpr Rep &data_in(UnitSlot) {
         static_assert(AreUnitsQuantityEquivalent<AssociatedUnitT<UnitSlot>, Unit>::value,
                       "Can only access value via Quantity-equivalent unit");
         return value_;
     }
     // Const access:
     template <typename UnitSlot>
-    const Rep &data_in(UnitSlot) const {
+    constexpr const Rep &data_in(UnitSlot) const {
         static_assert(AreUnitsQuantityEquivalent<AssociatedUnitT<UnitSlot>, Unit>::value,
                       "Can only access value via Quantity-equivalent unit");
         return value_;

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -174,29 +174,19 @@ class QuantityPoint {
 
     // Direct access to the underlying value member, with any Point-equivalent Unit.
     //
-    // Mutable access, QuantityPointMaker input.
-    template <typename U>
-    Rep &data_in(const QuantityPointMaker<U> &) {
-        static_assert(AreUnitsPointEquivalent<U, Unit>::value,
+    // Mutable access:
+    template <typename UnitSlot>
+    constexpr Rep &data_in(UnitSlot) {
+        static_assert(AreUnitsPointEquivalent<AssociatedUnitForPointsT<UnitSlot>, Unit>::value,
                       "Can only access value via Point-equivalent unit");
-        return x_.data_in(QuantityMaker<U>{});
+        return x_.data_in(AssociatedUnitForPointsT<UnitSlot>{});
     }
-    // Mutable access, Unit input.
-    template <typename U>
-    Rep &data_in(const U &) {
-        return data_in(QuantityPointMaker<U>{});
-    }
-    // Const access, QuantityPointMaker input.
-    template <typename U>
-    const Rep &data_in(const QuantityPointMaker<U> &) const {
-        static_assert(AreUnitsPointEquivalent<U, Unit>::value,
+    // Const access:
+    template <typename UnitSlot>
+    constexpr const Rep &data_in(UnitSlot) const {
+        static_assert(AreUnitsPointEquivalent<AssociatedUnitForPointsT<UnitSlot>, Unit>::value,
                       "Can only access value via Point-equivalent unit");
-        return x_.data_in(QuantityMaker<U>{});
-    }
-    // Const access, Unit input.
-    template <typename U>
-    const Rep &data_in(const U &) const {
-        return data_in(QuantityPointMaker<U>{});
+        return x_.data_in(AssociatedUnitForPointsT<UnitSlot>{});
     }
 
     // Comparison operators.

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -167,6 +167,19 @@ TEST(QuantityPoint, SupportsDirectConstAccessWithSameUnit) {
     EXPECT_THAT(static_cast<const void *>(&p.data_in(Meters{})), Eq(static_cast<const void *>(&p)));
 }
 
+TEST(QuantityPoint, DataInSupportsConstexprAccess) {
+    constexpr auto p = kelvins_pt(3).data_in(kelvins_pt);
+    static_assert(p == 3, "QuantityPoint::data_in should support constexpr access");
+    EXPECT_THAT(p, SameTypeAndValue(3));
+}
+
+TEST(QuantityPoint, DataInSupportsConstexprAccessOnConstObject) {
+    constexpr auto p = milli(meters_pt)(3.5);
+    constexpr auto v = p.data_in(Micro<Kilo<Meters>>{});
+    static_assert(v == 3.5, "data_in should support constexpr access on const objects");
+    EXPECT_THAT(v, SameTypeAndValue(3.5));
+}
+
 TEST(QuantityPoint, SupportsDirectAccessWithEquivalentUnit) {
     auto p = kelvins_pt(3);
     ++(p.data_in(Micro<Mega<Kelvins>>{}));

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -212,6 +212,19 @@ TEST(Quantity, SupportsDirectConstAccessWithSameUnit) {
     EXPECT_THAT(static_cast<const void *>(&x.data_in(Meters{})), Eq(static_cast<const void *>(&x)));
 }
 
+TEST(Quantity, DataInSupportsConstexprAccess) {
+    constexpr auto x = kilo(feet)(3).data_in(kilo(feet));
+    static_assert(x == 3, "Expected constexpr access to work");
+    EXPECT_THAT(x, SameTypeAndValue(3));
+}
+
+TEST(Quantity, DataInSupportsConstexprAccessOnConstObject) {
+    constexpr auto q = meters(5.5);
+    constexpr auto q_m = q.data_in(meters);
+    static_assert(q_m == 5.5, "Expected constexpr access to work");
+    EXPECT_THAT(q_m, SameTypeAndValue(5.5));
+}
+
 TEST(Quantity, SupportsDirectAccessWithEquivalentUnit) {
     auto x = (kilo(feet) / hour)(3);
     ++(x.data_in(Feet{} / Milli<Hours>{}));


### PR DESCRIPTION
Its omission was an oversight.

Additionally, we hadn't migrated `QuantityPoint::data_in` to use unit
slots yet!  So we take the opportunity to do that now, and get a nice
bit of extra simplification.

Fixes #556.