### PR TITLE
Avoid `T` suffix in `Pack` arithmetic helpers

### DIFF
--- a/au/dimension.hh
+++ b/au/dimension.hh
@@ -37,21 +37,21 @@ struct Dimension {
 
 // Define readable operations for product, quotient, power, inverse on Dimensions.
 template <typename... BPs>
-using DimProduct = PackProductT<Dimension, BPs...>;
+using DimProduct = PackProduct<Dimension, BPs...>;
 template <typename... BPs>
 using DimProductT = DimProduct<BPs...>;
 template <typename T, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
-using DimPower = PackPowerT<Dimension, T, ExpNum, ExpDen>;
+using DimPower = PackPower<Dimension, T, ExpNum, ExpDen>;
 template <typename T, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
 using DimPowerT = DimPower<T, ExpNum, ExpDen>;
 
 template <typename T, typename U>
-using DimQuotient = PackQuotientT<Dimension, T, U>;
+using DimQuotient = PackQuotient<Dimension, T, U>;
 template <typename T, typename U>
 using DimQuotientT = DimQuotient<T, U>;
 
 template <typename T>
-using DimInverse = PackInverseT<Dimension, T>;
+using DimInverse = PackInverse<Dimension, T>;
 template <typename T>
 using DimInverseT = DimInverse<T>;
 

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -54,33 +54,33 @@ struct Magnitude {
 
 // Define readable operations for product, quotient, power, inverse on Magnitudes.
 template <typename... BPs>
-using MagProduct = PackProductT<Magnitude, BPs...>;
+using MagProduct = PackProduct<Magnitude, BPs...>;
 template <typename... BPs>
 using MagProductT = MagProduct<BPs...>;
 
 template <typename T, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
-using MagPower = PackPowerT<Magnitude, T, ExpNum, ExpDen>;
+using MagPower = PackPower<Magnitude, T, ExpNum, ExpDen>;
 template <typename T, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
 using MagPowerT = MagPower<T, ExpNum, ExpDen>;
 
 template <typename T, typename U>
-using MagQuotient = PackQuotientT<Magnitude, T, U>;
+using MagQuotient = PackQuotient<Magnitude, T, U>;
 template <typename T, typename U>
 using MagQuotientT = MagQuotient<T, U>;
 
 template <typename T>
-using MagInverse = PackInverseT<Magnitude, T>;
+using MagInverse = PackInverse<Magnitude, T>;
 template <typename T>
 using MagInverseT = MagInverse<T>;
 
 // Enable negative magnitudes with a type representing (-1) that appears/disappears under powers.
 struct Negative {};
 template <typename... BPs, std::intmax_t ExpNum, std::intmax_t ExpDen>
-struct PackPower<Magnitude, Magnitude<Negative, BPs...>, std::ratio<ExpNum, ExpDen>>
+struct PackPowerImpl<Magnitude, Magnitude<Negative, BPs...>, std::ratio<ExpNum, ExpDen>>
     : std::conditional<(std::ratio<ExpNum, ExpDen>::num % 2 == 0),
 
                        // Even powers of (-1) are 1 for any root.
-                       PackPowerT<Magnitude, Magnitude<BPs...>, ExpNum, ExpDen>,
+                       MagPower<Magnitude<BPs...>, ExpNum, ExpDen>,
 
                        // At this point, we know we're taking the D'th root of (-1), which is (-1)
                        // if D is odd, and a hard compiler error if D is even.
@@ -91,7 +91,7 @@ struct PackPower<Magnitude, Magnitude<Negative, BPs...>, std::ratio<ExpNum, ExpD
                   "Cannot take even root of negative magnitude");
 };
 template <typename... LeftBPs, typename... RightBPs>
-struct PackProduct<Magnitude, Magnitude<Negative, LeftBPs...>, Magnitude<Negative, RightBPs...>>
+struct PackProductImpl<Magnitude, Magnitude<Negative, LeftBPs...>, Magnitude<Negative, RightBPs...>>
     : stdx::type_identity<MagProduct<Magnitude<LeftBPs...>, Magnitude<RightBPs...>>> {};
 
 // Define negation.

--- a/au/packs_test.cc
+++ b/au/packs_test.cc
@@ -121,45 +121,45 @@ TEST(UnpackIfSolo, ReturnsEnclosedElementIfExactlyOne) {
     StaticAssertTypeEq<UnpackIfSolo<Pack, Pack<int, char>>, Pack<int, char>>();
 }
 
