### PR TITLE
Add `Pack` suffix to unit product template type

### DIFF
--- a/au/fwd.hh
+++ b/au/fwd.hh
@@ -54,10 +54,10 @@ class Quantity;
 // on an instance of that alias.
 //
 template <typename... UnitPowers>
-struct UnitProduct;
+struct UnitProductPack;
 template <typename... UnitPowers>
 struct ForwardDeclareUnitProduct {
-    using unit_type = UnitProduct<UnitPowers...>;
+    using unit_type = UnitProductPack<UnitPowers...>;
 };
 
 //

--- a/au/prefix.hh
+++ b/au/prefix.hh
@@ -29,7 +29,7 @@ namespace detail {
 //
 // This includes:
 // - Direct Pow<B, N> or RatioPow<B, N, D> types
-// - UnitProduct<...> containing any powered units (recursively)
+// - UnitProductPack<...> containing any powered units (recursively)
 template <typename U>
 struct ContainsAnyPowers : std::false_type {};
 
@@ -40,7 +40,7 @@ template <typename B, std::intmax_t N, std::intmax_t D>
 struct ContainsAnyPowers<RatioPow<B, N, D>> : std::true_type {};
 
 template <typename... Us>
-struct ContainsAnyPowers<UnitProduct<Us...>> : stdx::disjunction<ContainsAnyPowers<Us>...> {};
+struct ContainsAnyPowers<UnitProductPack<Us...>> : stdx::disjunction<ContainsAnyPowers<Us>...> {};
 
 // Helper to generate labels for prefixed units.
 // Wraps unit label in brackets if the unit is a powered unit (Pow or RatioPow).

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -96,7 +96,7 @@ struct PerDay : decltype(UnitInverseT<Days>{}) {};
 constexpr auto per_day = QuantityMaker<PerDay>{};
 
 template <typename... Us>
-constexpr auto num_units_in_product(UnitProduct<Us...>) {
+constexpr auto num_units_in_product(UnitProductPack<Us...>) {
     return sizeof...(Us);
 }
 
@@ -673,14 +673,14 @@ TEST(Quantity, RatioOfEquivalentTypesIsScalar) {
 }
 
 TEST(Quantity, ProductOfInvertingUnitsIsScalar) {
-    // We pass `UnitProductT` to this function template, which ensures that we get a `UnitProduct`
-    // (note: NOT `UnitProductT`!) with the expected number of arguments.  Recall that
-    // `UnitProductT` is the user-facing "unit computation" interface, and `UnitProduct` is the
-    // named template which gets passed around the system.
+    // We pass `UnitProductT` to this function template, which ensures that we get a
+    // `UnitProductPack` (note: NOT `UnitProductT`!) with the expected number of arguments.  Recall
+    // that `UnitProductT` is the user-facing "unit computation" interface, and `UnitProductPack` is
+    // the named template which gets passed around the system.
     //
     // The point is to make sure that the product-unit of `Days` and `PerDay` does **not** reduce to
-    // something trivial, like `UnitProduct<>`.  Rather, it should be its own non-trivial
-    // unit---although, naturally, it must be **quantity-equivalent** to `UnitProduct<>`.
+    // something trivial, like `UnitProductPack<>`.  Rather, it should be its own non-trivial
+    // unit---although, naturally, it must be **quantity-equivalent** to `UnitProductPack<>`.
     ASSERT_THAT(num_units_in_product(UnitProductT<Days, PerDay>{}), Eq(2));
 
     EXPECT_THAT(days(3) * per_day(8), SameTypeAndValue(24));

--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -330,24 +330,26 @@ struct ScaledUnit : Unit {
 
 // Type template to hold the product of powers of Units.
 template <typename... UnitPows>
-struct UnitProduct {
+struct UnitProductPack {
     using Dim = DimProductT<detail::DimT<UnitPows>...>;
     using Mag = MagProductT<detail::MagT<UnitPows>...>;
 };
 
 // Helper to make a canonicalized product of units.
 //
-// On the input side, we treat every input unit as a UnitProduct.  Once we get our final result, we
-// simplify it using `UnpackIfSoloT`.  (The motivation is that we don't want to return, say,
-// `UnitProduct<Meters>`; we'd rather just return `Meters`.)
+// On the input side, we treat every input unit as a UnitProductPack.  Once we get our final result,
+// we simplify it using `UnpackIfSoloT`.  (The motivation is that we don't want to return, say,
+// `UnitProductPack<Meters>`; we'd rather just return `Meters`.)
 template <typename... UnitPows>
 using UnitProductT =
-    UnpackIfSoloT<UnitProduct, PackProductT<UnitProduct, AsPackT<UnitProduct, UnitPows>...>>;
+    UnpackIfSoloT<UnitProductPack,
+                  PackProductT<UnitProductPack, AsPackT<UnitProductPack, UnitPows>...>>;
 
 // Raise a Unit to a (possibly rational) Power.
 template <typename U, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
 using UnitPower =
-    UnpackIfSoloT<UnitProduct, PackPowerT<UnitProduct, AsPackT<UnitProduct, U>, ExpNum, ExpDen>>;
+    UnpackIfSoloT<UnitProductPack,
+                  PackPowerT<UnitProductPack, AsPackT<UnitProductPack, U>, ExpNum, ExpDen>>;
 template <typename U, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
 using UnitPowerT = UnitPower<U, ExpNum, ExpDen>;
 
@@ -608,12 +610,12 @@ struct CommonUnitPack {
 };
 
 template <typename A, typename B>
-struct InOrderFor<CommonUnitPack, A, B> : InOrderFor<UnitProduct, A, B> {};
+struct InOrderFor<CommonUnitPack, A, B> : InOrderFor<UnitProductPack, A, B> {};
 
 template <typename... Us>
 struct UnitList {};
 template <typename A, typename B>
-struct InOrderFor<UnitList, A, B> : InOrderFor<UnitProduct, A, B> {};
+struct InOrderFor<UnitList, A, B> : InOrderFor<UnitProductPack, A, B> {};
 
 namespace detail {
 // This machinery searches a unit list for one that "matches" a target unit.
@@ -752,7 +754,7 @@ using ReplaceCommonPointUnitWithCommonUnit =
 }  // namespace detail
 
 template <typename A, typename B>
-struct InOrderFor<detail::CommonUnitLabelImpl, A, B> : InOrderFor<UnitProduct, A, B> {};
+struct InOrderFor<detail::CommonUnitLabelImpl, A, B> : InOrderFor<UnitProductPack, A, B> {};
 
 template <typename... Us>
 using CommonUnitLabel = FlatDedupedTypeListT<detail::CommonUnitLabelImpl, Us...>;
@@ -830,7 +832,7 @@ struct CommonOrigin<Head, Tail...> :
 template <typename... Us>
 struct UnitOfLowestOriginImpl;
 template <typename... Us>
-using UnitOfLowestOrigin = typename SortAs<UnitProduct, UnitOfLowestOriginImpl<Us...>>::type;
+using UnitOfLowestOrigin = typename SortAs<UnitProductPack, UnitOfLowestOriginImpl<Us...>>::type;
 template <typename U>
 struct UnitOfLowestOriginImpl<U> : stdx::type_identity<U> {};
 template <typename U, typename U1, typename... Us>
@@ -912,7 +914,7 @@ struct ReplaceCommonPointUnitWithCommonUnitImpl<CommonPointUnitPack<Us...>>
 }  // namespace detail
 
 template <typename A, typename B>
-struct InOrderFor<CommonPointUnitPack, A, B> : InOrderFor<UnitProduct, A, B> {};
+struct InOrderFor<CommonPointUnitPack, A, B> : InOrderFor<UnitProductPack, A, B> {};
 
 template <typename... Us>
 using ComputeCommonPointUnitImpl = FlatDedupedTypeListT<CommonPointUnitPack, Us...>;
@@ -966,7 +968,7 @@ enum class ParensPolicy {
 template <typename T, ParensPolicy Policy = ParensPolicy::ADD_IF_MULITPLE>
 struct CompoundLabel;
 template <typename... Us, ParensPolicy Policy>
-struct CompoundLabel<UnitProduct<Us...>, Policy> {
+struct CompoundLabel<UnitProductPack<Us...>, Policy> {
     static constexpr auto value() {
         constexpr bool add_parens =
             (Policy == ParensPolicy::ADD_IF_MULITPLE) && (sizeof...(Us) > 1);
@@ -989,31 +991,31 @@ constexpr typename QuotientLabeler<N, D, T>::LabelT QuotientLabeler<N, D, T>::va
 
 // Special case for denominator of 1.
 template <typename N, typename T>
-struct QuotientLabeler<N, UnitProduct<>, T> {
+struct QuotientLabeler<N, UnitProductPack<>, T> {
     using LabelT = StringConstant<CompoundLabel<N, ParensPolicy::OMIT>::value().size()>;
     static constexpr LabelT value = CompoundLabel<N, ParensPolicy::OMIT>::value();
 };
 template <typename N, typename T>
-constexpr typename QuotientLabeler<N, UnitProduct<>, T>::LabelT
-    QuotientLabeler<N, UnitProduct<>, T>::value;
+constexpr typename QuotientLabeler<N, UnitProductPack<>, T>::LabelT
+    QuotientLabeler<N, UnitProductPack<>, T>::value;
 
 // Special case for numerator of 1.
 template <typename D, typename T>
-struct QuotientLabeler<UnitProduct<>, D, T> {
+struct QuotientLabeler<UnitProductPack<>, D, T> {
     using LabelT = StringConstant<CompoundLabel<D>::value().size() + 4>;
     static constexpr LabelT value = concatenate("1 / ", CompoundLabel<D>::value());
 };
 template <typename D, typename T>
-constexpr typename QuotientLabeler<UnitProduct<>, D, T>::LabelT
-    QuotientLabeler<UnitProduct<>, D, T>::value;
+constexpr typename QuotientLabeler<UnitProductPack<>, D, T>::LabelT
+    QuotientLabeler<UnitProductPack<>, D, T>::value;
 
 // Special case for numerator _and_ denominator of 1 (null product).
 template <typename T>
-struct QuotientLabeler<UnitProduct<>, UnitProduct<>, T> {
+struct QuotientLabeler<UnitProductPack<>, UnitProductPack<>, T> {
     static constexpr const char value[] = "";
 };
 template <typename T>
-constexpr const char QuotientLabeler<UnitProduct<>, UnitProduct<>, T>::value[];
+constexpr const char QuotientLabeler<UnitProductPack<>, UnitProductPack<>, T>::value[];
 }  // namespace detail
 
 // Unified implementation.
@@ -1032,11 +1034,11 @@ template <typename Unit, std::intmax_t N, std::intmax_t D>
 struct UnitLabel<RatioPow<Unit, N, D>>
     : detail::PowerLabeler<detail::ExpLabelForRatioPow<N, D>, Unit> {};
 
-// Implementation for UnitProduct: split into positive and negative powers.
+// Implementation for UnitProductPack: split into positive and negative powers.
 template <typename... Us>
-struct UnitLabel<UnitProduct<Us...>>
-    : detail::QuotientLabeler<detail::NumeratorPartT<UnitProduct<Us...>>,
-                              detail::DenominatorPartT<UnitProduct<Us...>>,
+struct UnitLabel<UnitProductPack<Us...>>
+    : detail::QuotientLabeler<detail::NumeratorPartT<UnitProductPack<Us...>>,
+                              detail::DenominatorPartT<UnitProductPack<Us...>>,
                               void> {};
 
 // Implementation for ScaledUnit: scaling unit U by M gets label `"[M U]"`.
@@ -1083,7 +1085,7 @@ constexpr const auto &unit_label(Unit) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-// `UnitProduct` implementation.
+// `UnitProductPack` implementation.
 //
 // It's just a standard pack product, so all we need to do is carefully define the total ordering.
 
@@ -1108,16 +1110,16 @@ template <typename U1, typename M1, typename U2, typename M2>
 struct OrderByScaledness<ScaledUnit<U1, M1>, ScaledUnit<U2, M2>>
     : LexicographicTotalOrdering<ScaledUnit<U1, M1>, ScaledUnit<U2, M2>, OrderByScaleFactor> {};
 
-// OrderAsUnitProduct<A, B> can only be true if both A and B are unit products, _and_ they are in
-// the standard pack order for unit products.  This default case handles the usual case where either
-// A or B (or both) is not a UnitProduct<...> in the first place.
+// OrderAsUnitProductPack<A, B> can only be true if both A and B are unit products, _and_ they are
+// in the standard pack order for unit products.  This default case handles the usual case where
+// either A or B (or both) is not a UnitProductPack<...> in the first place.
 template <typename A, typename B>
-struct OrderAsUnitProduct : std::false_type {};
+struct OrderAsUnitProductPack : std::false_type {};
 
-// This specialization handles the non-trivial case, where we do have two UnitProduct instances.
+// This specialization handles the non-trivial case, where we do have two UnitProductPack instances.
 template <typename... U1s, typename... U2s>
-struct OrderAsUnitProduct<UnitProduct<U1s...>, UnitProduct<U2s...>>
-    : InStandardPackOrder<UnitProduct<U1s...>, UnitProduct<U2s...>> {};
+struct OrderAsUnitProductPack<UnitProductPack<U1s...>, UnitProductPack<U2s...>>
+    : InStandardPackOrder<UnitProductPack<U1s...>, UnitProductPack<U2s...>> {};
 
 // OrderAsOriginDisplacementUnit<A, B> can only be true if both A and B are `OriginDisplacementUnit`
 // specializations, _and_ their first units are in order, or their first units are identical and
@@ -1131,14 +1133,14 @@ struct OrderByFirstInOriginDisplacementUnit;
 template <typename A1, typename A2, typename B1, typename B2>
 struct OrderByFirstInOriginDisplacementUnit<OriginDisplacementUnit<A1, A2>,
                                             OriginDisplacementUnit<B1, B2>>
-    : InOrderFor<UnitProduct, A1, B1> {};
+    : InOrderFor<UnitProductPack, A1, B1> {};
 
 template <typename A, typename B>
 struct OrderBySecondInOriginDisplacementUnit;
 template <typename A1, typename A2, typename B1, typename B2>
 struct OrderBySecondInOriginDisplacementUnit<OriginDisplacementUnit<A1, A2>,
                                              OriginDisplacementUnit<B1, B2>>
-    : InOrderFor<UnitProduct, A2, B2> {};
+    : InOrderFor<UnitProductPack, A2, B2> {};
 
 template <typename A1, typename A2, typename B1, typename B2>
 struct OrderAsOriginDisplacementUnit<OriginDisplacementUnit<A1, A2>, OriginDisplacementUnit<B1, B2>>
@@ -1152,10 +1154,11 @@ struct OrderByOrigin
     : stdx::bool_constant<(detail::OriginOf<A>::value() < detail::OriginOf<B>::value())> {};
 
 // "Unit avoidance" is a tiebreaker for quantity-equivalent units.  Anonymous units, such as
-// `UnitImpl<...>`, `ScaledUnit<...>`, and `UnitProduct<...>`, are more "avoidable" than units which
-// are none of these, because the latter are likely explicitly named and thus more user-facing.  The
-// relative ordering among these built-in template types is probably less important than the fact
-// that there _is_ a relative ordering among them (because we need to have a strict total ordering).
+// `UnitImpl<...>`, `ScaledUnit<...>`, and `UnitProductPack<...>`, are more "avoidable" than units
+// which are none of these, because the latter are likely explicitly named and thus more
+// user-facing.  The relative ordering among these built-in template types is probably less
+// important than the fact that there _is_ a relative ordering among them (because we need to have a
+// strict total ordering).
 template <typename T>
 struct CoarseUnitOrdering : std::integral_constant<int, 0> {};
 
@@ -1164,7 +1167,7 @@ struct OrderByCoarseUnitOrdering
     : stdx::bool_constant<(CoarseUnitOrdering<A>::value < CoarseUnitOrdering<B>::value)> {};
 
 template <typename... Ts>
-struct CoarseUnitOrdering<UnitProduct<Ts...>> : std::integral_constant<int, 1> {};
+struct CoarseUnitOrdering<UnitProductPack<Ts...>> : std::integral_constant<int, 1> {};
 
 template <typename... Ts>
 struct CoarseUnitOrdering<UnitImpl<Ts...>> : std::integral_constant<int, 2> {};
@@ -1197,7 +1200,7 @@ template <typename U>
 struct UnitOrderTiebreaker : detail::UnitAvoidance<U> {};
 
 template <typename A, typename B>
-struct InOrderFor<UnitProduct, A, B>
+struct InOrderFor<UnitProductPack, A, B>
     : LexicographicTotalOrdering<A,
                                  B,
                                  detail::OrderByCoarseUnitOrdering,
@@ -1205,7 +1208,7 @@ struct InOrderFor<UnitProduct, A, B>
                                  detail::OrderByMag,
                                  detail::OrderByScaleFactor,
                                  detail::OrderByOrigin,
-                                 detail::OrderAsUnitProduct,
+                                 detail::OrderAsUnitProductPack,
                                  detail::OrderAsOriginDisplacementUnit,
                                  detail::OrderByUnitOrderTiebreaker> {};
 

--- a/au/unit_of_measure_test.cc
+++ b/au/unit_of_measure_test.cc
@@ -180,14 +180,14 @@ TEST(Pow, FunctionGivesUnitWhichIsEquivalentToManuallyComputedPower) {
     EXPECT_THAT(are_units_quantity_equivalent(cubic_inches, in * in * in), IsTrue());
 }
 
-TEST(UnitProduct, IsUnitlessUnitForNoInputs) {
-    StaticAssertTypeEq<DimT<UnitProduct<>>, Dimension<>>();
-    StaticAssertTypeEq<MagT<UnitProduct<>>, Magnitude<>>();
+TEST(UnitProductPack, IsUnitlessUnitForNoInputs) {
+    StaticAssertTypeEq<DimT<UnitProductPack<>>, Dimension<>>();
+    StaticAssertTypeEq<MagT<UnitProductPack<>>, Magnitude<>>();
 }
 
-TEST(UnitProduct, ExactlyCancellingInstancesYieldsNullPack) {
+TEST(UnitProductPack, ExactlyCancellingInstancesYieldsNullPack) {
     StaticAssertTypeEq<decltype(Feet{} * Inches{} / Minutes{} / Inches{} * Minutes{} / Feet{}),
-                       UnitProduct<>>();
+                       UnitProductPack<>>();
 }
 
 TEST(UnitProductT, IdentityForSingleUnit) {
@@ -679,7 +679,7 @@ TEST(UnitLabel, PrintsExponentForUnitPower) {
     EXPECT_THAT(unit_label(RatioPow<Feet, -22, 7>{}), StrEq("ft^(-22/7)"));
 }
 
-TEST(UnitLabel, EmptyForNullProduct) { EXPECT_THAT(unit_label<UnitProduct<>>(), StrEq("")); }
+TEST(UnitLabel, EmptyForNullProduct) { EXPECT_THAT(unit_label<UnitProductPack<>>(), StrEq("")); }
 
 TEST(UnitLabel, NonintrusivelyLabelableByTrait) {
     EXPECT_THAT(unit_label<TraitLabeledUnit>(), StrEq("TLU"));
@@ -725,7 +725,7 @@ TEST(UnitLabel, LabelsCommonUnitCorrectly) {
                       StrEq("EQUIV{[(1 / 5000) m], [(1 / 127) in]}")));
 }
 
-TEST(UnitLabel, CommonUnitLabelWorksWithUnitProduct) {
+TEST(UnitLabel, CommonUnitLabelWorksWithUnitProductPack) {
     using U = CommonUnitT<UnitQuotientT<Meters, Minutes>, UnitQuotientT<Inches, Minutes>>;
     EXPECT_THAT(unit_label(U{}),
                 AnyOf(StrEq("EQUIV{[(1 / 127) in / min], [(1 / 5000) m / min]}"),
@@ -751,7 +751,7 @@ TEST(UnitLabel, LabelsCommonPointUnitCorrectly) {
                       StrEq("EQUIV{[(1 / 5000) m], [(1 / 127) in]}")));
 }
 
-TEST(UnitLabel, CommonPointUnitLabelWorksWithUnitProduct) {
+TEST(UnitLabel, CommonPointUnitLabelWorksWithUnitProductPack) {
     using U = CommonPointUnitT<UnitQuotientT<Meters, Minutes>, UnitQuotientT<Inches, Minutes>>;
     EXPECT_THAT(unit_label(U{}),
                 AnyOf(StrEq("EQUIV{[(1 / 127) in / min], [(1 / 5000) m / min]}"),

--- a/docs/howto/forward-declarations.md
+++ b/docs/howto/forward-declarations.md
@@ -84,21 +84,21 @@ We resolve this with a "warrant and check" approach, explained in the next secti
 ### Compound units
 
 The only way to forward declare a compound unit is to specify the exact types that go into the
-`UnitProduct<...>` template, and in the exact correct order.  We generally avoid having end users do
-this, both because it's hard to get right, and because it's an encapsulated implementation detail
-which could change.  However, for cases where the added speed from forward declaration really
+`UnitProductPack<...>` template, and in the exact correct order.  We generally avoid having end
+users do this, both because it's hard to get right, and because it's an encapsulated implementation
+detail which could change.  However, for cases where the added speed from forward declaration really
 matters, we can do the next best thing: make it easy to check that it's right.
 
 Here is a series of steps to follow to forward declare compound units.
 
-1.  **Find the types in `UnitProduct<...>`.**  One trick to do this is to assign an instance of the
-    compound unit type itself to another type, say, an `int`.  The _compiler error_ will contain the
-    correct type name.  Look for `UnitProduct<...>` in the error message.
+1.  **Find the types in `UnitProductPack<...>`.**  One trick to do this is to assign an instance of
+    the compound unit type itself to another type, say, an `int`.  The _compiler error_ will contain
+    the correct type name.  Look for `UnitProductPack<...>` in the error message.
 
 2.  **Forward declare the powers with `ForwardDeclareUnitPow<...>`.**  If any of the types in
-    `UnitProduct<...>` are instances of `Pow` or `RatioPow`, you'll want to make an alias for those
-    types.  If your compound unit is, say, the inverse cube of a unit, you can forward declare it
-    like this:
+    `UnitProductPack<...>` are instances of `Pow` or `RatioPow`, you'll want to make an alias for
+    those types.  If your compound unit is, say, the inverse cube of a unit, you can forward declare
+    it like this:
 
     ```cpp
     using InverseYourUnitsCubedFwd = au::ForwardDeclareUnitPow<YourUnits, -3>;
@@ -111,8 +111,8 @@ Here is a series of steps to follow to forward declare compound units.
 
 3.  **Forward declare the product itself with `ForwardDeclareUnitProduct<...>`.**  This is similar
     to the above.  For example, if the full product type from step 1 was
-    `UnitProduct<OtherUnits, Pow<YourUnits, -3>>`, you would forward declare it like this (using the
-    existing `InverseYourUnitsCubed` that you would have defined in step 2):
+    `UnitProductPack<OtherUnits, Pow<YourUnits, -3>>`, you would forward declare it like this (using
+    the existing `InverseYourUnitsCubed` that you would have defined in step 2):
 
     ```cpp
     using OtherUnitsPerYourUnitsCubedFwd = au::ForwardDeclareUnitProduct<OtherUnits, InverseYourUnitsCubed>;
@@ -141,11 +141,16 @@ Normally, we'd refer to our speed type as `QuantityD<UnitQuotientT<Kilo<Meters>,
 `UnitQuotientT` needs the full machinery of the library.  Instead, let's create an alias,
 `KilometersPerHour`, so we can write `QuantityD<KilometersPerHour>`.
 
-The first step is to find out which types go inside `UnitProduct<...>`, and in which order.  This
-[compiler explorer link](https://godbolt.org/z/cW3Gs7YzT) shows how to do this.  Note the
+The first step is to find out which types go inside `UnitProductPack<...>`, and in which order.
+This [compiler explorer link](https://godbolt.org/z/cW3Gs7YzT) shows how to do this.  Note the
 highlighted portion of the error message:
 
 ![Compiler error providing info for fwd decls](../assets/fwd_declare_compiler_error.png)
+
+!!! note
+    The screenshot is from an earlier version of software, where the unit product pack type name was
+    `UnitProduct<...>` rather than `UnitProductPack<...>`.  We will update both the link and the
+    screenshot in a follow-on PR.
 
 We can see that the types are `Kilo<Meters>` and `Pow<Hours, -1>`, in that order.  We'll need to
 start by defining an alias for the latter alone.  Then, we can define our `KilometersPerHour` alias,


### PR DESCRIPTION
This frees up `UnitProduct<...>` to be the user-facing utility.

It does create a follow-on task for the docs, where we need to update
the godbolt link and screenshot.  We'll need to do that after we land,
because the link is to the `main` version of the library.

Helps #86.