### PR TITLE
Avoid `T`-suffix names in `:packs`

### DIFF
--- a/au/packs.hh
+++ b/au/packs.hh
@@ -45,33 +45,41 @@ struct RatioPow;
 // powers of a base type `B`, and `RatioPow<B, N, D>` can represent rational powers of `B` (where
 // the power is `(N/D)`).
 template <typename T>
-struct Base : stdx::type_identity<T> {};
+struct BaseImpl : stdx::type_identity<T> {};
 template <typename T>
-using BaseT = typename Base<T>::type;
+using Base = typename BaseImpl<T>::type;
+template <typename T>
+using BaseT = Base<T>;
 
 // Type trait for the rational exponent of a type, interpreted as a base power.
 template <typename T>
-struct Exp : stdx::type_identity<std::ratio<1>> {};
+struct ExpImpl : stdx::type_identity<std::ratio<1>> {};
 template <typename T>
-using ExpT = typename Exp<T>::type;
+using Exp = typename ExpImpl<T>::type;
+template <typename T>
+using ExpT = Exp<T>;
 
 // Type trait for treating an arbitrary type as a given type of pack.
 //
 // This should be the identity for anything that is already a pack of this type, and otherwise
 // should wrap it in this type of pack.
 template <template <class... Ts> class Pack, typename T>
-struct AsPack : stdx::type_identity<Pack<T>> {};
+struct AsPackImpl : stdx::type_identity<Pack<T>> {};
 template <template <class... Ts> class Pack, typename T>
-using AsPackT = typename AsPack<Pack, T>::type;
+using AsPack = typename AsPackImpl<Pack, T>::type;
+template <template <class... Ts> class Pack, typename T>
+using AsPackT = AsPack<Pack, T>;
 
 // Type trait to remove a Pack enclosing a single item.
 //
 // Defined only if T is Pack<Ts...> for some typelist.  Always the identity, unless sizeof...(Ts) is
 // exactly 1, in which case, it returns the (sole) element.
 template <template <class... Ts> class Pack, typename T>
-struct UnpackIfSolo;
+struct UnpackIfSoloImpl;
 template <template <class... Ts> class Pack, typename T>
-using UnpackIfSoloT = typename UnpackIfSolo<Pack, T>::type;
+using UnpackIfSolo = typename UnpackIfSoloImpl<Pack, T>::type;
+template <template <class... Ts> class Pack, typename T>
+using UnpackIfSoloT = UnpackIfSolo<Pack, T>;
 
 // Trait to define whether two types are in order, based on the total ordering for some pack.
 //
@@ -118,9 +126,11 @@ using SortAs = typename SortAsImpl<PackForOrdering, ListT>::type;
 // undefined.  (This precondition will automatically be satisfied if *every* instance of `List<...>`
 // arises as the result of a call to `FlatDedupedTypeListT<...>`.)
 template <template <class...> class List, typename... Ts>
-struct FlatDedupedTypeList;
+struct FlatDedupedTypeListImpl;
 template <template <class...> class List, typename... Ts>
