### PR TITLE
Use `uintmax_t`, not `size_t`, in `mag` (#544)

### DIFF
--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 #include <utility>
 
@@ -102,7 +103,7 @@ template <typename MagT>
 constexpr const auto &mag_label(MagT = MagT{});
 
 // A helper function to create a Magnitude from an integer constant.
-template <std::size_t N>
+template <std::uintmax_t N>
 constexpr auto mag();
 
 // A base type for prime numbers.
@@ -315,7 +316,7 @@ struct PrimeFactorization {
 
 }  // namespace detail
 
-template <std::size_t N>
+template <std::uintmax_t N>
 constexpr auto mag() {
     return detail::PrimeFactorizationT<N>{};
 }


### PR DESCRIPTION
The point of `mag` is to plug into the prime factorization machinery,
all of which uses `uintmax_t`.  Apparently, we were able to get away
with the existing mismatch for quite some time, but it gets exposed on
architctures where `size_t` is 32 bits.

Fixes #542.

---------

Co-authored-by: Michael Hordijk <hordijk@aurora.tech>