### PR TITLE
Mark additional items as dev_dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,11 +16,27 @@ module(
     name = "au",
 )
 
-bazel_dep(name = "googletest", version = "1.12.1")  # NOTE: if updating this version, also update the version numbers in `CMakelists.txt`.
+# GoogleTest is required for our publically available `//au:testing` target.  We
+# specify the current version we use here so this will participate in any users
+# BCR resolution, but it won't actually be pulled down to the users workspace if
+# they don't actually depend on a target that depends on `googletest`.
+bazel_dep(
+    name = "googletest",
+    # NOTE: if updating this version, also update the version numbers in
+    # `CMakelists.txt`.
+    version = "1.12.1",
+)
 
+# Development dependencies are below.
+
+# Primary deps that we use directly.
 bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)
 bazel_dep(name = "fmt", version = "11.0.2", dev_dependency = True)
 bazel_dep(name = "rules_python", version = "1.6.0", dev_dependency = True)
+
+# Configuration of above deps.
+
+# Python configuration and pips
 
 python = use_extension(
     "@rules_python//python/extensions:python.bzl",
@@ -30,13 +46,17 @@ python = use_extension(
 python.defaults(python_version = "3.10")
 python.toolchain(python_version = "3.10")
 
-pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)
 pip.parse(
     hub_name = "au_pip_deps",
     python_version = "3.10",
     requirements_lock = "//:requirements_lock.txt",
 )
 use_repo(pip, "au_pip_deps")
+
+# Dependencies that don't have BCR equivalents.
+
+# nholthaus_units
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -50,12 +70,12 @@ http_archive(
     url = "https://github.com/nholthaus/units/archive/refs/tags/v2.3.3.tar.gz",
 )
 
-# Pull in buildifier
+# buildifier
 
 bazel_dep(name = "rules_go", version = "0.57.0", dev_dependency = True, repo_name = "io_bazel_rules_go")
 bazel_dep(name = "gazelle", version = "0.45.0", dev_dependency = True)
 
-go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps", dev_dependency = True)
 go_deps.module(
     path = "golang.org/x/tools",
     sum = "h1:DVSRzp7FwePZW356yEAChSdNcQo6Nsp+fex1SUW09lE=",


### PR DESCRIPTION
Our pip and go deps are only used in development.

Update some comments in our MODULE.bazel file, marking where dev
dependencies start in our MODULE.bazel file.  Add some comments to our
GoogleTest dependency.

Helps #485.