### PR TITLE
Enable customizing conversion strategy

### DIFF
--- a/au/apply_magnitude_test.cc
+++ b/au/apply_magnitude_test.cc
@@ -46,7 +46,7 @@ struct NewOverflowChecker {
 
 template <typename Mag, typename T, bool is_T_integral>
 struct ApplyMagnitudeImpl {
-    using Op = ConversionForRepsAndFactor<T, T, Mag>;
+    using Op = ConversionForRepsAndFactor<UseStaticCast, T, T, Mag>;
     constexpr T operator()(const T &x) { return Op::apply_to(x); }
 
     static constexpr bool would_overflow(const T &x) {

--- a/au/apply_rational_magnitude_to_integral_test.cc
+++ b/au/apply_rational_magnitude_to_integral_test.cc
@@ -78,7 +78,7 @@ constexpr void ensure_relevant_kind_of_magnitude(Magnitude<BPs...> m) {
 // replacement library.  This lets us get coverage from all of our old test cases.
 //
 template <typename T, typename MagT>
-struct MaxNonOverflowingValue : MaxGood<ConversionForRepsAndFactor<T, T, MagT>> {};
+struct MaxNonOverflowingValue : MaxGood<ConversionForRepsAndFactor<UseStaticCast, T, T, MagT>> {};
 
 enum class IsPromotable { NO, YES };
 enum class NumFitsInPromotedType { NO, YES };
@@ -100,7 +100,7 @@ struct TestSpec {
 // replacement library.  This lets us get coverage from all of our old test cases.
 //
 template <typename T, typename MagT>
-struct MinNonOverflowingValue : MinGood<ConversionForRepsAndFactor<T, T, MagT>> {};
+struct MinNonOverflowingValue : MinGood<ConversionForRepsAndFactor<UseStaticCast, T, T, MagT>> {};
 
 template <typename T, typename MagT>
 void validate_spec(TestSpec spec) {

--- a/au/conversion_strategy_test.cc
+++ b/au/conversion_strategy_test.cc
@@ -25,49 +25,78 @@ namespace detail {
 using ::testing::IsFalse;
 using ::testing::StaticAssertTypeEq;
 
+template <typename T, typename U, typename Factor>
+struct CastStrategyIndependentConversionForRepsAndFactorImpl {
+    using ViaStaticCast = ConversionForRepsAndFactor<UseStaticCast, T, U, Factor>;
+    using ViaImplicitConversion = ConversionForRepsAndFactor<UseImplicitConversion, T, U, Factor>;
+    static_assert(std::is_same<ViaStaticCast, ViaImplicitConversion>::value,
+                  "Must be independent of cast strategy to use this");
+    using type = ViaStaticCast;
+};
+template <typename T, typename U, typename Factor>
+using CastStrategyIndependentConversionForRepsAndFactor =
+    typename CastStrategyIndependentConversionForRepsAndFactorImpl<T, U, Factor>::type;
+
 TEST(ConversionForRepsAndFactor, SameRepAndNonPromotingTypeIsJustMultiplyByDefault) {
-    StaticAssertTypeEq<ConversionForRepsAndFactor<int32_t, int32_t, decltype(mag<15>())>,
-                       MultiplyTypeBy<int32_t, decltype(mag<15>())>>();
+    StaticAssertTypeEq<
+        CastStrategyIndependentConversionForRepsAndFactor<int32_t, int32_t, decltype(mag<15>())>,
+        MultiplyTypeBy<int32_t, decltype(mag<15>())>>();
 }
 
 TEST(ConversionForRepsAndFactor, SameRepAndNonPromotingTypeWithInverseIntegerIsJustDivideBy) {
-    StaticAssertTypeEq<ConversionForRepsAndFactor<int32_t, int32_t, decltype(mag<1>() / mag<16>())>,
-                       DivideTypeByInteger<int32_t, decltype(mag<16>())>>();
+    StaticAssertTypeEq<
+        CastStrategyIndependentConversionForRepsAndFactor<int32_t,
+                                                          int32_t,
+                                                          decltype(mag<1>() / mag<16>())>,
+        DivideTypeByInteger<int32_t, decltype(mag<16>())>>();
 
-    StaticAssertTypeEq<ConversionForRepsAndFactor<double, double, decltype(mag<1>() / mag<3456>())>,
-                       DivideTypeByInteger<double, decltype(mag<3456>())>>();
+    StaticAssertTypeEq<
+        CastStrategyIndependentConversionForRepsAndFactor<double,
+                                                          double,
+                                                          decltype(mag<1>() / mag<3456>())>,
+        DivideTypeByInteger<double, decltype(mag<3456>())>>();
 }
 
-TEST(ConversionForRepsAndFactor, SameRepForPromotingTypeHasStaticCastAtBeginningAndEnd) {
+TEST(ConversionForRepsAndFactor, SameRepForPromotingTypeHasCastAtBeginningAndEnd) {
     using T = uint16_t;
     using Promoted = PromotedType<T>;
     ASSERT_THAT((std::is_same<T, Promoted>::value), IsFalse());
 
-    StaticAssertTypeEq<ConversionForRepsAndFactor<T, T, decltype(mag<15>())>,
+    StaticAssertTypeEq<ConversionForRepsAndFactor<UseStaticCast, T, T, decltype(mag<15>())>,
                        OpSequence<StaticCast<T, Promoted>,
                                   MultiplyTypeBy<Promoted, decltype(mag<15>())>,
                                   StaticCast<Promoted, T>>>();
+    StaticAssertTypeEq<ConversionForRepsAndFactor<UseImplicitConversion, T, T, decltype(mag<15>())>,
+                       OpSequence<ImplicitConversion<T, Promoted>,
+                                  MultiplyTypeBy<Promoted, decltype(mag<15>())>,
+                                  ImplicitConversion<Promoted, T>>>();
 }
 
 TEST(ConversionForRepsAndFactor, ApplyingNontrivialRationalToIntegralTypeIsMultiplyThenDivide) {
     StaticAssertTypeEq<
-        ConversionForRepsAndFactor<uint64_t, uint64_t, decltype(mag<3>() / mag<4>())>,
+        CastStrategyIndependentConversionForRepsAndFactor<uint64_t,
+                                                          uint64_t,
+                                                          decltype(mag<3>() / mag<4>())>,
         OpSequence<MultiplyTypeBy<uint64_t, decltype(mag<3>())>,
                    DivideTypeByInteger<uint64_t, decltype(mag<4>())>>>();
 }
 
 TEST(ConversionForRepsAndFactor, ApplyingNontrivialRationalToFloatingPointIsSingleMultiply) {
-    StaticAssertTypeEq<ConversionForRepsAndFactor<double, double, decltype(mag<3>() / mag<4>())>,
-                       MultiplyTypeBy<double, decltype(mag<3>() / mag<4>())>>();
+    StaticAssertTypeEq<
+        CastStrategyIndependentConversionForRepsAndFactor<double,
+                                                          double,
+                                                          decltype(mag<3>() / mag<4>())>,
+        MultiplyTypeBy<double, decltype(mag<3>() / mag<4>())>>();
 }
 
 TEST(ConversionForRepsAndFactor,
      ApplyingNontrivialRationalToComplexIntegralTypeIsMultiplyThenDivide) {
-    StaticAssertTypeEq<ConversionForRepsAndFactor<std::complex<int>,
-                                                  std::complex<int>,
-                                                  decltype(mag<3>() / mag<4>())>,
-                       OpSequence<MultiplyTypeBy<std::complex<int>, decltype(mag<3>())>,
-                                  DivideTypeByInteger<std::complex<int>, decltype(mag<4>())>>>();
+    StaticAssertTypeEq<
+        CastStrategyIndependentConversionForRepsAndFactor<std::complex<int>,
+                                                          std::complex<int>,
+                                                          decltype(mag<3>() / mag<4>())>,
+        OpSequence<MultiplyTypeBy<std::complex<int>, decltype(mag<3>())>,
+                   DivideTypeByInteger<std::complex<int>, decltype(mag<4>())>>>();
 }
 
 TEST(ConversionForRepsAndFactor, WhenTargetIsPromotedTypeSkipFinalStaticCast) {
@@ -76,43 +105,86 @@ TEST(ConversionForRepsAndFactor, WhenTargetIsPromotedTypeSkipFinalStaticCast) {
     ASSERT_THAT((std::is_same<T, Promoted>::value), IsFalse());
 
     StaticAssertTypeEq<
-        ConversionForRepsAndFactor<T, Promoted, decltype(mag<15>())>,
+        ConversionForRepsAndFactor<UseStaticCast, T, Promoted, decltype(mag<15>())>,
         OpSequence<StaticCast<T, Promoted>, MultiplyTypeBy<Promoted, decltype(mag<15>())>>>();
+    StaticAssertTypeEq<
+        ConversionForRepsAndFactor<UseImplicitConversion, T, Promoted, decltype(mag<15>())>,
+        OpSequence<ImplicitConversion<T, Promoted>,
+                   MultiplyTypeBy<Promoted, decltype(mag<15>())>>>();
 }
 
 TEST(ConversionForRepsAndFactor, WhenOldRepIsPromotedCommonSkipInitialStaticCast) {
-    StaticAssertTypeEq<ConversionForRepsAndFactor<float, int, decltype(mag<13>() / mag<15>())>,
+    StaticAssertTypeEq<
+        ConversionForRepsAndFactor<UseStaticCast, float, int, decltype(mag<13>() / mag<15>())>,
+        OpSequence<MultiplyTypeBy<float, decltype(mag<13>() / mag<15>())>,
+                   StaticCast<float, int>>>();
+    StaticAssertTypeEq<ConversionForRepsAndFactor<UseImplicitConversion,
+                                                  float,
+                                                  int,
+                                                  decltype(mag<13>() / mag<15>())>,
                        OpSequence<MultiplyTypeBy<float, decltype(mag<13>() / mag<15>())>,
-                                  StaticCast<float, int>>>();
+                                  ImplicitConversion<float, int>>>();
 }
 
 TEST(ConversionForRepsAndFactor,
      StaticCastToScalarOfComplexAfterMultiplyForScalarFloatToComplexInt) {
-    StaticAssertTypeEq<ConversionForRepsAndFactor<double, std::complex<int>, decltype(mag<12>())>,
+    StaticAssertTypeEq<
+        ConversionForRepsAndFactor<UseStaticCast, double, std::complex<int>, decltype(mag<12>())>,
+        OpSequence<MultiplyTypeBy<double, decltype(mag<12>())>,
+                   StaticCast<double, int>,
+                   StaticCast<int, std::complex<int>>>>();
+    StaticAssertTypeEq<ConversionForRepsAndFactor<UseImplicitConversion,
+                                                  double,
+                                                  std::complex<int>,
+                                                  decltype(mag<12>())>,
                        OpSequence<MultiplyTypeBy<double, decltype(mag<12>())>,
-                                  StaticCast<double, int>,
-                                  StaticCast<int, std::complex<int>>>>();
+                                  ImplicitConversion<double, int>,
+                                  ImplicitConversion<int, std::complex<int>>>>();
 }
 
 TEST(ConversionForRepsAndFactor,
      StaticCastToScalarOfComplexBeforeMultiplyForScalarIntToComplexFloat) {
-    StaticAssertTypeEq<ConversionForRepsAndFactor<int, std::complex<double>, decltype(mag<12>())>,
-                       OpSequence<StaticCast<int, double>,
+    StaticAssertTypeEq<
+        ConversionForRepsAndFactor<UseStaticCast, int, std::complex<double>, decltype(mag<12>())>,
+        OpSequence<StaticCast<int, double>,
+                   MultiplyTypeBy<double, decltype(mag<12>())>,
+                   StaticCast<double, std::complex<double>>>>();
+    StaticAssertTypeEq<ConversionForRepsAndFactor<UseImplicitConversion,
+                                                  int,
+                                                  std::complex<double>,
+                                                  decltype(mag<12>())>,
+                       OpSequence<ImplicitConversion<int, double>,
                                   MultiplyTypeBy<double, decltype(mag<12>())>,
-                                  StaticCast<double, std::complex<double>>>>();
+                                  ImplicitConversion<double, std::complex<double>>>>();
 }
 
 TEST(ConversionForRepsAndFactor,
      PerformsConversionInHighestFidelityComplexForTwoComplexFloatTypes) {
-    StaticAssertTypeEq<
-        ConversionForRepsAndFactor<std::complex<float>, std::complex<double>, decltype(mag<12>())>,
-        OpSequence<StaticCast<std::complex<float>, std::complex<double>>,
-                   MultiplyTypeBy<std::complex<double>, decltype(mag<12>())>>>();
+    StaticAssertTypeEq<ConversionForRepsAndFactor<UseStaticCast,
+                                                  std::complex<float>,
+                                                  std::complex<double>,
+                                                  decltype(mag<12>())>,
+                       OpSequence<StaticCast<std::complex<float>, std::complex<double>>,
+                                  MultiplyTypeBy<std::complex<double>, decltype(mag<12>())>>>();
+    StaticAssertTypeEq<ConversionForRepsAndFactor<UseImplicitConversion,
+                                                  std::complex<float>,
+                                                  std::complex<double>,
+                                                  decltype(mag<12>())>,
+                       OpSequence<ImplicitConversion<std::complex<float>, std::complex<double>>,
+                                  MultiplyTypeBy<std::complex<double>, decltype(mag<12>())>>>();
 
-    StaticAssertTypeEq<
-        ConversionForRepsAndFactor<std::complex<double>, std::complex<float>, decltype(mag<12>())>,
-        OpSequence<MultiplyTypeBy<std::complex<double>, decltype(mag<12>())>,
-                   StaticCast<std::complex<double>, std::complex<float>>>>();
+    StaticAssertTypeEq<ConversionForRepsAndFactor<UseStaticCast,
+                                                  std::complex<double>,
+                                                  std::complex<float>,
+                                                  decltype(mag<12>())>,
+                       OpSequence<MultiplyTypeBy<std::complex<double>, decltype(mag<12>())>,
+                                  StaticCast<std::complex<double>, std::complex<float>>>>();
+    StaticAssertTypeEq<ConversionForRepsAndFactor<UseImplicitConversion,
+                                                  std::complex<double>,
+                                                  std::complex<float>,
+                                                  decltype(mag<12>())>,
+                       OpSequence<MultiplyTypeBy<std::complex<double>, decltype(mag<12>())>,
+                                  ImplicitConversion<std::complex<double>, std::complex<float>>>>();
 }
 
 }  // namespace detail

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -463,7 +463,10 @@ class Quantity {
         using OtherUnit = AssociatedUnit<OtherUnitSlot>;
         static_assert(IsUnit<OtherUnit>::value, "Invalid type passed to unit slot");
 
-        using Op = detail::ConversionForRepsAndFactor<Rep, OtherRep, UnitRatio<Unit, OtherUnit>>;
+        using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
+                                                      Rep,
+                                                      OtherRep,
+                                                      UnitRatio<Unit, OtherUnit>>;
 
         constexpr bool should_check_overflow =
             RiskPolicyT{}.should_check(detail::ConversionRisk::Overflow);
@@ -683,32 +686,40 @@ constexpr auto root(QuantityMaker<Unit>) {
 // Check conversion for overflow (no change of rep).
 template <typename U, typename R, typename TargetUnitSlot>
 constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot) {
-    using Op =
-        detail::ConversionForRepsAndFactor<R, R, UnitRatio<U, AssociatedUnit<TargetUnitSlot>>>;
+    using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
+                                                  R,
+                                                  R,
+                                                  UnitRatio<U, AssociatedUnit<TargetUnitSlot>>>;
     return detail::would_value_overflow<Op>(q.in(U{}));
 }
 
 // Check conversion for overflow (new rep).
 template <typename TargetRep, typename U, typename R, typename TargetUnitSlot>
 constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot) {
-    using Op = detail::
-        ConversionForRepsAndFactor<R, TargetRep, UnitRatio<U, AssociatedUnit<TargetUnitSlot>>>;
+    using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
+                                                  R,
+                                                  TargetRep,
+                                                  UnitRatio<U, AssociatedUnit<TargetUnitSlot>>>;
     return detail::would_value_overflow<Op>(q.in(U{}));
 }
 
 // Check conversion for truncation (no change of rep).
 template <typename U, typename R, typename TargetUnitSlot>
 constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot) {
-    using Op =
-        detail::ConversionForRepsAndFactor<R, R, UnitRatio<U, AssociatedUnit<TargetUnitSlot>>>;
+    using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
+                                                  R,
+                                                  R,
+                                                  UnitRatio<U, AssociatedUnit<TargetUnitSlot>>>;
     return detail::TruncationRiskFor<Op>::would_value_truncate(q.in(U{}));
 }
 
 // Check conversion for truncation (new rep).
 template <typename TargetRep, typename U, typename R, typename TargetUnitSlot>
 constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot) {
-    using Op = detail::
-        ConversionForRepsAndFactor<R, TargetRep, UnitRatio<U, AssociatedUnit<TargetUnitSlot>>>;
+    using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
+                                                  R,
+                                                  TargetRep,
+                                                  UnitRatio<U, AssociatedUnit<TargetUnitSlot>>>;
     return detail::TruncationRiskFor<Op>::would_value_truncate(q.in(U{}));
 }
 

--- a/fuzz/quantity_runtime_conversion_check.cc
+++ b/fuzz/quantity_runtime_conversion_check.cc
@@ -355,7 +355,10 @@ struct LossChecker<RepT, UnitT, DestRepT, DestUnitT, TestCategory::FLOAT_TO_INTE
         }
 
         if (round_trip == value) {
-            using Op = ConversionForRepsAndFactor<RepT, DestRepT, UnitRatio<UnitT, DestUnitT>>;
+            using Op = ConversionForRepsAndFactor<UseStaticCast,
+                                                  RepT,
+                                                  DestRepT,
+                                                  UnitRatio<UnitT, DestUnitT>>;
             const auto dest_value = FloatingPointPrefixPart<Op>::apply_to(value.in(UnitT{}));
             const bool definitely_truncates = (std::trunc(dest_value) != dest_value);
             std::ostringstream oss;
@@ -414,7 +417,8 @@ template <typename RepT, typename UnitT, typename DestRepT, typename DestUnitT, 
 struct NominalTestBodyImpl : LossChecker<RepT, UnitT, DestRepT, DestUnitT, Cat> {
     using LossChecker<RepT, UnitT, DestRepT, DestUnitT, Cat>::check_for_loss;
 
-    using Op = ConversionForRepsAndFactor<RepT, DestRepT, UnitRatio<UnitT, DestUnitT>>;
+    using Op =
+        ConversionForRepsAndFactor<UseStaticCast, RepT, DestRepT, UnitRatio<UnitT, DestUnitT>>;
 
     static void test(const Quantity<UnitT, RepT> &value) {
         const bool expect_loss = is_conversion_lossy<DestRepT>(value, DestUnitT{});


### PR DESCRIPTION
The helper, `ConversionForRepsAndFactor`, now gets a new mandatory first
template argument, which governs operations where it converts from one
underlying type to another.  Users provide `detail::UseStaticCast` to
use `static_cast` for these steps, and `detail::UseImplicitConversion`
to use implicit conversion.  Since this PR is a no-op, we update all
existing callsites to provide an explicit `detail::UseStaticCast`
argument.

This forces some changes to our `:conversion_policy` target.  The most
natural approach I saw was to add a `CastStrategy` parameter to both the
`PassesConversionRiskCheck` helper, and its `ImplicitConversionPolicy`
client, as well.  The reason is that later on, the `ConstructionPolicy`
will use implicit conversion, while the `ImplicitRepPermitted` will
stick with `static_cast`.  Granted, this does create potential for
confusion, since there are two different things that might be
"implicit": the rep (in a `.in` or `.as` call), or the conversion (from
one type to another).  I left a detailed comment calling this out and
explaining which one we chose.

Many of the conversion strategy tests would be repeated for both
`StaticCast` and `ImplicitConversion`.  For these, I created a helper,
`CastStrategyIndependentConversionForRepsAndFactor`, which computes both
types, and statically asserts that they are the same.  This should keep
the tests a little easier to maintain.  For operation sequences that do
contain a conversion, I duplicated the test cases so we would have
coverage for both.

Helps #528.  Future PR(s) will actually change some operations to use
implicit conversions, as appropriate.