### PR TITLE
Fix bzlmod CI failure by loading `cc_binary`

### DIFF
--- a/bzlmod_test_client/BUILD.bazel
+++ b/bzlmod_test_client/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 cc_binary(
     name = "test_au_client",
     srcs = ["test_au_client.cc"],


### PR DESCRIPTION
Very surprising that this didn't fail before, as apparently this load
statement was always needed for bzlmod.  It started failing in #637 ---
and, interestingly, only on a _second_ commit.  Still, the fix is
straightforward.