### PR TITLE
Implement `UnitSum` machinery

### DIFF
--- a/au/packs.hh
+++ b/au/packs.hh
@@ -426,6 +426,10 @@ struct SortAsImpl<PackForOrdering, Pack<T, Ts...>>
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `FlatDedupedTypeListT` implementation.
 
+// 0-ary trivial case:
+template <template <class...> class List>
+struct FlatDedupedTypeListImpl<List> : stdx::type_identity<List<>> {};
+
 // 1-ary Base case: a list with a single element is already done.
 //
 // (We explicitly assumed that any `List<...>` inputs would already be in sorted order.)

--- a/au/packs_test.cc
+++ b/au/packs_test.cc
@@ -163,6 +163,10 @@ TEST(PackPower, MultipliesExponentsAndSimplifies) {
         Pack<Pow<B<2>, 2>, Pow<B<3>, -6>, Pow<B<5>, -3>, B<7>>>();
 }
 
+TEST(FlatDedupedTypeList, EmptyInputsYieldsEmptyPack) {
+    StaticAssertTypeEq<FlatDedupedTypeListT<Pack>, Pack<>>();
+}
+
 TEST(FlatDedupedTypeListT, OrdersAsExpected) {
     StaticAssertTypeEq<FlatDedupedTypeListT<Pack, Pack<B<2>>>, Pack<B<2>>>();
 

--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -775,6 +775,85 @@ using ReplaceCommonPointUnitWithCommonUnit =
 template <typename A, typename B>
 struct InOrderFor<detail::CommonUnitLabelImpl, A, B> : InOrderFor<UnitProductPack, A, B> {};
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `UnitSum` helper implementation.
+
+namespace detail {
+
+// Compute the coefficient for a unit in a sum: the ratio of the unit to its unscaled version.
+template <typename U>
+using UnitCoefficient = UnitRatio<U, UnscaledUnit<U>>;
+
+// Given a list of distinct unscaled units, and a list of input units, compute the sum of
+// coefficients for each unscaled unit.
+template <typename DistinctUnscaled, typename... Us>
+struct ComputeCoefficientSumsImpl;
+template <typename DistinctUnscaled, typename... Us>
+using ComputeCoefficientSums = typename ComputeCoefficientSumsImpl<DistinctUnscaled, Us...>::type;
+
+template <template <class...> class Pack, typename... Unscaled, typename... Us>
+struct ComputeCoefficientSumsImpl<Pack<Unscaled...>, Us...> {
+    // For each unscaled unit, sum coefficients from all matching input units.
+    template <typename Target>
+    using CoeffSum = MagSum<std::conditional_t<std::is_same<UnscaledUnit<Us>, Target>::value,
+                                               UnitCoefficient<Us>,
+                                               Zero>...>;
+
+    // Produce the scaled unit (or Zero if coefficient is zero).
+    template <typename Target>
+    using ScaledResult = std::conditional_t<std::is_same<CoeffSum<Target>, Zero>::value,
+                                            Zero,
+                                            ComputeScaledUnit<Target, CoeffSum<Target>>>;
+
+    using type = Pack<ScaledResult<Unscaled>...>;
+};
+
+// Filter out Zero entries from a Pack.
+template <typename T>
+struct IsNonzero : stdx::negation<std::is_same<T, Zero>> {};
+
+template <typename UL>
+struct FilterOutZeroImpl;
+template <typename UL>
+using FilterOutZero = typename FilterOutZeroImpl<UL>::type;
+template <template <class...> class Pack, typename... Us>
+struct FilterOutZeroImpl<Pack<Us...>> {
+    using type = IncludeInPackIf<IsNonzero, Pack, Us...>;
+};
+
+// Convert a pack to `UnitSumPack`, mapping 0-ary results onto `Zero`, and unpacking 1-ary.
+template <typename UL>
+struct AsUnitSumPackImpl;
+template <typename UL>
+using AsSortedUnitSumPack = typename AsUnitSumPackImpl<SortAs<UnitSumPack, UL>>::type;
+template <template <class...> class Pack>
+struct AsUnitSumPackImpl<Pack<>> : stdx::type_identity<Zero> {};
+template <template <class...> class Pack, typename U>
+struct AsUnitSumPackImpl<Pack<U>> : stdx::type_identity<U> {};
+template <template <class...> class Pack, typename U, typename... Us>
+struct AsUnitSumPackImpl<Pack<U, Us...>> : stdx::type_identity<UnitSumPack<U, Us...>> {};
+
+// Helper to apply UnitSumImpl to a flattened UnitSumPack.
+template <typename FlatPack>
+struct CollectLikeTermsImpl;
+template <typename... Us>
+struct CollectLikeTermsImpl<UnitSumPack<Us...>>
+    : stdx::type_identity<AsSortedUnitSumPack<FilterOutZero<
+          ComputeCoefficientSums<FlatDedupedTypeList<UnitList, UnscaledUnit<Us>...>, Us...>>>> {};
+
+// Main implementation: first flatten any UnitSumPack arguments, then collect like terms.
+template <typename... Us>
+struct UnitSumImpl : CollectLikeTermsImpl<FlattenAs<UnitSumPack, Us...>> {};
+
+}  // namespace detail
+
+// Helper to make a canonicalized sum of units.
+//
+// Collects like terms (same unscaled unit), filters zeros, and sorts with positive coefficients
+// first. Returns Zero if all terms cancel, the single unit if only one remains, or a UnitSumPack.
+template <typename... Us>
+using UnitSum = typename detail::UnitSumImpl<Us...>::type;
+
 template <typename... Us>
 using CommonUnitLabel = FlatDedupedTypeListT<detail::CommonUnitLabelImpl, Us...>;
 
@@ -1286,5 +1365,24 @@ struct InOrderFor<UnitProductPack, A, B>
                                  detail::OrderAsUnitProductPack,
                                  detail::OrderAsOriginDisplacementUnit,
                                  detail::OrderByUnitOrderTiebreaker> {};
+
+namespace detail {
+// Order by sign: positive coefficients come before negative.
+template <typename A, typename B>
+struct OrderByPositiveCoefficient
+    : stdx::bool_constant<(IsPositive<MagT<A>>::value && !IsPositive<MagT<B>>::value)> {};
+
+// Order by unscaled unit, using UnitProductPack ordering.
+template <typename A, typename B>
+struct OrderByUnscaledUnit : InOrderFor<UnitProductPack, UnscaledUnit<A>, UnscaledUnit<B>> {};
+}  // namespace detail
+
+template <typename A, typename B>
+struct InOrderFor<UnitSumPack, A, B>
+    : LexicographicTotalOrdering<A,
+                                 B,
+                                 detail::OrderByPositiveCoefficient,
+                                 detail::OrderByUnscaledUnit,
+                                 detail::OrderByMag> {};
 
 }  // namespace au


