### PR TITLE
Remove `coerce` APIs (#521)

### DIFF
--- a/au/constant.hh
+++ b/au/constant.hh
@@ -48,12 +48,6 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
         return make_quantity<Unit>(static_cast<T>(1));
     }
 
-    // Convert this constant to a Quantity of the given unit and rep, ignoring safety checks.
-    template <typename T, typename OtherUnit>
-    constexpr auto coerce_as(OtherUnit u) const {
-        return as<T>().coerce_as(u);
-    }
-
     // Convert this constant to a Quantity of the given unit and rep.
     template <typename T, typename OtherUnit>
     constexpr auto as(OtherUnit u) const {
@@ -76,12 +70,6 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
         static_assert(!has_unacceptable_truncation, "Constant conversion known to truncate");
 
         return this_value.as(OtherUnit{}, ignore(ALL_RISKS));
-    }
-
-    // Get the value of this constant in the given unit and rep, ignoring safety checks.
-    template <typename T, typename OtherUnit>
-    constexpr auto coerce_in(OtherUnit u) const {
-        return as<T>().coerce_in(u);
     }
 
     // Get the value of this constant in the given unit and rep.

--- a/au/constant_test.cc
+++ b/au/constant_test.cc
@@ -114,12 +114,6 @@ TEST(Constant, UsesExactSafetyChecksInsteadOfHeuristics) {
     // c.as<int16_t>(meters / second);
 }
 
