### PR TITLE
Placate Green Hills compiler with ternary

### DIFF
--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -1007,12 +1007,12 @@ struct GetValueResultImplForDefaultCase<T, Magnitude<BPs...>> {
                               Exp<BPs>::num,
                               static_cast<std::uintmax_t>(Exp<BPs>::den)>(Base<BPs>::value())...});
 
-        if ((widened_result.outcome != MagRepresentationOutcome::OK) ||
-            !safe_to_cast_to<T>(widened_result.value)) {
-            return {MagRepresentationOutcome::ERR_CANNOT_FIT};
-        } else {
-            return {MagRepresentationOutcome::OK, static_cast<T>(widened_result.value)};
-        }
+        constexpr bool will_fit = widened_result.outcome == MagRepresentationOutcome::OK &&
+                                  safe_to_cast_to<T>(widened_result.value);
+
+        return will_fit ? MagRepresentationOrError<T>{MagRepresentationOutcome::OK,
+                                                      static_cast<T>(widened_result.value)}
+                        : MagRepresentationOrError<T>{MagRepresentationOutcome::ERR_CANNOT_FIT};
     }
 };
 


### PR DESCRIPTION
When the Green Hills compiler encounters an if/else branch whose
predicate is known at compile time, it complains about an unreachable
statement.  Even if the predicate depends on template parameters (i.e.,
is not a strict constant _across all template instantiations_), the
policy triggers on any _individual_ instantiations that contain an
unreachable statement.

Leaving aside the wisdom of this policy as it pertains to generic
programming, the fact is that we're stuck with it and we need to keep
the compiler happy.

To fix this instance, we simply use a ternary operator.  The ternary is
just the same as an if/else branch, but it's a single statement.  In
testing on AV code, this does seem to placate the Green Hills compiler.