### PR TITLE
Add no-`T` aliases for common unit helpers

### DIFF
--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -155,7 +155,7 @@ using AssociatedUnitForPoints = typename AssociatedUnitForPointsImpl<U>::type;
 template <typename U>
 using AssociatedUnitForPointsT = AssociatedUnitForPoints<U>;
 
-// `CommonUnitT`: the largest unit that evenly divides all input units.
+// `CommonUnit`: the largest unit that evenly divides all input units.
 //
 // A specialization will only exist if all input types are units.
 //
@@ -170,9 +170,11 @@ using AssociatedUnitForPointsT = AssociatedUnitForPoints<U>;
 template <typename... Us>
 struct ComputeCommonUnit;
 template <typename... Us>
-using CommonUnitT = typename ComputeCommonUnit<Us...>::type;
+using CommonUnit = typename ComputeCommonUnit<Us...>::type;
+template <typename... Us>
+using CommonUnitT = CommonUnit<Us...>;
 
-// `CommonPointUnitT`: the largest-magnitude, highest-origin unit which is "common" to the units of
+// `CommonPointUnit`: the largest-magnitude, highest-origin unit which is "common" to the units of
 // a collection of `QuantityPoint` instances.
 //
 // The key goal to keep in mind is that for a `QuantityPoint` of any unit `U` in `Us...`, converting
@@ -194,7 +196,9 @@ using CommonUnitT = typename ComputeCommonUnit<Us...>::type;
 template <typename... Us>
 struct ComputeCommonPointUnit;
 template <typename... Us>
-using CommonPointUnitT = typename ComputeCommonPointUnit<Us...>::type;
+using CommonPointUnit = typename ComputeCommonPointUnit<Us...>::type;
+template <typename... Us>
+using CommonPointUnitT = CommonPointUnit<Us...>;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Type traits (instance-based interface).

--- a/docs/discussion/concepts/common_unit.md
+++ b/docs/discussion/concepts/common_unit.md
@@ -109,19 +109,19 @@ There are two main abstractions for common units which users might encounter.
         - In either case: **never** write `CommonUnitPack<...>` with _specific_ template arguments!
           Only use it for matching.
     - Remember: `CommonUnitPack<...>` can arise only as _the result of some type computation_.
-- **`CommonUnitT<...>`**.  This _computes_ the common unit of the provided units.
+- **`CommonUnit<...>`**.  This _computes_ the common unit of the provided units.
 
 Let's clarify this relationship with an example.  Suppose you're writing a function based on two
 arbitrary (but same-dimension) units, `U1` and `U2`, and you need their "common unit".
 
-- What you would _write_ is `CommonUnitT<U1, U2>`, **not** `CommonUnitPack<U1, U2>`.
-    - `CommonUnitT<...>` says "_please calculate_ the common unit".
+- What you would _write_ is `CommonUnit<U1, U2>`, **not** `CommonUnitPack<U1, U2>`.
+    - `CommonUnit<...>` says "_please calculate_ the common unit".
     - `CommonUnitPack<...>` says "_this is the result_ of calculating the common unit".
 - What you _get_ depends on the specific units.
-    - For `CommonUnitT<Inches, Meters>`, the result might be `CommonUnitPack<Inches, Meters>`.[^1]
+    - For `CommonUnit<Inches, Meters>`, the result might be `CommonUnitPack<Inches, Meters>`.[^1]
       This is because the greatest common divisor for `Inches` and `Meters` is smaller than both of
       them.
-    - For `CommonUnitT<Inches, Feet>`, the result would simply be `Inches`, because `Inches` is
+    - For `CommonUnit<Inches, Feet>`, the result would simply be `Inches`, because `Inches` is
       quantity-equivalent to this common unit (it evenly divides both `Inches` and `Feet`).
 
 [^1]:  It might also be `CommonUnitPack<Meters, Inches>`.  The ordering is deterministic, but
@@ -129,7 +129,7 @@ unspecified.
 
 ??? info "Implementation approach details (deep in the weeds)"
 
-    There are two main tools we use to implement `CommonUnitT`.
+    There are two main tools we use to implement `CommonUnit`.
 
     1. `FlatDedupedTypeList`.  For a given variadic pack `List<...>` (which, for us, will be
        `CommonUnitPack<...>`), `FlatDedupedTypeList<List, Ts...>` will produce a `List<...>`, whose
@@ -161,9 +161,9 @@ and `Kelvins`.
   of 273.15 `Kelvins`.  This additive offset means that we'll need to convert both to
   `Centi<Kelvins>` before we can subtract and/or compare them!
 
-Thus, what we've been calling `CommonUnitT` is really more like `CommonQuantityUnitT` (although
+Thus, what we've been calling `CommonUnit` is really more like `CommonQuantityUnit` (although
 we've kept the name short because `Quantity` is by far the typical use case).  For `QuantityPoint`
