### PR TITLE
Add `Impl` suffix for library-internal helpers

### DIFF
--- a/au/au_test.cc
+++ b/au/au_test.cc
@@ -54,7 +54,7 @@ TEST(Conversions, SupportIntMHzToU32Hz) {
 }
 
 TEST(CommonUnit, HandlesPrefixesReasonably) {
-    StaticAssertTypeEq<CommonUnitT<Kilo<Meters>, Meters>, Meters>();
+    StaticAssertTypeEq<CommonUnit<Kilo<Meters>, Meters>, Meters>();
 }
 
 template <typename U, typename R>

--- a/au/constant.hh
+++ b/au/constant.hh
@@ -125,7 +125,7 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
 // Note that the argument is a _unit slot_, and thus can also accept things like `QuantityMaker` and
 // `SymbolFor` in addition to regular units.
 template <typename UnitSlot>
-constexpr Constant<AssociatedUnitT<UnitSlot>> make_constant(UnitSlot) {
+constexpr Constant<AssociatedUnit<UnitSlot>> make_constant(UnitSlot) {
     return {};
 }
 

--- a/au/constant_test.cc
+++ b/au/constant_test.cc
@@ -83,7 +83,7 @@ TEST(MakeConstant, MakesAdHocConstantFromQuantityMaker) {
     constexpr auto ad_hoc_c = make_constant(meters / second * mag<299'792'458>());
     EXPECT_THAT((1.0 * ad_hoc_c).in(meters / second), SameTypeAndValue(299'792'458.0));
 
-    auto foo = [](Quantity<UnitQuotientT<Meters, Seconds>, int> q) { std::cout << q << std::endl; };
+    auto foo = [](Quantity<UnitQuotient<Meters, Seconds>, int> q) { std::cout << q << std::endl; };
     foo(c);
 }
 
@@ -180,7 +180,7 @@ TEST(Constant, MakesScaledConstantWhenPreMultipliedByMagnitude) {
 }
 
 TEST(Constant, MakesScaledInverseConstantWhenDividedIntoMagnitude) {
-    StaticAssertTypeEq<decltype(PI / c), Constant<decltype(UnitInverseT<SpeedOfLight>{} * PI)>>();
+    StaticAssertTypeEq<decltype(PI / c), Constant<decltype(UnitInverse<SpeedOfLight>{} * PI)>>();
 }
 
 TEST(Constant, ChangesUnitsForQuantityWhenPostMultiplying) {

--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -181,23 +181,23 @@ struct ImplicitRepPermitted : detail::ImplicitConversionPolicy<Rep, ScaleFactor,
 
 template <typename Rep, typename SourceUnitSlot, typename TargetUnitSlot>
 constexpr bool implicit_rep_permitted_from_source_to_target(SourceUnitSlot, TargetUnitSlot) {
-    using SourceUnit = AssociatedUnitT<SourceUnitSlot>;
-    using TargetUnit = AssociatedUnitT<TargetUnitSlot>;
+    using SourceUnit = AssociatedUnit<SourceUnitSlot>;
+    using TargetUnit = AssociatedUnit<TargetUnitSlot>;
     static_assert(HasSameDimension<SourceUnit, TargetUnit>::value,
                   "Can only convert same-dimension units");
 
-    return ImplicitRepPermitted<Rep, UnitRatioT<SourceUnit, TargetUnit>>::value;
+    return ImplicitRepPermitted<Rep, UnitRatio<SourceUnit, TargetUnit>>::value;
 }
 
 template <typename Unit, typename Rep>
 struct ConstructionPolicy {
-    // Note: it's tempting to use the UnitRatioT trait here, but we can't, because it produces a
+    // Note: it's tempting to use the UnitRatio trait here, but we can't, because it produces a
     // hard error for units with different dimensions.  This is for good reason: magnitude ratios
-    // are meaningless unless the dimension is the same.  UnitRatioT is the user-facing tool, so we
+    // are meaningless unless the dimension is the same.  UnitRatio is the user-facing tool, so we
     // build in this hard error for safety.  Here, we need a soft error, so we do the dimension
     // check manually below.
     template <typename SourceUnit>
-    using ScaleFactor = MagQuotientT<detail::MagT<SourceUnit>, detail::MagT<Unit>>;
+    using ScaleFactor = MagQuotient<detail::MagT<SourceUnit>, detail::MagT<Unit>>;
 
     template <typename SourceUnit, typename SourceRep>
     using PermitImplicitFrom = stdx::conjunction<

--- a/au/conversion_strategy.hh
+++ b/au/conversion_strategy.hh
@@ -67,7 +67,7 @@ using ApplicationStrategyFor = typename ApplicationStrategyForImpl<T, Mag, MagKi
 
 template <typename T, typename Mag>
 struct ApplicationStrategyForImpl<T, Mag, MagKindHolder<MagKind::INTEGER_DIVIDE>>
-    : stdx::type_identity<DivideTypeByInteger<T, MagProductT<Sign<Mag>, DenominatorT<Mag>>>> {};
+    : stdx::type_identity<DivideTypeByInteger<T, MagProduct<Sign<Mag>, DenominatorT<Mag>>>> {};
 
 template <typename T, typename Mag>
 struct ApplicationStrategyForImpl<T, Mag, MagKindHolder<MagKind::NONTRIVIAL_RATIONAL>>

--- a/au/dimension.hh
+++ b/au/dimension.hh
@@ -57,21 +57,21 @@ using DimInverseT = DimInverse<T>;
 
 template <typename... BP1s, typename... BP2s>
 constexpr auto operator*(Dimension<BP1s...>, Dimension<BP2s...>) {
-    return DimProductT<Dimension<BP1s...>, Dimension<BP2s...>>{};
+    return DimProduct<Dimension<BP1s...>, Dimension<BP2s...>>{};
 }
 
 template <typename... BP1s, typename... BP2s>
 constexpr auto operator/(Dimension<BP1s...>, Dimension<BP2s...>) {
-    return DimQuotientT<Dimension<BP1s...>, Dimension<BP2s...>>{};
+    return DimQuotient<Dimension<BP1s...>, Dimension<BP2s...>>{};
 }
 
 // Roots and powers for Dimension instances.
 template <std::intmax_t N, typename... BPs>
-constexpr DimPowerT<Dimension<BPs...>, N> pow(Dimension<BPs...>) {
+constexpr DimPower<Dimension<BPs...>, N> pow(Dimension<BPs...>) {
     return {};
 }
 template <std::intmax_t N, typename... BPs>
-constexpr DimPowerT<Dimension<BPs...>, 1, N> root(Dimension<BPs...>) {
+constexpr DimPower<Dimension<BPs...>, 1, N> root(Dimension<BPs...>) {
     return {};
 }
 

--- a/au/dimension_test.cc
+++ b/au/dimension_test.cc
@@ -22,8 +22,8 @@ using ::testing::StaticAssertTypeEq;
 
 namespace au {
 
-using Speed = DimQuotientT<Length, Time>;
-using Accel = DimQuotientT<Speed, Time>;
+using Speed = DimQuotient<Length, Time>;
+using Accel = DimQuotient<Speed, Time>;
 
 // Test code for a new user-defined dimension.
 struct PixelBaseDim : base_dim::BaseDimension<1690384951> {};
@@ -41,29 +41,29 @@ TEST(Dimension, CanDefineNewBaseDimension) {
 TEST(Dimension, AllProvidedBaseDimensionsAreCompatible) {
     // This tests the strict total ordering for all recognized base dimensions.  It makes sure they
     // are all distinguishable and orderable, and thus can be combined in a single dimension.
-    (void)DimProductT<Length,
-                      Mass,
-                      Time,
-                      Current,
-                      Temperature,
-                      AmountOfSubstance,
-                      LuminousIntensity,
-                      Angle,
-                      Information>{};
+    (void)DimProduct<Length,
+                     Mass,
+                     Time,
+                     Current,
+                     Temperature,
+                     AmountOfSubstance,
+                     LuminousIntensity,
+                     Angle,
+                     Information>{};
 }
 
 TEST(Dimension, ProductAndQuotientBehaveAsExpected) {
-    StaticAssertTypeEq<DimProductT<Speed, Time>, Length>();
+    StaticAssertTypeEq<DimProduct<Speed, Time>, Length>();
     StaticAssertTypeEq<decltype(Speed{} * Time{}), Length>();
 
-    StaticAssertTypeEq<DimQuotientT<DimProductT<Length, Time>, Length>, Time>();
+    StaticAssertTypeEq<DimQuotient<DimProduct<Length, Time>, Length>, Time>();
     StaticAssertTypeEq<decltype(Length{} / Time{}), Speed>();
 }
 
 TEST(Dimension, PowersBehaveAsExpected) {
-    StaticAssertTypeEq<DimQuotientT<DimPowerT<Speed, 2>, Length>, Accel>();
+    StaticAssertTypeEq<DimQuotient<DimPower<Speed, 2>, Length>, Accel>();
 
-    StaticAssertTypeEq<DimProductT<Accel, DimPowerT<Time, 2>>, Length>();
+    StaticAssertTypeEq<DimProduct<Accel, DimPower<Time, 2>>, Length>();
 }
 
 TEST(Inverse, RaisesToPowerNegativeOne) {

--- a/au/fwd.hh
+++ b/au/fwd.hh
@@ -63,7 +63,7 @@ struct ForwardDeclareUnitProduct {
 //
 // Machinery for forward-declaring a unit power.
 //
-// To use, make an alias with the same unit and power(s) that `UnitPowerT` would produce, in the
+// To use, make an alias with the same unit and power(s) that `UnitPower` would produce, in the
 // `_fwd.hh` file.  In the `.hh` file, call `is_forward_declared_unit_valid(...)` (defined in
 // `unit_of_measure.hh`) on that alias.
 //

--- a/au/magnitude_test.cc
+++ b/au/magnitude_test.cc
@@ -69,7 +69,7 @@ TEST(Magnitude, PowersBehaveCorrectly) {
 TEST(Magnitude, RootsBehaveCorrectly) { EXPECT_THAT(root<3>(mag<8>()), Eq(mag<2>())); }
 
 TEST(Magnitude, CanNegate) {
-    EXPECT_THAT(-mag<5>(), Eq(MagProductT<Magnitude<Negative>, decltype(mag<5>())>{}));
+    EXPECT_THAT(-mag<5>(), Eq(MagProduct<Magnitude<Negative>, decltype(mag<5>())>{}));
 }
 
 TEST(Magnitude, NegativeCancelsOutWhenRepeated) {
@@ -581,22 +581,22 @@ TEST(GetValueResult, GivesAppropriateErrorForNegativeNumberInUnsignedType) {
     EXPECT_THAT(get_value_result<uint64_t>(neg_5), NegativeNumberInUnsignedType());
 }
 
-TEST(PrimeFactorizationT, NullMagnitudeFor1) {
-    StaticAssertTypeEq<PrimeFactorizationT<1u>, Magnitude<>>();
+TEST(PrimeFactorization, NullMagnitudeFor1) {
+    StaticAssertTypeEq<PrimeFactorization<1u>, Magnitude<>>();
 }
 
-TEST(PrimeFactorizationT, FactorsInputs) {
-    StaticAssertTypeEq<PrimeFactorizationT<2u>, Magnitude<Prime<2u>>>();
-    StaticAssertTypeEq<PrimeFactorizationT<3u>, Magnitude<Prime<3u>>>();
-    StaticAssertTypeEq<PrimeFactorizationT<4u>, Magnitude<Pow<Prime<2u>, 2u>>>();
-    StaticAssertTypeEq<PrimeFactorizationT<5u>, Magnitude<Prime<5u>>>();
-    StaticAssertTypeEq<PrimeFactorizationT<6u>, Magnitude<Prime<2u>, Prime<3u>>>();
+TEST(PrimeFactorization, FactorsInputs) {
+    StaticAssertTypeEq<PrimeFactorization<2u>, Magnitude<Prime<2u>>>();
+    StaticAssertTypeEq<PrimeFactorization<3u>, Magnitude<Prime<3u>>>();
+    StaticAssertTypeEq<PrimeFactorization<4u>, Magnitude<Pow<Prime<2u>, 2u>>>();
+    StaticAssertTypeEq<PrimeFactorization<5u>, Magnitude<Prime<5u>>>();
+    StaticAssertTypeEq<PrimeFactorization<6u>, Magnitude<Prime<2u>, Prime<3u>>>();
 
-    StaticAssertTypeEq<PrimeFactorizationT<12u>, Magnitude<Pow<Prime<2u>, 2u>, Prime<3u>>>();
+    StaticAssertTypeEq<PrimeFactorization<12u>, Magnitude<Pow<Prime<2u>, 2u>, Prime<3u>>>();
 }
 
 TEST(DenominatorPart, OmitsSignForNegativeNumbers) {
-    StaticAssertTypeEq<DenominatorPartT<decltype(-mag<3>() / mag<7>())>, decltype(mag<7>())>();
+    StaticAssertTypeEq<DenominatorPart<decltype(-mag<3>() / mag<7>())>, decltype(mag<7>())>();
 }
 
 }  // namespace detail

--- a/au/overflow_boundary.hh
+++ b/au/overflow_boundary.hh
@@ -359,7 +359,7 @@ struct LowestOfLimitsDividedByValue {
 template <typename T, typename M, typename Limits>
 struct ClampLowestOfLimitsTimesInverseValue {
     static constexpr T value() {
-        constexpr auto ABS_DIVISOR = MagInverseT<Abs<M>>{};
+        constexpr auto ABS_DIVISOR = MagInverse<Abs<M>>{};
 
         constexpr T RELEVANT_LIMIT = IsPositive<M>::value
                                          ? LowerLimit<T, Limits>::value()
@@ -409,7 +409,7 @@ struct HighestOfLimitsDividedByValue {
 template <typename T, typename M, typename Limits>
 struct ClampHighestOfLimitsTimesInverseValue {
     static constexpr T value() {
-        constexpr auto ABS_DIVISOR = MagInverseT<Abs<M>>{};
+        constexpr auto ABS_DIVISOR = MagInverse<Abs<M>>{};
 
         constexpr T RELEVANT_LIMIT = IsPositive<M>::value
                                          ? UpperLimit<T, Limits>::value()
@@ -688,7 +688,7 @@ struct MaxGoodImpl<MultiplyTypeBy<T, M>, Limits>
 
 template <typename T, typename M, typename Limits>
 struct MinGoodImplForDivideTypeByIntegerAssumingSigned
-    : stdx::type_identity<ClampLowestOfLimitsTimesInverseValue<T, MagInverseT<M>, Limits>> {};
+    : stdx::type_identity<ClampLowestOfLimitsTimesInverseValue<T, MagInverse<M>, Limits>> {};
 
 template <typename T, typename M, typename Limits>
 struct MinGoodImplForDivideTypeByIntegerUsingRealPart
@@ -706,7 +706,7 @@ struct MinGoodImpl<DivideTypeByInteger<T, M>, Limits>
 
 template <typename T, typename M, typename Limits>
 struct MaxGoodImplForDivideTypeByIntegerAssumingSignedTypeOrPositiveFactor
-    : stdx::type_identity<ClampHighestOfLimitsTimesInverseValue<T, MagInverseT<M>, Limits>> {};
+    : stdx::type_identity<ClampHighestOfLimitsTimesInverseValue<T, MagInverse<M>, Limits>> {};
 
 template <typename T, typename M, typename Limits>
 struct MaxGoodImplForDivideTypeByIntegerUsingRealPart

--- a/au/packs_test.cc
+++ b/au/packs_test.cc
@@ -71,54 +71,54 @@ template <typename A, typename B>
 struct InOrderFor<LexiPack, A, B> : LexicographicTotalOrdering<A, B, OrderByFirst, OrderBySecond> {
 };
 
-TEST(BaseT, IdentityForArbitraryTypes) {
-    StaticAssertTypeEq<BaseT<int>, int>();
-    StaticAssertTypeEq<BaseT<char>, char>();
+TEST(Base, IdentityForArbitraryTypes) {
+    StaticAssertTypeEq<Base<int>, int>();
+    StaticAssertTypeEq<Base<char>, char>();
 }
 
-TEST(BaseT, FirstArgumentOfPow) {
-    StaticAssertTypeEq<BaseT<Pow<int, 3>>, int>();
-    StaticAssertTypeEq<BaseT<Pow<char, -1>>, char>();
+TEST(Base, FirstArgumentOfPow) {
+    StaticAssertTypeEq<Base<Pow<int, 3>>, int>();
+    StaticAssertTypeEq<Base<Pow<char, -1>>, char>();
 }
 
-TEST(BaseT, FirstArgumentOfRatioPow) {
-    StaticAssertTypeEq<BaseT<RatioPow<int, 3, 2>>, int>();
-    StaticAssertTypeEq<BaseT<RatioPow<char, -1, 4>>, char>();
+TEST(Base, FirstArgumentOfRatioPow) {
+    StaticAssertTypeEq<Base<RatioPow<int, 3, 2>>, int>();
+    StaticAssertTypeEq<Base<RatioPow<char, -1, 4>>, char>();
 }
 
-TEST(ExpT, Ratio1ForArbitraryTypes) {
-    StaticAssertTypeEq<ExpT<int>, std::ratio<1>>();
-    StaticAssertTypeEq<ExpT<char>, std::ratio<1>>();
+TEST(Exp, Ratio1ForArbitraryTypes) {
+    StaticAssertTypeEq<Exp<int>, std::ratio<1>>();
+    StaticAssertTypeEq<Exp<char>, std::ratio<1>>();
 }
 
-TEST(ExpT, SecondArgumentOfPowAsRatio) {
-    StaticAssertTypeEq<ExpT<Pow<int, 3>>, std::ratio<3>>();
-    StaticAssertTypeEq<ExpT<Pow<char, -1>>, std::ratio<-1>>();
+TEST(Exp, SecondArgumentOfPowAsRatio) {
+    StaticAssertTypeEq<Exp<Pow<int, 3>>, std::ratio<3>>();
+    StaticAssertTypeEq<Exp<Pow<char, -1>>, std::ratio<-1>>();
 }
 
-TEST(ExpT, RatioOfFinalTwoArgumentsOfRatioPow) {
-    StaticAssertTypeEq<ExpT<RatioPow<int, 3, 2>>, std::ratio<3, 2>>();
-    StaticAssertTypeEq<ExpT<RatioPow<char, -1, 4>>, std::ratio<-1, 4>>();
+TEST(Exp, RatioOfFinalTwoArgumentsOfRatioPow) {
+    StaticAssertTypeEq<Exp<RatioPow<int, 3, 2>>, std::ratio<3, 2>>();
+    StaticAssertTypeEq<Exp<RatioPow<char, -1, 4>>, std::ratio<-1, 4>>();
 }
 
-TEST(AsPackT, IdentityForPackOfSameType) {
-    StaticAssertTypeEq<AsPackT<Pack, Pack<>>, Pack<>>();
-    StaticAssertTypeEq<AsPackT<Pack, Pack<int>>, Pack<int>>();
-    StaticAssertTypeEq<AsPackT<Pack, Pack<int, char>>, Pack<int, char>>();
+TEST(AsPack, IdentityForPackOfSameType) {
+    StaticAssertTypeEq<AsPack<Pack, Pack<>>, Pack<>>();
+    StaticAssertTypeEq<AsPack<Pack, Pack<int>>, Pack<int>>();
+    StaticAssertTypeEq<AsPack<Pack, Pack<int, char>>, Pack<int, char>>();
 }
 
-TEST(AsPackT, WrapsOtherTypes) {
-    StaticAssertTypeEq<AsPackT<Pack, int>, Pack<int>>();
-    StaticAssertTypeEq<AsPackT<Pack, char>, Pack<char>>();
+TEST(AsPack, WrapsOtherTypes) {
+    StaticAssertTypeEq<AsPack<Pack, int>, Pack<int>>();
+    StaticAssertTypeEq<AsPack<Pack, char>, Pack<char>>();
 }
 
-TEST(UnpackIfSoloT, ReturnsEnclosedElementIfExactlyOne) {
-    StaticAssertTypeEq<UnpackIfSoloT<Pack, Pack<>>, Pack<>>();
+TEST(UnpackIfSolo, ReturnsEnclosedElementIfExactlyOne) {
+    StaticAssertTypeEq<UnpackIfSolo<Pack, Pack<>>, Pack<>>();
 
-    StaticAssertTypeEq<UnpackIfSoloT<Pack, Pack<int>>, int>();
-    StaticAssertTypeEq<UnpackIfSoloT<Pack, Pack<char>>, char>();
+    StaticAssertTypeEq<UnpackIfSolo<Pack, Pack<int>>, int>();
+    StaticAssertTypeEq<UnpackIfSolo<Pack, Pack<char>>, char>();
 
-    StaticAssertTypeEq<UnpackIfSoloT<Pack, Pack<int, char>>, Pack<int, char>>();
+    StaticAssertTypeEq<UnpackIfSolo<Pack, Pack<int, char>>, Pack<int, char>>();
 }
 
 TEST(PackProductT, UnaryProductIsIdentity) {
@@ -280,7 +280,7 @@ TEST(InStandardPackOrder, IfLeadingBasesUnequalPicksWhicheverComesFirst) {
     EXPECT_THAT((InStandardPackOrder<Pack<B<2>>, Pack<RatioPow<B<3>, -1, 38>>>::value), IsTrue());
 }
 
-TEST(InStandardPackOrder, IfLeadingBasesEqualUsesSmallerExpToBreakTie) {
+TEST(InStandardPackOrder, IfLeadingBasesEqualUsesSmallerExpoBreakTie) {
     EXPECT_THAT((InStandardPackOrder<Pack<Pow<B<2>, -1>>, Pack<B<2>>>::value), IsTrue());
 
     EXPECT_THAT((InStandardPackOrder<Pack<B<2>>, Pack<RatioPow<B<2>, 11, 10>>>::value), IsTrue());
@@ -380,13 +380,13 @@ TEST(AreAllPowersNonzero, AllMustSatisfyForMultiElementPack) {
 
 namespace detail {
 
-TEST(SimplifyBasePowersT, SimplifiesEachIndividualBasePower) {
-    StaticAssertTypeEq<SimplifyBasePowersT<Pack<B<2>,                      // A. Leave alone.
-                                                Pow<B<3>, 1>,              // B. Reduce to base.
-                                                Pow<B<5>, 3>,              // C. Leave alone.
-                                                RatioPow<B<7>, 1, 1>,      // D. Reduce to base.
-                                                RatioPow<B<11>, -4, 1>,    // E. Reduce to int pow.
-                                                RatioPow<B<13>, -4, 5>>>,  // F. Leave alone.
+TEST(SimplifyBasePowers, SimplifiesEachIndividualBasePower) {
+    StaticAssertTypeEq<SimplifyBasePowers<Pack<B<2>,                      // A. Leave alone.
+                                               Pow<B<3>, 1>,              // B. Reduce to base.
+                                               Pow<B<5>, 3>,              // C. Leave alone.
+                                               RatioPow<B<7>, 1, 1>,      // D. Reduce to base.
+                                               RatioPow<B<11>, -4, 1>,    // E. Reduce to int pow.
+                                               RatioPow<B<13>, -4, 5>>>,  // F. Leave alone.
 
                        Pack<B<2>,                        // A. Unchanged.
                             B<3>,                        // B. Reduced to base.
@@ -396,32 +396,32 @@ TEST(SimplifyBasePowersT, SimplifiesEachIndividualBasePower) {
                             RatioPow<B<13>, -4, 5>>>();  // F. Unchanged.
 }
 
-TEST(NumeratorPartT, PullsOutPositivePowers) {
-    StaticAssertTypeEq<NumeratorPartT<Pack<>>, Pack<>>();
-    StaticAssertTypeEq<NumeratorPartT<Pack<B<2>>>, Pack<B<2>>>();
+TEST(NumeratorPart, PullsOutPositivePowers) {
+    StaticAssertTypeEq<NumeratorPart<Pack<>>, Pack<>>();
+    StaticAssertTypeEq<NumeratorPart<Pack<B<2>>>, Pack<B<2>>>();
 
-    StaticAssertTypeEq<NumeratorPartT<Pack<Pow<B<2>, 3>>>, Pack<Pow<B<2>, 3>>>();
-    StaticAssertTypeEq<NumeratorPartT<Pack<Pow<B<2>, -3>>>, Pack<>>();
+    StaticAssertTypeEq<NumeratorPart<Pack<Pow<B<2>, 3>>>, Pack<Pow<B<2>, 3>>>();
+    StaticAssertTypeEq<NumeratorPart<Pack<Pow<B<2>, -3>>>, Pack<>>();
 
-    StaticAssertTypeEq<NumeratorPartT<Pack<RatioPow<B<2>, 3, 2>>>, Pack<RatioPow<B<2>, 3, 2>>>();
-    StaticAssertTypeEq<NumeratorPartT<Pack<RatioPow<B<2>, -3, 2>>>, Pack<>>();
+    StaticAssertTypeEq<NumeratorPart<Pack<RatioPow<B<2>, 3, 2>>>, Pack<RatioPow<B<2>, 3, 2>>>();
+    StaticAssertTypeEq<NumeratorPart<Pack<RatioPow<B<2>, -3, 2>>>, Pack<>>();
 
-    StaticAssertTypeEq<NumeratorPartT<Pack<Pow<B<2>, 2>, Pow<B<3>, -6>, Pow<B<5>, -3>, B<7>>>,
+    StaticAssertTypeEq<NumeratorPart<Pack<Pow<B<2>, 2>, Pow<B<3>, -6>, Pow<B<5>, -3>, B<7>>>,
                        Pack<Pow<B<2>, 2>, B<7>>>();
 }
 
-TEST(DenominatorPartT, PullsOutAndInvertsNegativePowers) {
-    StaticAssertTypeEq<DenominatorPartT<Pack<>>, Pack<>>();
+TEST(DenominatorPart, PullsOutAndInvertsNegativePowers) {
+    StaticAssertTypeEq<DenominatorPart<Pack<>>, Pack<>>();
 
-    StaticAssertTypeEq<DenominatorPartT<Pack<Pow<B<2>, -1>>>, Pack<B<2>>>();
+    StaticAssertTypeEq<DenominatorPart<Pack<Pow<B<2>, -1>>>, Pack<B<2>>>();
 
-    StaticAssertTypeEq<DenominatorPartT<Pack<Pow<B<2>, 3>>>, Pack<>>();
-    StaticAssertTypeEq<DenominatorPartT<Pack<Pow<B<2>, -3>>>, Pack<Pow<B<2>, 3>>>();
+    StaticAssertTypeEq<DenominatorPart<Pack<Pow<B<2>, 3>>>, Pack<>>();
+    StaticAssertTypeEq<DenominatorPart<Pack<Pow<B<2>, -3>>>, Pack<Pow<B<2>, 3>>>();
 
-    StaticAssertTypeEq<DenominatorPartT<Pack<RatioPow<B<2>, 3, 2>>>, Pack<>>();
-    StaticAssertTypeEq<DenominatorPartT<Pack<RatioPow<B<2>, -3, 2>>>, Pack<RatioPow<B<2>, 3, 2>>>();
+    StaticAssertTypeEq<DenominatorPart<Pack<RatioPow<B<2>, 3, 2>>>, Pack<>>();
+    StaticAssertTypeEq<DenominatorPart<Pack<RatioPow<B<2>, -3, 2>>>, Pack<RatioPow<B<2>, 3, 2>>>();
 
-    StaticAssertTypeEq<DenominatorPartT<Pack<Pow<B<2>, 2>, Pow<B<3>, -6>, Pow<B<5>, -3>, B<7>>>,
+    StaticAssertTypeEq<DenominatorPart<Pack<Pow<B<2>, 2>, Pow<B<3>, -6>, Pow<B<5>, -3>, B<7>>>,
                        Pack<Pow<B<3>, 6>, Pow<B<5>, 3>>>();
 }
 

--- a/au/prefix_test.cc
+++ b/au/prefix_test.cc
@@ -190,25 +190,25 @@ TEST(BinaryPrefixes, CorrectlyLabelUnits) {
 }
 
 TEST(PrefixedPoweredUnitLabels, OmitsBracketsIfPrefixAppliesBeforeThePower) {
-    expect_label<UnitInverseT<Milli<XeroxedBytes>>>("mX^(-1)");
-    expect_label<UnitPowerT<Kilo<XeroxedBytes>, 2>>("kX^2");
-    expect_label<UnitPowerT<Mega<XeroxedBytes>, 3>>("MX^3");
+    expect_label<UnitInverse<Milli<XeroxedBytes>>>("mX^(-1)");
+    expect_label<UnitPower<Kilo<XeroxedBytes>, 2>>("kX^2");
+    expect_label<UnitPower<Mega<XeroxedBytes>, 3>>("MX^3");
 }
 
 TEST(PrefixedPoweredUnitLabels, IncludesBracketsIfPrefixAppliesAfterThePower) {
-    expect_label<Milli<UnitInverseT<XeroxedBytes>>>("m[X^(-1)]");
-    expect_label<Kilo<UnitPowerT<XeroxedBytes, 2>>>("k[X^2]");
-    expect_label<Mega<UnitPowerT<XeroxedBytes, 3>>>("M[X^3]");
+    expect_label<Milli<UnitInverse<XeroxedBytes>>>("m[X^(-1)]");
+    expect_label<Kilo<UnitPower<XeroxedBytes, 2>>>("k[X^2]");
+    expect_label<Mega<UnitPower<XeroxedBytes, 3>>>("M[X^3]");
 }
 
 TEST(PrefixedPoweredUnitLabels, IncludesBracketsForCompoundUnitsContainingPowers) {
-    using SquareInchesTimesXeroxedBytes = UnitProductT<UnitPowerT<Inches, 2>, XeroxedBytes>;
+    using SquareInchesTimesXeroxedBytes = UnitProduct<UnitPower<Inches, 2>, XeroxedBytes>;
     expect_label<Kilo<SquareInchesTimesXeroxedBytes>>("k[in^2 * X]");
 
-    using SquareInchesPerXeroxedByte = UnitQuotientT<UnitPowerT<Inches, 2>, XeroxedBytes>;
+    using SquareInchesPerXeroxedByte = UnitQuotient<UnitPower<Inches, 2>, XeroxedBytes>;
     expect_label<Milli<SquareInchesPerXeroxedByte>>("m[in^2 / X]");
 
-    using XeroxedBytesPerSquareInch = UnitQuotientT<XeroxedBytes, UnitPowerT<Inches, 2>>;
+    using XeroxedBytesPerSquareInch = UnitQuotient<XeroxedBytes, UnitPower<Inches, 2>>;
     expect_label<Gibi<XeroxedBytesPerSquareInch>>("Gi[X / in^2]");
 }
 

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -151,7 +151,7 @@ TEST(QuantityPoint, IntermediateTypeIsSignedIfExplicitRepIsSigned) {
 }
 
 TEST(QuantityPoint, CanConstructExpected) {
-    using Com = CommonPointUnitT<Kelvins, Celsius>;
+    using Com = CommonPointUnit<Kelvins, Celsius>;
     QuantityPointI<Com> pt{celsius_pt(0)};
     EXPECT_THAT(pt, Eq((kelvins_pt / mag<20>())(273'15 / 5)));
 }

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -69,7 +69,7 @@ static constexpr QuantityMaker<Meters> meters{};
 static_assert(are_units_quantity_equivalent(Centi<Meters>{} * mag<254>(), Inches{} * mag<100>()),
               "Double-check this ad hoc definition of meters");
 
-struct Unos : decltype(UnitProductT<>{}) {};
+struct Unos : decltype(UnitProduct<>{}) {};
 constexpr auto unos = QuantityMaker<Unos>{};
 
 struct Percent : decltype(Unos{} / mag<100>()) {};
@@ -92,7 +92,7 @@ constexpr auto hertz = QuantityMaker<Hertz>{};
 struct Days : decltype(Hours{} * mag<24>()) {};
 constexpr auto days = QuantityMaker<Days>{};
 
-struct PerDay : decltype(UnitInverseT<Days>{}) {};
+struct PerDay : decltype(UnitInverse<Days>{}) {};
 constexpr auto per_day = QuantityMaker<PerDay>{};
 
 template <typename... Us>
@@ -164,19 +164,19 @@ TEST(QuantityMaker, CreatesAppropriateQuantityIfCalled) {
 }
 
 TEST(QuantityMaker, CanBeMultipliedBySingularUnitToGetMakerOfProductUnit) {
-    StaticAssertTypeEq<decltype(hour * feet), QuantityMaker<UnitProductT<Feet, Hours>>>();
+    StaticAssertTypeEq<decltype(hour * feet), QuantityMaker<UnitProduct<Feet, Hours>>>();
 }
 
 TEST(QuantityMaker, CanMultiplyByOtherMakerToGetMakerOfProductUnit) {
-    StaticAssertTypeEq<decltype(hours * feet), QuantityMaker<UnitProductT<Feet, Hours>>>();
+    StaticAssertTypeEq<decltype(hours * feet), QuantityMaker<UnitProduct<Feet, Hours>>>();
 }
 
 TEST(QuantityMaker, CanDivideBySingularUnitToGetMakerOfQuotientUnit) {
-    StaticAssertTypeEq<decltype(feet / hour), QuantityMaker<UnitQuotientT<Feet, Hours>>>();
+    StaticAssertTypeEq<decltype(feet / hour), QuantityMaker<UnitQuotient<Feet, Hours>>>();
 }
 
 TEST(QuantityMaker, CanDivideByOtherMakerToGetMakerOfQuotientUnit) {
-    StaticAssertTypeEq<decltype(feet / hours), QuantityMaker<UnitQuotientT<Feet, Hours>>>();
+    StaticAssertTypeEq<decltype(feet / hours), QuantityMaker<UnitQuotient<Feet, Hours>>>();
 }
 
 TEST(QuantityMaker, CanTakePowerToGetMakerOfPowerUnit) {
@@ -193,7 +193,7 @@ TEST(QuantityMaker, CanDivideByMagnitudeToGetMakerOfDescaledUnit) {
 
 TEST(QuantityMaker, CanMultiplyByMultipleSingularUnits) {
     StaticAssertTypeEq<decltype(mile * minute * days),
-                       QuantityMaker<UnitProductT<Miles, Minutes, Days>>>();
+                       QuantityMaker<UnitProduct<Miles, Minutes, Days>>>();
 }
 
 TEST(Quantity, CanRetrieveInDifferentUnitsWithSameDimension) {
@@ -673,15 +673,15 @@ TEST(Quantity, RatioOfEquivalentTypesIsScalar) {
 }
 
 TEST(Quantity, ProductOfInvertingUnitsIsScalar) {
-    // We pass `UnitProductT` to this function template, which ensures that we get a
-    // `UnitProductPack` (note: NOT `UnitProductT`!) with the expected number of arguments.  Recall
-    // that `UnitProductT` is the user-facing "unit computation" interface, and `UnitProductPack` is
+    // We pass `UnitProduct` to this function template, which ensures that we get a
+    // `UnitProductPack` (note: NOT `UnitProduct`!) with the expected number of arguments.  Recall
+    // that `UnitProduct` is the user-facing "unit computation" interface, and `UnitProductPack` is
     // the named template which gets passed around the system.
     //
     // The point is to make sure that the product-unit of `Days` and `PerDay` does **not** reduce to
     // something trivial, like `UnitProductPack<>`.  Rather, it should be its own non-trivial
     // unit---although, naturally, it must be **quantity-equivalent** to `UnitProductPack<>`.
-    ASSERT_THAT(num_units_in_product(UnitProductT<Days, PerDay>{}), Eq(2));
+    ASSERT_THAT(num_units_in_product(UnitProduct<Days, PerDay>{}), Eq(2));
 
     EXPECT_THAT(days(3) * per_day(8), SameTypeAndValue(24));
 }
@@ -916,7 +916,7 @@ TEST(QuantityNTTP, CanConvertFromNttpToAnyCompatibleQuantityType) {
 
 TEST(Quantity, CommonTypeRespectsImplicitRepSafetyChecks) {
     // The following test should fail to compile.  Uncomment both lines to check.
-    // constexpr auto feeters = QuantityMaker<CommonUnitT<Meters, Feet>>{};
+    // constexpr auto feeters = QuantityMaker<CommonUnit<Meters, Feet>>{};
     // EXPECT_THAT(meters(uint16_t{53}), Ne(feeters(uint16_t{714})));
 
     // Why the above values?  The common unit of Meters and Feet (herein called the "Feeter") is
@@ -933,7 +933,7 @@ TEST(Quantity, CommonTypeRespectsImplicitRepSafetyChecks) {
 }
 
 TEST(QuantityMaker, ProvidesAssociatedUnit) {
-    StaticAssertTypeEq<AssociatedUnitT<QuantityMaker<Hours>>, Hours>();
+    StaticAssertTypeEq<AssociatedUnit<QuantityMaker<Hours>>, Hours>();
 }
 
 TEST(AsRawNumber, ExtractsRawNumberForUnitlessQuantity) {

--- a/au/rep.hh
+++ b/au/rep.hh
@@ -82,24 +82,24 @@ using LooksLikeAuOrOtherQuantity = stdx::disjunction<IsAuType<T>, HasCorrespondi
 // `au::Quantity`, but also `au::QuantityPoint`, and "quantity-like" types from other libraries
 // (which we consider as "anything that has a `CorrespondingQuantity`".
 template <template <class...> class Op, typename... Ts>
-struct ResultIfNoneAreQuantity;
+struct ResultIfNoneAreQuantityImpl;
 template <template <class...> class Op, typename... Ts>
-using ResultIfNoneAreQuantityT = typename ResultIfNoneAreQuantity<Op, Ts...>::type;
+using ResultIfNoneAreQuantity = typename ResultIfNoneAreQuantityImpl<Op, Ts...>::type;
 
 // Default implementation where we know that none are quantities.
 template <bool AreAnyQuantity, template <class...> class Op, typename... Ts>
-struct ResultIfNoneAreQuantityImpl : stdx::type_identity<Op<Ts...>> {};
+struct ResultIfNoneAreQuantityHelper : stdx::type_identity<Op<Ts...>> {};
 
 // Implementation if any of the types are quantities.
 template <template <class...> class Op, typename... Ts>
-struct ResultIfNoneAreQuantityImpl<true, Op, Ts...> : stdx::type_identity<void> {};
+struct ResultIfNoneAreQuantityHelper<true, Op, Ts...> : stdx::type_identity<void> {};
 
 // The main implementation.
 template <template <class...> class Op, typename... Ts>
-struct ResultIfNoneAreQuantity
-    : ResultIfNoneAreQuantityImpl<stdx::disjunction<LooksLikeAuOrOtherQuantity<Ts>...>::value,
-                                  Op,
-                                  Ts...> {};
+struct ResultIfNoneAreQuantityImpl
+    : ResultIfNoneAreQuantityHelper<stdx::disjunction<LooksLikeAuOrOtherQuantity<Ts>...>::value,
+                                    Op,
+                                    Ts...> {};
 
 // The `std::is_empty` is a good way to catch all of the various unit and other monovalue types in
 // our library, which have little else in common.  It's also just intrinsically true that it
@@ -132,10 +132,10 @@ struct IsValidRep : stdx::negation<detail::IsKnownInvalidRep<T>> {};
 
 template <typename T, typename U>
 struct IsProductValidRep
-    : IsValidRep<detail::ResultIfNoneAreQuantityT<detail::ProductTypeOrVoid, T, U>> {};
+    : IsValidRep<detail::ResultIfNoneAreQuantity<detail::ProductTypeOrVoid, T, U>> {};
 
 template <typename T, typename U>
 struct IsQuotientValidRep
-    : IsValidRep<detail::ResultIfNoneAreQuantityT<detail::QuotientTypeOrVoid, T, U>> {};
+    : IsValidRep<detail::ResultIfNoneAreQuantity<detail::QuotientTypeOrVoid, T, U>> {};
 
 }  // namespace au

--- a/au/rep_test.cc
+++ b/au/rep_test.cc
@@ -145,21 +145,21 @@ TEST(IsQuotientValidRep, TrueOnlyForSideWhereQuotientExists) {
 namespace detail {
 
 TEST(ResultIfNoneAreQuantity, GivesResultWhenNoneAreQuantity) {
-    StaticAssertTypeEq<int, ResultIfNoneAreQuantityT<std::common_type_t, int, int>>();
+    StaticAssertTypeEq<int, ResultIfNoneAreQuantity<std::common_type_t, int, int>>();
     StaticAssertTypeEq<std::tuple<int, double, float>,
-                       ResultIfNoneAreQuantityT<std::tuple, int, double, float>>();
+                       ResultIfNoneAreQuantity<std::tuple, int, double, float>>();
 }
 
 TEST(ResultIfNoneAreQuantity, GivesVoidWhenAnyIsQuantity) {
     StaticAssertTypeEq<void,
-                       ResultIfNoneAreQuantityT<std::common_type_t, int, Quantity<Miles, int>>>();
+                       ResultIfNoneAreQuantity<std::common_type_t, int, Quantity<Miles, int>>>();
     StaticAssertTypeEq<void,
-                       ResultIfNoneAreQuantityT<std::tuple, int, Quantity<Miles, int>, float>>();
+                       ResultIfNoneAreQuantity<std::tuple, int, Quantity<Miles, int>, float>>();
 }
 
 TEST(ResultIfNoneAreQuantity, GivesVoidWhenAnyIsCorrespondingQuantity) {
-    StaticAssertTypeEq<void, ResultIfNoneAreQuantityT<std::common_type_t, int, MyMeters>>();
-    StaticAssertTypeEq<void, ResultIfNoneAreQuantityT<std::tuple, int, std::chrono::nanoseconds>>();
+    StaticAssertTypeEq<void, ResultIfNoneAreQuantity<std::common_type_t, int, MyMeters>>();
+    StaticAssertTypeEq<void, ResultIfNoneAreQuantity<std::tuple, int, std::chrono::nanoseconds>>();
 }
 
 TEST(ProductTypeOrVoid, GivesProductTypeForArithmeticInputs) {

--- a/au/truncation_risk.hh
+++ b/au/truncation_risk.hh
@@ -140,7 +140,7 @@ struct TruncationRiskForDivideIntegralByInteger
     : std::conditional<(get_value_result<T>(M{}).outcome ==
                         MagRepresentationOutcome::ERR_CANNOT_FIT),
                        ValueIsNotZero<T>,
-                       ValueTimesRatioIsNotInteger<T, MagInverseT<M>>> {};
+                       ValueTimesRatioIsNotInteger<T, MagInverse<M>>> {};
 
 template <typename T, typename M>
 struct TruncationRiskForDivideArithmeticByInteger
@@ -204,12 +204,12 @@ struct UpdateRiskImpl<DivideTypeByInteger<T, M>, Risk<RealPart<T>>>
 template <typename T, typename M1, typename M2>
 struct UpdateRiskImpl<MultiplyTypeBy<T, M1>, ValueTimesRatioIsNotInteger<RealPart<T>, M2>>
     : std::conditional<IsRational<M1>::value,
-                       ReduceValueTimesRatioIsNotInteger<RealPart<T>, MagProductT<M1, M2>>,
+                       ReduceValueTimesRatioIsNotInteger<RealPart<T>, MagProduct<M1, M2>>,
                        ValueIsNotZero<RealPart<T>>> {};
 
 template <typename T, typename M1, typename M2>
 struct UpdateRiskImpl<DivideTypeByInteger<T, M1>, ValueTimesRatioIsNotInteger<RealPart<T>, M2>>
-    : stdx::type_identity<ReduceValueTimesRatioIsNotInteger<RealPart<T>, MagQuotientT<M2, M1>>> {};
+    : stdx::type_identity<ReduceValueTimesRatioIsNotInteger<RealPart<T>, MagQuotient<M2, M1>>> {};
 
 //
 // `BiggestRiskImpl<Risk1, Risk2>` is a helper that computes the "biggest" risk between two risks.
@@ -296,14 +296,14 @@ struct ValueTimesRatioIsNotIntegerImplForFloatGeneric {
 template <typename T, typename M>
 struct ValueTimesRatioIsNotIntegerImplForFloatDivideByInteger {
     static constexpr bool would_value_truncate(const T &value) {
-        const auto result = value / get_value<RealPart<T>>(MagInverseT<M>{});
+        const auto result = value / get_value<RealPart<T>>(MagInverse<M>{});
         return std::trunc(result) != result;
     }
 };
 
 template <typename T, typename M>
 struct ValueTimesRatioIsNotIntegerImplForFloat
-    : std::conditional_t<IsInteger<MagInverseT<M>>::value,
+    : std::conditional_t<IsInteger<MagInverse<M>>::value,
                          ValueTimesRatioIsNotIntegerImplForFloatDivideByInteger<T, M>,
                          ValueTimesRatioIsNotIntegerImplForFloatGeneric<T, M>> {};
 

--- a/au/truncation_risk_test.cc
+++ b/au/truncation_risk_test.cc
@@ -33,7 +33,7 @@ template <typename T, typename M>
 using ValueTimesIntIsNotInteger = ValueTimesRatioIsNotInteger<T, M>;
 
 template <typename T, typename M>
-using ValueDivIntIsNotInteger = ValueTimesRatioIsNotInteger<T, MagInverseT<M>>;
+using ValueDivIntIsNotInteger = ValueTimesRatioIsNotInteger<T, MagInverse<M>>;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `TruncationRiskFor` section:

--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -128,7 +128,7 @@ struct IsUnitlessUnit
 //
 // Useful in doing unit conversions.
 template <typename U1, typename U2>
-struct UnitRatioImpl : stdx::type_identity<MagQuotientT<detail::MagT<U1>, detail::MagT<U2>>> {
+struct UnitRatioImpl : stdx::type_identity<MagQuotient<detail::MagT<U1>, detail::MagT<U2>>> {
     static_assert(HasSameDimension<U1, U2>::value,
                   "Can only compute ratio of same-dimension units");
 };
@@ -185,7 +185,7 @@ using CommonUnitT = CommonUnit<Us...>;
 //
 // This helps us support the widest range of Rep types (in particular, unsigned integers).
 //
-// As with `CommonUnitT`, this isn't always possible: in particular, we can't do this for units with
+// As with `CommonUnit`, this isn't always possible: in particular, we can't do this for units with
 // irrational relative magnitudes or origin displacements.  However, we still provide _some_ answer,
 // which is consistent with the above policy whenever it's achievable, and produces reasonable
 // results in all other cases.
@@ -212,81 +212,81 @@ constexpr bool is_unit(T) {
 // `fits_in_unit_slot(T)`: check whether this value is valid for a unit slot.
 template <typename T>
 constexpr bool fits_in_unit_slot(T) {
-    return IsUnit<AssociatedUnitT<T>>::value;
+    return IsUnit<AssociatedUnit<T>>::value;
 }
 
 // Check whether the units associated with these objects have the same Dimension.
 template <typename... Us>
 constexpr bool has_same_dimension(Us...) {
-    return HasSameDimension<AssociatedUnitT<Us>...>::value;
+    return HasSameDimension<AssociatedUnit<Us>...>::value;
 }
 
 // Check whether two Unit types are exactly quantity-equivalent.
 template <typename U1, typename U2>
 constexpr bool are_units_quantity_equivalent(U1, U2) {
-    return AreUnitsQuantityEquivalent<AssociatedUnitT<U1>, AssociatedUnitT<U2>>::value;
+    return AreUnitsQuantityEquivalent<AssociatedUnit<U1>, AssociatedUnit<U2>>::value;
 }
 
 // Check whether two Unit types are exactly point-equivalent.
 template <typename U1, typename U2>
 constexpr bool are_units_point_equivalent(U1, U2) {
-    return AreUnitsPointEquivalent<AssociatedUnitT<U1>, AssociatedUnitT<U2>>::value;
+    return AreUnitsPointEquivalent<AssociatedUnit<U1>, AssociatedUnit<U2>>::value;
 }
 
 // Check whether this value is an instance of a dimensionless Unit.
 template <typename U>
 constexpr bool is_dimensionless(U) {
-    return IsDimensionless<AssociatedUnitT<U>>::value;
+    return IsDimensionless<AssociatedUnit<U>>::value;
 }
 
 // Type trait to detect whether a Unit is "the unitless unit".
 template <typename U>
 constexpr bool is_unitless_unit(U) {
-    return IsUnitlessUnit<AssociatedUnitT<U>>::value;
+    return IsUnitlessUnit<AssociatedUnit<U>>::value;
 }
 
 // A Magnitude representing the ratio of two same-dimensioned units.
 //
 // Useful in doing unit conversions.
 template <typename U1, typename U2>
-constexpr UnitRatioT<AssociatedUnitT<U1>, AssociatedUnitT<U2>> unit_ratio(U1, U2) {
+constexpr UnitRatio<AssociatedUnit<U1>, AssociatedUnit<U2>> unit_ratio(U1, U2) {
     return {};
 }
 
 // Type trait for the sign of a Unit (represented as a Magnitude).
 template <typename U>
-constexpr UnitSign<AssociatedUnitT<U>> unit_sign(U) {
+constexpr UnitSign<AssociatedUnit<U>> unit_sign(U) {
     return {};
 }
 
 template <typename U>
 constexpr auto associated_unit(U) {
-    return AssociatedUnitT<U>{};
+    return AssociatedUnit<U>{};
 }
 
 template <typename U>
 constexpr auto associated_unit_for_points(U) {
-    return AssociatedUnitForPointsT<U>{};
+    return AssociatedUnitForPoints<U>{};
 }
 
 template <typename... Us>
 constexpr auto common_unit(Us...) {
-    return CommonUnitT<AssociatedUnitT<Us>...>{};
+    return CommonUnit<AssociatedUnit<Us>...>{};
 }
 
 template <typename... Us>
 constexpr auto common_point_unit(Us...) {
-    return CommonPointUnitT<AssociatedUnitForPointsT<Us>...>{};
+    return CommonPointUnit<AssociatedUnitForPoints<Us>...>{};
 }
 
 template <template <class> class Utility, typename... Us>
 constexpr auto make_common(Utility<Us>...) {
-    return Utility<CommonUnitT<AssociatedUnitT<Us>...>>{};
+    return Utility<CommonUnit<AssociatedUnit<Us>...>>{};
 }
 
 template <template <class> class Utility, typename... Us>
 constexpr auto make_common_point(Utility<Us>...) {
-    return Utility<CommonPointUnitT<AssociatedUnitForPointsT<Us>...>>{};
+    return Utility<CommonPointUnit<AssociatedUnitForPoints<Us>...>>{};
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -312,7 +312,7 @@ template <typename Unit, typename ScaleFactor>
 using ComputeScaledUnit = typename ComputeScaledUnitImpl<Unit, ScaleFactor>::type;
 template <typename Unit, typename ScaleFactor, typename OldScaleFactor>
 struct ComputeScaledUnitImpl<ScaledUnit<Unit, OldScaleFactor>, ScaleFactor>
-    : ComputeScaledUnitImpl<Unit, MagProductT<OldScaleFactor, ScaleFactor>> {};
+    : ComputeScaledUnitImpl<Unit, MagProduct<OldScaleFactor, ScaleFactor>> {};
 template <typename Unit>
 struct ComputeScaledUnitImpl<Unit, Magnitude<>> : stdx::type_identity<Unit> {};
 // Disambiguating specialization:
@@ -325,33 +325,33 @@ struct ScaledUnit : Unit {
     static_assert(IsValidPack<Magnitude, ScaleFactor>::value,
                   "Can only scale by a Magnitude<...> type");
     using Dim = detail::DimT<Unit>;
-    using Mag = MagProductT<detail::MagT<Unit>, ScaleFactor>;
+    using Mag = MagProduct<detail::MagT<Unit>, ScaleFactor>;
 };
 
 // Type template to hold the product of powers of Units.
 template <typename... UnitPows>
 struct UnitProductPack {
-    using Dim = DimProductT<detail::DimT<UnitPows>...>;
-    using Mag = MagProductT<detail::MagT<UnitPows>...>;
+    using Dim = DimProduct<detail::DimT<UnitPows>...>;
+    using Mag = MagProduct<detail::MagT<UnitPows>...>;
 };
 
 // Helper to make a canonicalized product of units.
 //
 // On the input side, we treat every input unit as a UnitProductPack.  Once we get our final result,
-// we simplify it using `UnpackIfSoloT`.  (The motivation is that we don't want to return, say,
+// we simplify it using `UnpackIfSolo`.  (The motivation is that we don't want to return, say,
 // `UnitProductPack<Meters>`; we'd rather just return `Meters`.)
 template <typename... UnitPows>
 using UnitProduct =
-    UnpackIfSoloT<UnitProductPack,
-                  PackProductT<UnitProductPack, AsPackT<UnitProductPack, UnitPows>...>>;
+    UnpackIfSolo<UnitProductPack,
+                 PackProductT<UnitProductPack, AsPack<UnitProductPack, UnitPows>...>>;
 template <typename... UnitPows>
 using UnitProductT = UnitProduct<UnitPows...>;
 
 // Raise a Unit to a (possibly rational) Power.
 template <typename U, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
 using UnitPower =
-    UnpackIfSoloT<UnitProductPack,
-                  PackPowerT<UnitProductPack, AsPackT<UnitProductPack, U>, ExpNum, ExpDen>>;
+    UnpackIfSolo<UnitProductPack,
+                 PackPowerT<UnitProductPack, AsPack<UnitProductPack, U>, ExpNum, ExpDen>>;
 template <typename U, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
 using UnitPowerT = UnitPower<U, ExpNum, ExpDen>;
 
@@ -363,20 +363,20 @@ using UnitInverseT = UnitInverse<U>;
 
 // Compute the quotient of two units.
 template <typename U1, typename U2>
-using UnitQuotient = UnitProductT<U1, UnitInverse<U2>>;
+using UnitQuotient = UnitProduct<U1, UnitInverse<U2>>;
 template <typename U1, typename U2>
 using UnitQuotientT = UnitQuotient<U1, U2>;
 
 template <typename... Us>
 constexpr bool is_forward_declared_unit_valid(ForwardDeclareUnitProduct<Us...>) {
     return std::is_same<typename ForwardDeclareUnitProduct<Us...>::unit_type,
-                        UnitProductT<Us...>>::value;
+                        UnitProduct<Us...>>::value;
 }
 
 template <typename U, std::intmax_t ExpNum, std::intmax_t ExpDen>
 constexpr bool is_forward_declared_unit_valid(ForwardDeclareUnitPow<U, ExpNum, ExpDen>) {
     return std::is_same<typename ForwardDeclareUnitPow<U, ExpNum, ExpDen>::unit_type,
-                        UnitPowerT<U, ExpNum, ExpDen>>::value;
+                        UnitPower<U, ExpNum, ExpDen>>::value;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -390,7 +390,7 @@ constexpr ComputeScaledUnit<U, Magnitude<BPs...>> operator*(U, Magnitude<BPs...>
 
 // Scale this Unit by dividing by a Magnitude.
 template <typename U, typename = std::enable_if_t<IsUnit<U>::value>, typename... BPs>
-constexpr ComputeScaledUnit<U, MagInverseT<Magnitude<BPs...>>> operator/(U, Magnitude<BPs...>) {
+constexpr ComputeScaledUnit<U, MagInverse<Magnitude<BPs...>>> operator/(U, Magnitude<BPs...>) {
     return {};
 }
 
@@ -398,7 +398,7 @@ constexpr ComputeScaledUnit<U, MagInverseT<Magnitude<BPs...>>> operator/(U, Magn
 template <typename U1,
           typename U2,
           typename = std::enable_if_t<stdx::conjunction<IsUnit<U1>, IsUnit<U2>>::value>>
-constexpr UnitProductT<U1, U2> operator*(U1, U2) {
+constexpr UnitProduct<U1, U2> operator*(U1, U2) {
     return {};
 }
 
@@ -406,19 +406,19 @@ constexpr UnitProductT<U1, U2> operator*(U1, U2) {
 template <typename U1,
           typename U2,
           typename = std::enable_if_t<stdx::conjunction<IsUnit<U1>, IsUnit<U2>>::value>>
-constexpr UnitQuotientT<U1, U2> operator/(U1, U2) {
+constexpr UnitQuotient<U1, U2> operator/(U1, U2) {
     return {};
 }
 
 // Raise a Unit to an integral power.
 template <std::intmax_t Exp, typename U, typename = std::enable_if_t<IsUnit<U>::value>>
-constexpr UnitPowerT<U, Exp> pow(U) {
+constexpr UnitPower<U, Exp> pow(U) {
     return {};
 }
 
 // Take the Root (of some integral degree) of a Unit.
 template <std::intmax_t Deg, typename U, typename = std::enable_if_t<IsUnit<U>::value>>
-constexpr UnitPowerT<U, 1, Deg> root(U) {
+constexpr UnitPower<U, 1, Deg> root(U) {
     return {};
 }
 
@@ -445,7 +445,7 @@ struct SingularNameFor {
     // `radians / (meter * second)`.
     template <typename OtherUnit>
     constexpr auto operator*(SingularNameFor<OtherUnit>) const {
-        return SingularNameFor<UnitProductT<Unit, OtherUnit>>{};
+        return SingularNameFor<UnitProduct<Unit, OtherUnit>>{};
     }
 };
 
@@ -455,7 +455,7 @@ struct AssociatedUnitImpl<SingularNameFor<U>> : stdx::type_identity<U> {};
 
 template <int Exp, typename Unit>
 constexpr auto pow(SingularNameFor<Unit>) {
-    return SingularNameFor<UnitPowerT<Unit, Exp>>{};
+    return SingularNameFor<UnitPower<Unit, Exp>>{};
 }
 
 //
@@ -599,7 +599,7 @@ struct AreUnitsPointEquivalent
 //
 // To be well-formed, the units must be listed in the same order every time.  End users cannot be
 // responsible for this; thus, they should never name this type directly.  Rather, they should name
-// the `CommonUnitT` alias, which will handle the canonicalization.
+// the `CommonUnit` alias, which will handle the canonicalization.
 template <typename... Us>
 struct CommonUnitPack {
     static_assert(AreElementsInOrder<CommonUnitPack, CommonUnitPack<Us...>>::value,
@@ -607,8 +607,8 @@ struct CommonUnitPack {
     static_assert(HasSameDimension<Us...>::value,
                   "Common unit only meaningful if units have same dimension");
 
-    using Dim = CommonDimensionT<detail::DimT<Us>...>;
-    using Mag = CommonMagnitudeT<detail::MagT<Us>...>;
+    using Dim = CommonDimension<detail::DimT<Us>...>;
+    using Mag = CommonMagnitude<detail::MagT<Us>...>;
 };
 
 template <typename A, typename B>
@@ -671,8 +671,8 @@ struct IsFirstUnitRedundant
                          std::true_type,
                          std::conditional_t<AreUnitsQuantityEquivalent<U1, U2>::value,
                                             InOrderFor<Pack, U2, U1>,
-                                            stdx::conjunction<IsInteger<UnitRatioT<U1, U2>>,
-                                                              IsPositive<UnitRatioT<U1, U2>>>>> {};
+                                            stdx::conjunction<IsInteger<UnitRatio<U1, U2>>,
+                                                              IsPositive<UnitRatio<U1, U2>>>>> {};
 
 // Recursive case: eliminate first unit if it is redundant; else, keep it and eliminate any later
 // units that are redundant with it.
@@ -689,7 +689,7 @@ struct EliminateRedundantUnitsImpl<Pack<H, Ts...>>
           // To get that result, we first replace any units _that `H` makes redundant_ with `void`.
           // Then, we drop all `void`, before finally recursively eliminating any units that are
           // redundant among those that remain.
-          PrependT<
+          Prepend<
               EliminateRedundantUnits<DropAll<
                   void,
 
@@ -740,7 +740,7 @@ template <>
 struct SimplifyIfOnlyOneUnscaledUnitImpl<Zero, UnitList<Zero>> : stdx::type_identity<Zero> {};
 template <typename U, typename SoleUnscaledUnit>
 struct SimplifyIfOnlyOneUnscaledUnitImpl<U, UnitList<SoleUnscaledUnit>>
-    : stdx::type_identity<decltype(SoleUnscaledUnit{} * UnitRatioT<U, SoleUnscaledUnit>{})> {};
+    : stdx::type_identity<decltype(SoleUnscaledUnit{} * UnitRatio<U, SoleUnscaledUnit>{})> {};
 template <typename U, typename... Us>
 struct SimplifyIfOnlyOneUnscaledUnitImpl<U, UnitList<Us...>> : stdx::type_identity<U> {};
 
@@ -780,7 +780,7 @@ struct ComputeCommonUnit
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-// `CommonPointUnitT` helper implementation.
+// `CommonPointUnit` helper implementation.
 
 namespace detail {
 
@@ -848,7 +848,7 @@ struct OriginDisplacementUnit {
     static_assert(OriginOf<U1>::value() != OriginOf<U2>::value(),
                   "OriginDisplacementUnit must be an actual unit, so it must be nonzero.");
 
-    using Dim = CommonDimensionT<DimT<U1>, DimT<U2>>;
+    using Dim = CommonDimension<DimT<U1>, DimT<U2>>;
     using Mag = ValueDisplacementMagnitude<OriginOf<U1>, OriginOf<U2>>;
 };
 
@@ -863,8 +863,8 @@ using ComputeOriginDisplacementUnit =
 
 template <typename U1, typename U2>
 constexpr auto origin_displacement_unit(U1, U2) {
-    return ComputeOriginDisplacementUnit<AssociatedUnitForPointsT<U1>,
-                                         AssociatedUnitForPointsT<U2>>{};
+    return ComputeOriginDisplacementUnit<AssociatedUnitForPoints<U1>,
+                                         AssociatedUnitForPoints<U2>>{};
 }
 
 // MagTypeT<T> gives some measure of the size of the unit for this "quantity-alike" type.
@@ -894,11 +894,11 @@ constexpr typename UnitLabel<detail::OriginDisplacementUnit<U1, U2>>::LabelT
 //
 // To be well-formed, the units must be listed in the same order every time.  End users cannot be
 // responsible for this; thus, they should never name this type directly.  Rather, they should name
-// the `CommonPointUnitT` alias, which will handle the canonicalization.
+// the `CommonPointUnit` alias, which will handle the canonicalization.
 template <typename... Us>
 using CommonAmongUnitsAndOriginDisplacements =
-    CommonUnitT<Us...,
-                detail::ComputeOriginDisplacementUnit<detail::UnitOfLowestOrigin<Us...>, Us>...>;
+    CommonUnit<Us...,
+               detail::ComputeOriginDisplacementUnit<detail::UnitOfLowestOrigin<Us...>, Us>...>;
 template <typename... Us>
 struct CommonPointUnitPack : CommonAmongUnitsAndOriginDisplacements<Us...> {
     static_assert(AreElementsInOrder<CommonPointUnitPack, CommonPointUnitPack<Us...>>::value,
@@ -1039,8 +1039,8 @@ struct UnitLabel<RatioPow<Unit, N, D>>
 // Implementation for UnitProductPack: split into positive and negative powers.
 template <typename... Us>
 struct UnitLabel<UnitProductPack<Us...>>
-    : detail::QuotientLabeler<detail::NumeratorPartT<UnitProductPack<Us...>>,
-                              detail::DenominatorPartT<UnitProductPack<Us...>>,
+    : detail::QuotientLabeler<detail::NumeratorPart<UnitProductPack<Us...>>,
+                              detail::DenominatorPart<UnitProductPack<Us...>>,
                               void> {};
 
 // Implementation for ScaledUnit: scaling unit U by M gets label `"[M U]"`.
@@ -1083,7 +1083,7 @@ struct UnitLabel<CommonPointUnitPack<Us...>>
 
 template <typename Unit>
 constexpr const auto &unit_label(Unit) {
-    return detail::as_char_array(UnitLabel<AssociatedUnitT<Unit>>::value);
+    return detail::as_char_array(UnitLabel<AssociatedUnit<Unit>>::value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/au/unit_of_measure_test.cc
+++ b/au/unit_of_measure_test.cc
@@ -70,7 +70,7 @@ struct UnitWithOrigin : decltype(One{} * mag<123>()) {
 };
 
 struct AdHocSpeedUnit {
-    using Dim = DimQuotientT<Length, Time>;
+    using Dim = DimQuotient<Length, Time>;
     using Mag = decltype(mag<1234>());
 };
 
@@ -105,8 +105,8 @@ MATCHER_P(QuantityEquivalentToUnit, target, "") {
 MATCHER_P(PointEquivalentToUnit, target, "") { return are_units_point_equivalent(arg, target); }
 
 TEST(Unit, ProductWithMagnitudeGivesSameDimensionAndMultipliesMagnitude) {
-    StaticAssertTypeEq<UnitRatioT<Yards, Feet>, decltype(mag<3>())>();
-    StaticAssertTypeEq<UnitRatioT<Yards, Inches>, decltype(mag<36>())>();
+    StaticAssertTypeEq<UnitRatio<Yards, Feet>, decltype(mag<3>())>();
+    StaticAssertTypeEq<UnitRatio<Yards, Inches>, decltype(mag<36>())>();
 }
 
 TEST(Unit, OriginRetainedForProductWithMagnitudeButNotWithUnit) {
@@ -161,15 +161,15 @@ TEST(Product, IsUnitWithProductOfMagnitudesAndDimensions) {
     constexpr auto foot_yards = Feet{} * Yards{};
     EXPECT_THAT(is_unit(foot_yards), IsTrue());
 
-    StaticAssertTypeEq<MagT<decltype(foot_yards)>, MagProductT<MagT<Feet>, MagT<Yards>>>();
-    StaticAssertTypeEq<DimT<decltype(foot_yards)>, DimProductT<DimT<Feet>, DimT<Yards>>>();
+    StaticAssertTypeEq<MagT<decltype(foot_yards)>, MagProduct<MagT<Feet>, MagT<Yards>>>();
+    StaticAssertTypeEq<DimT<decltype(foot_yards)>, DimProduct<DimT<Feet>, DimT<Yards>>>();
 }
 
 TEST(Quotient, IsUnitWithQuotientOfMagnitudesAndDimensions) {
     constexpr auto in_per_min = Inches{} / Minutes{};
     EXPECT_THAT(is_unit(in_per_min), IsTrue());
-    StaticAssertTypeEq<MagT<decltype(in_per_min)>, MagQuotientT<MagT<Inches>, MagT<Minutes>>>();
-    StaticAssertTypeEq<DimT<decltype(in_per_min)>, DimQuotientT<DimT<Inches>, DimT<Minutes>>>();
+    StaticAssertTypeEq<MagT<decltype(in_per_min)>, MagQuotient<MagT<Inches>, MagT<Minutes>>>();
+    StaticAssertTypeEq<DimT<decltype(in_per_min)>, DimQuotient<DimT<Inches>, DimT<Minutes>>>();
 }
 
 TEST(Pow, FunctionGivesUnitWhichIsEquivalentToManuallyComputedPower) {
@@ -190,28 +190,28 @@ TEST(UnitProductPack, ExactlyCancellingInstancesYieldsNullPack) {
                        UnitProductPack<>>();
 }
 
-TEST(UnitProductT, IdentityForSingleUnit) {
-    StaticAssertTypeEq<UnitProductT<Feet>, Feet>();
-    StaticAssertTypeEq<UnitProductT<Minutes>, Minutes>();
+TEST(UnitProduct, IdentityForSingleUnit) {
+    StaticAssertTypeEq<UnitProduct<Feet>, Feet>();
+    StaticAssertTypeEq<UnitProduct<Minutes>, Minutes>();
 }
 
-TEST(UnitProductT, ProductOfTwoUnitsIsUnitWithProductsOfDimAndMag) {
-    using FootInches = UnitProductT<Feet, Inches>;
+TEST(UnitProduct, ProductOfTwoUnitsIsUnitWithProductsOfDimAndMag) {
+    using FootInches = UnitProduct<Feet, Inches>;
     EXPECT_THAT(IsUnit<FootInches>::value, IsTrue());
-    StaticAssertTypeEq<DimT<FootInches>, DimProductT<DimT<Feet>, DimT<Inches>>>();
-    StaticAssertTypeEq<MagT<FootInches>, MagProductT<MagT<Feet>, MagT<Inches>>>();
+    StaticAssertTypeEq<DimT<FootInches>, DimProduct<DimT<Feet>, DimT<Inches>>>();
+    StaticAssertTypeEq<MagT<FootInches>, MagProduct<MagT<Feet>, MagT<Inches>>>();
 }
 
-TEST(UnitProductT, AchievesExactCancellations) {
-    using FootInchesPerFoot = UnitProductT<Feet, Inches, UnitInverseT<Feet>>;
+TEST(UnitProduct, AchievesExactCancellations) {
+    using FootInchesPerFoot = UnitProduct<Feet, Inches, UnitInverse<Feet>>;
     StaticAssertTypeEq<FootInchesPerFoot, Inches>();
 }
 
-TEST(UnitProductT, CreatesPowForIntegerPowers) {
-    using FeetSquared = UnitProductT<Feet, Feet>;
+TEST(UnitProduct, CreatesPowForIntegerPowers) {
+    using FeetSquared = UnitProduct<Feet, Feet>;
     StaticAssertTypeEq<FeetSquared, Pow<Feet, 2>>();
 
-    StaticAssertTypeEq<UnitProductT<FeetSquared, UnitInverseT<Feet>>, Feet>();
+    StaticAssertTypeEq<UnitProduct<FeetSquared, UnitInverse<Feet>>, Feet>();
 }
 
 TEST(UnitProduct, CanonicalizesOrdering) {
@@ -219,49 +219,49 @@ TEST(UnitProduct, CanonicalizesOrdering) {
     StaticAssertTypeEq<UnitProduct<Feet, Minutes>, UnitProduct<Minutes, Feet>>();
 }
 
-TEST(UnitPowerT, ProducesSimplifiedPowersOfAllExponents) {
-    using Input = UnitProductT<Feet, Pow<Minutes, 3>, Pow<Inches, -6>, RatioPow<Yards, 3, 2>>;
+TEST(UnitPower, ProducesSimplifiedPowersOfAllExponents) {
+    using Input = UnitProduct<Feet, Pow<Minutes, 3>, Pow<Inches, -6>, RatioPow<Yards, 3, 2>>;
 
     using ExpectedCbrtInput =
-        UnitProductT<RatioPow<Feet, 1, 3>, Minutes, Pow<Inches, -2>, RatioPow<Yards, 1, 2>>;
+        UnitProduct<RatioPow<Feet, 1, 3>, Minutes, Pow<Inches, -2>, RatioPow<Yards, 1, 2>>;
 
-    StaticAssertTypeEq<UnitPowerT<Input, 1, 3>, ExpectedCbrtInput>();
+    StaticAssertTypeEq<UnitPower<Input, 1, 3>, ExpectedCbrtInput>();
 }
 
-TEST(UnitQuotientT, InteractsAndCancelsAsExpected) {
-    StaticAssertTypeEq<UnitProductT<UnitQuotientT<Feet, Minutes>, Minutes>, Feet>();
+TEST(UnitQuotient, InteractsAndCancelsAsExpected) {
+    StaticAssertTypeEq<UnitProduct<UnitQuotient<Feet, Minutes>, Minutes>, Feet>();
 }
 
-TEST(UnitInverseT, CreatesAppropriateUnitPower) {
-    StaticAssertTypeEq<UnitInverseT<Feet>, Pow<Feet, -1>>();
-    StaticAssertTypeEq<UnitInverseT<UnitInverseT<Minutes>>, Minutes>();
+TEST(UnitInverse, CreatesAppropriateUnitPower) {
+    StaticAssertTypeEq<UnitInverse<Feet>, Pow<Feet, -1>>();
+    StaticAssertTypeEq<UnitInverse<UnitInverse<Minutes>>, Minutes>();
 }
 
-TEST(AssociatedUnitT, IsIdentityForUnits) { StaticAssertTypeEq<AssociatedUnitT<Feet>, Feet>(); }
+TEST(AssociatedUnit, IsIdentityForUnits) { StaticAssertTypeEq<AssociatedUnit<Feet>, Feet>(); }
 
-TEST(AssociatedUnitT, FunctionalInterfaceHandlesInstancesCorrectly) {
+TEST(AssociatedUnit, FunctionalInterfaceHandlesInstancesCorrectly) {
     StaticAssertTypeEq<decltype(associated_unit(Feet{} / Minutes{})),
                        decltype(Feet{} / Minutes{})>();
 }
 
-TEST(AssociatedUnitT, IsIdentityForTypeWithNoAssociatedUnit) {
+TEST(AssociatedUnit, IsIdentityForTypeWithNoAssociatedUnit) {
     // We might have returned `void`, but this would require depending on `IsUnit`, which could slow
-    // down `AssociatedUnitT` because it's used so widely.  It's simpler to think of it as a trait
+    // down `AssociatedUnit` because it's used so widely.  It's simpler to think of it as a trait
     // which "redirects" a type only when there is a definite, positive reason to do so.
-    StaticAssertTypeEq<AssociatedUnitT<double>, double>();
+    StaticAssertTypeEq<AssociatedUnit<double>, double>();
 }
 
-TEST(AssociatedUnitT, HandlesWrappersWhichHaveSpecializedAssociatedUnit) {
-    StaticAssertTypeEq<AssociatedUnitT<SomeUnitWrapper<Feet>>, Feet>();
+TEST(AssociatedUnit, HandlesWrappersWhichHaveSpecializedAssociatedUnit) {
+    StaticAssertTypeEq<AssociatedUnit<SomeUnitWrapper<Feet>>, Feet>();
 }
 
-TEST(AssociatedUnitT, SupportsSingularNameFor) {
-    StaticAssertTypeEq<AssociatedUnitT<SingularNameFor<Feet>>, Feet>();
+TEST(AssociatedUnit, SupportsSingularNameFor) {
+    StaticAssertTypeEq<AssociatedUnit<SingularNameFor<Feet>>, Feet>();
 }
 
-TEST(UnitInverseT, CommutesWithProduct) {
-    StaticAssertTypeEq<UnitInverseT<UnitProductT<Feet, Minutes>>,
-                       UnitProductT<UnitInverseT<Feet>, UnitInverseT<Minutes>>>();
+TEST(UnitInverse, CommutesWithProduct) {
+    StaticAssertTypeEq<UnitInverse<UnitProduct<Feet, Minutes>>,
+                       UnitProduct<UnitInverse<Feet>, UnitInverse<Minutes>>>();
 }
 
 TEST(Root, FunctionalInterfaceHandlesInstancesCorrectly) {
@@ -295,11 +295,10 @@ TEST(Cbrt, TakesThirdRoot) {
 TEST(IsDimensionless, PicksOutDimensionlessUnit) {
     EXPECT_THAT((IsDimensionless<Feet>::value), IsFalse());
 
-    EXPECT_THAT((IsDimensionless<UnitQuotientT<Inches, Yards>>::value), IsTrue());
+    EXPECT_THAT((IsDimensionless<UnitQuotient<Inches, Yards>>::value), IsTrue());
 
-    EXPECT_THAT(
-        (IsDimensionless<UnitQuotientT<AdHocSpeedUnit, UnitQuotientT<Feet, Minutes>>>::value),
-        IsTrue());
+    EXPECT_THAT((IsDimensionless<UnitQuotient<AdHocSpeedUnit, UnitQuotient<Feet, Minutes>>>::value),
+                IsTrue());
 }
 
 TEST(IsDimensionless, FunctionalInterfaceHandlesInstancesCorrectly) {
@@ -354,9 +353,9 @@ TEST(HasSameDimension, FunctionalInterfaceHandlesQuantityMakersCorrectly) {
 }
 
 TEST(UnitRatio, ComputesRatioForSameDimensionedUnits) {
-    StaticAssertTypeEq<UnitRatioT<Yards, Inches>, decltype(mag<36>())>();
-    StaticAssertTypeEq<UnitRatioT<Inches, Inches>, decltype(mag<1>())>();
-    StaticAssertTypeEq<UnitRatioT<Inches, Yards>, decltype(mag<1>() / mag<36>())>();
+    StaticAssertTypeEq<UnitRatio<Yards, Inches>, decltype(mag<36>())>();
+    StaticAssertTypeEq<UnitRatio<Inches, Inches>, decltype(mag<1>())>();
+    StaticAssertTypeEq<UnitRatio<Inches, Yards>, decltype(mag<1>() / mag<36>())>();
 }
 
 TEST(UnitRatio, FunctionalInterfaceHandlesInstancesCorrectly) {
@@ -452,47 +451,47 @@ TEST(DisplaceOrigin, DisplacesOrigin) {
 }
 
 TEST(CommonUnit, FindsCommonMagnitude) {
-    EXPECT_THAT((CommonUnitT<Feet, Feet>{}), QuantityEquivalentToUnit(Feet{}));
-    EXPECT_THAT((CommonUnitT<Feet, Inches>{}), QuantityEquivalentToUnit(Inches{}));
-    EXPECT_THAT((CommonUnitT<Inches, Feet>{}), QuantityEquivalentToUnit(Inches{}));
-    EXPECT_THAT((CommonUnitT<Inches, Inches>{}), QuantityEquivalentToUnit(Inches{}));
+    EXPECT_THAT((CommonUnit<Feet, Feet>{}), QuantityEquivalentToUnit(Feet{}));
+    EXPECT_THAT((CommonUnit<Feet, Inches>{}), QuantityEquivalentToUnit(Inches{}));
+    EXPECT_THAT((CommonUnit<Inches, Feet>{}), QuantityEquivalentToUnit(Inches{}));
+    EXPECT_THAT((CommonUnit<Inches, Inches>{}), QuantityEquivalentToUnit(Inches{}));
 }
 
 TEST(CommonUnit, IndependentOfOrderingAndRepetitions) {
-    using U = CommonUnitT<Feet, Yards, Inches>;
-    StaticAssertTypeEq<U, CommonUnitT<Yards, Feet, Inches>>();
-    StaticAssertTypeEq<U, CommonUnitT<Inches, Yards, Feet>>();
-    StaticAssertTypeEq<U, CommonUnitT<Feet, Yards, Feet, Feet, Inches, Yards>>();
+    using U = CommonUnit<Feet, Yards, Inches>;
+    StaticAssertTypeEq<U, CommonUnit<Yards, Feet, Inches>>();
+    StaticAssertTypeEq<U, CommonUnit<Inches, Yards, Feet>>();
+    StaticAssertTypeEq<U, CommonUnit<Feet, Yards, Feet, Feet, Inches, Yards>>();
 }
 
 TEST(CommonUnit, PrefersUnitFromListIfAnyIdentical) {
-    StaticAssertTypeEq<CommonUnitT<Feet, Feet>, Feet>();
-    StaticAssertTypeEq<CommonUnitT<Feet, Inches, Yards>, Inches>();
+    StaticAssertTypeEq<CommonUnit<Feet, Feet>, Feet>();
+    StaticAssertTypeEq<CommonUnit<Feet, Inches, Yards>, Inches>();
 }
 
 TEST(CommonUnit, DedupesUnitsMadeIdenticalAfterUnscalingSameScaledUnit) {
-    StaticAssertTypeEq<CommonUnitT<decltype(Feet{} * mag<3>()), decltype(Feet{} * mag<5>())>,
+    StaticAssertTypeEq<CommonUnit<decltype(Feet{} * mag<3>()), decltype(Feet{} * mag<5>())>,
                        Feet>();
 }
 
 TEST(CommonUnit, HandlesAndNeglectsZero) {
-    StaticAssertTypeEq<CommonUnitT<Yards, Zero, Feet>, Feet>();
-    StaticAssertTypeEq<CommonUnitT<Zero, Feet, Zero>, Feet>();
+    StaticAssertTypeEq<CommonUnit<Yards, Zero, Feet>, Feet>();
+    StaticAssertTypeEq<CommonUnit<Zero, Feet, Zero>, Feet>();
 }
 
 TEST(CommonUnit, ZeroIfAllInputsAreZero) {
-    StaticAssertTypeEq<CommonUnitT<>, Zero>();
-    StaticAssertTypeEq<CommonUnitT<Zero>, Zero>();
-    StaticAssertTypeEq<CommonUnitT<Zero, Zero>, Zero>();
-    StaticAssertTypeEq<CommonUnitT<Zero, Zero, Zero>, Zero>();
+    StaticAssertTypeEq<CommonUnit<>, Zero>();
+    StaticAssertTypeEq<CommonUnit<Zero>, Zero>();
+    StaticAssertTypeEq<CommonUnit<Zero, Zero>, Zero>();
+    StaticAssertTypeEq<CommonUnit<Zero, Zero, Zero>, Zero>();
 }
 
 TEST(CommonUnit, DownranksAnonymousScaledUnits) {
-    StaticAssertTypeEq<CommonUnitT<Yards, decltype(Feet{} * mag<3>())>, Yards>();
+    StaticAssertTypeEq<CommonUnit<Yards, decltype(Feet{} * mag<3>())>, Yards>();
 }
 
 TEST(CommonUnit, WhenCommonUnitLabelWouldBeIdenticalToSomeUnitJustUsesThatUnit) {
-    StaticAssertTypeEq<CommonUnitT<decltype(Feet{} * mag<6>()), decltype(Feet{} * mag<10>())>,
+    StaticAssertTypeEq<CommonUnit<decltype(Feet{} * mag<6>()), decltype(Feet{} * mag<10>())>,
                        decltype(Feet{} * mag<2>())>();
 }
 
@@ -515,17 +514,17 @@ struct Y : decltype(Inches{} * mag<5>()) {};
 struct Z : decltype(Inches{} * mag<7>()) {};
 
 TEST(CommonUnitPack, UnpacksTypesInNestedCommonUnit) {
-    using C1 = CommonUnitT<W, X>;
+    using C1 = CommonUnit<W, X>;
     ASSERT_THAT((detail::IsPackOf<CommonUnitPack, C1>{}), IsTrue());
 
-    using C2 = CommonUnitT<Y, Z>;
+    using C2 = CommonUnit<Y, Z>;
     ASSERT_THAT((detail::IsPackOf<CommonUnitPack, C2>{}), IsTrue());
 
-    using Common = CommonUnitT<C1, C2>;
+    using Common = CommonUnit<C1, C2>;
     ASSERT_THAT((detail::IsPackOf<CommonUnitPack, Common>{}), IsTrue());
 
     // Check that `c(c(w, x), c(y, z))` is the same as `c(w, x, y, z)`.
-    StaticAssertTypeEq<Common, CommonUnitT<W, X, Y, Z>>();
+    StaticAssertTypeEq<Common, CommonUnit<W, X, Y, Z>>();
 }
 
 TEST(CommonUnit, CanCombineUnitsThatWouldBothBeAnonymousScaledUnits) {
@@ -533,25 +532,25 @@ TEST(CommonUnit, CanCombineUnitsThatWouldBothBeAnonymousScaledUnits) {
 }
 
 TEST(CommonUnit, SupportsUnitSlots) {
-    StaticAssertTypeEq<decltype(common_unit(feet, meters)), CommonUnitT<Feet, Meters>>();
+    StaticAssertTypeEq<decltype(common_unit(feet, meters)), CommonUnit<Feet, Meters>>();
 }
 
 TEST(CommonPointUnit, FindsCommonMagnitude) {
-    EXPECT_THAT((CommonPointUnitT<Feet, Feet>{}), PointEquivalentToUnit(Feet{}));
-    EXPECT_THAT((CommonPointUnitT<Feet, Inches>{}), PointEquivalentToUnit(Inches{}));
-    EXPECT_THAT((CommonPointUnitT<Inches, Feet>{}), PointEquivalentToUnit(Inches{}));
-    EXPECT_THAT((CommonPointUnitT<Inches, Inches>{}), PointEquivalentToUnit(Inches{}));
+    EXPECT_THAT((CommonPointUnit<Feet, Feet>{}), PointEquivalentToUnit(Feet{}));
+    EXPECT_THAT((CommonPointUnit<Feet, Inches>{}), PointEquivalentToUnit(Inches{}));
+    EXPECT_THAT((CommonPointUnit<Inches, Feet>{}), PointEquivalentToUnit(Inches{}));
+    EXPECT_THAT((CommonPointUnit<Inches, Inches>{}), PointEquivalentToUnit(Inches{}));
 }
 
 TEST(CommonPointUnit, HasMinimumOrigin) {
-    EXPECT_THAT(origin_displacement(CommonPointUnitT<Kelvins, Celsius>{}, Kelvins{}), Eq(ZERO));
-    EXPECT_THAT(origin_displacement(CommonPointUnitT<Fahrenheit, Celsius>{}, Fahrenheit{}),
+    EXPECT_THAT(origin_displacement(CommonPointUnit<Kelvins, Celsius>{}, Kelvins{}), Eq(ZERO));
+    EXPECT_THAT(origin_displacement(CommonPointUnit<Fahrenheit, Celsius>{}, Fahrenheit{}),
                 Eq(ZERO));
 }
 
 TEST(CommonPointUnit, TakesOriginMagnitudeIntoAccount) {
-    using CommonByQuantity = CommonUnitT<Kelvins, Celsius>;
-    using CommonByPoint = CommonPointUnitT<Kelvins, Celsius>;
+    using CommonByQuantity = CommonUnit<Kelvins, Celsius>;
+    using CommonByPoint = CommonPointUnit<Kelvins, Celsius>;
 
     EXPECT_THAT(unit_ratio(CommonByQuantity{}, CommonByPoint{}), Eq(mag<20>()));
 
@@ -561,34 +560,34 @@ TEST(CommonPointUnit, TakesOriginMagnitudeIntoAccount) {
 }
 
 TEST(CommonPointUnit, IndependentOfOrderingAndRepetitions) {
-    using U = CommonPointUnitT<Celsius, Kelvins, Fahrenheit>;
-    StaticAssertTypeEq<U, CommonPointUnitT<Kelvins, Celsius, Fahrenheit>>();
-    StaticAssertTypeEq<U, CommonPointUnitT<Fahrenheit, Kelvins, Celsius>>();
-    StaticAssertTypeEq<U, CommonPointUnitT<Kelvins, Celsius, Celsius, Fahrenheit, Kelvins>>();
+    using U = CommonPointUnit<Celsius, Kelvins, Fahrenheit>;
+    StaticAssertTypeEq<U, CommonPointUnit<Kelvins, Celsius, Fahrenheit>>();
+    StaticAssertTypeEq<U, CommonPointUnit<Fahrenheit, Kelvins, Celsius>>();
+    StaticAssertTypeEq<U, CommonPointUnit<Kelvins, Celsius, Celsius, Fahrenheit, Kelvins>>();
 }
 
 TEST(CommonPointUnit, PrefersUnitFromListIfAnyIdentical) {
-    StaticAssertTypeEq<CommonPointUnitT<Celsius, Celsius>, Celsius>();
-    StaticAssertTypeEq<CommonPointUnitT<Celsius, Milli<Kelvins>, Milli<Celsius>>, Milli<Kelvins>>();
+    StaticAssertTypeEq<CommonPointUnit<Celsius, Celsius>, Celsius>();
+    StaticAssertTypeEq<CommonPointUnit<Celsius, Milli<Kelvins>, Milli<Celsius>>, Milli<Kelvins>>();
 }
 
 TEST(CommonPointUnitPack, UnpacksTypesInNestedCommonUnit) {
-    using C1 = CommonPointUnitT<W, X>;
+    using C1 = CommonPointUnit<W, X>;
     ASSERT_THAT((detail::IsPackOf<CommonPointUnitPack, C1>{}), IsTrue());
 
-    using C2 = CommonPointUnitT<Y, Z>;
+    using C2 = CommonPointUnit<Y, Z>;
     ASSERT_THAT((detail::IsPackOf<CommonPointUnitPack, C2>{}), IsTrue());
 
-    using Common = CommonPointUnitT<C1, C2>;
+    using Common = CommonPointUnit<C1, C2>;
     ASSERT_THAT((detail::IsPackOf<CommonPointUnitPack, Common>{}), IsTrue());
 
     // Check that `c(c(w, x), c(y, z))` is the same as `c(w, x, y, z)`.
-    StaticAssertTypeEq<Common, CommonPointUnitT<W, X, Y, Z>>();
+    StaticAssertTypeEq<Common, CommonPointUnit<W, X, Y, Z>>();
 }
 
 TEST(CommonPointUnit, SupportsUnitSlots) {
     StaticAssertTypeEq<decltype(common_point_unit(kelvins_pt, celsius_pt)),
-                       CommonPointUnitT<Kelvins, Celsius>>();
+                       CommonPointUnit<Kelvins, Celsius>>();
 }
 
 TEST(MakeCommon, PreservesCategory) {
@@ -705,7 +704,7 @@ TEST(UnitLabel, NumeratorGetsParensIfMultipleInputs) {
 }
 
 TEST(UnitLabel, NumeratorIsOneIfAllPowersNegative) {
-    EXPECT_THAT(unit_label(UnitInverseT<decltype(Feet{} * Minutes{})>{}),
+    EXPECT_THAT(unit_label(UnitInverse<decltype(Feet{} * Minutes{})>{}),
                 AnyOf(StrEq("1 / (ft * min)"), StrEq("1 / (min * ft)")));
 }
 
@@ -724,14 +723,14 @@ TEST(UnitLabel, PowersAndProductsComposeNicely) {
 }
 
 TEST(UnitLabel, LabelsCommonUnitCorrectly) {
-    using U = CommonUnitT<Inches, Meters>;
+    using U = CommonUnit<Inches, Meters>;
     EXPECT_THAT(unit_label(U{}),
                 AnyOf(StrEq("EQUIV{[(1 / 127) in], [(1 / 5000) m]}"),
                       StrEq("EQUIV{[(1 / 5000) m], [(1 / 127) in]}")));
 }
 
 TEST(UnitLabel, CommonUnitLabelWorksWithUnitProductPack) {
-    using U = CommonUnitT<UnitQuotientT<Meters, Minutes>, UnitQuotientT<Inches, Minutes>>;
+    using U = CommonUnit<UnitQuotient<Meters, Minutes>, UnitQuotient<Inches, Minutes>>;
     EXPECT_THAT(unit_label(U{}),
                 AnyOf(StrEq("EQUIV{[(1 / 127) in / min], [(1 / 5000) m / min]}"),
                       StrEq("EQUIV{[(1 / 5000) m / min], [(1 / 127) in / min]}")));
@@ -750,29 +749,28 @@ TEST(UnitLabel, ReducesToSingleUnitLabelIfAllUnitsAreTheSame) {
 }
 
 TEST(UnitLabel, LabelsCommonPointUnitCorrectly) {
-    using U = CommonPointUnitT<Inches, Meters>;
+    using U = CommonPointUnit<Inches, Meters>;
     EXPECT_THAT(unit_label(U{}),
                 AnyOf(StrEq("EQUIV{[(1 / 127) in], [(1 / 5000) m]}"),
                       StrEq("EQUIV{[(1 / 5000) m], [(1 / 127) in]}")));
 }
 
 TEST(UnitLabel, CommonPointUnitLabelWorksWithUnitProductPack) {
-    using U = CommonPointUnitT<UnitQuotientT<Meters, Minutes>, UnitQuotientT<Inches, Minutes>>;
+    using U = CommonPointUnit<UnitQuotient<Meters, Minutes>, UnitQuotient<Inches, Minutes>>;
     EXPECT_THAT(unit_label(U{}),
                 AnyOf(StrEq("EQUIV{[(1 / 127) in / min], [(1 / 5000) m / min]}"),
                       StrEq("EQUIV{[(1 / 5000) m / min], [(1 / 127) in / min]}")));
 }
 
 TEST(UnitLabel, CommonPointUnitLabelTakesOriginOffsetIntoAccount) {
-    using U = CommonPointUnitT<Celsius, OffsetCelsius>;
+    using U = CommonPointUnit<Celsius, OffsetCelsius>;
     EXPECT_THAT(unit_label(U{}),
                 AnyOf(StrEq("EQUIV{[(1 / 3) deg_C], [(1 / 5) (@(0 offset_deg_C) - @(0 deg_C))]}"),
                       StrEq("EQUIV{[(1 / 5) (@(0 offset_deg_C) - @(0 deg_C))], [(1 / 3) deg_C]}")));
 }
 
 TEST(UnitLabel, CommonUnitOfCommonPointUnitsPerformsFlattening) {
-    using U =
-        CommonUnitT<CommonPointUnitT<Celsius, Kelvins>, CommonPointUnitT<Celsius, Fahrenheit>>;
+    using U = CommonUnit<CommonPointUnit<Celsius, Kelvins>, CommonPointUnit<Celsius, Fahrenheit>>;
 
     // When enumerating the possibilities, we know that anonymous ad hoc units (such as the unit for
     // the origin displacement from Kelvins to Celsius) will go last.  But we want to remain
@@ -809,7 +807,7 @@ struct UnitOrderTiebreaker<Trinches> : std::integral_constant<int, 1> {};
 TEST(UnitOrderTiebreaker, CanBreakTiesForDistinctButOtherwiseUnorderableUnits) {
     // The point of this test is that this line would fail to compile if not for the
     // `UnitOrderTiebreaker<Trinches>` specialization just above, whose value must not be `0`.
-    StaticAssertTypeEq<UnitProductT<Trinches, Quarterfeet>, UnitProductT<Quarterfeet, Trinches>>();
+    StaticAssertTypeEq<UnitProduct<Trinches, Quarterfeet>, UnitProduct<Quarterfeet, Trinches>>();
 }
 
 namespace detail {
@@ -825,7 +823,7 @@ TEST(UnitAvoidance, CanTemporarilyBreakTiesForDistinctButOtherwiseUnorderableUni
     //
     // This method of making distinct units orderable is deprecated, because it relies on end users
     // naming a type in our `detail::` namespace.
-    StaticAssertTypeEq<UnitProductT<Yards, Threet>, UnitProductT<Threet, Yards>>();
+    StaticAssertTypeEq<UnitProduct<Yards, Threet>, UnitProduct<Threet, Yards>>();
 }
 
 TEST(Origin, ZeroForUnitWithNoSpecifiedOrigin) {

--- a/au/unit_symbol.hh
+++ b/au/unit_symbol.hh
@@ -44,7 +44,7 @@ struct SymbolFor : detail::MakesQuantityFromNumber<SymbolFor, Unit>,
 //
 template <typename UnitSlot>
 constexpr auto symbol_for(UnitSlot) {
-    return SymbolFor<AssociatedUnitT<UnitSlot>>{};
+    return SymbolFor<AssociatedUnit<UnitSlot>>{};
 }
 
 // Support using symbols in unit slot APIs (e.g., `v.in(m / s)`).

--- a/au/units/unos.hh
+++ b/au/units/unos.hh
@@ -29,7 +29,7 @@ struct UnosLabel {
 };
 template <typename T>
 constexpr const char UnosLabel<T>::label[];
-struct Unos : UnitProductT<>, UnosLabel<void> {
+struct Unos : UnitProduct<>, UnosLabel<void> {
     using UnosLabel<void>::label;
 };
 constexpr auto unos = QuantityMaker<Unos>{};

--- a/au/utility/test/type_traits_test.cc
+++ b/au/utility/test/type_traits_test.cc
@@ -30,8 +30,8 @@ template <typename... Ts>
 struct Pack;
 
 TEST(Prepend, PrependsToPack) {
-    StaticAssertTypeEq<PrependT<Pack<>, int>, Pack<int>>();
-    StaticAssertTypeEq<PrependT<Pack<double, char>, int>, Pack<int, double, char>>();
+    StaticAssertTypeEq<Prepend<Pack<>, int>, Pack<int>>();
+    StaticAssertTypeEq<Prepend<Pack<double, char>, int>, Pack<int, double, char>>();
 }
 
 TEST(SameTypeIgnoringCvref, IgnoresCvrefQualifiers) {

--- a/au/utility/type_traits.hh
+++ b/au/utility/type_traits.hh
@@ -22,9 +22,9 @@ namespace au {
 namespace detail {
 
 template <typename PackT, typename T>
-struct Prepend;
+struct PrependImpl;
 template <typename PackT, typename T>
-using PrependT = typename Prepend<PackT, T>::type;
+using Prepend = typename PrependImpl<PackT, T>::type;
 
 template <template <class> class Condition, template <class...> class Pack, typename... Ts>
 struct IncludeInPackIfImpl;
@@ -72,10 +72,10 @@ using PromotedType = typename PromotedTypeImpl<T>::type;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-// `Prepend` implementation.
+// `PrependImpl` implementation.
 
 template <template <typename...> class Pack, typename T, typename... Us>
-struct Prepend<Pack<Us...>, T> {
+struct PrependImpl<Pack<Us...>, T> {
     using type = Pack<T, Us...>;
 };
 
@@ -110,7 +110,7 @@ struct ListMatchingTypesImpl<Condition, GenericTypeList<>>
 template <template <class> class Condition, typename H, typename... Ts>
 struct ListMatchingTypesImpl<Condition, GenericTypeList<H, Ts...>>
     : std::conditional<Condition<H>::value,
-                       PrependT<ListMatchingTypes<Condition, GenericTypeList<Ts...>>, H>,
+                       Prepend<ListMatchingTypes<Condition, GenericTypeList<Ts...>>, H>,
                        ListMatchingTypes<Condition, GenericTypeList<Ts...>>> {};
 
 template <template <class> class Condition, template <class...> class Pack, typename... Ts>
@@ -130,7 +130,7 @@ template <typename T, template <class...> class Pack, typename H, typename... Ts
 struct DropAllImpl<T, Pack<H, Ts...>>
     : std::conditional<std::is_same<T, H>::value,
                        DropAll<T, Pack<Ts...>>,
-                       detail::PrependT<DropAll<T, Pack<Ts...>>, H>> {};
+                       detail::Prepend<DropAll<T, Pack<Ts...>>, H>> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `FlattenAs` implementation.

--- a/au/wrapper_operations_test.cc
+++ b/au/wrapper_operations_test.cc
@@ -94,35 +94,35 @@ TEST(ScalesQuantity, ChangesUnitsAndInvertsQuantityWhenDividing) {
 
 TEST(ComposesWith, ComposesWithSelf) {
     constexpr auto mol = UnitWrapper<Moles>{};
-    StaticAssertTypeEq<decltype(mol * mol), UnitWrapper<UnitProductT<Moles, Moles>>>();
-    StaticAssertTypeEq<decltype(mol / mol), UnitWrapper<UnitProductT<>>>();
+    StaticAssertTypeEq<decltype(mol * mol), UnitWrapper<UnitProduct<Moles, Moles>>>();
+    StaticAssertTypeEq<decltype(mol / mol), UnitWrapper<UnitProduct<>>>();
 }
 
 TEST(ComposesWith, ComposesWithOtherSpecializationsOfSameWrapper) {
     constexpr auto mol = UnitWrapper<Moles>{};
     constexpr auto L = UnitWrapper<Liters>{};
-    StaticAssertTypeEq<decltype(mol * L), UnitWrapper<UnitProductT<Moles, Liters>>>();
-    StaticAssertTypeEq<decltype(mol / L), UnitWrapper<UnitQuotientT<Moles, Liters>>>();
+    StaticAssertTypeEq<decltype(mol * L), UnitWrapper<UnitProduct<Moles, Liters>>>();
+    StaticAssertTypeEq<decltype(mol / L), UnitWrapper<UnitQuotient<Moles, Liters>>>();
 }
 
 TEST(ComposesWith, MakesScaledQuantityMakerWhenPreMultiplyingQuantityMaker) {
     constexpr auto L = UnitWrapper<Liters>{};
-    StaticAssertTypeEq<decltype(L * moles), QuantityMaker<UnitProductT<Moles, Liters>>>();
+    StaticAssertTypeEq<decltype(L * moles), QuantityMaker<UnitProduct<Moles, Liters>>>();
 }
 
 TEST(ComposesWith, MakesScaledQuantityMakerWhenPostMultiplyingQuantityMaker) {
     constexpr auto L = UnitWrapper<Liters>{};
-    StaticAssertTypeEq<decltype(moles * L), QuantityMaker<UnitProductT<Moles, Liters>>>();
+    StaticAssertTypeEq<decltype(moles * L), QuantityMaker<UnitProduct<Moles, Liters>>>();
 }
 
 TEST(ComposesWith, MakesScaledQuantityMakerWhenDividingIntoQuantityMaker) {
     constexpr auto L = UnitWrapper<Liters>{};
-    StaticAssertTypeEq<decltype(moles / L), QuantityMaker<UnitQuotientT<Moles, Liters>>>();
+    StaticAssertTypeEq<decltype(moles / L), QuantityMaker<UnitQuotient<Moles, Liters>>>();
 }
 
 TEST(ComposesWith, MakesScaledQuantityMakerWhenDividingQuantityMaker) {
     constexpr auto L = UnitWrapper<Liters>{};
-    StaticAssertTypeEq<decltype(L / moles), QuantityMaker<UnitQuotientT<Liters, Moles>>>();
+    StaticAssertTypeEq<decltype(L / moles), QuantityMaker<UnitQuotient<Liters, Moles>>>();
 }
 
 TEST(CanScaleByMagnitude, MakesScaledWrapperWhenPreMultiplyingByMagnitude) {

--- a/compatibility/nholthaus_units.hh
+++ b/compatibility/nholthaus_units.hh
@@ -170,9 +170,9 @@ using NholthausUnitMagT = typename NholthausUnitMag<NholthausUnit>::type;
 // Implementation for derived units: apply top-level scaling factor to recursive result.
 template <class RationalScale, class BaseUnit, class PiPower, class X4>
 struct NholthausUnitMag<units::unit<RationalScale, BaseUnit, PiPower, X4>>
-    : stdx::type_identity<MagProductT<MagFromRatioT<RationalScale>,
-                                      MagPowerT<Magnitude<Pi>, PiPower::num, PiPower::den>,
-                                      NholthausUnitMagT<BaseUnit>>> {};
+    : stdx::type_identity<MagProduct<MagFromRatioT<RationalScale>,
+                                     MagPower<Magnitude<Pi>, PiPower::num, PiPower::den>,
+                                     NholthausUnitMagT<BaseUnit>>> {};
 
 // Implementation for base units: always 1 (i.e., the null Magnitude) by definition.
 template <class... Es>
@@ -186,7 +186,7 @@ struct AuUnit {
     using NU = NholthausUnit;
 
     // If you want to use only a subset of units, you can avoid depending on the Au analogues for
-    // all 9 nholthaus base units.  Simply delete the corresponding `UnitPowerT` from the
+    // all 9 nholthaus base units.  Simply delete the corresponding `UnitPower` from the
     // `decltype()` expression below.
     //
     // **NOTE:** For safety, if you do this, make sure that you also add a line like the following
@@ -194,15 +194,15 @@ struct AuUnit {
     //
     // static_assert(MoleExpT<NU>::num == 0, "Moles not supported");
 
-    using type = decltype(UnitPowerT<Meters, MeterExpT<NU>::num, MeterExpT<NU>::den>{} *
-                          UnitPowerT<Kilo<Grams>, KilogramExpT<NU>::num, KilogramExpT<NU>::den>{} *
-                          UnitPowerT<Seconds, SecondExpT<NU>::num, SecondExpT<NU>::den>{} *
-                          UnitPowerT<Radians, RadianExpT<NU>::num, RadianExpT<NU>::den>{} *
-                          UnitPowerT<Amperes, AmpExpT<NU>::num, AmpExpT<NU>::den>{} *
-                          UnitPowerT<Kelvins, KelvinExpT<NU>::num, KelvinExpT<NU>::den>{} *
-                          UnitPowerT<Bytes, ByteExpT<NU>::num, ByteExpT<NU>::den>{} *
-                          UnitPowerT<Candelas, CandelaExpT<NU>::num, CandelaExpT<NU>::den>{} *
-                          UnitPowerT<Moles, MoleExpT<NU>::num, MoleExpT<NU>::den>{} *
+    using type = decltype(UnitPower<Meters, MeterExpT<NU>::num, MeterExpT<NU>::den>{} *
+                          UnitPower<Kilo<Grams>, KilogramExpT<NU>::num, KilogramExpT<NU>::den>{} *
+                          UnitPower<Seconds, SecondExpT<NU>::num, SecondExpT<NU>::den>{} *
+                          UnitPower<Radians, RadianExpT<NU>::num, RadianExpT<NU>::den>{} *
+                          UnitPower<Amperes, AmpExpT<NU>::num, AmpExpT<NU>::den>{} *
+                          UnitPower<Kelvins, KelvinExpT<NU>::num, KelvinExpT<NU>::den>{} *
+                          UnitPower<Bytes, ByteExpT<NU>::num, ByteExpT<NU>::den>{} *
+                          UnitPower<Candelas, CandelaExpT<NU>::num, CandelaExpT<NU>::den>{} *
+                          UnitPower<Moles, MoleExpT<NU>::num, MoleExpT<NU>::den>{} *
                           NholthausUnitMagT<NU>{});
 };
 

--- a/fuzz/quantity_runtime_conversion_check.cc
+++ b/fuzz/quantity_runtime_conversion_check.cc
@@ -166,7 +166,7 @@ constexpr TestCategory categorize_testing_scenario() {
     }
 
     using Common = std::common_type_t<RepT, DestRepT>;
-    constexpr auto conversion_factor = UnitRatioT<UnitT, DestUnitT>{};
+    constexpr auto conversion_factor = UnitRatio<UnitT, DestUnitT>{};
 
     if (is_integer(conversion_factor) &&
         (get_value_result<Common>(conversion_factor).outcome != MagRepresentationOutcome::OK)) {
@@ -265,7 +265,7 @@ struct LossChecker<RepT, UnitT, DestRepT, DestUnitT, TestCategory::INTEGRAL_TO_I
                                     const Quantity<DestUnitT, DestRepT> &destination,
                                     const Quantity<UnitT, RepT> &round_trip) {
         const bool expect_sign_flip =
-            std::is_same<Sign<UnitRatioT<UnitT, DestUnitT>>, Magnitude<Negative>>::value;
+            std::is_same<Sign<UnitRatio<UnitT, DestUnitT>>, Magnitude<Negative>>::value;
         const bool wrong_sign = (sign_flip(value, destination) != expect_sign_flip);
 
         const bool actual_loss = (value != round_trip) || wrong_sign;
@@ -355,7 +355,7 @@ struct LossChecker<RepT, UnitT, DestRepT, DestUnitT, TestCategory::FLOAT_TO_INTE
         }
 
         if (round_trip == value) {
-            using Op = ConversionForRepsAndFactor<RepT, DestRepT, UnitRatioT<UnitT, DestUnitT>>;
+            using Op = ConversionForRepsAndFactor<RepT, DestRepT, UnitRatio<UnitT, DestUnitT>>;
             const auto dest_value = FloatingPointPrefixPart<Op>::apply_to(value.in(UnitT{}));
             const bool definitely_truncates = (std::trunc(dest_value) != dest_value);
             std::ostringstream oss;
@@ -381,7 +381,7 @@ struct LossChecker<RepT, UnitT, DestRepT, DestUnitT, TestCategory::FLOAT_TO_INTE
         std::ostringstream oss;
         oss << "Distance was " << dist << " steps" << (dist >= MAX_DIST ? " (truncated)" : "");
 
-        if (std::is_same<Abs<UnitRatioT<UnitT, DestUnitT>>, Magnitude<>>::value) {
+        if (std::is_same<Abs<UnitRatio<UnitT, DestUnitT>>, Magnitude<>>::value) {
             oss << ".  Saw round trip error on conversion factor whose absolute value was 1.";
             return {
                 RoundTripResult::SIGNIFICANT_LOSS,
@@ -414,7 +414,7 @@ template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT, 
 struct NominalTestBodyImpl : LossChecker<RepT, UnitT, DestRepT, DestUnitT, Cat> {
     using LossChecker<RepT, UnitT, DestRepT, DestUnitT, Cat>::check_for_loss;
 
-    using Op = ConversionForRepsAndFactor<RepT, DestRepT, UnitRatioT<UnitT, DestUnitT>>;
+    using Op = ConversionForRepsAndFactor<RepT, DestRepT, UnitRatio<UnitT, DestUnitT>>;
 
     static void test(const Quantity<UnitT, RepT> &value) {
         const bool expect_loss = is_conversion_lossy<DestRepT>(value, DestUnitT{});

--- a/fuzz/quantity_runtime_conversion_checkers.hh
+++ b/fuzz/quantity_runtime_conversion_checkers.hh
@@ -123,7 +123,7 @@ template <typename T, typename... Packs>
 using PrependToEach = typename PrependToEachImpl<T, Packs...>::type;
 template <template <class...> class Pack, typename T, typename... Ts>
 struct PrependToEachImpl<T, Pack<Ts...>> {
-    using type = Pack<detail::PrependT<Ts, T>...>;
+    using type = Pack<detail::Prepend<Ts, T>...>;
 };
 
 template <template <class...> class Tuple,


### PR DESCRIPTION
We've evolved a really nice idiom where the "user" facing alias gets the
natural name, and the struct that helps implement it gets called the
"Impl".  I put "user" in scare quotes because now we're fixing up the
library-internal utilities to be consistent with this new approach.

It's certainly a lot better than the old approach, where the
implementation struct got the natural name, and the user-facing alias
had the `T` suffix.  This was just a recipe for confusion, even for
experts.

There was at least one case where we were already using the `Impl`
suffix for something else, so we changed that instance to a `Helper`
suffix to free it up.

Helps #86.  This will unblock us from removing the `T` suffix from our
internal helpers in a future PR.