### PR TITLE
Add `Pack` suffix to templates for common units

### DIFF
--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -593,8 +593,8 @@ struct AreUnitsPointEquivalent
 // responsible for this; thus, they should never name this type directly.  Rather, they should name
 // the `CommonUnitT` alias, which will handle the canonicalization.
 template <typename... Us>
-struct CommonUnit {
-    static_assert(AreElementsInOrder<CommonUnit, CommonUnit<Us...>>::value,
+struct CommonUnitPack {
+    static_assert(AreElementsInOrder<CommonUnitPack, CommonUnitPack<Us...>>::value,
                   "Elements must be listed in ascending order");
     static_assert(HasSameDimension<Us...>::value,
                   "Common unit only meaningful if units have same dimension");
@@ -604,7 +604,7 @@ struct CommonUnit {
 };
 
 template <typename A, typename B>
-struct InOrderFor<CommonUnit, A, B> : InOrderFor<UnitProduct, A, B> {};
+struct InOrderFor<CommonUnitPack, A, B> : InOrderFor<UnitProduct, A, B> {};
 
 template <typename... Us>
 struct UnitList {};
@@ -720,7 +720,7 @@ struct DistinctUnscaledUnitsImpl : stdx::type_identity<UnitList<UnscaledUnit<U>>
 template <typename U>
 using DistinctUnscaledUnits = typename DistinctUnscaledUnitsImpl<U>::type;
 template <typename... Us>
-struct DistinctUnscaledUnitsImpl<CommonUnit<Us...>>
+struct DistinctUnscaledUnitsImpl<CommonUnitPack<Us...>>
     : stdx::type_identity<FlatDedupedTypeListT<UnitList, UnscaledUnit<Us>...>> {};
 
 template <typename U, typename DistinctUnits>
@@ -756,8 +756,8 @@ using CommonUnitLabel = FlatDedupedTypeListT<detail::CommonUnitLabelImpl, Us...>
 template <typename... Us>
 struct ComputeCommonUnitImpl
     : stdx::type_identity<detail::EliminateRedundantUnits<
-          FlatDedupedTypeListT<CommonUnit, detail::ReplaceCommonPointUnitWithCommonUnit<Us>...>>> {
-};
+          FlatDedupedTypeListT<CommonUnitPack,
+                               detail::ReplaceCommonPointUnitWithCommonUnit<Us>...>>> {};
 template <>
 struct ComputeCommonUnitImpl<> : stdx::type_identity<Zero> {};
 
@@ -892,8 +892,8 @@ using CommonAmongUnitsAndOriginDisplacements =
     CommonUnitT<Us...,
                 detail::ComputeOriginDisplacementUnit<detail::UnitOfLowestOrigin<Us...>, Us>...>;
 template <typename... Us>
-struct CommonPointUnit : CommonAmongUnitsAndOriginDisplacements<Us...> {
-    static_assert(AreElementsInOrder<CommonPointUnit, CommonPointUnit<Us...>>::value,
+struct CommonPointUnitPack : CommonAmongUnitsAndOriginDisplacements<Us...> {
+    static_assert(AreElementsInOrder<CommonPointUnitPack, CommonPointUnitPack<Us...>>::value,
                   "Elements must be listed in ascending order");
     static_assert(HasSameDimension<Us...>::value,
                   "Common unit only meaningful if units have same dimension");
@@ -903,15 +903,15 @@ struct CommonPointUnit : CommonAmongUnitsAndOriginDisplacements<Us...> {
 
 namespace detail {
 template <typename... Us>
-struct ReplaceCommonPointUnitWithCommonUnitImpl<CommonPointUnit<Us...>>
+struct ReplaceCommonPointUnitWithCommonUnitImpl<CommonPointUnitPack<Us...>>
     : stdx::type_identity<CommonAmongUnitsAndOriginDisplacements<Us...>> {};
 }  // namespace detail
 
 template <typename A, typename B>
-struct InOrderFor<CommonPointUnit, A, B> : InOrderFor<UnitProduct, A, B> {};
+struct InOrderFor<CommonPointUnitPack, A, B> : InOrderFor<UnitProduct, A, B> {};
 
 template <typename... Us>
-using ComputeCommonPointUnitImpl = FlatDedupedTypeListT<CommonPointUnit, Us...>;
+using ComputeCommonPointUnitImpl = FlatDedupedTypeListT<CommonPointUnitPack, Us...>;
 
 template <typename... Us>
 struct ComputeCommonPointUnit
@@ -1061,16 +1061,16 @@ template <typename U>
 constexpr typename UnitLabel<ScaledUnit<U, Magnitude<Negative>>>::LabelT
     UnitLabel<ScaledUnit<U, Magnitude<Negative>>>::value;
 
-// Implementation for CommonUnit: give size in terms of each constituent unit.
+// Implementation for CommonUnitPack: give size in terms of each constituent unit.
 template <typename... Us>
-struct UnitLabel<CommonUnit<Us...>>
+struct UnitLabel<CommonUnitPack<Us...>>
     : CommonUnitLabel<decltype(Us{} *
-                               (detail::MagT<CommonUnit<Us...>>{} / detail::MagT<Us>{}))...> {};
+                               (detail::MagT<CommonUnitPack<Us...>>{} / detail::MagT<Us>{}))...> {};
 
-// Implementation for CommonPointUnit: give size in terms of each constituent unit, taking any
+// Implementation for CommonPointUnitPack: give size in terms of each constituent unit, taking any
 // origin displacements into account.
 template <typename... Us>
-struct UnitLabel<CommonPointUnit<Us...>>
+struct UnitLabel<CommonPointUnitPack<Us...>>
     : UnitLabel<CommonAmongUnitsAndOriginDisplacements<Us...>> {};
 
 template <typename Unit>
@@ -1175,10 +1175,10 @@ template <typename B, std::intmax_t N, std::intmax_t D>
 struct CoarseUnitOrdering<RatioPow<B, N, D>> : std::integral_constant<int, 5> {};
 
 template <typename... Us>
-struct CoarseUnitOrdering<CommonUnit<Us...>> : std::integral_constant<int, 6> {};
+struct CoarseUnitOrdering<CommonUnitPack<Us...>> : std::integral_constant<int, 6> {};
 
 template <typename... Us>
-struct CoarseUnitOrdering<CommonPointUnit<Us...>> : std::integral_constant<int, 7> {};
+struct CoarseUnitOrdering<CommonPointUnitPack<Us...>> : std::integral_constant<int, 7> {};
 
 template <typename A, typename B>
 struct OrderByUnitOrderTiebreaker

--- a/au/unit_of_measure_test.cc
+++ b/au/unit_of_measure_test.cc
@@ -94,7 +94,7 @@ struct AssociatedUnitImpl<SomeUnitWrapper<UnitT>> : stdx::type_identity<UnitT> {
 template <typename... Units>
 struct SomePack {};
 template <typename A, typename B>
-struct InOrderFor<SomePack, A, B> : InOrderFor<CommonUnit, A, B> {};
+struct InOrderFor<SomePack, A, B> : InOrderFor<CommonUnitPack, A, B> {};
 
 struct UnlabeledUnit : UnitImpl<Length> {};
 
@@ -509,15 +509,15 @@ struct X : decltype(Inches{} * mag<3>()) {};
 struct Y : decltype(Inches{} * mag<5>()) {};
 struct Z : decltype(Inches{} * mag<7>()) {};
 
-TEST(CommonUnit, UnpacksTypesInNestedCommonUnit) {
+TEST(CommonUnitPack, UnpacksTypesInNestedCommonUnit) {
     using C1 = CommonUnitT<W, X>;
-    ASSERT_THAT((detail::IsPackOf<CommonUnit, C1>{}), IsTrue());
+    ASSERT_THAT((detail::IsPackOf<CommonUnitPack, C1>{}), IsTrue());
 
     using C2 = CommonUnitT<Y, Z>;
-    ASSERT_THAT((detail::IsPackOf<CommonUnit, C2>{}), IsTrue());
+    ASSERT_THAT((detail::IsPackOf<CommonUnitPack, C2>{}), IsTrue());
 
     using Common = CommonUnitT<C1, C2>;
-    ASSERT_THAT((detail::IsPackOf<CommonUnit, Common>{}), IsTrue());
+    ASSERT_THAT((detail::IsPackOf<CommonUnitPack, Common>{}), IsTrue());
 
     // Check that `c(c(w, x), c(y, z))` is the same as `c(w, x, y, z)`.
     StaticAssertTypeEq<Common, CommonUnitT<W, X, Y, Z>>();
@@ -567,15 +567,15 @@ TEST(CommonPointUnit, PrefersUnitFromListIfAnyIdentical) {
     StaticAssertTypeEq<CommonPointUnitT<Celsius, Milli<Kelvins>, Milli<Celsius>>, Milli<Kelvins>>();
 }
 
-TEST(CommonPointUnit, UnpacksTypesInNestedCommonUnit) {
+TEST(CommonPointUnitPack, UnpacksTypesInNestedCommonUnit) {
     using C1 = CommonPointUnitT<W, X>;
-    ASSERT_THAT((detail::IsPackOf<CommonPointUnit, C1>{}), IsTrue());
+    ASSERT_THAT((detail::IsPackOf<CommonPointUnitPack, C1>{}), IsTrue());
 
     using C2 = CommonPointUnitT<Y, Z>;
-    ASSERT_THAT((detail::IsPackOf<CommonPointUnit, C2>{}), IsTrue());
+    ASSERT_THAT((detail::IsPackOf<CommonPointUnitPack, C2>{}), IsTrue());
 
     using Common = CommonPointUnitT<C1, C2>;
-    ASSERT_THAT((detail::IsPackOf<CommonPointUnit, Common>{}), IsTrue());
+    ASSERT_THAT((detail::IsPackOf<CommonPointUnitPack, Common>{}), IsTrue());
 
     // Check that `c(c(w, x), c(y, z))` is the same as `c(w, x, y, z)`.
     StaticAssertTypeEq<Common, CommonPointUnitT<W, X, Y, Z>>();

--- a/docs/discussion/concepts/common_unit.md
+++ b/docs/discussion/concepts/common_unit.md
@@ -88,42 +88,43 @@ should it have?
 
 2. **Deduplication.**  Any given input unit can appear at most once in the resulting unit type.
     - This is to keep compiler errors as concise and readable as possible.
-3. **Flattening.**  If an input unit is a `CommonUnit<...>` type, "unpack" it and replace it with
-   its constituent Units.
+3. **Flattening.**  If an input unit is a `CommonUnitPack<...>` type, "unpack" it and replace it
+   with its constituent Units.
     - To see why, let `c(...)` be "the common unit", and `x`, `y`, and `z` be units.  We wouldn't
       want `c(x, c(y, z))` to be different from `c(x, y, z)`!
 4. **Semantic.**  Prefer user-meaningful units, because they show up in compiler errors. Thus, if
    any input unit is _equivalent_ to the "common unit", we'll prefer that input unit.
-    - The common unit of `Inches` and `Feet` is just `Inches`, not `CommonUnit<Inches, Feet>`!
+    - The common unit of `Inches` and `Feet` is just `Inches`, not `CommonUnitPack<Inches, Feet>`!
 
 ### User-facing types
 
 There are two main abstractions for common units which users might encounter.
 
-- **`CommonUnit<...>`**.  This is a template that defines new units from old ones, just like
+- **`CommonUnitPack<...>`**.  This is a template that defines new units from old ones, just like
   `UnitProduct<...>` or `ScaledUnit<...>`.
     - This should _rarely, if ever_ be named in code.
         - In implementations, we need to do this, for example, for defining the _unit label_ of
-          a `CommonUnit<...>`, or defining its ordering relative to other units.
+          a `CommonUnitPack<...>`, or defining its ordering relative to other units.
         - In end user code, this should probably _never_ be named.
-        - In either case: **never** write `CommonUnit<...>` with _specific_ template arguments!
+        - In either case: **never** write `CommonUnitPack<...>` with _specific_ template arguments!
           Only use it for matching.
-    - Remember: `CommonUnit<...>` can arise only as _the result of some type computation_.
+    - Remember: `CommonUnitPack<...>` can arise only as _the result of some type computation_.
 - **`CommonUnitT<...>`**.  This _computes_ the common unit of the provided units.
 
 Let's clarify this relationship with an example.  Suppose you're writing a function based on two
 arbitrary (but same-dimension) units, `U1` and `U2`, and you need their "common unit".
 
-- What you would _write_ is `CommonUnitT<U1, U2>`, **not** `CommonUnit<U1, U2>`.
+- What you would _write_ is `CommonUnitT<U1, U2>`, **not** `CommonUnitPack<U1, U2>`.
     - `CommonUnitT<...>` says "_please calculate_ the common unit".
-    - `CommonUnit<...>` says "_this is the result_ of calculating the common unit".
+    - `CommonUnitPack<...>` says "_this is the result_ of calculating the common unit".
 - What you _get_ depends on the specific units.
-    - For `CommonUnitT<Inches, Meters>`, the result might be `CommonUnit<Inches, Meters>`.[^1]  This
-      is because the greatest common divisor for `Inches` and `Meters` is smaller than both of them.
+    - For `CommonUnitT<Inches, Meters>`, the result might be `CommonUnitPack<Inches, Meters>`.[^1]
+      This is because the greatest common divisor for `Inches` and `Meters` is smaller than both of
+      them.
     - For `CommonUnitT<Inches, Feet>`, the result would simply be `Inches`, because `Inches` is
       quantity-equivalent to this common unit (it evenly divides both `Inches` and `Feet`).
 
-[^1]:  It might also be `CommonUnit<Meters, Inches>`.  The ordering is deterministic, but
+[^1]:  It might also be `CommonUnitPack<Meters, Inches>`.  The ordering is deterministic, but
 unspecified.
 
 ??? info "Implementation approach details (deep in the weeds)"
@@ -131,19 +132,19 @@ unspecified.
     There are two main tools we use to implement `CommonUnitT`.
 
     1. `FlatDedupedTypeList`.  For a given variadic pack `List<...>` (which, for us, will be
-       `CommonUnit<...>`), `FlatDedupedTypeList<List, Ts...>` will produce a `List<...>`, whose
+       `CommonUnitPack<...>`), `FlatDedupedTypeList<List, Ts...>` will produce a `List<...>`, whose
        elements are `Ts...`, but sorted according to `InOrderFor<List, ...>`, and with duplicates
        removed.
 
         - If any of the `Ts` are already `List<Us...>`, we effectively "unpack" it, replacing it with
           `Us...`.  This is the "flat" part in `FlatDedupedTypeList`.
 
-    2. `FirstQuantityEquivalentUnit`.  The above step produces a `CommonUnit<...>` specialization, which
-       itself meets [the definition of a unit](../../reference/unit.md).  But is it the unit we
+    2. `FirstQuantityEquivalentUnit`.  The above step produces a `CommonUnitPack<...>` specialization,
+       which itself meets [the definition of a unit](../../reference/unit.md).  But is it the unit we
        really want to provide?  Not if there's a simpler one!
-       `FirstQuantityEquivalentUnit<CommonUnit<Us...>>` searches through the unit list `Us...`, and
-       returns the first quantity-equivalent one it finds. If no such unit is available, then we
-       fall back to returning `CommonUnit<Us...>`.
+       `FirstQuantityEquivalentUnit<CommonUnitPack<Us...>>` searches through the unit list `Us...`,
+       and returns the first quantity-equivalent one it finds. If no such unit is available, then we
+       fall back to returning `CommonUnitPack<Us...>`.
 
 ## Changes for `QuantityPoint` {#common-quantity-point}
 
@@ -163,7 +164,7 @@ and `Kelvins`.
 Thus, what we've been calling `CommonUnitT` is really more like `CommonQuantityUnitT` (although
 we've kept the name short because `Quantity` is by far the typical use case).  For `QuantityPoint`
 operations, we have the `CommonPointUnitT<Us...>` alias, which typically creates some instance of
-`CommonPointUnit<Us...>` with the `Us...` in their canonical ordering.
+`CommonPointUnitPack<Us...>` with the `Us...` in their canonical ordering.
 
 So: what _is_ the "common quantity _point_ unit"?  Well, we can start with the "common _quantity_
 unit," but the origin adds a new complication.  We'll need to choose a convention.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1063,7 +1063,7 @@ sufficient condition: for example, even `UnitInverseT<Seconds>` and `Hertz` won'
     In case you want to understand more, here is the gist.
 
     Au is _heavily_ based on [parameter packs](./reference/detail/packs.md).  Some of these packs,
-    such as `UnitProduct<...>` and `CommonUnit<...>`, take _units_ as their arguments.
+    such as `UnitProduct<...>` and `CommonUnitPack<...>`, take _units_ as their arguments.
 
     Every parameter pack needs an unambiguous canonical ordering for any possible set of input
     arguments.  Therefore, we need to create a _strict total ordering_ for the (infinitely many!)


### PR DESCRIPTION
This naming convention should be a lot easier to keep straight than the
old names.  For example, when users invoke `CommonUnitT<...>`, they'll
get a `CommonUnitPack<...>` rather than a `CommonUnit<...>`.  This
unblocks us from making the `T` and no-`T` versions identical.

Helps #86.