-TEST(PackProductT, UnaryProductIsIdentity) {
-    StaticAssertTypeEq<PackProductT<Pack, Pack<>>, Pack<>>();
-    StaticAssertTypeEq<PackProductT<Pack, Pack<B<3>>>, Pack<B<3>>>();
+TEST(PackProduct, UnaryProductIsIdentity) {
+    StaticAssertTypeEq<PackProduct<Pack, Pack<>>, Pack<>>();
+    StaticAssertTypeEq<PackProduct<Pack, Pack<B<3>>>, Pack<B<3>>>();
 }
 
-TEST(PackProductT, BinaryProductOfNullPacksIsNullPack) {
-    StaticAssertTypeEq<PackProductT<Pack, Pack<>, Pack<>>, Pack<>>();
+TEST(PackProduct, BinaryProductOfNullPacksIsNullPack) {
+    StaticAssertTypeEq<PackProduct<Pack, Pack<>, Pack<>>, Pack<>>();
 }
 
-TEST(PackProductT, BinaryProductOfNullPackWithNonNullPackGivesNonNullPack) {
-    StaticAssertTypeEq<PackProductT<Pack, Pack<>, Pack<B<2>, B<3>>>, Pack<B<2>, B<3>>>();
-    StaticAssertTypeEq<PackProductT<Pack, Pack<B<2>, B<3>>, Pack<>>, Pack<B<2>, B<3>>>();
+TEST(PackProduct, BinaryProductOfNullPackWithNonNullPackGivesNonNullPack) {
+    StaticAssertTypeEq<PackProduct<Pack, Pack<>, Pack<B<2>, B<3>>>, Pack<B<2>, B<3>>>();
+    StaticAssertTypeEq<PackProduct<Pack, Pack<B<2>, B<3>>, Pack<>>, Pack<B<2>, B<3>>>();
 }
 
-TEST(PackProductT, BinaryProductOfNonNullPackWithEarlierBasePrependsBase) {
-    StaticAssertTypeEq<PackProductT<Pack, Pack<B<1>>, Pack<B<2>, B<3>>>, Pack<B<1>, B<2>, B<3>>>();
-    StaticAssertTypeEq<PackProductT<Pack, Pack<B<2>>, Pack<B<1>, B<3>>>, Pack<B<1>, B<2>, B<3>>>();
+TEST(PackProduct, BinaryProductOfNonNullPackWithEarlierBasePrependsBase) {
+    StaticAssertTypeEq<PackProduct<Pack, Pack<B<1>>, Pack<B<2>, B<3>>>, Pack<B<1>, B<2>, B<3>>>();
+    StaticAssertTypeEq<PackProduct<Pack, Pack<B<2>>, Pack<B<1>, B<3>>>, Pack<B<1>, B<2>, B<3>>>();
 }
 
-TEST(PackProductT, BinaryProductWithSameHeadBaseAddsExponents) {
-    StaticAssertTypeEq<PackProductT<Pack, Pack<B<2>>, Pack<B<2>>>, Pack<Pow<B<2>, 2>>>();
+TEST(PackProduct, BinaryProductWithSameHeadBaseAddsExponents) {
+    StaticAssertTypeEq<PackProduct<Pack, Pack<B<2>>, Pack<B<2>>>, Pack<Pow<B<2>, 2>>>();
 
-    StaticAssertTypeEq<PackProductT<Pack, Pack<Pow<B<2>, -1>>, Pack<B<2>>>, Pack<>>();
+    StaticAssertTypeEq<PackProduct<Pack, Pack<Pow<B<2>, -1>>, Pack<B<2>>>, Pack<>>();
 
-    StaticAssertTypeEq<PackProductT<Pack, Pack<Pow<B<2>, 2>>, Pack<RatioPow<B<2>, -3, 4>>>,
+    StaticAssertTypeEq<PackProduct<Pack, Pack<Pow<B<2>, 2>>, Pack<RatioPow<B<2>, -3, 4>>>,
                        Pack<RatioPow<B<2>, 5, 4>>>();
 
-    StaticAssertTypeEq<PackProductT<Pack, Pack<RatioPow<B<2>, 7, 4>>, Pack<RatioPow<B<2>, -3, 4>>>,
+    StaticAssertTypeEq<PackProduct<Pack, Pack<RatioPow<B<2>, 7, 4>>, Pack<RatioPow<B<2>, -3, 4>>>,
                        Pack<B<2>>>();
 }
 
-TEST(PackProductT, NaryProductRecurses) {
-    StaticAssertTypeEq<PackProductT<Pack, Pack<B<7>>, Pack<B<2>>, Pack<B<5>>>,
+TEST(PackProduct, NaryProductRecurses) {
+    StaticAssertTypeEq<PackProduct<Pack, Pack<B<7>>, Pack<B<2>>, Pack<B<5>>>,
                        Pack<B<2>, B<5>, B<7>>>();
 }
 
-TEST(PackPowerT, MultipliesExponentsAndSimplifies) {
+TEST(PackPower, MultipliesExponentsAndSimplifies) {
     StaticAssertTypeEq<
-        PackPowerT<Pack, Pack<B<2>, Pow<B<3>, -3>, RatioPow<B<5>, -3, 2>, RatioPow<B<7>, 1, 2>>, 2>,
+        PackPower<Pack, Pack<B<2>, Pow<B<3>, -3>, RatioPow<B<5>, -3, 2>, RatioPow<B<7>, 1, 2>>, 2>,
         Pack<Pow<B<2>, 2>, Pow<B<3>, -6>, Pow<B<5>, -3>, B<7>>>();
 }
 
@@ -191,31 +191,31 @@ TEST(FlatDedupedTypeListT, DedupesAtAnyPosition) {
     StaticAssertTypeEq<FlatDedupedTypeListT<Pack, T, Pack<B<2>>, T, B<11>, T>, T>();
 }
 
-TEST(PackPowerT, SupportsRationalPowers) {
+TEST(PackPower, SupportsRationalPowers) {
     StaticAssertTypeEq<
-        PackPowerT<Pack, Pack<Pow<B<2>, 2>, Pow<B<3>, -6>, Pow<B<5>, -3>, B<7>>, 1, 2>,
+        PackPower<Pack, Pack<Pow<B<2>, 2>, Pow<B<3>, -6>, Pow<B<5>, -3>, B<7>>, 1, 2>,
         Pack<B<2>, Pow<B<3>, -3>, RatioPow<B<5>, -3, 2>, RatioPow<B<7>, 1, 2>>>();
 }
 
-TEST(PackPowerT, SupportsZeroPower) {
-    StaticAssertTypeEq<PackPowerT<Pack, Pack<Pow<B<2>, 2>, Pow<B<3>, -6>, Pow<B<5>, -3>, B<7>>, 0>,
+TEST(PackPower, SupportsZeroPower) {
+    StaticAssertTypeEq<PackPower<Pack, Pack<Pow<B<2>, 2>, Pow<B<3>, -6>, Pow<B<5>, -3>, B<7>>, 0>,
                        Pack<>>();
 }
 
-TEST(PackQuotientT, PackQuotientWithItselfIsNullPack) {
-    StaticAssertTypeEq<PackQuotientT<Pack, Pack<B<2>>, Pack<B<2>>>, Pack<>>();
+TEST(PackQuotient, PackQuotientWithItselfIsNullPack) {
+    StaticAssertTypeEq<PackQuotient<Pack, Pack<B<2>>, Pack<B<2>>>, Pack<>>();
 
     using ArbitraryPack = Pack<Pow<B<2>, 2>, RatioPow<Pie, 22, 7>, B<13>>;
-    StaticAssertTypeEq<PackQuotientT<Pack, ArbitraryPack, ArbitraryPack>, Pack<>>();
+    StaticAssertTypeEq<PackQuotient<Pack, ArbitraryPack, ArbitraryPack>, Pack<>>();
 }
 
-TEST(PackQuotientT, InverseOfProduct) {
-    using B2_B5 = PackProductT<Pack, Pack<B<2>>, Pack<B<5>>>;
-    StaticAssertTypeEq<PackQuotientT<Pack, B2_B5, Pack<B<2>>>, Pack<B<5>>>();
+TEST(PackQuotient, InverseOfProduct) {
+    using B2_B5 = PackProduct<Pack, Pack<B<2>>, Pack<B<5>>>;
+    StaticAssertTypeEq<PackQuotient<Pack, B2_B5, Pack<B<2>>>, Pack<B<5>>>();
 }
 
-TEST(PackInverseT, ProductWithOriginalIsNullPack) {
-    StaticAssertTypeEq<PackProductT<Pack, PackInverseT<Pack, Pack<B<2>>>, Pack<B<2>>>, Pack<>>();
+TEST(PackInverse, ProductWithOriginalIsNullPack) {
+    StaticAssertTypeEq<PackProduct<Pack, PackInverse<Pack, Pack<B<2>>>, Pack<B<2>>>, Pack<>>();
 }
 
 TEST(IsValidPack, FalseIfNotInstanceOfPack) {

--- a/au/power_aliases_test.cc
+++ b/au/power_aliases_test.cc
@@ -39,13 +39,13 @@ constexpr int B<N>::index;
 
 // Defining `pow<N>(Vector<...>)` is what unlocks `squared`, `cubed`, and `inverse`.
 template <std::intmax_t N, typename... BPs>
-constexpr PackPowerT<Vector, Vector<BPs...>, N> pow(Vector<BPs...>) {
+constexpr PackPower<Vector, Vector<BPs...>, N> pow(Vector<BPs...>) {
     return {};
 }
 
 // Defining `root<N>(Vector<...>)` is what unlocks `sqrt` and `cbrt`.
 template <std::intmax_t N, typename... BPs>
-constexpr PackPowerT<Vector, Vector<BPs...>, 1, N> root(Vector<BPs...>) {
+constexpr PackPower<Vector, Vector<BPs...>, 1, N> root(Vector<BPs...>) {
     return {};
 }
 

--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -343,7 +343,7 @@ struct UnitProductPack {
 template <typename... UnitPows>
 using UnitProduct =
     UnpackIfSolo<UnitProductPack,
-                 PackProductT<UnitProductPack, AsPack<UnitProductPack, UnitPows>...>>;
+                 PackProduct<UnitProductPack, AsPack<UnitProductPack, UnitPows>...>>;
 template <typename... UnitPows>
 using UnitProductT = UnitProduct<UnitPows...>;
 
@@ -351,7 +351,7 @@ using UnitProductT = UnitProduct<UnitPows...>;
 template <typename U, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
 using UnitPower =
     UnpackIfSolo<UnitProductPack,
-                 PackPowerT<UnitProductPack, AsPack<UnitProductPack, U>, ExpNum, ExpDen>>;
+                 PackPower<UnitProductPack, AsPack<UnitProductPack, U>, ExpNum, ExpDen>>;
 template <typename U, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
 using UnitPowerT = UnitPower<U, ExpNum, ExpDen>;
 

--- a/docs/reference/detail/packs.md
+++ b/docs/reference/detail/packs.md
@@ -111,11 +111,11 @@ Let's take the "pack product" operation as an example, using `Dimension` as our 
 ```cpp
 // The `//au:packs` library provides this:
 template <template <class...> typename Pack, typename... Ts>
-using PackProductT = /* (implementation; irrelevant here) */;
+using PackProduct = /* (implementation; irrelevant here) */;
 
 // A _particular_ Pack (say, `Dimension`) would expose it to their users like this:
 template <typename... Dims>
-using DimProduct = PackProductT<Dimension, Dims...>;
+using DimProduct = PackProduct<Dimension, Dims...>;
 
 // End users would use the _latter_, e.g.:
 using Length = DimProduct<Speed, Time>;
@@ -125,8 +125,8 @@ using Length = DimProduct<Speed, Time>;
 
 Here are the operations we support:
 
-- `PackProductT<Pack, Ps...>`: the product of arbitrarily many (0 or more) `Pack<...>` instances,
+- `PackProduct<Pack, Ps...>`: the product of arbitrarily many (0 or more) `Pack<...>` instances,
   `Ps...`.
-- `PackQuotientT<Pack, P1, P2>`: the quotient `P1 / P2`.
-- `PackPowerT<Pack, P, N, D=1>`: raise the Pack `P` to the rational power `N / D`.
-- `PackInverseT<Pack, P>`: the Pack that gives the null pack when multiplied with the Pack `P`.
+- `PackQuotient<Pack, P1, P2>`: the quotient `P1 / P2`.
+- `PackPower<Pack, P, N, D=1>`: raise the Pack `P` to the rational power `N / D`.
+- `PackInverse<Pack, P>`: the Pack that gives the null pack when multiplied with the Pack `P`.


### PR DESCRIPTION
These are not in the `detail` namespace, but they are nevertheless
simply implementation details, so we won't bother preserving the old
names.

Fixes #86.