-operations, we have the `CommonPointUnitT<Us...>` alias, which typically creates some instance of
+operations, we have the `CommonPointUnit<Us...>` alias, which typically creates some instance of
 `CommonPointUnitPack<Us...>` with the `Us...` in their canonical ordering.
 
 So: what _is_ the "common quantity _point_ unit"?  Well, we can start with the "common _quantity_

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -171,8 +171,8 @@ expand the note below for further details.
     The unit of the return type depends on whether we are working with `Quantity` inputs, or
     `QuantityPoint`.
 
-    - For `Quantity`, the return type's unit is `CommonUnitT<UV, ULo, UHi>`.
-    - For `QuantityPoint`, the return type's unit is `CommonPointUnitT<UV, ULo, UHi>`: this is the
+    - For `Quantity`, the return type's unit is `CommonUnit<UV, ULo, UHi>`.
+    - For `QuantityPoint`, the return type's unit is `CommonPointUnit<UV, ULo, UHi>`: this is the
       [common point unit](../discussion/concepts/common_unit.md#common-quantity-point), which takes
       relative origin offsets into account.
 

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -860,7 +860,7 @@ More precisely, suppose we have instances of two `Quantity` types: `Quantity<U1,
 `Quantity<U2, R2> q2`.  Then `q1 % q2` is defined only when:
 
 1. `(R1{} % R2{})` is defined (that is, both `R1` and `R2` are integral types).
-2. `CommonUnitT<U1, U2>` is defined (that is, `U1` and `U2` have the same dimension).
+2. `CommonUnit<U1, U2>` is defined (that is, `U1` and `U2` have the same dimension).
 
 When these conditions hold, the result is equivalent to first converting `q1` and `q2` to their
 common unit, and then computing the remainder from performing integer division on their values.

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -641,8 +641,8 @@ implementation choice will be driven by convenience and simplicity.
 
     For example, consider `common_unit(meters, feet)`.  Recall that the type of `meters` is
     `QuantityMaker<Meters>`, and that of `feet` is `QuantityMaker<Feet>`.  In this case, the return
-    value is an instance of `CommonUnitT<Meters, Feet>`, _not_
-    `QuantityMaker<CommonUnitT<Meters, Feet>>`.
+    value is an instance of `CommonUnit<Meters, Feet>`, _not_
+    `QuantityMaker<CommonUnit<Meters, Feet>>`.
 
     If you want something that still computes the common unit, but preserves the _category_ of the
     inputs, see [`make_common(us...)`](#make-common).
@@ -650,7 +650,7 @@ implementation choice will be driven by convenience and simplicity.
 **Syntax:**
 
 - For _types_ `Us...`:
-    - `CommonUnitT<Us...>`
+    - `CommonUnit<Us...>`
 - For _instances_ `us...`:
     - `common_unit(us...)`
 
@@ -668,7 +668,7 @@ its value to the common point-unit should involve only:
 
 This helps us support the widest range of Rep types (in particular, unsigned integers).
 
-As with `CommonUnitT`, this isn't always possible: in particular, we can't do this for units with
+As with `CommonUnit`, this isn't always possible: in particular, we can't do this for units with
 irrational relative magnitudes or origin displacements.  However, we still provide _some_ answer,
 which is consistent with the above policy whenever it's achievable, and produces reasonable results
 in all other cases.
@@ -695,8 +695,8 @@ implicitly.  Then, the _common point unit_ is defined as the unit such that:
 
     For example, consider `common_unit(meters, feet)`.  Recall that the type of `meters` is
     `QuantityMaker<Meters>`, and that of `feet` is `QuantityMaker<Feet>`.  In this case, the return
-    value is an instance of `CommonUnitT<Meters, Feet>`, _not_
-    `QuantityMaker<CommonUnitT<Meters, Feet>>`.
+    value is an instance of `CommonUnit<Meters, Feet>`, _not_
+    `QuantityMaker<CommonUnit<Meters, Feet>>`.
 
     If you want something that still computes the common unit, but preserves the _category_ of the
     inputs, see [`make_common_point(us...)`](#make-common-point).
@@ -704,7 +704,7 @@ implicitly.  Then, the _common point unit_ is defined as the unit such that:
 **Syntax:**
 
 - For _types_ `Us...`:
-    - `CommonPointUnitT<Us...>`
+    - `CommonPointUnit<Us...>`
 - For _instances_ `us...`:
     - `common_point_unit(us...)`
 


### PR DESCRIPTION
These should be easier to use.  In fact, many times over the years I've
already run into trouble typing `CommonUnit<...>` when I meant to type
`CommonUnitT<...>`.  And I'm the primary author of the library!

Helps #86.