### PR TITLE
Update numeric_limit tests to check against std::numeric_limits

### DIFF
--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -804,9 +804,15 @@ struct NumericLimits {
     }
 };
 
-TEST(numeric_limits, MemberVariablesSetCorrectlyForQuantitySpecialization) {
+TEST(NumericLimits, MemberVariablesSetCorrectlyForQuantitySpecializationInt) {
     NumericLimits<Meters, int>::parity();
+}
+
+TEST(NumericLimits, MemberVariablesSetCorrectlyForQuantitySpecializationUint32T) {
     NumericLimits<Radians, uint32_t>::parity();
+}
+
+TEST(NumericLimits, MemberVariablesSetCorrectlyForQuantitySpecializationFloat) {
     NumericLimits<Celsius, float>::parity();
 }
 


### PR DESCRIPTION
Specifically, the `traps` test was failing on MacOS for `int`.  Update
the tests to verify that `numeric_limits` is indeed specialized for the
type, and verify that the behavior matches the behavior for the
underlying type on the system.
