### PR TITLE
Make every unit definition independent

### DIFF
--- a/au/units/arcminutes.hh
+++ b/au/units/arcminutes.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/degrees.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct ArcminutesLabel {
 };
 template <typename T>
 constexpr const char ArcminutesLabel<T>::label[];
-struct Arcminutes : decltype(Degrees{} / mag<60>()), ArcminutesLabel<void> {
+struct Arcminutes
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Angle, Magnitude<Pow<Prime<2>, -4>, Pow<Prime<3>, -3>, Pi, Pow<Prime<5>, -2>>>,
+      ArcminutesLabel<void> {
     using ArcminutesLabel<void>::label;
 };
 constexpr auto arcminute = SingularNameFor<Arcminutes>{};

--- a/au/units/arcseconds.hh
+++ b/au/units/arcseconds.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/degrees.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct ArcsecondsLabel {
 };
 template <typename T>
 constexpr const char ArcsecondsLabel<T>::label[];
-struct Arcseconds : decltype(Degrees{} / mag<3600>()), ArcsecondsLabel<void> {
+struct Arcseconds
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Angle, Magnitude<Pow<Prime<2>, -6>, Pow<Prime<3>, -4>, Pi, Pow<Prime<5>, -3>>>,
+      ArcsecondsLabel<void> {
     using ArcsecondsLabel<void>::label;
 };
 constexpr auto arcsecond = SingularNameFor<Arcseconds>{};

--- a/au/units/bars.hh
+++ b/au/units/bars.hh
@@ -17,10 +17,8 @@
 #include "au/units/bars_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
 
-#include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/pascals.hh"
 
 namespace au {
 
@@ -32,7 +30,14 @@ struct BarsLabel {
 };
 template <typename T>
 constexpr const char BarsLabel<T>::label[];
-struct Bars : decltype(Kilo<Pascals>{} * mag<100>()), BarsLabel<void> {
+struct Bars
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, -1>, base_dim::Mass, Pow<base_dim::Time, -2>>,
+               Magnitude<Pow<Prime<2>, 8>, Pow<Prime<5>, 8>>>,
+      BarsLabel<void> {
     using BarsLabel<void>::label;
 };
 constexpr auto bar = SingularNameFor<Bars>{};

--- a/au/units/becquerel.hh
+++ b/au/units/becquerel.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/seconds.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct BecquerelLabel {
 };
 template <typename T>
 constexpr const char BecquerelLabel<T>::label[];
-struct Becquerel : UnitInverseT<Seconds>, BecquerelLabel<void> {
+struct Becquerel
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Time, -1>>>,
+      BecquerelLabel<void> {
     using BecquerelLabel<void>::label;
 };
 constexpr auto becquerel = QuantityMaker<Becquerel>{};

--- a/au/units/bytes.hh
+++ b/au/units/bytes.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/bits.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct BytesLabel {
 };
 template <typename T>
 constexpr const char BytesLabel<T>::label[];
-struct Bytes : decltype(Bits{} * mag<8>()), BytesLabel<void> {
+struct Bytes
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Information, Magnitude<Pow<Prime<2>, 3>>>,
+      BytesLabel<void> {
     using BytesLabel<void>::label;
 };
 constexpr auto byte = SingularNameFor<Bytes>{};

--- a/au/units/celsius.hh
+++ b/au/units/celsius.hh
@@ -21,7 +21,6 @@
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/kelvins.hh"
 
 namespace au {
 
@@ -33,9 +32,12 @@ struct CelsiusLabel {
 };
 template <typename T>
 constexpr const char CelsiusLabel<T>::label[];
-struct Celsius : Kelvins, CelsiusLabel<void> {
+struct Celsius : UnitImpl<Temperature>, CelsiusLabel<void> {
     using CelsiusLabel<void>::label;
-    static constexpr auto origin() { return centi(kelvins)(273'15); }
+    static constexpr auto origin() {
+        // 273.15 K = 27315 centi-kelvins
+        return make_quantity<Centi<UnitImpl<Temperature>>>(27315);
+    }
 };
 constexpr auto celsius_qty = QuantityMaker<Celsius>{};
 constexpr auto celsius_pt = QuantityPointMaker<Celsius>{};

--- a/au/units/coulombs.hh
+++ b/au/units/coulombs.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/amperes.hh"
-#include "au/units/seconds.hh"
 
 namespace au {
 
@@ -32,7 +30,13 @@ struct CoulombsLabel {
 };
 template <typename T>
 constexpr const char CoulombsLabel<T>::label[];
-struct Coulombs : decltype(Amperes{} * Seconds{}), CoulombsLabel<void> {
+struct Coulombs
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<base_dim::Time, base_dim::Current>>,
+      CoulombsLabel<void> {
     using CoulombsLabel<void>::label;
 };
 constexpr auto coulomb = SingularNameFor<Coulombs>{};

--- a/au/units/days.hh
+++ b/au/units/days.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/hours.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct DaysLabel {
 };
 template <typename T>
 constexpr const char DaysLabel<T>::label[];
-struct Days : decltype(Hours{} * mag<24>()), DaysLabel<void> {
+struct Days
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Time, Magnitude<Pow<Prime<2>, 7>, Pow<Prime<3>, 3>, Pow<Prime<5>, 2>>>,
+      DaysLabel<void> {
     using DaysLabel<void>::label;
 };
 constexpr auto day = SingularNameFor<Days>{};

--- a/au/units/degrees.hh
+++ b/au/units/degrees.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/radians.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct DegreesLabel {
 };
 template <typename T>
 constexpr const char DegreesLabel<T>::label[];
-struct Degrees : decltype(Radians{} * Magnitude<Pi>{} / mag<180>()), DegreesLabel<void> {
+struct Degrees
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Angle, Magnitude<Pow<Prime<2>, -2>, Pow<Prime<3>, -2>, Pi, Pow<Prime<5>, -1>>>,
+      DegreesLabel<void> {
     using DegreesLabel<void>::label;
 };
 constexpr auto degree = SingularNameFor<Degrees>{};

--- a/au/units/fahrenheit.hh
+++ b/au/units/fahrenheit.hh
@@ -21,7 +21,6 @@
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/kelvins.hh"
 
 namespace au {
 
@@ -33,11 +32,19 @@ struct FahrenheitLabel {
 };
 template <typename T>
 constexpr const char FahrenheitLabel<T>::label[];
-struct Rankines : decltype(Kelvins{} * mag<5>() / mag<9>()) {};
+struct Rankines
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Temperature, Magnitude<Pow<Prime<3>, -2>, Prime<5>>> {};
 constexpr auto rankines = QuantityMaker<Rankines>{};
 struct Fahrenheit : Rankines, FahrenheitLabel<void> {
     using FahrenheitLabel<void>::label;
-    static constexpr auto origin() { return centi(rankines)(459'67); }
+    static constexpr auto origin() {
+        // 459.67 Rankines = 45967 centi-rankines
+        return make_quantity<Centi<Rankines>>(45967);
+    }
 };
 constexpr auto fahrenheit_qty = QuantityMaker<Fahrenheit>{};
 constexpr auto fahrenheit_pt = QuantityPointMaker<Fahrenheit>{};

--- a/au/units/farads.hh
+++ b/au/units/farads.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/coulombs.hh"
-#include "au/units/volts.hh"
 
 namespace au {
 
@@ -32,7 +30,17 @@ struct FaradsLabel {
 };
 template <typename T>
 constexpr const char FaradsLabel<T>::label[];
-struct Farads : decltype(Coulombs{} / Volts{}), FaradsLabel<void> {
+struct Farads
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, -2>,
+                         Pow<base_dim::Mass, -1>,
+                         Pow<base_dim::Time, 4>,
+                         Pow<base_dim::Current, 2>>,
+               Magnitude<Pow<Prime<2>, -3>, Pow<Prime<5>, -3>>>,
+      FaradsLabel<void> {
     using FaradsLabel<void>::label;
 };
 constexpr auto farad = SingularNameFor<Farads>{};

--- a/au/units/fathoms.hh
+++ b/au/units/fathoms.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/feet.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct FathomsLabel {
 };
 template <typename T>
 constexpr const char FathomsLabel<T>::label[];
-struct Fathoms : decltype(Feet{} * mag<6>()), FathomsLabel<void> {
+struct Fathoms
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Length, Magnitude<Pow<Prime<3>, 2>, Pow<Prime<5>, -4>, Prime<127>>>,
+      FathomsLabel<void> {
     using FathomsLabel<void>::label;
 };
 constexpr auto fathom = SingularNameFor<Fathoms>{};

--- a/au/units/feet.hh
+++ b/au/units/feet.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/inches.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct FeetLabel {
 };
 template <typename T>
 constexpr const char FeetLabel<T>::label[];
-struct Feet : decltype(Inches{} * mag<12>()), FeetLabel<void> {
+struct Feet
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Length, Magnitude<Pow<Prime<2>, -1>, Prime<3>, Pow<Prime<5>, -4>, Prime<127>>>,
+      FeetLabel<void> {
     using FeetLabel<void>::label;
 };
 constexpr auto foot = SingularNameFor<Feet>{};

--- a/au/units/football_fields.hh
+++ b/au/units/football_fields.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/yards.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct FootballFieldsLabel {
 };
 template <typename T>
 constexpr const char FootballFieldsLabel<T>::label[];
-struct FootballFields : decltype(Yards{} * mag<100>()), FootballFieldsLabel<void> {
+struct FootballFields
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Length, Magnitude<Prime<2>, Pow<Prime<3>, 2>, Pow<Prime<5>, -2>, Prime<127>>>,
+      FootballFieldsLabel<void> {
     using FootballFieldsLabel<void>::label;
 };
 constexpr auto football_field = SingularNameFor<FootballFields>{};

--- a/au/units/furlongs.hh
+++ b/au/units/furlongs.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/miles.hh"
 
 namespace au {
 
@@ -31,7 +30,14 @@ struct FurlongsLabel {
 };
 template <typename T>
 constexpr const char FurlongsLabel<T>::label[];
-struct Furlongs : decltype(Miles{} / mag<8>()), FurlongsLabel<void> {
+struct Furlongs
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Length,
+               Magnitude<Prime<2>, Pow<Prime<3>, 2>, Pow<Prime<5>, -3>, Prime<11>, Prime<127>>>,
+      FurlongsLabel<void> {
     using FurlongsLabel<void>::label;
 };
 constexpr auto furlong = SingularNameFor<Furlongs>{};

--- a/au/units/grays.hh
+++ b/au/units/grays.hh
@@ -17,11 +17,8 @@
 #include "au/units/grays_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
 
-#include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/grams.hh"
-#include "au/units/joules.hh"
 
 namespace au {
 
@@ -33,7 +30,13 @@ struct GraysLabel {
 };
 template <typename T>
 constexpr const char GraysLabel<T>::label[];
-struct Grays : decltype(Joules{} / Kilo<Grams>{}), GraysLabel<void> {
+struct Grays
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, 2>, Pow<base_dim::Time, -2>>>,
+      GraysLabel<void> {
     using GraysLabel<void>::label;
 };
 constexpr auto gray = SingularNameFor<Grays>{};

--- a/au/units/henries.hh
+++ b/au/units/henries.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/amperes.hh"
-#include "au/units/webers.hh"
 
 namespace au {
 
@@ -32,7 +30,17 @@ struct HenriesLabel {
 };
 template <typename T>
 constexpr const char HenriesLabel<T>::label[];
-struct Henries : decltype(Webers{} / Amperes{}), HenriesLabel<void> {
+struct Henries
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, 2>,
+                         base_dim::Mass,
+                         Pow<base_dim::Time, -2>,
+                         Pow<base_dim::Current, -2>>,
+               Magnitude<Pow<Prime<2>, 3>, Pow<Prime<5>, 3>>>,
+      HenriesLabel<void> {
     using HenriesLabel<void>::label;
 };
 constexpr auto henry = SingularNameFor<Henries>{};

--- a/au/units/hertz.hh
+++ b/au/units/hertz.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/seconds.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct HertzLabel {
 };
 template <typename T>
 constexpr const char HertzLabel<T>::label[];
-struct Hertz : UnitInverseT<Seconds>, HertzLabel<void> {
+struct Hertz
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Time, -1>>>,
+      HertzLabel<void> {
     using HertzLabel<void>::label;
 };
 constexpr auto hertz = QuantityMaker<Hertz>{};

--- a/au/units/hours.hh
+++ b/au/units/hours.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/minutes.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct HoursLabel {
 };
 template <typename T>
 constexpr const char HoursLabel<T>::label[];
-struct Hours : decltype(Minutes{} * mag<60>()), HoursLabel<void> {
+struct Hours
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Time, Magnitude<Pow<Prime<2>, 4>, Pow<Prime<3>, 2>, Pow<Prime<5>, 2>>>,
+      HoursLabel<void> {
     using HoursLabel<void>::label;
 };
 constexpr auto hour = SingularNameFor<Hours>{};

--- a/au/units/inches.hh
+++ b/au/units/inches.hh
@@ -17,10 +17,8 @@
 #include "au/units/inches_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
 
-#include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/meters.hh"
 
 namespace au {
 
@@ -32,7 +30,13 @@ struct InchesLabel {
 };
 template <typename T>
 constexpr const char InchesLabel<T>::label[];
-struct Inches : decltype(Centi<Meters>{} * mag<254>() / mag<100>()), InchesLabel<void> {
+struct Inches
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Length, Magnitude<Pow<Prime<2>, -3>, Pow<Prime<5>, -4>, Prime<127>>>,
+      InchesLabel<void> {
     using InchesLabel<void>::label;
 };
 constexpr auto inch = SingularNameFor<Inches>{};

--- a/au/units/joules.hh
+++ b/au/units/joules.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/meters.hh"
-#include "au/units/newtons.hh"
 
 namespace au {
 
@@ -32,7 +30,14 @@ struct JoulesLabel {
 };
 template <typename T>
 constexpr const char JoulesLabel<T>::label[];
-struct Joules : decltype(Newtons{} * Meters{}), JoulesLabel<void> {
+struct Joules
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, 2>, base_dim::Mass, Pow<base_dim::Time, -2>>,
+               Magnitude<Pow<Prime<2>, 3>, Pow<Prime<5>, 3>>>,
+      JoulesLabel<void> {
     using JoulesLabel<void>::label;
 };
 constexpr auto joule = SingularNameFor<Joules>{};

--- a/au/units/katals.hh
+++ b/au/units/katals.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/moles.hh"
-#include "au/units/seconds.hh"
 
 namespace au {
 
@@ -32,7 +30,13 @@ struct KatalsLabel {
 };
 template <typename T>
 constexpr const char KatalsLabel<T>::label[];
-struct Katals : decltype(Moles{} / Seconds{}), KatalsLabel<void> {
+struct Katals
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Time, -1>, base_dim::AmountOfSubstance>>,
+      KatalsLabel<void> {
     using KatalsLabel<void>::label;
 };
 constexpr auto katal = SingularNameFor<Katals>{};

--- a/au/units/knots.hh
+++ b/au/units/knots.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/hours.hh"
-#include "au/units/nautical_miles.hh"
 
 namespace au {
 
@@ -32,7 +30,14 @@ struct KnotsLabel {
 };
 template <typename T>
 constexpr const char KnotsLabel<T>::label[];
-struct Knots : decltype(NauticalMiles{} / Hours{}), KnotsLabel<void> {
+struct Knots
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<base_dim::Length, Pow<base_dim::Time, -1>>,
+               Magnitude<Pow<Prime<2>, -2>, Pow<Prime<3>, -2>, Pow<Prime<5>, -2>, Prime<463>>>,
+      KnotsLabel<void> {
     using KnotsLabel<void>::label;
 };
 constexpr auto knot = SingularNameFor<Knots>{};

--- a/au/units/liters.hh
+++ b/au/units/liters.hh
@@ -17,10 +17,8 @@
 #include "au/units/liters_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
 
-#include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/meters.hh"
 
 namespace au {
 
@@ -32,7 +30,14 @@ struct LitersLabel {
 };
 template <typename T>
 constexpr const char LitersLabel<T>::label[];
-struct Liters : decltype(cubed(Deci<Meters>{})), LitersLabel<void> {
+struct Liters
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, 3>>,
+               Magnitude<Pow<Prime<2>, -3>, Pow<Prime<5>, -3>>>,
+      LitersLabel<void> {
     using LitersLabel<void>::label;
 };
 constexpr auto liter = SingularNameFor<Liters>{};

--- a/au/units/lumens.hh
+++ b/au/units/lumens.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/candelas.hh"
-#include "au/units/steradians.hh"
 
 namespace au {
 
@@ -32,7 +30,13 @@ struct LumensLabel {
 };
 template <typename T>
 constexpr const char LumensLabel<T>::label[];
-struct Lumens : decltype(Candelas{} * Steradians{}), LumensLabel<void> {
+struct Lumens
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Angle, 2>, base_dim::LuminousIntensity>>,
+      LumensLabel<void> {
     using LumensLabel<void>::label;
 };
 constexpr auto lumen = SingularNameFor<Lumens>{};

--- a/au/units/lux.hh
+++ b/au/units/lux.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/lumens.hh"
-#include "au/units/meters.hh"
 
 namespace au {
 
@@ -32,7 +30,15 @@ struct LuxLabel {
 };
 template <typename T>
 constexpr const char LuxLabel<T>::label[];
-struct Lux : decltype(Lumens{} / squared(Meters{})), LuxLabel<void> {
+struct Lux
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, -2>,
+                         Pow<base_dim::Angle, 2>,
+                         base_dim::LuminousIntensity>>,
+      LuxLabel<void> {
     using LuxLabel<void>::label;
 };
 constexpr auto lux = QuantityMaker<Lux>{};

--- a/au/units/miles.hh
+++ b/au/units/miles.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/feet.hh"
 
 namespace au {
 
@@ -31,7 +30,15 @@ struct MilesLabel {
 };
 template <typename T>
 constexpr const char MilesLabel<T>::label[];
-struct Miles : decltype(Feet{} * mag<5'280>()), MilesLabel<void> {
+struct Miles
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<
+          Length,
+          Magnitude<Pow<Prime<2>, 4>, Pow<Prime<3>, 2>, Pow<Prime<5>, -3>, Prime<11>, Prime<127>>>,
+      MilesLabel<void> {
     using MilesLabel<void>::label;
 };
 constexpr auto mile = SingularNameFor<Miles>{};

--- a/au/units/minutes.hh
+++ b/au/units/minutes.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/seconds.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct MinutesLabel {
 };
 template <typename T>
 constexpr const char MinutesLabel<T>::label[];
-struct Minutes : decltype(Seconds{} * mag<60>()), MinutesLabel<void> {
+struct Minutes
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Time, Magnitude<Pow<Prime<2>, 2>, Prime<3>, Prime<5>>>,
+      MinutesLabel<void> {
     using MinutesLabel<void>::label;
 };
 constexpr auto minute = SingularNameFor<Minutes>{};

--- a/au/units/nautical_miles.hh
+++ b/au/units/nautical_miles.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/meters.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct NauticalMilesLabel {
 };
 template <typename T>
 constexpr const char NauticalMilesLabel<T>::label[];
-struct NauticalMiles : decltype(Meters{} * mag<1'852>()), NauticalMilesLabel<void> {
+struct NauticalMiles
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Length, Magnitude<Pow<Prime<2>, 2>, Prime<463>>>,
+      NauticalMilesLabel<void> {
     using NauticalMilesLabel<void>::label;
 };
 constexpr auto nautical_mile = SingularNameFor<NauticalMiles>{};

--- a/au/units/newtons.hh
+++ b/au/units/newtons.hh
@@ -17,12 +17,8 @@
 #include "au/units/newtons_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
 
-#include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/grams.hh"
-#include "au/units/meters.hh"
-#include "au/units/seconds.hh"
 
 namespace au {
 
@@ -34,7 +30,14 @@ struct NewtonsLabel {
 };
 template <typename T>
 constexpr const char NewtonsLabel<T>::label[];
-struct Newtons : decltype(Kilo<Grams>{} * Meters{} / squared(Seconds{})), NewtonsLabel<void> {
+struct Newtons
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<base_dim::Length, base_dim::Mass, Pow<base_dim::Time, -2>>,
+               Magnitude<Pow<Prime<2>, 3>, Pow<Prime<5>, 3>>>,
+      NewtonsLabel<void> {
     using NewtonsLabel<void>::label;
 };
 constexpr auto newton = SingularNameFor<Newtons>{};

--- a/au/units/ohms.hh
+++ b/au/units/ohms.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/amperes.hh"
-#include "au/units/volts.hh"
 
 namespace au {
 
@@ -32,7 +30,17 @@ struct OhmsLabel {
 };
 template <typename T>
 constexpr const char OhmsLabel<T>::label[];
-struct Ohms : decltype(Volts{} / Amperes{}), OhmsLabel<void> {
+struct Ohms
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, 2>,
+                         base_dim::Mass,
+                         Pow<base_dim::Time, -3>,
+                         Pow<base_dim::Current, -2>>,
+               Magnitude<Pow<Prime<2>, 3>, Pow<Prime<5>, 3>>>,
+      OhmsLabel<void> {
     using OhmsLabel<void>::label;
 };
 constexpr auto ohm = SingularNameFor<Ohms>{};

--- a/au/units/pascals.hh
+++ b/au/units/pascals.hh
@@ -20,8 +20,6 @@
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/meters.hh"
-#include "au/units/newtons.hh"
 
 namespace au {
 
@@ -33,7 +31,14 @@ struct PascalsLabel {
 };
 template <typename T>
 constexpr const char PascalsLabel<T>::label[];
-struct Pascals : decltype(Newtons{} / squared(Meters{})), PascalsLabel<void> {
+struct Pascals
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, -1>, base_dim::Mass, Pow<base_dim::Time, -2>>,
+               Magnitude<Pow<Prime<2>, 3>, Pow<Prime<5>, 3>>>,
+      PascalsLabel<void> {
     using PascalsLabel<void>::label;
 };
 

--- a/au/units/percent.hh
+++ b/au/units/percent.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/unos.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct PercentLabel {
 };
 template <typename T>
 constexpr const char PercentLabel<T>::label[];
-struct Percent : decltype(Unos{} / mag<100>()), PercentLabel<void> {
+struct Percent
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<>, Magnitude<Pow<Prime<2>, -2>, Pow<Prime<5>, -2>>>,
+      PercentLabel<void> {
     using PercentLabel<void>::label;
 };
 constexpr auto percent = QuantityMaker<Percent>{};

--- a/au/units/pounds_force.hh
+++ b/au/units/pounds_force.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/pounds_mass.hh"
-#include "au/units/standard_gravity.hh"
 
 namespace au {
 
@@ -32,7 +30,20 @@ struct PoundsForceLabel {
 };
 template <typename T>
 constexpr const char PoundsForceLabel<T>::label[];
-struct PoundsForce : decltype(PoundsMass{} * StandardGravity{}), PoundsForceLabel<void> {
+struct PoundsForce
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<base_dim::Length, base_dim::Mass, Pow<base_dim::Time, -2>>,
+               Magnitude<Pow<Prime<2>, -10>,
+                         Pow<Prime<5>, -9>,
+                         Pow<Prime<7>, 2>,
+                         Prime<11>,
+                         Prime<97>,
+                         Prime<6073>,
+                         Prime<28019>>>,
+      PoundsForceLabel<void> {
     using PoundsForceLabel<void>::label;
 };
 constexpr auto pound_force = SingularNameFor<PoundsForce>{};

--- a/au/units/pounds_mass.hh
+++ b/au/units/pounds_mass.hh
@@ -17,10 +17,8 @@
 #include "au/units/pounds_mass_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
 
-#include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/grams.hh"
 
 namespace au {
 
@@ -32,7 +30,19 @@ struct PoundsMassLabel {
 };
 template <typename T>
 constexpr const char PoundsMassLabel<T>::label[];
-struct PoundsMass : decltype(Micro<Grams>{} * mag<453'592'370>()), PoundsMassLabel<void> {
+struct PoundsMass
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Mass,
+               Magnitude<Pow<Prime<2>, -5>,
+                         Pow<Prime<5>, -5>,
+                         Prime<7>,
+                         Prime<11>,
+                         Prime<97>,
+                         Prime<6073>>>,
+      PoundsMassLabel<void> {
     using PoundsMassLabel<void>::label;
 };
 constexpr auto pound_mass = SingularNameFor<PoundsMass>{};

--- a/au/units/revolutions.hh
+++ b/au/units/revolutions.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/degrees.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct RevolutionsLabel {
 };
 template <typename T>
 constexpr const char RevolutionsLabel<T>::label[];
-struct Revolutions : decltype(Degrees{} * mag<360>()), RevolutionsLabel<void> {
+struct Revolutions
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Angle, Magnitude<Prime<2>, Pi>>,
+      RevolutionsLabel<void> {
     using RevolutionsLabel<void>::label;
 };
 constexpr auto revolution = SingularNameFor<Revolutions>{};

--- a/au/units/siemens.hh
+++ b/au/units/siemens.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/ohms.hh"
 
 namespace au {
 
@@ -31,7 +30,17 @@ struct SiemensLabel {
 };
 template <typename T>
 constexpr const char SiemensLabel<T>::label[];
-struct Siemens : UnitInverseT<Ohms>, SiemensLabel<void> {
+struct Siemens
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, -2>,
+                         Pow<base_dim::Mass, -1>,
+                         Pow<base_dim::Time, 3>,
+                         Pow<base_dim::Current, 2>>,
+               Magnitude<Pow<Prime<2>, -3>, Pow<Prime<5>, -3>>>,
+      SiemensLabel<void> {
     using SiemensLabel<void>::label;
 };
 constexpr auto siemen = SingularNameFor<Siemens>{};

--- a/au/units/slugs.hh
+++ b/au/units/slugs.hh
@@ -19,9 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/feet.hh"
-#include "au/units/pounds_force.hh"
-#include "au/units/seconds.hh"
 
 namespace au {
 
@@ -33,7 +30,22 @@ struct SlugsLabel {
 };
 template <typename T>
 constexpr const char SlugsLabel<T>::label[];
-struct Slugs : decltype(PoundsForce{} * squared(Seconds{}) / Feet{}), SlugsLabel<void> {
+struct Slugs
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Mass,
+               Magnitude<Pow<Prime<2>, -9>,
+                         Pow<Prime<3>, -1>,
+                         Pow<Prime<5>, -5>,
+                         Pow<Prime<7>, 2>,
+                         Prime<11>,
+                         Prime<97>,
+                         Pow<Prime<127>, -1>,
+                         Prime<6073>,
+                         Prime<28019>>>,
+      SlugsLabel<void> {
     using SlugsLabel<void>::label;
 };
 constexpr auto slug = SingularNameFor<Slugs>{};

--- a/au/units/standard_gravity.hh
+++ b/au/units/standard_gravity.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/meters.hh"
-#include "au/units/seconds.hh"
 
 namespace au {
 
@@ -33,7 +31,12 @@ struct StandardGravityLabel {
 template <typename T>
 constexpr const char StandardGravityLabel<T>::label[];
 struct StandardGravity
-    : decltype((Meters{} / squared(Seconds{})) * (mag<980'665>() / mag<100'000>())),
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<base_dim::Length, Pow<base_dim::Time, -2>>,
+               Magnitude<Pow<Prime<2>, -5>, Pow<Prime<5>, -4>, Prime<7>, Prime<28019>>>,
       StandardGravityLabel<void> {
     using StandardGravityLabel<void>::label;
 };

--- a/au/units/steradians.hh
+++ b/au/units/steradians.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/radians.hh"
 
 namespace au {
 
@@ -31,7 +30,13 @@ struct SteradiansLabel {
 };
 template <typename T>
 constexpr const char SteradiansLabel<T>::label[];
-struct Steradians : decltype(squared(Radians{})), SteradiansLabel<void> {
+struct Steradians
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Angle, 2>>>,
+      SteradiansLabel<void> {
     using SteradiansLabel<void>::label;
 };
 constexpr auto steradian = SingularNameFor<Steradians>{};

--- a/au/units/tesla.hh
+++ b/au/units/tesla.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/meters.hh"
-#include "au/units/webers.hh"
 
 namespace au {
 
@@ -32,7 +30,14 @@ struct TeslaLabel {
 };
 template <typename T>
 constexpr const char TeslaLabel<T>::label[];
-struct Tesla : decltype(Webers{} / squared(Meters{})), TeslaLabel<void> {
+struct Tesla
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<base_dim::Mass, Pow<base_dim::Time, -2>, Pow<base_dim::Current, -1>>,
+               Magnitude<Pow<Prime<2>, 3>, Pow<Prime<5>, 3>>>,
+      TeslaLabel<void> {
     using TeslaLabel<void>::label;
 };
 constexpr auto tesla = QuantityMaker<Tesla>{};

--- a/au/units/us_gallons.hh
+++ b/au/units/us_gallons.hh
@@ -17,7 +17,8 @@
 #include "au/units/us_gallons_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
 
-#include "au/units/inches.hh"
+#include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -29,7 +30,19 @@ struct USGallonsLabel {
 };
 template <typename T>
 constexpr const char USGallonsLabel<T>::label[];
-struct USGallons : decltype(cubed(Inches{}) * mag<231>()), USGallonsLabel<void> {
+struct USGallons
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, 3>>,
+               Magnitude<Pow<Prime<2>, -9>,
+                         Prime<3>,
+                         Pow<Prime<5>, -12>,
+                         Prime<7>,
+                         Prime<11>,
+                         Pow<Prime<127>, 3>>>,
+      USGallonsLabel<void> {
     using USGallonsLabel<void>::label;
 };
 constexpr auto us_gallon = SingularNameFor<USGallons>{};

--- a/au/units/us_pints.hh
+++ b/au/units/us_pints.hh
@@ -17,7 +17,8 @@
 #include "au/units/us_pints_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
 
-#include "au/units/inches.hh"
+#include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -29,7 +30,19 @@ struct USPintsLabel {
 };
 template <typename T>
 constexpr const char USPintsLabel<T>::label[];
-struct USPints : decltype(cubed(Inches{}) * (mag<231>() / mag<8>())), USPintsLabel<void> {
+struct USPints
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, 3>>,
+               Magnitude<Pow<Prime<2>, -12>,
+                         Prime<3>,
+                         Pow<Prime<5>, -12>,
+                         Prime<7>,
+                         Prime<11>,
+                         Pow<Prime<127>, 3>>>,
+      USPintsLabel<void> {
     using USPintsLabel<void>::label;
 };
 constexpr auto us_pint = SingularNameFor<USPints>{};

--- a/au/units/us_quarts.hh
+++ b/au/units/us_quarts.hh
@@ -17,7 +17,8 @@
 #include "au/units/us_quarts_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
 
-#include "au/units/inches.hh"
+#include "au/quantity.hh"
+#include "au/unit_symbol.hh"
 
 namespace au {
 
@@ -29,7 +30,19 @@ struct USQuartsLabel {
 };
 template <typename T>
 constexpr const char USQuartsLabel<T>::label[];
-struct USQuarts : decltype(cubed(Inches{}) * (mag<231>() / mag<4>())), USQuartsLabel<void> {
+struct USQuarts
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, 3>>,
+               Magnitude<Pow<Prime<2>, -11>,
+                         Prime<3>,
+                         Pow<Prime<5>, -12>,
+                         Prime<7>,
+                         Prime<11>,
+                         Pow<Prime<127>, 3>>>,
+      USQuartsLabel<void> {
     using USQuartsLabel<void>::label;
 };
 constexpr auto us_quart = SingularNameFor<USQuarts>{};

--- a/au/units/volts.hh
+++ b/au/units/volts.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/amperes.hh"
-#include "au/units/watts.hh"
 
 namespace au {
 
@@ -32,7 +30,17 @@ struct VoltsLabel {
 };
 template <typename T>
 constexpr const char VoltsLabel<T>::label[];
-struct Volts : decltype(Watts{} / Amperes{}), VoltsLabel<void> {
+struct Volts
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, 2>,
+                         base_dim::Mass,
+                         Pow<base_dim::Time, -3>,
+                         Pow<base_dim::Current, -1>>,
+               Magnitude<Pow<Prime<2>, 3>, Pow<Prime<5>, 3>>>,
+      VoltsLabel<void> {
     using VoltsLabel<void>::label;
 };
 constexpr auto volt = SingularNameFor<Volts>{};

--- a/au/units/watts.hh
+++ b/au/units/watts.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/joules.hh"
-#include "au/units/seconds.hh"
 
 namespace au {
 
@@ -32,7 +30,14 @@ struct WattsLabel {
 };
 template <typename T>
 constexpr const char WattsLabel<T>::label[];
-struct Watts : decltype(Joules{} / Seconds{}), WattsLabel<void> {
+struct Watts
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, 2>, base_dim::Mass, Pow<base_dim::Time, -3>>,
+               Magnitude<Pow<Prime<2>, 3>, Pow<Prime<5>, 3>>>,
+      WattsLabel<void> {
     using WattsLabel<void>::label;
 };
 constexpr auto watt = SingularNameFor<Watts>{};

--- a/au/units/webers.hh
+++ b/au/units/webers.hh
@@ -19,8 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/seconds.hh"
-#include "au/units/volts.hh"
 
 namespace au {
 
@@ -32,7 +30,17 @@ struct WebersLabel {
 };
 template <typename T>
 constexpr const char WebersLabel<T>::label[];
-struct Webers : decltype(Volts{} * Seconds{}), WebersLabel<void> {
+struct Webers
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Dimension<Pow<base_dim::Length, 2>,
+                         base_dim::Mass,
+                         Pow<base_dim::Time, -2>,
+                         Pow<base_dim::Current, -1>>,
+               Magnitude<Pow<Prime<2>, 3>, Pow<Prime<5>, 3>>>,
+      WebersLabel<void> {
     using WebersLabel<void>::label;
 };
 constexpr auto weber = SingularNameFor<Webers>{};

--- a/au/units/yards.hh
+++ b/au/units/yards.hh
@@ -19,7 +19,6 @@
 
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
-#include "au/units/feet.hh"
 
 namespace au {
 
@@ -31,7 +30,14 @@ struct YardsLabel {
 };
 template <typename T>
 constexpr const char YardsLabel<T>::label[];
-struct Yards : decltype(Feet{} * mag<3>()), YardsLabel<void> {
+struct Yards
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Length,
+               Magnitude<Pow<Prime<2>, -1>, Pow<Prime<3>, 2>, Pow<Prime<5>, -4>, Prime<127>>>,
+      YardsLabel<void> {
     using YardsLabel<void>::label;
 };
 constexpr auto yard = SingularNameFor<Yards>{};


### PR DESCRIPTION
The goal of this commit is that each unit should be defined purely by
its dimension, and an essentially "magic" number, with no explicit
reference to any other unit.  They all enter on equal footing.  We rely
on the _unit tests_ --- which we do not change --- to make sure that
every unit has the correct relationship with every other unit.

This simplifies the logical structure of the library, and reduces
entanglements.  It may also slightly improve compile time performance.

The downside is that any code that was relying on _transitive includes_
to bring in some of the units that it needed will break.  The fix is
very simple: include the file directly for every unit that you use.

Finally, we completely abandon user-friendly definitions and aliases in
our unit definitions.  Since these units are included directly with the
library, we have enough test coverage to be perfectly confident that we
got them right. Therefore, we spell out the concrete `Dimension<...>`
and `Magnitude<...>` types directly.  End users must never do this in
their code, so we include a stark extra warning with every instance.
This direct approach should be the easiest possible for compilers to
handle, which we assume fixes #560.

Fixes #451.