### PR TITLE
Support newest and oldest available GCC version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,12 +22,15 @@ build --workspace_status_command=./tools/bin/workspace_status.sh
 build:clang11 --platforms=@//build/platform:clang_11
 build:clang14 --platforms=@//build/platform:clang_14
 build:clang17 --platforms=@//build/platform:clang_17
-build:gcc14 --platforms=@//build/platform:gcc_14
-build:gcc14 --copt=-std=c++14
+build:gcc12 --platforms=@//build/platform:gcc_12
+build:gcc12 --copt=-std=c++14
+build:gcc15 --platforms=@//build/platform:gcc_15
+build:gcc15 --copt=-std=c++14
 
 # Add a generic alias if the user doesn't care about the exact version.
 build:clang --config=clang17
-build:gcc --config=gcc14
+build:clang --config=clang14
+build:gcc --config=gcc15
 
 # Compile with clang by default
 build --config=clang

--- a/.github/workflows/gcc12-ubuntu.yml
+++ b/.github/workflows/gcc12-ubuntu.yml
@@ -1,0 +1,27 @@
+# Copyright 2025 Aurora Operations, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: gcc12-ubuntu
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-and-test-gcc12:
+    uses: ./.github/workflows/build-and-test.yml
+    with:
+      config: gcc12

--- a/.github/workflows/gcc15-ubuntu.yml
+++ b/.github/workflows/gcc15-ubuntu.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 Aurora Operations, Inc.
+# Copyright 2025 Aurora Operations, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: gcc14-ubuntu
+name: gcc15-ubuntu
 
 on:
   push:
@@ -21,7 +21,7 @@ on:
   pull_request:
 
 jobs:
-  build-and-test-gcc14:
+  build-and-test-gcc15:
     uses: ./.github/workflows/build-and-test.yml
     with:
-      config: gcc14
+      config: gcc15

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -120,19 +120,37 @@ single_version_override(
     ],
 )
 
