### PR TITLE
Break users of `UnitAvoidance` (#522)

### DIFF
--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -1173,12 +1173,12 @@ struct OrderByUnitOrderTiebreaker
     : stdx::bool_constant<(UnitOrderTiebreaker<A>::value < UnitOrderTiebreaker<B>::value)> {};
 
 template <typename U>
-struct UnitAvoidance : std::integral_constant<int, 0> {};
+struct RenamedUnitAvoidance : std::integral_constant<int, 0> {};
 
 }  // namespace detail
 
 template <typename U>
-struct UnitOrderTiebreaker : detail::UnitAvoidance<U> {};
+struct UnitOrderTiebreaker : detail::RenamedUnitAvoidance<U> {};
 
 template <typename A, typename B>
 struct InOrderFor<UnitProduct, A, B>

--- a/au/unit_of_measure_test.cc
+++ b/au/unit_of_measure_test.cc
@@ -812,11 +812,11 @@ namespace detail {
 struct Threet : decltype(Feet{} * mag<3>()) {};
 
 template <>
-struct UnitAvoidance<Threet> : std::integral_constant<int, 1234> {};
+struct RenamedUnitAvoidance<Threet> : std::integral_constant<int, 1234> {};
 
 TEST(UnitAvoidance, CanTemporarilyBreakTiesForDistinctButOtherwiseUnorderableUnits) {
     // The point of this test is that this line would fail to compile if not for the
-    // `UnitAvoidance<Threet>` specialization just above.
+    // `RenamedUnitAvoidance<Threet>` specialization just above.
     //
     // This method of making distinct units orderable is deprecated, because it relies on end users
     // naming a type in our `detail::` namespace.


### PR DESCRIPTION
This is the future-proof release for #429 for the 0.5.1 release.

This is not how we will actually land this for 0.6.0.  Instead, we'll
deprecate it until 0.7.0.  But for a future proof release, doing a hard
removal is more reliable than deprecation warnings, which can be
ignored.