### PR TITLE
Add CI support for clang17

### DIFF
--- a/.github/workflows/clang17-ubuntu.yml
+++ b/.github/workflows/clang17-ubuntu.yml
@@ -1,0 +1,27 @@
+# Copyright 2025 Aurora Operations, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: clang17-ubuntu
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-and-test-clang17:
+    uses: ./.github/workflows/build-and-test.yml
+    with:
+      config: clang17

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![Au library logo](docs/assets/au-logo-color.png)
 
-[![clang14-ubuntu](
+[![clang17-ubuntu](
+https://github.com/aurora-opensource/au/actions/workflows/clang17-ubuntu.yml/badge.svg?branch=main&event=push)](
+https://github.com/aurora-opensource/au/actions/workflows/clang17-ubuntu.yml) [![clang14-ubuntu](
 https://github.com/aurora-opensource/au/actions/workflows/clang14-ubuntu.yml/badge.svg?branch=main&event=push)](
 https://github.com/aurora-opensource/au/actions/workflows/clang14-ubuntu.yml) [![clang11-ubuntu](
 https://github.com/aurora-opensource/au/actions/workflows/clang11-ubuntu.yml/badge.svg?branch=main&event=push)](

--- a/docs/supported-compilers.md
+++ b/docs/supported-compilers.md
@@ -53,6 +53,7 @@ Here are the configurations that have Full Support status.
 |----------|----------|--------|
 | Ubuntu | clang 11 | [![clang11-ubuntu]( https://github.com/aurora-opensource/au/actions/workflows/clang11-ubuntu.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/clang11-ubuntu.yml) |
 | Ubuntu | clang 14 | [![clang14-ubuntu]( https://github.com/aurora-opensource/au/actions/workflows/clang14-ubuntu.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/clang14-ubuntu.yml) |
+| Ubuntu | clang 17 | [![clang17-ubuntu]( https://github.com/aurora-opensource/au/actions/workflows/clang17-ubuntu.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/clang17-ubuntu.yml) |
 | Ubuntu | gcc 10 | [![gcc10-ubuntu]( https://github.com/aurora-opensource/au/actions/workflows/gcc10-ubuntu.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/gcc10-ubuntu.yml) |
 
 ### Best effort support


### PR DESCRIPTION
Helps #487.

The badges should show up after the first time that the new workflow has
run.