### PR TITLE
Bring AU to Au

### DIFF
--- a/au/CMakeLists.txt
+++ b/au/CMakeLists.txt
@@ -65,6 +65,8 @@ header_only_library(
     units/arcminutes_fwd.hh
     units/arcseconds.hh
     units/arcseconds_fwd.hh
+    units/astronomical_units.hh
+    units/astronomical_units_fwd.hh
     units/bars.hh
     units/bars_fwd.hh
     units/becquerel.hh
@@ -326,6 +328,7 @@ gtest_based_test(
     units/test/amperes_test.cc
     units/test/arcminutes_test.cc
     units/test/arcseconds_test.cc
+    units/test/astronomical_units_test.cc
     units/test/bars_test.cc
     units/test/becquerel_test.cc
     units/test/bits_test.cc

--- a/au/units/astronomical_units.hh
+++ b/au/units/astronomical_units.hh
@@ -1,0 +1,54 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/units/astronomical_units_fwd.hh"
+// Keep corresponding `_fwd.hh` file on top.
+
+#include "au/quantity.hh"
+#include "au/unit_symbol.hh"
+
+namespace au {
+
+// DO NOT follow this pattern to define your own units.  This is for library-defined units.
+// Instead, follow instructions at (https://aurora-opensource.github.io/au/main/howto/new-units/).
+template <typename T>
+struct AstronomicalUnitsLabel {
+    static constexpr const char label[] = "AU";
+};
+template <typename T>
+constexpr const char AstronomicalUnitsLabel<T>::label[];
+struct AstronomicalUnits
+    // In particular, do NOT manually specify `Dimension<...>` and `Magnitude<...>` types.  The
+    // ordering of the arguments is very particular, and could change out from under you in future
+    // versions, making the program ill-formed.  Only units defined within the Au library itself can
+    // safely use this pattern.
+    : UnitImpl<Length,
+               Magnitude<Pow<Prime<2>, 2>,
+                         Prime<3>,
+                         Pow<Prime<5>, 2>,
+                         Prime<73>,
+                         Prime<877>,
+                         Prime<7789>>>,
+      AstronomicalUnitsLabel<void> {
+    using AstronomicalUnitsLabel<void>::label;
+};
+constexpr auto astronomical_unit = SingularNameFor<AstronomicalUnits>{};
+constexpr auto astronomical_units = QuantityMaker<AstronomicalUnits>{};
+
+namespace symbols {
+constexpr auto AU = SymbolFor<AstronomicalUnits>{};
+}
+}  // namespace au

--- a/au/units/astronomical_units_fwd.hh
+++ b/au/units/astronomical_units_fwd.hh
@@ -1,0 +1,21 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace au {
+
+struct AstronomicalUnits;
+
+}  // namespace au

--- a/au/units/test/astronomical_units_test.cc
+++ b/au/units/test/astronomical_units_test.cc
@@ -1,0 +1,37 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/units/astronomical_units.hh"
+
+#include "au/testing.hh"
+#include "au/units/meters.hh"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace au {
+
+using ::testing::Eq;
+
+TEST(AstronomicalUnits, HasExpectedLabel) { expect_label<AstronomicalUnits>("AU"); }
+
+TEST(AstronomicalUnits, EquivalentTo149597870700Meters) {
+    EXPECT_THAT(astronomical_units(1), Eq(meters(149'597'870'700)));
+}
+
+TEST(AstronomicalUnits, HasExpectedSymbol) {
+    using symbols::AU;
+    EXPECT_THAT(5 * AU, SameTypeAndValue(astronomical_units(5)));
+}
+
+}  // namespace au


### PR DESCRIPTION
It's about time we added the Astronomical Unit!

We'll use the slightly older "AU" symbol, rather than "au", to avoid
confusion with our ubiquitous namespace.