### PR TITLE
Rename internal alias for corresponding quantity

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -179,9 +179,10 @@ class Quantity {
     constexpr Quantity() noexcept = default;
 
     // Implicit construction from any exactly-equivalent type.
-    template <typename T,
-              std::enable_if_t<std::is_convertible<detail::CorrespondingQuantityType<T>, Quantity>::value,
-                               int> = 0>
+    template <
+        typename T,
+        std::enable_if_t<std::is_convertible<detail::CorrespondingQuantityType<T>, Quantity>::value,
+                         int> = 0>
     constexpr Quantity(T &&x) : Quantity{as_quantity(std::forward<T>(x))} {}
 
     // `q.as<Rep>(new_unit)`, or `q.as<Rep>(new_unit, risk_policy)`
@@ -370,12 +371,14 @@ class Quantity {
     }
 
     // Automatic conversion to any equivalent type that supports it.
-    template <typename T,
-              std::enable_if_t<std::is_convertible<Quantity, detail::CorrespondingQuantityType<T>>::value,
-                               int> = 0>
+    template <
+        typename T,
+        std::enable_if_t<std::is_convertible<Quantity, detail::CorrespondingQuantityType<T>>::value,
+                         int> = 0>
     constexpr operator T() const {
         return CorrespondingQuantity<T>::construct_from_value(
-            detail::CorrespondingQuantityType<T>{*this}.in(typename CorrespondingQuantity<T>::Unit{}));
+            detail::CorrespondingQuantityType<T>{*this}.in(
+                typename CorrespondingQuantity<T>::Unit{}));
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is just internal to the library, but it was still a "names differ
by only `T` suffix" situtaion, so we wanted to fix it.  To emphasize its
internal-only nature, we also move it into the `detail` sub-namespace.

In the unlikely event that any external users are using this, they can
simply find-and-replace and update to the new name.  The number of uses
should be very small at most.

Helps #86.