### PR TITLE
Always return Quantity from Quantity operations (#523)

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -37,12 +37,6 @@ constexpr auto make_quantity(T value) {
     return QuantityMaker<UnitT>{}(value);
 }
 
-template <typename Unit, typename T>
-constexpr auto make_quantity_unless_unitless(T value) {
-    return std::conditional_t<IsUnitlessUnit<Unit>::value, stdx::identity, QuantityMaker<Unit>>{}(
-        value);
-}
-
 // Trait to check whether two Quantity types are exactly equivalent.
 //
 // For purposes of our library, "equivalent" means that they have the same Dimension and Magnitude.
@@ -302,16 +296,14 @@ class Quantity {
     // Multiplication for dimensioned quantities.
     template <typename OtherUnit, typename OtherRep>
     constexpr auto operator*(Quantity<OtherUnit, OtherRep> q) const {
-        return make_quantity_unless_unitless<UnitProductT<Unit, OtherUnit>>(value_ *
-                                                                            q.in(OtherUnit{}));
+        return make_quantity<UnitProductT<Unit, OtherUnit>>(value_ * q.in(OtherUnit{}));
     }
 
     // Division for dimensioned quantities.
     template <typename OtherUnit, typename OtherRep>
     constexpr auto operator/(Quantity<OtherUnit, OtherRep> q) const {
         warn_if_integer_division<OtherUnit, OtherRep>();
-        return make_quantity_unless_unitless<UnitQuotientT<Unit, OtherUnit>>(value_ /
-                                                                             q.in(OtherUnit{}));
+        return make_quantity<UnitQuotientT<Unit, OtherUnit>>(value_ / q.in(OtherUnit{}));
     }
 
     // Short-hand addition and subtraction assignment.

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -646,20 +646,20 @@ TEST(Quantity, CanDivideArbitraryQuantities) {
     EXPECT_THAT(v, Eq(d / t));
 }
 
-TEST(Quantity, RatioOfSameTypeIsScalar) {
+TEST(Quantity, RatioOfSameTypeIsQuantity) {
     constexpr auto x = yards(8.2);
 
-    EXPECT_THAT(x / x, SameTypeAndValue(1.0));
+    EXPECT_THAT(x / x, QuantityEquivalent(unos(1.0)));
 }
 
-TEST(Quantity, RatioOfEquivalentTypesIsScalar) {
+TEST(Quantity, RatioOfEquivalentTypesIsQuantity) {
     constexpr auto x = feet(10.0);
     constexpr auto y = (feet * mag<1>())(5.0);
 
-    EXPECT_THAT(x / y, SameTypeAndValue(2.0));
+    EXPECT_THAT(x / y, QuantityEquivalent(unos(2.0)));
 }
 
-TEST(Quantity, ProductOfInvertingUnitsIsScalar) {
+TEST(Quantity, ProductOfInvertingUnitsIsQuantity) {
     // We pass `UnitProductT` to this function template, which ensures that we get a `UnitProduct`
     // (note: NOT `UnitProductT`!) with the expected number of arguments.  Recall that
     // `UnitProductT` is the user-facing "unit computation" interface, and `UnitProduct` is the
@@ -670,7 +670,7 @@ TEST(Quantity, ProductOfInvertingUnitsIsScalar) {
     // unit---although, naturally, it must be **quantity-equivalent** to `UnitProduct<>`.
     ASSERT_THAT(num_units_in_product(UnitProductT<Days, PerDay>{}), Eq(2));
 
-    EXPECT_THAT(days(3) * per_day(8), SameTypeAndValue(24));
+    EXPECT_THAT(days(3) * per_day(8), QuantityEquivalent(unos(24)));
 }
 
 TEST(Quantity, ScalarDivisionWorks) {
@@ -1176,7 +1176,7 @@ TEST(UnblockIntDiv, IsNoOpForDivisionThatWouldBeAllowedAnyway) {
 
 TEST(Quantity, CanIntegerDivideQuantitiesOfQuantityEquivalentUnits) {
     constexpr auto ratio = meters(60) / meters(25);
-    EXPECT_THAT(ratio, Eq(2));
+    EXPECT_THAT(ratio, QuantityEquivalent(unos(2)));
 }
 
 TEST(mod, ComputesRemainderForSameUnits) {

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -564,10 +564,9 @@ Here are the usage patterns, and their corresponding signatures.
 ### Dimensionless and unitless results: `as_raw_number` {#as-raw-number}
 
 Users may expect that the product of quantities such as `seconds` and `hertz` would completely
-cancel out, and produce a raw, simple C++ numeric type.  Currently, this is indeed the case, but we
-have also found that it makes the library harder to reason about.  Instead, we hope in the future to
-return a `Quantity` type _consistently_ from arithmetical operations on `Quantity` inputs (see
-[#185]).
+cancel out, and produce a raw, simple C++ numeric type.  While this was formerly the case, we found
+that it made the library harder to reason about consistently.  Instead, we return a `Quantity` type
+_consistently_ from arithmetical operations on `Quantity` inputs.
 
 In order to obtain that raw number robustly, both now and in the future, you can use the
 `as_raw_number` function, a callsite-readable way to "exit" the library.  This will also opt into
@@ -579,8 +578,7 @@ all mechanisms and safety features of the library.  In particular:
   represented exactly as a raw `int`), we will also fail to compile, unless users provide a second
   policy argument to override the safety check.
 
-Users should get in the habit of using `as_raw_number` whenever they really want a raw number.  This
-communicates intent, and also works both before and after [#185] is implemented.
+Users should use `as_raw_number` whenever they really want a raw number.  This communicates intent.
 
 Here are the available APIs:
 
@@ -945,7 +943,6 @@ the following conditions hold.
     - `AreQuantityTypesEquivalent<U1, U2>::value`
 
 [#122]: https://github.com/aurora-opensource/au/issues/122
-[#185]: https://github.com/aurora-opensource/au/issues/185
 [#481]: https://github.com/aurora-opensource/au/issues/481
 [0.6.0]: https://github.com/aurora-opensource/au/milestone/9
 [integer division section]: ../troubleshooting.md#integer-division-forbidden


### PR DESCRIPTION
This is a long-desired breaking change.  This PR is the future-proof
release for 0.5.1 for #185, preparing the way for the 0.6.0 release.