-gcc_14 = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
-gcc_14.toolchain(
-    name = "gcc_14",
+gcc_12 = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
+gcc_12.toolchain(
+    name = "gcc_12",
     extra_cflags = EXTRA_COPTS,
+    extra_cxxflags = EXTRA_COPTS,
     extra_ldflags = ["-l:libstdc++.a"],
-    extra_target_compatible_with = ["@//build/compiler:gcc_14"],
-    gcc_version = "14.3.0",
+    extra_target_compatible_with = ["@//build/compiler:gcc_12"],
+    gcc_version = "12.5.0",
     target_arch = "x86_64",
 )
-use_repo(gcc_14, "gcc_14")
+use_repo(gcc_12, "gcc_12")
 
 register_toolchains(
-    "@gcc_14//:all",
+    "@gcc_12//:all",
+    dev_dependency = True,
+)
+
+gcc_15 = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
+gcc_15.toolchain(
+    name = "gcc_15",
+    extra_cflags = EXTRA_COPTS,
+    extra_cxxflags = EXTRA_COPTS,
+    extra_ldflags = ["-l:libstdc++.a"],
+    extra_target_compatible_with = ["@//build/compiler:gcc_15"],
+    gcc_version = "15.2.0",
+    target_arch = "x86_64",
+)
+use_repo(gcc_15, "gcc_15")
+
+register_toolchains(
+    "@gcc_15//:all",
     dev_dependency = True,
 )
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,20 @@
 
 [![clang17-ubuntu](
 https://github.com/aurora-opensource/au/actions/workflows/clang17-ubuntu.yml/badge.svg?branch=main&event=push)](
-https://github.com/aurora-opensource/au/actions/workflows/clang17-ubuntu.yml) [![clang14-ubuntu](
+https://github.com/aurora-opensource/au/actions/workflows/clang17-ubuntu.yml)
+[![clang14-ubuntu](
 https://github.com/aurora-opensource/au/actions/workflows/clang14-ubuntu.yml/badge.svg?branch=main&event=push)](
-https://github.com/aurora-opensource/au/actions/workflows/clang14-ubuntu.yml) [![clang11-ubuntu](
+https://github.com/aurora-opensource/au/actions/workflows/clang14-ubuntu.yml)
+[![clang11-ubuntu](
 https://github.com/aurora-opensource/au/actions/workflows/clang11-ubuntu.yml/badge.svg?branch=main&event=push)](
-https://github.com/aurora-opensource/au/actions/workflows/clang11-ubuntu.yml) [![gcc14-ubuntu](
-https://github.com/aurora-opensource/au/actions/workflows/gcc14-ubuntu.yml/badge.svg?branch=main&event=push)](
-https://github.com/aurora-opensource/au/actions/workflows/gcc14-ubuntu.yml) [![MSVC 2022 x64](
+https://github.com/aurora-opensource/au/actions/workflows/clang11-ubuntu.yml)
+[![gcc12-ubuntu](
+https://github.com/aurora-opensource/au/actions/workflows/gcc12-ubuntu.yml/badge.svg?branch=main&event=push)](
+https://github.com/aurora-opensource/au/actions/workflows/gcc12-ubuntu.yml)
+[![gcc15-ubuntu](
+https://github.com/aurora-opensource/au/actions/workflows/gcc15-ubuntu.yml/badge.svg?branch=main&event=push)](
+https://github.com/aurora-opensource/au/actions/workflows/gcc15-ubuntu.yml)
+[![MSVC 2022 x64](
 https://github.com/aurora-opensource/au/actions/workflows/msvc-2022-x64.yml/badge.svg?branch=main&event=push)](
 https://github.com/aurora-opensource/au/actions/workflows/msvc-2022-x64.yml)
 

--- a/build/compiler/BUILD.bazel
+++ b/build/compiler/BUILD.bazel
@@ -33,7 +33,13 @@ constraint_value(
 )
 
 constraint_value(
-    name = "gcc_14",
+    name = "gcc_12",
+    constraint_setting = ":version",
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
+    name = "gcc_15",
     constraint_setting = ":version",
     visibility = ["//visibility:public"],
 )

--- a/build/platform/BUILD.bazel
+++ b/build/platform/BUILD.bazel
@@ -31,7 +31,13 @@ platform(
 )
 
 platform(
-    name = "gcc_14",
-    constraint_values = ["//build/compiler:gcc_14"],
+    name = "gcc_12",
+    constraint_values = ["//build/compiler:gcc_12"],
+    parents = ["@platforms//host"],
+)
+
+platform(
+    name = "gcc_15",
+    constraint_values = ["//build/compiler:gcc_15"],
     parents = ["@platforms//host"],
 )

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -156,10 +156,10 @@ bazel test //au:all //release:au_hh_test
 
 Au comes pre-packaged with support for several different compiler toolchains.  To use a specific
 toolchain --- say, `X` --- pass it as a `--config=X` argument.  For example, here's how you would
-run all of the tests using gcc 10:
+run all of the tests using gcc 15:
 
 ```sh
-bazel test --config=gcc14 //...:all
+bazel test --config=gcc15 //...:all
 ```
 
 Here are the possible values we support for `--config`:
@@ -169,7 +169,8 @@ Here are the possible values we support for `--config`:
 | `clang17` | Clang 17 (default) |
 | `clang14` | Clang 14 |
 | `clang11` | Clang 11 |
-| `gcc14` | gcc 14 |
+| `gcc12` | gcc 12 |
+| `gcc12` | gcc 15 |
 
 ??? question "What if your preferred compiler isn't in this list?"
     Our goal is for Au to work with any standards-compliant compiler that fully supports C++14, or

--- a/docs/supported-compilers.md
+++ b/docs/supported-compilers.md
@@ -54,7 +54,8 @@ Here are the configurations that have Full Support status.
 | Ubuntu | clang 11 | [![clang11-ubuntu]( https://github.com/aurora-opensource/au/actions/workflows/clang11-ubuntu.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/clang11-ubuntu.yml) |
 | Ubuntu | clang 14 | [![clang14-ubuntu]( https://github.com/aurora-opensource/au/actions/workflows/clang14-ubuntu.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/clang14-ubuntu.yml) |
 | Ubuntu | clang 17 | [![clang17-ubuntu]( https://github.com/aurora-opensource/au/actions/workflows/clang17-ubuntu.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/clang17-ubuntu.yml) |
-| Ubuntu | gcc 14 | [![gcc14-ubuntu]( https://github.com/aurora-opensource/au/actions/workflows/gcc14-ubuntu.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/gcc14-ubuntu.yml) |
+| Ubuntu | gcc 12 | [![gcc12-ubuntu]( https://github.com/aurora-opensource/au/actions/workflows/gcc12-ubuntu.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/gcc12-ubuntu.yml) |
+| Ubuntu | gcc 15 | [![gcc15-ubuntu]( https://github.com/aurora-opensource/au/actions/workflows/gcc15-ubuntu.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/gcc15-ubuntu.yml) |
 
 ### Best effort support
 


### PR DESCRIPTION
The toolchain rules we're currently using allow support GCC 12 and 15
natively. We could add additional versions using this toolchain as
needed.