-using FlatDedupedTypeListT = typename FlatDedupedTypeList<List, AsPackT<List, Ts>...>::type;
+using FlatDedupedTypeList = typename FlatDedupedTypeListImpl<List, AsPack<List, Ts>...>::type;
+template <template <class...> class List, typename... Ts>
+using FlatDedupedTypeListT = FlatDedupedTypeList<List, Ts...>;
 
 namespace detail {
 // Express a base power in its simplest form (base alone if power is 1, or Pow if exp is integral).
@@ -255,39 +265,39 @@ struct RatioPow {
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-// `BaseT` implementation.
+// `Base` implementation.
 
 template <typename T, std::intmax_t N>
-struct Base<Pow<T, N>> : stdx::type_identity<T> {};
+struct BaseImpl<Pow<T, N>> : stdx::type_identity<T> {};
 
 template <typename T, std::intmax_t N, std::intmax_t D>
-struct Base<RatioPow<T, N, D>> : stdx::type_identity<T> {};
+struct BaseImpl<RatioPow<T, N, D>> : stdx::type_identity<T> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-// `ExpT` implementation.
+// `Exp` implementation.
 
 template <typename T, std::intmax_t N>
-struct Exp<Pow<T, N>> : stdx::type_identity<std::ratio<N>> {};
+struct ExpImpl<Pow<T, N>> : stdx::type_identity<std::ratio<N>> {};
 
 template <typename T, std::intmax_t N, std::intmax_t D>
-struct Exp<RatioPow<T, N, D>> : stdx::type_identity<std::ratio<N, D>> {};
+struct ExpImpl<RatioPow<T, N, D>> : stdx::type_identity<std::ratio<N, D>> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-// `AsPackT` implementation.
+// `AsPack` implementation.
 
 template <template <class... Ts> class Pack, typename... Ts>
-struct AsPack<Pack, Pack<Ts...>> : stdx::type_identity<Pack<Ts...>> {};
+struct AsPackImpl<Pack, Pack<Ts...>> : stdx::type_identity<Pack<Ts...>> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-// `UnpackIfSoloT` implementation.
+// `UnpackIfSolo` implementation.
 
 // Null pack case: do not unpack.
 template <template <class... Ts> class Pack>
-struct UnpackIfSolo<Pack, Pack<>> : stdx::type_identity<Pack<>> {};
+struct UnpackIfSoloImpl<Pack, Pack<>> : stdx::type_identity<Pack<>> {};
 
 // Non-null pack case: unpack only if there is nothing after the head element.
 template <template <class... Ts> class Pack, typename T, typename... Ts>
-struct UnpackIfSolo<Pack, Pack<T, Ts...>>
+struct UnpackIfSoloImpl<Pack, Pack<T, Ts...>>
     : std::conditional<(sizeof...(Ts) == 0u), T, Pack<T, Ts...>> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -420,20 +430,20 @@ struct SortAsImpl<PackForOrdering, Pack<T, Ts...>>
 //
 // (We explicitly assumed that any `List<...>` inputs would already be in sorted order.)
 template <template <class...> class List, typename... Ts>
-struct FlatDedupedTypeList<List, List<Ts...>> : stdx::type_identity<List<Ts...>> {};
+struct FlatDedupedTypeListImpl<List, List<Ts...>> : stdx::type_identity<List<Ts...>> {};
 
 // 2-ary base case: if we exhaust elements in the second list, the first list is the answer.
 //
 // (Again: this relies on the explicit assumption that any `List<...>` inputs are already in order.)
 template <template <class...> class List, typename... Ts>
-struct FlatDedupedTypeList<List, List<Ts...>, List<>> : stdx::type_identity<List<Ts...>> {};
+struct FlatDedupedTypeListImpl<List, List<Ts...>, List<>> : stdx::type_identity<List<Ts...>> {};
 
 // 2-ary recursive case, single-element head.
 //
 // This use case also serves as the core "insertion logic", inserting `T` into the proper place
 // within `List<H, Ts...>`.
 template <template <class...> class List, typename T, typename H, typename... Ts>
-struct FlatDedupedTypeList<List, List<T>, List<H, Ts...>> :
+struct FlatDedupedTypeListImpl<List, List<T>, List<H, Ts...>> :
 
     // If the candidate element exactly equals the head, disregard it (de-dupe!).
     std::conditional<
@@ -457,18 +467,18 @@ template <template <class...> class List,
           typename... T1,
           typename H2,
           typename... T2>
-struct FlatDedupedTypeList<List, List<H1, N1, T1...>, List<H2, T2...>>
-    : FlatDedupedTypeList<List,
-                          // Put H2 first so we can use single-element-head case from above.
-                          FlatDedupedTypeListT<List, List<H2>, List<H1, N1, T1...>>,
-                          List<T2...>> {};
+struct FlatDedupedTypeListImpl<List, List<H1, N1, T1...>, List<H2, T2...>>
+    : FlatDedupedTypeListImpl<List,
+                              // Put H2 first so we can use single-element-head case from above.
+                              FlatDedupedTypeListT<List, List<H2>, List<H1, N1, T1...>>,
+                              List<T2...>> {};
 
 // N-ary case, multi-element head: peel off tail-of-head, and recurse.
 //
 // Note that this also handles the 2-ary case where the head list has more than one element.
 template <template <class...> class List, typename L1, typename L2, typename L3, typename... Ls>
-struct FlatDedupedTypeList<List, L1, L2, L3, Ls...>
-    : FlatDedupedTypeList<List, FlatDedupedTypeListT<List, L1, L2>, L3, Ls...> {};
+struct FlatDedupedTypeListImpl<List, L1, L2, L3, Ls...>
+    : FlatDedupedTypeListImpl<List, FlatDedupedTypeListT<List, L1, L2>, L3, Ls...> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `PackProductT` implementation.

--- a/docs/discussion/implementation/vector_space.md
+++ b/docs/discussion/implementation/vector_space.md
@@ -172,9 +172,9 @@ container type (in this case, `UnitProduct<...>`) unless we have to: after all, 
 user-friendly than `UnitProduct<Meters>`, let alone something awful like
 `UnitProduct<RatioPow<Meters, 1, 0>>`!  We support this use case with the following strategy:
 
-- **wrap-if-necessary** on the way **in** (via `AsPackT`)
+- **wrap-if-necessary** on the way **in** (via `AsPack`)
 
-- **unwrap-if-possible** on the way **out** (via `UnpackIfSoloT`)
+- **unwrap-if-possible** on the way **out** (via `UnpackIfSolo`)
 
 This was the only machinery we needed to add: apart from that, we were able to leverage our
 pre-existing [packs](../../reference/detail/packs.md) support to provide a fluent experience for

--- a/docs/reference/detail/packs.md
+++ b/docs/reference/detail/packs.md
@@ -7,8 +7,8 @@ Products of base powers are the foundation for the Au library.  We use them for:
   - Making _compound_ Units (products of powers of units, e.g., $\text{m} \cdot \text{s}^{-2}$).
 
 We represent them as variadic parameter packs.  Each pack element represents a "base power": this is
-some "base", raised to some rational exponent.  For a base power `BP`, `BaseT<BP>` retrieves its
-base, and `ExpT<BP>` retrieves its exponent (as a `std::ratio`).
+some "base", raised to some rational exponent.  For a base power `BP`, `Base<BP>` retrieves its
+base, and `Exp<BP>` retrieves its exponent (as a `std::ratio`).
 
 !!! note
     This approach, with products of base powers, is known as the [_vector space
@@ -86,7 +86,7 @@ verifies that `T` is an instance of `Pack<...>`, and that its parameters satisfy
 conditions.  Specifically, those conditions are:
 
 - `AreBasesInOrder<Pack, T>`: assuming `T` is `Pack<BPs...>`, verifies that all consecutive elements
-  in `BaseT<BPs>...` are all properly ordered (according to `InOrderFor<Pack, ...>`, naturally).
+  in `Base<BPs>...` are all properly ordered (according to `InOrderFor<Pack, ...>`, naturally).
 
 - `AreAllPowersNonzero<Pack, T>`: assuming `T` is `Pack<BPs...>`, verifies that
   `Exp<BPs>::num` is nonzero for every element in `BPs`.


### PR DESCRIPTION
These four cases are easy.  Since we never expose the "no `T`" names
publicly (they are pure implementation details), we can simply rename
them with an `Impl` suffix, freeing up the "no `T`" name for what we
want end users to actually use.

Helps #86.