### PR TITLE
Split out more tests by `-Wconversion` status

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -452,6 +452,8 @@ cc_test(
     srcs = ["no_wconversion_test.cc"],
     tags = ["no_wconversion"],
     deps = [
+        ":chrono_interop",
+        ":chrono_policy_validation",
         ":quantity",
         ":testing",
         ":units",
@@ -577,10 +579,20 @@ cc_library(
 cc_test(
     name = "quantity_test",
     size = "small",
-    srcs = [
-        "quantity_chrono_policy_correspondence_test.cc",
-        "quantity_test.cc",
+    srcs = ["quantity_test.cc"],
+    deps = [
+        ":prefix",
+        ":quantity",
+        ":testing",
+        "@googletest//:gtest_main",
     ],
+)
+
+cc_test(
+    name = "quantity_chrono_policy_correspondence_test",
+    size = "small",
+    srcs = ["quantity_chrono_policy_correspondence_test.cc"],
+    tags = ["no_wconversion"],
     deps = [
         ":chrono_policy_validation",
         ":prefix",

--- a/au/au_test.cc
+++ b/au/au_test.cc
@@ -48,11 +48,6 @@ auto IsBetween(T lower, U upper) {
 
 }  // namespace
 
-TEST(Conversions, SupportIntMHzToU32Hz) {
-    constexpr QuantityU32<Hertz> freq = mega(hertz)(40);
-    EXPECT_THAT(freq, SameTypeAndValue(hertz(40'000'000u)));
-}
-
 TEST(CommonUnit, HandlesPrefixesReasonably) {
     StaticAssertTypeEq<CommonUnit<Kilo<Meters>, Meters>, Meters>();
 }

--- a/au/chrono_interop_test.cc
+++ b/au/chrono_interop_test.cc
@@ -44,11 +44,6 @@ TEST(DurationQuantity, InterconvertsWithExactlyEquivalentChronoDuration) {
     EXPECT_THAT(from_au.count(), SameTypeAndValue(val));
 }
 
-TEST(DurationQuantity, InterconvertsWithIndirectlyEquivalentChronoDuration) {
-    constexpr QuantityD<Seconds> from_chrono = as_quantity(1234ms);
-    EXPECT_THAT(from_chrono, SameTypeAndValue(seconds(1.234)));
-}
-
 TEST(DurationQuantity, EquivalentOfChronoNanosecondsHasNsLabel) {
     constexpr auto from_chrono_ns = as_quantity(std::chrono::nanoseconds{123});
     EXPECT_THAT(stream_to_string(from_chrono_ns), StrEq("123 ns"));

--- a/au/no_wconversion_test.cc
+++ b/au/no_wconversion_test.cc
@@ -12,15 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+
+#include "au/chrono_interop.hh"
+#include "au/chrono_policy_validation.hh"
 #include "au/quantity.hh"
 #include "au/testing.hh"
 #include "au/units/feet.hh"
+#include "au/units/hertz.hh"
 #include "au/units/hours.hh"
 #include "au/units/miles.hh"
+#include "au/units/seconds.hh"
 #include "au/units/yards.hh"
 #include "gtest/gtest.h"
 
 namespace au {
+
+using namespace std::chrono_literals;
+
+using ::testing::IsTrue;
 
 // This file is for any tests which would fail if `-Wconversion` were enabled.
 //
@@ -117,6 +127,16 @@ TEST(QuantityShorthandMultiplicationAndDivisionAssignment, RespectUnderlyingType
     expect_shorthand_assignment_models_underlying_types(2, 3);
     // expect_shorthand_assignment_models_underlying_types(2, 3.f);
     // expect_shorthand_assignment_models_underlying_types(2, 3.);
+}
+
+TEST(DurationQuantity, InterconvertsWithIndirectlyEquivalentChronoDuration) {
+    constexpr QuantityD<Seconds> from_chrono = as_quantity(1234ms);
+    EXPECT_THAT(from_chrono, SameTypeAndValue(seconds(1.234)));
+}
+
+TEST(Conversions, SupportIntMHzToU32Hz) {
+    constexpr QuantityU32<Hertz> freq = mega(hertz)(40);
+    EXPECT_THAT(freq, SameTypeAndValue(hertz(40'000'000u)));
 }
 
 }  // namespace au

--- a/compatibility/BUILD.bazel
+++ b/compatibility/BUILD.bazel
@@ -27,6 +27,8 @@ cc_test(
         "nholthaus_units_example_usage.hh",
         "nholthaus_units_test.cc",
     ],
+    # The external nholthaus_units library has -Wconversion issues we can't fix.
+    tags = ["no_wconversion"],
     deps = [
         ":nholthaus_units",
         "//au",


### PR DESCRIPTION
The original `:no_wconversion_test` was in service of our principle that
Au should not _add_ warnings or errors.  Suppose a user had, say,
`-Wconversion` enabled, and their code built just fine with raw numbers.
If they converted to Au types and suddenly got `-Wconversion` warnings,
that would be a huge bummer.  So we test all our code with
`-Wconversion`.  But of course, we also want to test cases for users who
_don't_ use `-Wconversion`, so we need to exclude those tests from our
`-Wconversion` CI jobs.  Hence, `:no_wconversion_test`.

With #528, we realized there's another side to the coin.  Our policy
should also not _subtract_ warnings or errors.  Suppose again that a
user has `-Wconversion` enabled, and relies on it to catch implicit
conversions from `double` to `float`.  If they start using `Quantity`
types in the same way, but `QuantityD` converts implicitly to
`QuantityF` without complaint, that's a huge problem!

Really, what we're aiming at is a policy where the mechanisms for
customizing _type_ conversion risks are _identical_ with and without Au:
just the same exact compiler flags.

Of course, Au today _does_ "subtract" compiler errors, because we use
`static_cast` for all our conversions.  We're going to fix that soon,
but first we need to get ahead of all the upcoming compiler warnings and
errors that fixing this will cause.

This PR migrates all such test cases to be guarded by the
`:no_wconversion` tag.  If we can easily move individual test cases, we
do so: thus, `:no_wconversion_test` now has one test case from
`:au_test` and one from `:chrono_interop_test`.  Other tests are too big
to move easily, so we tag them wholesale.  We extract the
`quantity_chrono_policy_correspondence_test.cc` file into its own test
target, `:quantity_chrono_policy_correspondence_test`, because it has a
lot of machinery defined within that file itself.  And we apply the tag
to the `:nholthaus_units_test` target, because we can't fix warnings in
third party code.

Helps #528.