### PR TITLE
Support adding and subtracting `Constant`

### DIFF
--- a/au/constant.hh
+++ b/au/constant.hh
@@ -211,4 +211,35 @@ constexpr Zero operator%(Zero, Constant<U>) {
     return {};
 }
 
+// Addition (+) for `Constant`.
+template <typename U1, typename U2>
+constexpr auto operator+(Constant<U1>, Constant<U2>) {
+    return make_constant(UnitSum<U1, U2>{});
+}
+
+// Subtraction (-) for `Constant`.
+template <typename U1, typename U2>
+constexpr auto operator-(Constant<U1>, Constant<U2>) {
+    using NegU2 = decltype(U2{} * Magnitude<Negative>{});
+    return make_constant(UnitSum<U1, NegU2>{});
+}
+
+// Arithmetic operators mixing `Constant` with `Zero`.
+template <typename U>
+constexpr Constant<U> operator+(Constant<U>, Zero) {
+    return {};
+}
+template <typename U>
+constexpr Constant<U> operator+(Zero, Constant<U>) {
+    return {};
+}
+template <typename U>
+constexpr Constant<U> operator-(Constant<U>, Zero) {
+    return {};
+}
+template <typename U>
+constexpr auto operator-(Zero, Constant<U>) {
+    return -Constant<U>{};
+}
+
 }  // namespace au

--- a/docs/reference/constant.md
+++ b/docs/reference/constant.md
@@ -574,3 +574,47 @@ constexpr auto seven_inches = make_constant(inches * mag<7>());
 // 5 feet = 60 inches; 60 % 7 = 4
 constexpr auto result = five_feet % seven_inches;  // Constant representing 4 inches
 ```
+
+### Addition and subtraction †
+
+Two `Constant` instances of the same dimension can be added or subtracted, producing a new
+`Constant`.  Like other `Constant` operations, this is performed purely at compile time.
+
+!!! warning
+    Unlike "core" operations, such as powers and products, `Constant` is not fully closed under
+    addition and subtraction.  If the inputs completely additively cancel, the result will either be
+    `Zero`, or else a compile time error.
+
+    Users should generally avoid forming this kind of `Constant`.
+
+`Constant` also interacts with `Zero` for addition and subtraction:
+
+- Adding `Zero` to a `Constant` (in either order) returns the original `Constant`.
+- Subtracting `Zero` from a `Constant` returns the original `Constant`.
+- Subtracting a `Constant` from `Zero` returns the negation of that `Constant`.
+
+† _This feature is subject to the same [compile-time arithmetic
+limitations](./magnitude.md#compile-time-arithmetic-limitations) as `Magnitude` arithmetic, because
+the computation is built on `Magnitude` operations._
+
+**Syntax:**
+
+For `Constant` instances `c1` and `c2` with the same dimension:
+
+- `c1 + c2`
+- `c1 - c2`
+
+**Result:** Whenever the result is nonzero, a new `Constant` representing the sum or difference.
+
+**Example:**
+
+```cpp
+constexpr auto one_foot = make_constant(feet);
+constexpr auto one_inch = make_constant(inches);
+
+// Sum of 1 foot and 1 inch
+constexpr auto sum = one_foot + one_inch;  // Constant representing (ft + in)
+
+// Difference
+constexpr auto diff = one_foot - one_inch;  // Constant representing (ft - in)
+```


### PR DESCRIPTION
Now that we have `UnitSum<...>` in place, it has become straightforward
to get the labels we want.

The trickiest bit here is when the constant fully cancels additively.
Recall that we are grouping inputs according to the _unscaled_ units
(roughly corresponding to "actual unit symbols").  When every unscaled
unit additively cancels _individually_, the result is zero.  When we end
up with multiple unscaled units which nevertheless cancel together, we
represent that as-is, and don't try to cancel it, because this is also
how we handle input units in multiplication and division.  But the
result is still not-a-unit!  And we have the static assert from the
parent.

From an external user's point of view, we simply recommend that they
_not try to form_ any `Constant` that additively cancels, regardless of
whether it produces `Zero` or a compiler error.  This is a weird thing
to do that probably doesn't have any actual use cases.  We already don't
support all combinations of inputs, and don't plan to, and this feels
like a safe "starter policy" at the very least.

Fixes #607.