### PR TITLE
Improve `Magnitude`-like ergonomics for `Zero`

### DIFF
--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -124,6 +124,12 @@ constexpr bool representable_in(Magnitude<BPs...> m);
 template <typename T, typename... BPs>
 constexpr T get_value(Magnitude<BPs...>);
 
+// Let `Zero` "act like" a `Magnitude` for purposes of `get_value`.
+template <typename T>
+constexpr T get_value(Zero) {
+    return T{0};
+}
+
 // A base type for prime numbers.
 template <std::uintmax_t N>
 struct Prime {

--- a/au/magnitude_test.cc
+++ b/au/magnitude_test.cc
@@ -542,6 +542,10 @@ TEST(GetValue, SupportsIntegerOutputForIntegerMagnitude) {
     EXPECT_THAT(get_value<double>(m), SameTypeAndValue(412.));
 }
 
+TEST(GetValue, SupportsZero) {
+    EXPECT_THAT(get_value<std::size_t>(ZERO), SameTypeAndValue(std::size_t{0}));
+}
+
 TEST(GetValue, SupportsNegativePowersOfIntegerBase) {
     constexpr auto m = pow<-3>(mag<2>());
     EXPECT_THAT(get_value<float>(m), SameTypeAndValue(0.125f));

--- a/au/wrapper_operations.hh
+++ b/au/wrapper_operations.hh
@@ -216,6 +216,10 @@ struct CanScaleByMagnitude {
         return UnitWrapper<decltype(Unit{} / m)>{};
     }
 
+    // (0 * W) and (W * 0), for wrapper W.
+    friend constexpr Zero operator*(Zero, UnitWrapper<Unit>) { return {}; }
+    friend constexpr Zero operator*(UnitWrapper<Unit>, Zero) { return {}; }
+
     friend constexpr auto operator-(UnitWrapper<Unit>) {
         return UnitWrapper<decltype(Unit{} * (-mag<1>()))>{};
     }

--- a/au/wrapper_operations_test.cc
+++ b/au/wrapper_operations_test.cc
@@ -135,6 +135,16 @@ TEST(CanScaleByMagnitude, MakesScaledWrapperWhenPostMultiplyingByMagnitude) {
     StaticAssertTypeEq<decltype(mol * mag<3>()), UnitWrapper<decltype(Moles{} * mag<3>())>>();
 }
 
+TEST(CanScaleByMagnitude, CanPreMultiplyByZero) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    StaticAssertTypeEq<decltype(ZERO * mol), Zero>();
+}
+
+TEST(CanScaleByMagnitude, CanPostMultiplyByZero) {
+    constexpr auto mol = UnitWrapper<Moles>{};
+    StaticAssertTypeEq<decltype(mol * ZERO), Zero>();
+}
+
 TEST(CanScaleByMagnitude, MakesScaledWrapperOfInverseUnitWhenDividingIntoMagnitude) {
     constexpr auto mol = UnitWrapper<Moles>{};
     StaticAssertTypeEq<decltype(PI / mol), UnitWrapper<decltype(inverse(Moles{}) * PI)>>();

--- a/docs/reference/constant.md
+++ b/docs/reference/constant.md
@@ -421,6 +421,15 @@ In the following table, let `m` be an instance of `Magnitude<BPs...>`.
 | `Magnitude<BPs...> * Constant<Unit>` | `Constant<decltype(Unit{} * m)>` |
 | `Magnitude<BPs...> / Constant<Unit>` | `Constant<decltype(UnitInverseT<Unit>{} * m)>` |
 
+#### `Zero`
+
+Multiplying `Constant<Unit>` with [`Zero`](./zero.md) produces `Zero`.
+
+| Operation | Resulting Type |
+| --------- | -------------- |
+| `Constant<Unit> * Zero` | `Zero` |
+| `Zero * Constant<Unit>` | `Zero` |
+
 #### `QuantityPointMaker<U>` (deleted)
 
 Multiplying or dividing `Constant<Unit>` with a `QuantityPointMaker<U>` is explicitly deleted,

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -108,7 +108,9 @@ to extract that represented value, and store it in a more conventional numeric t
 or `double`.
 
 To extract the value of a `Magnitude` instance `m` into a given numeric type `T`, call
-`get_value<T>(m)`.  Here are some important aspects of this utility.
+`get_value<T>(m)`.  This also works with [`Zero`](./zero.md): `get_value<T>(ZERO)` returns `T{0}`.
+
+Here are some important aspects of this utility.
 
 1. The computation takes place completely at compile time.
 2. The computation takes place in the widest type of the same kind.  (That is, when `T` is floating

--- a/docs/reference/zero.md
+++ b/docs/reference/zero.md
@@ -34,6 +34,19 @@ This is explicitly deleted.  There is no unambiguous notion of which point is la
 depends on the choice of units.  Therefore, we delete this constructor to prevent users from relying
 on this dubious notion.
 
+## Operations
+
+### `get_value<T>(ZERO)`
+
+`Zero` can be passed to [`get_value`](./magnitude.md#extracting-values), just like a `Magnitude`.
+The result is always `T{0}` for any numeric type `T`.
+
+??? example
+    ```cpp
+    get_value<double>(ZERO);  // Returns 0.0
+    get_value<int>(ZERO);     // Returns 0
+    ```
+
 ## I/O
 
 If you include I/O support, then `Zero` will be streamed as `"0"`.


### PR DESCRIPTION
The motivation is that many of the new mathematical functions, which
venture outside of the "classical" operations we support (i.e., products
and powers), must necessarily return "either `Magnitude` or `Zero`" as
outputs.  This means we need to be able to use `Zero` _as an input_ in a
wider variety of operations.  Here are the upgrades in this PR.

First, we now enable `Zero` to pre- or post-multiply any `Constant`,
just as `Magnitude` can.  In this case, `Zero` kills everything that is
there: both dimension, and magnitude.  The answer is always just `Zero`.

Next, we support `Zero` in `get_value<T>` expressions, which is pretty
easy.  (I declined to add `representable_in<T>` support, because I don't
yet have any reason to think we'll need it, but we can add it if we
want.)

Helps #531 and #607.