### PR TITLE
Avoid `T`-suffix names in `:unit_of_measure`

### DIFF
--- a/au/constant.hh
+++ b/au/constant.hh
@@ -133,6 +133,6 @@ constexpr Zero make_constant(Zero) { return {}; }
 
 // Support using `Constant` in a unit slot.
 template <typename Unit>
-struct AssociatedUnit<Constant<Unit>> : stdx::type_identity<Unit> {};
+struct AssociatedUnitImpl<Constant<Unit>> : stdx::type_identity<Unit> {};
 
 }  // namespace au

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -490,14 +490,14 @@ class Quantity {
 
 // Give more readable error messages when passing `Quantity` to a unit slot.
 template <typename U, typename R>
-struct AssociatedUnit<Quantity<U, R>> {
+struct AssociatedUnitImpl<Quantity<U, R>> {
     static_assert(
         detail::AlwaysFalse<U, R>::value,
         "Can't pass `Quantity` to a unit slot (see: "
         "https://aurora-opensource.github.io/au/main/troubleshooting/#quantity-to-unit-slot)");
 };
 template <typename U, typename R>
-struct AssociatedUnitForPoints<Quantity<U, R>> {
+struct AssociatedUnitForPointsImpl<Quantity<U, R>> {
     static_assert(
         detail::AlwaysFalse<U, R>::value,
         "Can't pass `Quantity` to a unit slot for points (see: "
@@ -650,7 +650,7 @@ struct QuantityMaker {
 };
 
 template <typename U>
-struct AssociatedUnit<QuantityMaker<U>> : stdx::type_identity<U> {};
+struct AssociatedUnitImpl<QuantityMaker<U>> : stdx::type_identity<U> {};
 
 template <int Exp, typename Unit>
 constexpr auto pow(QuantityMaker<Unit>) {

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -279,18 +279,18 @@ struct QuantityPointMaker {
 };
 
 template <typename U>
-struct AssociatedUnitForPoints<QuantityPointMaker<U>> : stdx::type_identity<U> {};
+struct AssociatedUnitForPointsImpl<QuantityPointMaker<U>> : stdx::type_identity<U> {};
 
 // Provide nicer error messages when users try passing a `QuantityPoint` to a unit slot.
 template <typename U, typename R>
-struct AssociatedUnit<QuantityPoint<U, R>> {
+struct AssociatedUnitImpl<QuantityPoint<U, R>> {
     static_assert(
         detail::AlwaysFalse<U, R>::value,
         "Cannot pass QuantityPoint to a unit slot (see: "
         "https://aurora-opensource.github.io/au/main/troubleshooting/#quantity-to-unit-slot)");
 };
 template <typename U, typename R>
-struct AssociatedUnitForPoints<QuantityPoint<U, R>> {
+struct AssociatedUnitForPointsImpl<QuantityPoint<U, R>> {
     static_assert(
         detail::AlwaysFalse<U, R>::value,
         "Cannot pass QuantityPoint to a unit slot (see: "

--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -128,26 +128,32 @@ struct IsUnitlessUnit
 //
 // Useful in doing unit conversions.
 template <typename U1, typename U2>
-struct UnitRatio : stdx::type_identity<MagQuotientT<detail::MagT<U1>, detail::MagT<U2>>> {
+struct UnitRatioImpl : stdx::type_identity<MagQuotientT<detail::MagT<U1>, detail::MagT<U2>>> {
     static_assert(HasSameDimension<U1, U2>::value,
                   "Can only compute ratio of same-dimension units");
 };
 template <typename U1, typename U2>
-using UnitRatioT = typename UnitRatio<U1, U2>::type;
+using UnitRatio = typename UnitRatioImpl<U1, U2>::type;
+template <typename U1, typename U2>
+using UnitRatioT = UnitRatio<U1, U2>;
 
 // The sign of a unit: almost always `mag<1>()`, but `-mag<1>()` for "negative" units.
 template <typename U>
 using UnitSign = Sign<detail::MagT<U>>;
 
 template <typename U>
-struct AssociatedUnit : stdx::type_identity<U> {};
+struct AssociatedUnitImpl : stdx::type_identity<U> {};
 template <typename U>
-using AssociatedUnitT = typename AssociatedUnit<U>::type;
+using AssociatedUnit = typename AssociatedUnitImpl<U>::type;
+template <typename U>
+using AssociatedUnitT = AssociatedUnit<U>;
 
 template <typename U>
-struct AssociatedUnitForPoints : stdx::type_identity<U> {};
+struct AssociatedUnitForPointsImpl : stdx::type_identity<U> {};
 template <typename U>
-using AssociatedUnitForPointsT = typename AssociatedUnitForPoints<U>::type;
+using AssociatedUnitForPoints = typename AssociatedUnitForPointsImpl<U>::type;
+template <typename U>
+using AssociatedUnitForPointsT = AssociatedUnitForPoints<U>;
 
 // `CommonUnitT`: the largest unit that evenly divides all input units.
 //
@@ -431,7 +437,7 @@ struct SingularNameFor {
 
 // Support `SingularNameFor` in (quantity) unit slots.
 template <typename U>
-struct AssociatedUnit<SingularNameFor<U>> : stdx::type_identity<U> {};
+struct AssociatedUnitImpl<SingularNameFor<U>> : stdx::type_identity<U> {};
 
 template <int Exp, typename Unit>
 constexpr auto pow(SingularNameFor<Unit>) {

--- a/au/unit_of_measure_test.cc
+++ b/au/unit_of_measure_test.cc
@@ -88,7 +88,7 @@ struct InvalidWrongMagType {
 template <typename UnitT>
 struct SomeUnitWrapper {};
 template <typename UnitT>
-struct AssociatedUnit<SomeUnitWrapper<UnitT>> : stdx::type_identity<UnitT> {};
+struct AssociatedUnitImpl<SomeUnitWrapper<UnitT>> : stdx::type_identity<UnitT> {};
 
 // Useful for testing parameter pack logic.
 template <typename... Units>

--- a/au/unit_symbol.hh
+++ b/au/unit_symbol.hh
@@ -49,6 +49,6 @@ constexpr auto symbol_for(UnitSlot) {
 
 // Support using symbols in unit slot APIs (e.g., `v.in(m / s)`).
 template <typename U>
-struct AssociatedUnit<SymbolFor<U>> : stdx::type_identity<U> {};
+struct AssociatedUnitImpl<SymbolFor<U>> : stdx::type_identity<U> {};
 
 }  // namespace au

--- a/docs/discussion/idioms/unit-slots.md
+++ b/docs/discussion/idioms/unit-slots.md
@@ -103,9 +103,9 @@ automatically: for example, you can't pass `meters` to a `QuantityPoint`'s unit 
 pass `meters_pt` to a `Quantity`'s unit slot.
 
 To get the associated unit for a type, use the
-[`AssociatedUnitT`](../../reference/unit.md#associated-unit) trait when you're dealing with
+[`AssociatedUnit`](../../reference/unit.md#associated-unit) trait when you're dealing with
 `Quantity`, and use the
-[`AssociatedUnitForPointsT`](../../reference/unit.md#associated-unit-for-points) trait when dealing
+[`AssociatedUnitForPoints`](../../reference/unit.md#associated-unit-for-points) trait when dealing
 with `QuantityPoint`.
 
 ## Examples: rounding to RPM

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -473,9 +473,14 @@ as an inch.
 **Syntax:**
 
 - For _types_ `U1` and `U2`:
-    - `UnitRatioT<U1, U2>::value`
+    - `UnitRatio<U1, U2>::value`
 - For _instances_ `u1` and `u2`:
     - `unit_ratio(u1, u2)`
+
+!!! note
+    Formerly, this was `UnitRatioT`, not `UnitRatio` (note the extra `T` on the end).  `UnitRatioT`
+    currently still works, but it is deprecated, and will be removed in a future release.  Please
+    migrate all current instances of `UnitRatioT` to `UnitRatio`.
 
 ### Unit sign
 
@@ -559,9 +564,14 @@ The use case for this trait is to _implement_ the unit slot argument for a funct
 **Syntax:**
 
 - For a _type_ `U`:
-    - `AssociatedUnitT<U>`
+    - `AssociatedUnit<U>`
 - For an _instance_ `u`:
     - `associated_unit(u)`
+
+!!! note
+    Formerly, this was `AssociatedUnitT`, not `AssociatedUnit` (note the extra `T` on the end).
+    `AssociatedUnitT` currently still works, but it is deprecated, and will be removed in a future
+    release.  Please migrate all current instances of `AssociatedUnitT` to `AssociatedUnit`.
 
 ### Associated unit (for points) {#associated-unit-for-points}
 
@@ -589,9 +599,15 @@ associated with quantity points.
 **Syntax:**
 
 - For a _type_ `U`:
-    - `AssociatedUnitForPointsT<U>`
+    - `AssociatedUnitForPoints<U>`
 - For an _instance_ `u`:
     - `associated_unit_for_points(u)`
+
+!!! note
+    Formerly, this was `AssociatedUnitForPointsT`, not `AssociatedUnitForPoints` (note the extra `T`
+    on the end).  `AssociatedUnitForPointsT` currently still works, but it is deprecated, and will
+    be removed in a future release.  Please migrate all current instances of
+    `AssociatedUnitForPointsT` to `AssociatedUnitForPoints`.
 
 ### Common unit
 


### PR DESCRIPTION
We're taking the `T` off of `UnitRatio`, `AssociatedUnit`, and
`AssociatedUnitForPoints`.  These are public facing utilities, so we
also add clear deprecation warnings to the (newly updated) documentation
in each case.

Helps #86.