### PR DESCRIPTION
`UnitSum<...>` takes a bunch of input units, and produces the canonical
type that represents their sum.  Usually, this will be a unit, but it
could also be `Zero`.  Core tasks include:

- Unpacking any inputs that are already `UnitSumPack<...>`;
- Identifying unique "unscaled units"
- Collecting like terms
- Eliminating groups of unscaled units that get "zeroed out"
- Putting what's left in the right order
- Handling cases where only 0 or 1 units are left

The main subtlety has to do with when the overall unit completely
cancels out.  The result is not-a-unit: it is equivalent to `Zero`.
When every individual group of unscaled units cancels out, then it's
very easy for us to actually return `Zero`.  But, philosophically, we
have avoided the implementation complexity of looking "extra hard" for
cancellation in cases such as `s * Hz`, for example.  Taking a similar
tack here means that we could produce a result like `(ft - 12 in)`,
which is 0, but is not `Zero`, and which would act really weird if we
used it like a unit.

For now, I think the conservative approach is to make this a compiler
error.  I really doubt there are true use cases for this.  I plan to
simply tell users not to form _any_ `Constant` sum that adds to zero,
regardless of whether or not the library would call it `Zero`.  We can
change this later if we come up with an elegant and simple formulation,
and/or if somebody provides a really compelling use case.  But starting
out with this pathway means that we won't break any existing code, _and_
a future upgrade that would allow this would _also_ not break any
existing code.

Helps #607.