-TEST(Constant, CanCoerce) {
-    EXPECT_THAT(c.coerce_in<int>(kilo(meters) / second), SameTypeAndValue(299'792));
-    EXPECT_THAT(c.coerce_as<int>(kilo(meters) / second),
-                SameTypeAndValue((kilo(meters) / second)(299'792)));
-}
-
 TEST(Constant, CanProvidePolicy) {
     EXPECT_THAT(c.in<int>(kilo(meters) / second, ignore(TRUNCATION_RISK)),
                 SameTypeAndValue(299'792));

--- a/au/prefix_test.cc
+++ b/au/prefix_test.cc
@@ -48,7 +48,7 @@ TEST(PrefixApplier, ConvertsQuantityMakerToMakerOfCorrespondingPrefixedType) {
     constexpr auto d = inches(2);
     EXPECT_THAT(d.in(make_milli(inches)), SameTypeAndValue(2'000));
 
-    EXPECT_THAT(make_milli(inches)(5'777).coerce_in(inches), SameTypeAndValue(5));
+    EXPECT_THAT(make_milli(inches)(5'777).in(inches, ignore(TRUNCATION_RISK)), SameTypeAndValue(5));
 }
 
 TEST(PrefixApplier, ConvertsSingularNameForToCorrespondingPrefixedType) {

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -209,28 +209,6 @@ class Quantity {
         return in_impl<Rep>(u, policy);
     }
 
-    // "Forcing" conversions, which explicitly ignore safety checks for overflow and truncation.
-    template <typename NewUnit>
-    constexpr auto coerce_as(NewUnit) const {
-        // Usage example: `q.coerce_as(new_units)`.
-        return as<Rep>(NewUnit{});
-    }
-    template <typename NewRep, typename NewUnit>
-    constexpr auto coerce_as(NewUnit) const {
-        // Usage example: `q.coerce_as<T>(new_units)`.
-        return as<NewRep>(NewUnit{});
-    }
-    template <typename NewUnit>
-    constexpr auto coerce_in(NewUnit) const {
-        // Usage example: `q.coerce_in(new_units)`.
-        return in<Rep>(NewUnit{});
-    }
-    template <typename NewRep, typename NewUnit>
-    constexpr auto coerce_in(NewUnit) const {
-        // Usage example: `q.coerce_in<T>(new_units)`.
-        return in<NewRep>(NewUnit{});
-    }
-
     // Direct access to the underlying value member, with any Quantity-equivalent Unit.
     //
     // Mutable access:

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -150,28 +150,6 @@ class QuantityPoint {
         return in_impl<Rep>(u, policy);
     }
 
-    // "Forcing" conversions, which explicitly ignore safety checks for overflow and truncation.
-    template <typename NewUnit>
-    constexpr auto coerce_as(NewUnit) const {
-        // Usage example: `p.coerce_as(new_units)`.
-        return as<Rep>(NewUnit{});
-    }
-    template <typename NewRep, typename NewUnit>
-    constexpr auto coerce_as(NewUnit) const {
-        // Usage example: `p.coerce_as<T>(new_units)`.
-        return as<NewRep>(NewUnit{});
-    }
-    template <typename NewUnit>
-    constexpr auto coerce_in(NewUnit) const {
-        // Usage example: `p.coerce_in(new_units)`.
-        return in<Rep>(NewUnit{});
-    }
-    template <typename NewRep, typename NewUnit>
-    constexpr auto coerce_in(NewUnit) const {
-        // Usage example: `p.coerce_in<T>(new_units)`.
-        return in<NewRep>(NewUnit{});
-    }
-
     // Direct access to the underlying value member, with any Point-equivalent Unit.
     //
     // Mutable access, QuantityPointMaker input.

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -44,12 +44,6 @@ struct Meters : UnitImpl<Length> {};
 constexpr QuantityMaker<Meters> meters{};
 constexpr QuantityPointMaker<Meters> meters_pt{};
 
-struct Inches : decltype(Centi<Meters>{} * mag<254>() / mag<100>()) {};
-constexpr auto inches_pt = QuantityPointMaker<Inches>{};
-
-struct Feet : decltype(Inches{} * mag<12>()) {};
-constexpr auto feet_pt = QuantityPointMaker<Feet>{};
-
 struct Kelvins : UnitImpl<Temperature> {
     static constexpr const char label[] = "K";
 };
@@ -146,7 +140,7 @@ TEST(QuantityPoint, CanGetValueInDifferentUnits) {
 }
 
 TEST(QuantityPoint, IntermediateTypeIsSignedIfExplicitRepIsSigned) {
-    EXPECT_THAT(milli(kelvins_pt)(0u).coerce_as<int>(celsius_pt),
+    EXPECT_THAT(milli(kelvins_pt)(0u).as<int>(celsius_pt, ignore(TRUNCATION_RISK)),
                 SameTypeAndValue(celsius_pt(-273)));
 }
 
@@ -240,14 +234,16 @@ TEST(QuantityPoint, CanRequestOutputRepWhenCallingIn) {
 }
 
 TEST(QuantityPoint, CanCastToUnitWithDifferentMagnitude) {
-    EXPECT_THAT(centi(meters_pt)(75).coerce_as(meters_pt), SameTypeAndValue(meters_pt(0)));
+    EXPECT_THAT(centi(meters_pt)(75).as(meters_pt, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue(meters_pt(0)));
 
     EXPECT_THAT(centi(meters_pt)(75.0).as(meters_pt), SameTypeAndValue(meters_pt(0.75)));
 }
 
 TEST(QuantityPoint, CanCastToUnitWithDifferentOrigin) {
     EXPECT_THAT(celsius_pt(10.).as(kelvins_pt), IsNear(kelvins_pt(283.15), nano(kelvins)(1)));
-    EXPECT_THAT(celsius_pt(10).coerce_as(Kelvins{}), SameTypeAndValue(kelvins_pt(283)));
+    EXPECT_THAT(celsius_pt(10).as(Kelvins{}, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue(kelvins_pt(283)));
 }
 
 TEST(QuantityPoint, AsCanProvideConversionPolicy) {
@@ -274,59 +270,8 @@ TEST(QuantityPoint, InWithExplicitRepCanProvideConversionPolicy) {
 }
 
 TEST(QuantityPoint, HandlesConversionWithSignedSourceAndUnsignedDestination) {
-    EXPECT_THAT(celsius_pt(int16_t{-5}).coerce_as<uint16_t>(kelvins_pt),
+    EXPECT_THAT(celsius_pt(int16_t{-5}).as<uint16_t>(kelvins_pt),
                 SameTypeAndValue(kelvins_pt(uint16_t{268})));
-}
-
-TEST(QuantityPoint, CoerceAsWillForceLossyConversion) {
-    // Truncation.
-    EXPECT_THAT(inches_pt(30).coerce_as(feet_pt), SameTypeAndValue(feet_pt(2)));
-
-    // Unsigned overflow.
-    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet_pt(uint8_t{30}).coerce_as(inches_pt),
-                SameTypeAndValue(inches_pt(uint8_t{104})));
-}
-
-TEST(QuantityPoint, CoerceAsExplicitRepSetsOutputType) {
-    // Coerced truncation.
-    EXPECT_THAT(inches_pt(30).coerce_as<std::size_t>(feet_pt),
-                SameTypeAndValue(feet_pt(std::size_t{2})));
-
-    // Exact answer for floating point destination type.
-    EXPECT_THAT(inches_pt(30).coerce_as<float>(feet_pt), SameTypeAndValue(feet_pt(2.5f)));
-
-    // Coerced unsigned overflow.
-    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet_pt(30).coerce_as<uint8_t>(inches_pt),
-                SameTypeAndValue(inches_pt(uint8_t{104})));
-}
-
-TEST(QuantityPoint, CoerceInWillForceLossyConversion) {
-    // Truncation.
-    EXPECT_THAT(inches_pt(30).coerce_in(feet_pt), SameTypeAndValue(2));
-
-    // Unsigned overflow.
-    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet_pt(uint8_t{30}).coerce_in(inches_pt), SameTypeAndValue(uint8_t{104}));
-}
-
-TEST(QuantityPoint, CoerceInExplicitRepSetsOutputType) {
-    // Coerced truncation.
-    EXPECT_THAT(inches_pt(30).coerce_in<std::size_t>(feet_pt), SameTypeAndValue(std::size_t{2}));
-
-    // Exact answer for floating point destination type.
-    EXPECT_THAT(inches_pt(30).coerce_in<float>(feet_pt), SameTypeAndValue(2.5f));
-
-    // Coerced unsigned overflow.
-    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet_pt(30).coerce_in<uint8_t>(inches_pt), SameTypeAndValue(uint8_t{104}));
-}
-
-TEST(QuantityPoint, CoerceAsPerformsConversionInWidestType) {
-    constexpr QuantityPointU32<Milli<Kelvins>> temp = milli(kelvins_pt)(313'150u);
-    EXPECT_THAT(temp.coerce_as<uint16_t>(deci(kelvins_pt)),
-                SameTypeAndValue(deci(kelvins_pt)(uint16_t{3131})));
 }
 
 TEST(QuantityPoint, ComparisonsWorkAsExpected) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -272,54 +272,6 @@ TEST(Quantity, SupportsDirectConstAccessWithQuantityMakerOfEquivalentUnit) {
     //             Eq(static_cast<const void *>(&x)));
 }
 
-TEST(Quantity, CoerceAsWillForceLossyConversion) {
-    // Truncation.
-    EXPECT_THAT(inches(30).coerce_as(feet), SameTypeAndValue(feet(2)));
-
-    // Unsigned overflow.
-    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet(uint8_t{30}).coerce_as(inches), SameTypeAndValue(inches(uint8_t{104})));
-}
-
-TEST(Quantity, CoerceAsExplicitRepSetsOutputType) {
-    // Coerced truncation.
-    EXPECT_THAT(inches(30).coerce_as<std::size_t>(feet), SameTypeAndValue(feet(std::size_t{2})));
-
-    // Exact answer for floating point destination type.
-    EXPECT_THAT(inches(30).coerce_as<float>(feet), SameTypeAndValue(feet(2.5f)));
-
-    // Coerced unsigned overflow.
-    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet(30).coerce_as<uint8_t>(inches), SameTypeAndValue(inches(uint8_t{104})));
-}
-
-TEST(Quantity, CoerceInWillForceLossyConversion) {
-    // Truncation.
-    EXPECT_THAT(inches(30).coerce_in(feet), SameTypeAndValue(2));
-
-    // Unsigned overflow.
-    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet(uint8_t{30}).coerce_in(inches), SameTypeAndValue(uint8_t{104}));
-}
-
-TEST(Quantity, CoerceInExplicitRepSetsOutputType) {
-    // Coerced truncation.
-    EXPECT_THAT(inches(30).coerce_in<std::size_t>(feet), SameTypeAndValue(std::size_t{2}));
-
-    // Exact answer for floating point destination type.
-    EXPECT_THAT(inches(30).coerce_in<float>(feet), SameTypeAndValue(2.5f));
-
-    // Coerced unsigned overflow.
-    ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet(30).coerce_in<uint8_t>(inches), SameTypeAndValue(uint8_t{104}));
-}
-
-TEST(Quantity, CoerceAsPerformsConversionInWidestType) {
-    constexpr QuantityU32<Milli<Meters>> length = milli(meters)(313'150u);
-    EXPECT_THAT(length.coerce_as<uint16_t>(deci(meters)),
-                SameTypeAndValue(deci(meters)(uint16_t{3131})));
-}
-
 TEST(Quantity, CanImplicitlyConvertToDifferentUnitOfSameDimension) {
     constexpr QuantityI32<Inches> x = yards(2);
     EXPECT_THAT(x.in(inches), Eq(72));
@@ -776,20 +728,20 @@ TEST(Quantity, UnitCastRequiresExplicitTypeForDangerousReps) {
 
     // Unsafe instances: small integral types.
     //
-    // To "test" these, try replacing `.coerce_as(...)` with `.as(...)`.  Make sure it fails with a
-    // readable `static_assert`.
-    EXPECT_THAT(feet(uint16_t{1}).coerce_as(centi(feet)),
+    // To "test" these, try deleting the `ignore(OVERFLOW_RISK)` argument.  Make sure it fails with
+    // a readable `static_assert`.
+    EXPECT_THAT(feet(uint16_t{1}).as(centi(feet), ignore(OVERFLOW_RISK)),
                 SameTypeAndValue(centi(feet)(uint16_t{100})));
 }
 
 TEST(Quantity, CanCastToDifferentUnit) {
-    EXPECT_THAT(inches(6).coerce_as(feet), SameTypeAndValue(feet(0)));
+    EXPECT_THAT(inches(6).as(feet, ignore(TRUNCATION_RISK)), SameTypeAndValue(feet(0)));
     EXPECT_THAT(inches(6.).as(feet), SameTypeAndValue(feet(0.5)));
 }
 
 TEST(Quantity, QuantityCastSupportsConstexprAndConst) {
     constexpr auto eighteen_inches_double = inches(18.);
-    constexpr auto one_foot_int = eighteen_inches_double.coerce_as<int>(feet);
+    constexpr auto one_foot_int = eighteen_inches_double.as<int>(feet, ignore(TRUNCATION_RISK));
     EXPECT_THAT(one_foot_int, SameTypeAndValue(feet(1)));
 }
 
@@ -814,8 +766,7 @@ TEST(Quantity, QuantityCastAvoidsPreventableOverflowWhenGoingToSmallerType) {
     // Make sure we don't overflow in uint64_t.
     ASSERT_THAT(lots_of_nanoinches.in(nano(inches)), Eq(would_overflow_uint32));
 
-    EXPECT_THAT(lots_of_nanoinches.coerce_as<uint32_t>(inches),
-                SameTypeAndValue(inches(uint32_t{9})));
+    EXPECT_THAT(lots_of_nanoinches.as<uint32_t>(inches), SameTypeAndValue(inches(uint32_t{9})));
 }
 
 TEST(Quantity, CommonTypeMagnitudeEvenlyDividesBoth) {
@@ -1076,8 +1027,8 @@ TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions
              i <= std::numeric_limits<uint16_t>::max();
              ++i) {
             const auto original = source_units(static_cast<uint16_t>(i));
-            const auto converted = original.coerce_as(target_units);
-            const auto round_trip = converted.coerce_as(source_units);
+            const auto converted = original.as(target_units, ignore(ALL_RISKS));
+            const auto round_trip = converted.as(source_units, ignore(ALL_RISKS));
 
             const bool did_value_change = (original != round_trip);
 

--- a/docs/discussion/concepts/overflow.md
+++ b/docs/discussion/concepts/overflow.md
@@ -166,15 +166,15 @@ template <typename U, typename R, typename TargetUnitSlot>
 constexpr auto try_converting(au::Quantity<U, R> q, TargetUnitSlot target) {
     return is_conversion_lossy(q, target)
         ? std::nullopt
-        : std::make_optional(q.coerce_as(target));
+        : std::make_optional(q.as(target, ignore(ALL_RISKS)));
 }
 ```
 
 The goal of `is_conversion_lossy` is to produce an implementation for each individual conversion
 (based on both the numeric type, and the conversion factor) that is as _accurate and efficient_ as
 an expertly hand-written implementation.  If it passes those checks, then it's safe and correct to
-call `.coerce_as` instead of simply `.as`: we can override the _approximate_ safety checks of the
-latter because we've performed an _exact_ safety check.
+pass `ignore(ALL_RISKS)`: we are overriding _approximate_ safety checks because we've already
+performed _exact_ safety checks.
 
 ??? note "An example of the kind of details we take care of"
     When we say "expertly hand-written", we mean it.  We even handle obscure C++ minutae such as

--- a/docs/reference/constant.md
+++ b/docs/reference/constant.md
@@ -176,8 +176,8 @@ concise symbol.  The example below demonstrates the difference.
 
 By default, this conversion policy is _perfect_.  This means that it permits converting to any
 `Quantity` that can represent the value exactly, and disallows all other conversions.  Users can
-also override this policy by choosing the "coerce" variant of any API (say, using `.coerce_as()`
-instead of `.as()`).
+also override this policy by providing a [conversion risk policy](./conversion_risk_policies.md) as
+a second argument (say, `.as<T>(u, ignore(TRUNCATION_RISK))` instead of `.as<T>(u)`).
 
 Finally, it's important to appreciate that `Constant` has no rep, no underlying numeric type.
 Therefore, every `Quantity` conversion API requires an explicit template parameter to specify the
@@ -223,23 +223,6 @@ specific conversion will _actually cause truncation_.
     imagine, as they will produce a grossly incorrect result with no physical relationship to the
     actual value.
 
-### `.coerce_as<T>(unit)`
-
-!!! warning
-    We plan to deprecate APIs with `coerce` in their name in the [0.6.0] release ([#481]).  For
-    a `Constant` `c`, instead of `c.coerce_as<T>(unit)`, prefer `c.as<T>(unit, policy)`, where
-    `policy` is the desired [conversion risk policy](./conversion_risk_policies.md).
-
-This function expresses the constant as a `Quantity` in the requested unit, using a rep of `T`.  It
-is similar to [`.as<T>(unit)`](#as-T-unit), except that it will ignore the safety checks that
-prevent truncation and overflow.
-
-!!! warning
-    Because `.as<T>(unit)` has a perfect conversion policy, we know that this function either
-    produces the exact same result (in which case you could simply _call_ `.as<T>(unit)`), _or_ it
-    produces a result which is **guaranteed to be lossy**.  Therefore, be very judicious in using
-    this function.
-
 ### `.in<T>(unit)` {#in-T-unit}
 
 This function produces a raw numeric value, of type `T`, holding the value of the constant in the
@@ -274,23 +257,6 @@ specific conversion will _actually cause truncation_.
     a less precise version of the context.  Use cases for `ignore(OVERFLOW_RISK)` are very hard to
     imagine, as they will produce a grossly incorrect result with no physical relationship to the
     actual value.
-
-### `.coerce_in<T>(unit)`
-
-!!! warning
-    We plan to deprecate APIs with `coerce` in their name in the [0.6.0] release ([#481]).  For
-    a `Constant` `c`, instead of `c.coerce_in<T>(unit)`, prefer `c.in<T>(unit, policy)`, where
-    `policy` is the desired [conversion risk policy](./conversion_risk_policies.md).
-
-This function produces a raw numeric value, of type `T`, holding the value of the constant in the
-requested unit.  It is similar to [`.in<T>(unit)`](#in-T-unit), except that it will ignore the
-safety checks that prevent truncation and overflow.
-
-!!! warning
-    Because `.in<T>(unit)` has a perfect conversion policy, we know that this function either
-    produces the exact same result (in which case you could simply _call_ `.in<T>(unit)`), _or_ it
-    produces a result which is **guaranteed to be lossy**.  Therefore, be very judicious in using
-    this function.
 
 ### Implicit `Quantity` conversion
 

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -390,64 +390,10 @@ To be concrete, here are the signatures of the functions that support the policy
     In most cases, prefer **not** to use the policy versions if possible, because you will get more
     safety checks.  The risks which the "base" versions warn about are real.
 
-    However, one place where it's _very safe_ to use the "coercing versions" is right after running
-    a _runtime conversion checker_.  These provide _exact_ conversion checks, even more accurate than
-    the default compile-time safety surface (although at the cost of runtime operations).  See the
-    [subsequent section](#runtime-conversion-checkers) for more details.
-
-### Forcing lossy conversions: `.coerce_as(unit)`, `.coerce_in(unit)` {#coerce}
-
-!!! warning
-    We are planning to deprecate these functions in the [0.6.0] release.  See [#481] to track the
-    progress.
-
-    In the meantime, here is how you convert.
-
-    First, figure out which conversion risks you are trying to override: **overflow**, or
-    **truncation**, or **both**.  (If you don't have an explicit `<Rep>` argument, you can simply
-    delete the `"coerce_"` word and compile, and the error message will tell you which one is
-    relevant.  Otherwise, you will need to use your knowledge of the types and units involved to
-    figure this out.)
-
-    Then, follow this table to rewrite your conversion, using the conversion risk you identified
-    above.
-
-    | "Coerce" version (dis-preferred; will be deprecated) | "Policy" version (preferred) |
-    |------------------------------------------------------|------------------------------|
-    | `q.coerce_as(unit)` | One of:<br>`q.as(unit, ignore(OVERFLOW_RISK))`<br>`q.as(unit, ignore(TRUNCATION_RISK))`<br>`q.as(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
-    | `q.coerce_as<T>(unit)` | One of:<br>`q.as<T>(unit, ignore(OVERFLOW_RISK))`<br>`q.as<T>(unit, ignore(TRUNCATION_RISK))`<br>`q.as<T>(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
-    | `q.coerce_in(unit)` | One of:<br>`q.in(unit, ignore(OVERFLOW_RISK))`<br>`q.in(unit, ignore(TRUNCATION_RISK))`<br>`q.in(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
-    | `q.coerce_in<T>(unit)` | One of:<br>`q.in<T>(unit, ignore(OVERFLOW_RISK))`<br>`q.in<T>(unit, ignore(TRUNCATION_RISK))`<br>`q.in<T>(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
-
-    These new versions are both more clear about their intent, and safer (because they only turn off
-    the safety checks that they need to).
-
-This function performs the exact same kind of unit conversion as if the string `coerce_` were
-removed.  However, it will ignore any safety checks for overflow or truncation.
-
-??? example "Example: forcing a conversion from inches to feet"
-    `inches(24).as(feet)` is not allowed.  This conversion will divide the underlying value, `24`,
-    by `12`.  While this particular value would produce an integer result, most other `int` values
-    would not.  Because our result uses `int` for storage --- same as the input --- we forbid this.
-
-    `inches(24).coerce_as(feet)` _is_ allowed.  The `coerce_` prefix has "forcing" semantics.  This
-    would produce `feet(2)`.  However, note that this operation uses integer division, which
-    truncates: so, for example, `inches(23).coerce_as(feet)` would produce `feet(1)`.
-
-These functions also support an explicit template parameter: so, `.coerce_as<T>(unit)` and
-`.coerce_in<T>(unit)`.  If you supply this parameter, it will be the rep of the result.
-
-??? example "Example: simultaneous unit and type conversion"
-    `inches(27.8).coerce_as<int>(feet)` will return `feet(2)`.
-
-!!! tip
-    In most cases, prefer **not** to use the "coercing versions" if possible, because you will get
-    more safety checks.  The risks which the "base" versions warn about are real.
-
-    However, one place where it's _very safe_ to use the "coercing versions" is right after running
-    a _runtime conversion checker_.  These provde _exact_ conversion checks, even more accurate than
-    the default compile-time safety surface (although at the cost of runtime operations).  See the
-    next section for more details.
+    However, one place where it's _very safe_ to use the policy-base versions is right after running
+    a _runtime conversion checker_.  These provide _exact_ conversion checks, even more accurate
+    than the default compile-time safety surface (although at the cost of runtime operations).  See
+    the [subsequent section](#runtime-conversion-checkers) for more details.
 
 ### Runtime conversion checkers {#runtime-conversion-checkers}
 

--- a/docs/reference/quantity_point.md
+++ b/docs/reference/quantity_point.md
@@ -110,7 +110,7 @@ https://github.com/mkdocs/mkdocs/issues/1198#issuecomment-1253896100
 Note that every case in the above table is _physically_ meaningful (because the source and target
 have the same dimension), but some conversions are forbidden due to the risk of larger-than-usual
 errors.  The library can still perform these conversions, but not via this constructor, and it must
-be "forced" to do so. See [`.coerce_as(unit)`](#coerce) for more details.
+be "forced" to do so. See the [policy argument](#policy-argument) section for more details.
 
 ### Constructing from another `QuantityPoint`, with explicit risk policy
 
@@ -317,58 +317,6 @@ To be concrete, here are the signatures of the functions that support the policy
     However, once we provide runtime conversion checkers for `QuantityPoint` (see [#352]), then it
     will always be safe to provide a policy argument that ignores a risk that you have just verified
     to be absent.
-
-### Forcing lossy conversions: `.coerce_as(unit)`, `.coerce_in(unit)` {#coerce}
-
-!!! warning
-    We are planning to deprecate these functions in the [0.6.0] release.  See [#481] to track the
-    progress.
-
-    In the meantime, here is how you convert.
-
-    First, figure out which conversion risks you are trying to override: **overflow**, or
-    **truncation**, or **both**.  (If you don't have an explicit `<Rep>` argument, you can simply
-    delete the `"coerce_"` word and compile, and the error message will tell you which one is
-    relevant.  Otherwise, you will need to use your knowledge of the types and units involved to
-    figure this out.)
-
-    Then, follow this table to rewrite your conversion, using the conversion risk you identified
-    above.
-
-    | "Coerce" version (dis-preferred; will be deprecated) | "Policy" version (preferred) |
-    |------------------------------------------------------|------------------------------|
-    | `q.coerce_as(unit)` | One of:<br>`q.as(unit, ignore(OVERFLOW_RISK))`<br>`q.as(unit, ignore(TRUNCATION_RISK))`<br>`q.as(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
-    | `q.coerce_as<T>(unit)` | One of:<br>`q.as<T>(unit, ignore(OVERFLOW_RISK))`<br>`q.as<T>(unit, ignore(TRUNCATION_RISK))`<br>`q.as<T>(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
-    | `q.coerce_in(unit)` | One of:<br>`q.in(unit, ignore(OVERFLOW_RISK))`<br>`q.in(unit, ignore(TRUNCATION_RISK))`<br>`q.in(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
-    | `q.coerce_in<T>(unit)` | One of:<br>`q.in<T>(unit, ignore(OVERFLOW_RISK))`<br>`q.in<T>(unit, ignore(TRUNCATION_RISK))`<br>`q.in<T>(unit, ignore(OVERFLOW_RISK | TRUNCATION_RISK))` |
-
-    These new versions are both more clear about their intent, and safer (because they only turn off
-    the safety checks that they need to).
-
-This function performs the exact same kind of unit conversion as if the string `coerce_` were
-removed.  However, it will ignore any safety checks for overflow or truncation.
-
-??? example "Example: forcing a conversion from centimeters to meters"
-    `centi(meters_pt)(200).in(meters_pt)` is not allowed.  This conversion will divide the
-    underlying value, `200`, by `100`.  Now, it so happens that this _particular_ value _would_
-    produce an integer result. However, the compiler must decide whether to permit this operation
-    _at compile time_, which means we don't yet know the value.  Since most `int` values would _not_
-    produce integer results, we forbid this.
-
-    `centi(meters_pt)(200).coerce_in(meters_pt)` _is_ allowed.  The `coerce_` prefix has "forcing"
-    semantics.  This would produce `2`. However, note that this operation uses integer division,
-    which truncates: so, for example, `centi(meters_pt)(199).coerce_in(meters_pt)` would produce
-    `1`.
-
-These functions also support an explicit template parameter: so, `.coerce_as<T>(unit)` and
-`.coerce_in<T>(unit)`.  If you supply this parameter, it will be the rep of the result.
-
-??? example "Example: simultaneous unit and type conversion"
-    `centi(meters_pt)(271.8).coerce_as<int>(meters_pt)` will return `meters_pt(2)`.
-
-!!! tip
-    Prefer **not** to use the "coercing versions" if possible, because you will get more safety
-    checks.  The risks which the "base" versions warn about are real.
 
 ## Operations
 

--- a/fuzz/quantity_runtime_conversion_check.cc
+++ b/fuzz/quantity_runtime_conversion_check.cc
@@ -421,7 +421,7 @@ struct NominalTestBodyImpl : LossChecker<RepT, UnitT, DestRepT, DestUnitT, Cat> 
         const bool expect_trunc = will_conversion_truncate<DestRepT>(value, DestUnitT{});
         const bool expect_overflow = will_conversion_overflow<DestRepT>(value, DestUnitT{});
 
-        const auto destination = value.template coerce_as<DestRepT>(DestUnitT{});
+        const auto destination = value.template as<DestRepT>(DestUnitT{}, ignore(ALL_RISKS));
         const auto dest_from_op = Op::apply_to(value.in(UnitT{}));
         if (!std::isnan(dest_from_op) && dest_from_op != destination.in(DestUnitT{})) {
             std::cerr << "Programming error: either `Op` is wrong, or it was applied wrong.\n"
@@ -436,7 +436,7 @@ struct NominalTestBodyImpl : LossChecker<RepT, UnitT, DestRepT, DestUnitT, Cat> 
             std::terminate();
         }
 
-        const auto round_trip = destination.template coerce_as<RepT>(UnitT{});
+        const auto round_trip = destination.template as<RepT>(UnitT{}, ignore(ALL_RISKS));
 
         const auto loss_check = check_for_loss(value, destination, round_trip);
         const auto actual_loss = loss_check.result;

--- a/fuzz/quantity_runtime_conversion_checkers_test.cc
+++ b/fuzz/quantity_runtime_conversion_checkers_test.cc
@@ -103,7 +103,8 @@ TYPED_TEST_P(QuantityRuntimeConversionChecker, RoundTripIsIdentityIffConversionN
 
         const bool expect_loss = is_conversion_lossy(value, destination_unit);
 
-        const auto round_trip = value.coerce_as(destination_unit).coerce_as(meters);
+        const auto round_trip =
+            value.as(destination_unit, ignore(ALL_RISKS)).as(meters, ignore(ALL_RISKS));
         const bool actual_loss = (value != round_trip);
 
         EXPECT_THAT(expect_loss, Eq(actual_loss))

--- a/single-file-test.cc
+++ b/single-file-test.cc
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
         {
             expect_equal((meters / second)(5) * seconds(6), meters(30)),
             expect_equal(SPEED_OF_LIGHT.as<int>(m / s), 299'792'458 * m / s),
-            expect_equal((10 * m).coerce_in(m * mag<5>() / mag<7>()), 14),
+            expect_equal((10 * m).in(m * mag<5>() / mag<7>(), ignore(TRUNCATION_RISK)), 14),
             expect_equal(inverse_as(ns, 333 / s), 3'003'003 * ns),
         },
     };


### PR DESCRIPTION
This is to be `0.5.1-future-481`, paving the way to fix #481 in the
0.6.0 release.  After this commit, there is no instance of `coerce`
anywhere in the repo (with case-insensitive matching).