### PR TITLE
Add `AU_DEVICE_FUNC` macro for CUDA/HIP support

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -676,6 +676,7 @@ cc_library(
         "stdx/*.hh",
         "stdx/experimental/*.hh",
     ]),
+    deps = [":config"],
 )
 
 cc_test(

--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -94,6 +94,12 @@ cc_test(
 )
 
 cc_library(
+    name = "config",
+    hdrs = ["config.hh"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "fwd",
     hdrs = ["fwd.hh"],
     visibility = ["//visibility:public"],
@@ -792,7 +798,10 @@ cc_test(
 cc_library(
     name = "zero",
     hdrs = ["zero.hh"],
-    deps = [":fwd"],
+    deps = [
+        ":config",
+        ":fwd",
+    ],
 )
 
 cc_test(

--- a/au/CMakeLists.txt
+++ b/au/CMakeLists.txt
@@ -24,6 +24,7 @@ header_only_library(
     abstract_operations.hh
     au.hh
     chrono_interop.hh
+    config.hh
     constant.hh
     conversion_policy.hh
     conversion_strategy.hh

--- a/au/abstract_operations.hh
+++ b/au/abstract_operations.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "au/config.hh"
 #include "au/magnitude.hh"
 
 namespace au {
@@ -93,7 +94,7 @@ struct OpOutputImpl<StaticCast<T, U>> : stdx::type_identity<U> {};
 // `StaticCast<T, U>` operation:
 template <typename T, typename U>
 struct StaticCast {
-    static constexpr U apply_to(T value) { return static_cast<U>(value); }
+    static AU_DEVICE_FUNC constexpr U apply_to(T value) { return static_cast<U>(value); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -108,7 +109,7 @@ struct OpOutputImpl<ImplicitConversion<T, U>> : stdx::type_identity<U> {};
 // `ImplicitConversion<T, U>` operation:
 template <typename T, typename U>
 struct ImplicitConversion {
-    static constexpr U apply_to(T value) { return value; }
+    static AU_DEVICE_FUNC constexpr U apply_to(T value) { return value; }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -123,7 +124,7 @@ struct OpOutputImpl<MultiplyTypeBy<T, M>> : stdx::type_identity<T> {};
 // `MultiplyTypeBy<T, M>` operation:
 template <typename T, typename Mag>
 struct MultiplyTypeBy {
-    static constexpr T apply_to(T value) {
+    static AU_DEVICE_FUNC constexpr T apply_to(T value) {
         return static_cast<T>(value * get_value<RealPart<T>>(Mag{}));
     }
 };
@@ -139,7 +140,7 @@ struct OpOutputImpl<DivideTypeByInteger<T, M>> : stdx::type_identity<T> {};
 
 template <typename T, typename M, MagRepresentationOutcome MagOutcome>
 struct DivideTypeByIntegerImpl {
-    static constexpr T apply_to(T value) {
+    static AU_DEVICE_FUNC constexpr T apply_to(T value) {
         static_assert(MagOutcome == MagRepresentationOutcome::OK, "Internal library error");
         return static_cast<T>(value / get_value<RealPart<T>>(M{}));
     }
@@ -148,7 +149,7 @@ struct DivideTypeByIntegerImpl {
 template <typename T, typename M>
 struct DivideTypeByIntegerImpl<T, M, MagRepresentationOutcome::ERR_CANNOT_FIT> {
     // If a number is too big to fit in the type, then dividing by it should produce 0.
-    static constexpr T apply_to(T) { return T{0}; }
+    static AU_DEVICE_FUNC constexpr T apply_to(T) { return T{0}; }
 };
 
 template <typename T, typename M>
@@ -175,12 +176,14 @@ struct OpOutputImpl<OpSequenceImpl<OnlyOp>> : stdx::type_identity<OpOutput<OnlyO
 
 template <typename Op>
 struct OpSequenceImpl<Op> {
-    static constexpr auto apply_to(OpInput<OpSequenceImpl> value) { return Op::apply_to(value); }
+    static AU_DEVICE_FUNC constexpr auto apply_to(OpInput<OpSequenceImpl> value) {
+        return Op::apply_to(value);
+    }
 };
 
 template <typename Op, typename... Ops>
 struct OpSequenceImpl<Op, Ops...> {
-    static constexpr auto apply_to(OpInput<OpSequenceImpl> value) {
+    static AU_DEVICE_FUNC constexpr auto apply_to(OpInput<OpSequenceImpl> value) {
         return OpSequenceImpl<Ops...>::apply_to(Op::apply_to(value));
     }
 };

--- a/au/config.hh
+++ b/au/config.hh
@@ -1,4 +1,4 @@
-// Copyright 2022 Aurora Operations, Inc.
+// Copyright 2026 Aurora Operations, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,20 +14,14 @@
 
 #pragma once
 
-#include <utility>
+//
+// Device/GPU support (CUDA, HIP)
+//
+// The AU_DEVICE_FUNC macro marks functions as callable from both host and device.
+//
 
-#include "au/config.hh"
-
-namespace au {
-namespace stdx {
-
-// Source: adapted from (https://en.cppreference.com/w/cpp/utility/functional/identity)
-struct identity {
-    template <class T>
-    AU_DEVICE_FUNC constexpr T &&operator()(T &&t) const noexcept {
-        return std::forward<T>(t);
-    }
-};
-
-}  // namespace stdx
-}  // namespace au
+#if defined(__CUDACC__) || defined(__HIPCC__)
+#define AU_DEVICE_FUNC __host__ __device__
+#else
+#define AU_DEVICE_FUNC
+#endif

--- a/au/constant.hh
+++ b/au/constant.hh
@@ -18,6 +18,7 @@
 #include <compare>
 #endif
 
+#include "au/config.hh"
 #include "au/fwd.hh"
 #include "au/quantity.hh"
 #include "au/stdx/type_traits.hh"
@@ -48,7 +49,7 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
                   detail::CanScaleByMagnitude<Constant, Unit> {
     // Convert this constant to a Quantity of the given rep.
     template <typename T>
-    constexpr auto as() const {
+    AU_DEVICE_FUNC constexpr auto as() const {
         return make_quantity<Unit>(static_cast<T>(1));
     }
 
@@ -60,13 +61,13 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
 
     // Convert this constant to a Quantity of the given unit and rep.
     template <typename T, typename OtherUnit>
-    constexpr auto as(OtherUnit u) const {
+    AU_DEVICE_FUNC constexpr auto as(OtherUnit u) const {
         return as<T>(u, check_for(ALL_RISKS));
     }
 
     // Convert this constant to a Quantity of the given unit and rep, following this risk policy.
     template <typename T, typename OtherUnit, typename RiskPolicyT>
-    constexpr auto as(OtherUnit, RiskPolicyT) const {
+    AU_DEVICE_FUNC constexpr auto as(OtherUnit, RiskPolicyT) const {
         constexpr auto this_value = make_quantity<Unit>(static_cast<T>(1));
 
         constexpr bool has_unacceptable_overflow =
@@ -90,19 +91,19 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
 
     // Get the value of this constant in the given unit and rep.
     template <typename T, typename OtherUnit>
-    constexpr auto in(OtherUnit u) const {
+    AU_DEVICE_FUNC constexpr auto in(OtherUnit u) const {
         return in<T>(u, check_for(ALL_RISKS));
     }
 
     // Get the value of this constant in the given unit and rep, following this risk policy.
     template <typename T, typename OtherUnit, typename RiskPolicyT>
-    constexpr auto in(OtherUnit u, RiskPolicyT policy) const {
+    AU_DEVICE_FUNC constexpr auto in(OtherUnit u, RiskPolicyT policy) const {
         return as<T>(u, policy).in(u);
     }
 
     // Implicitly convert to any quantity type which passes safety checks.
     template <typename U, typename R>
-    constexpr operator Quantity<U, R>() const {
+    AU_DEVICE_FUNC constexpr operator Quantity<U, R>() const {
         return as<R>(U{});
     }
 
@@ -118,7 +119,7 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
         typename T,
         typename = std::enable_if_t<can_store_value_in<typename CorrespondingQuantity<T>::Rep>(
             typename CorrespondingQuantity<T>::Unit{})>>
-    constexpr operator T() const {
+    AU_DEVICE_FUNC constexpr operator T() const {
         return as<typename CorrespondingQuantity<T>::Rep>(
             typename CorrespondingQuantity<T>::Unit{});
     }
@@ -126,22 +127,22 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     // Comparison with Zero.
     //
     // A Constant represents a value of 1 in its unit, which is never zero.
-    friend constexpr bool operator==(Constant, Zero) { return false; }
-    friend constexpr bool operator!=(Constant, Zero) { return true; }
-    friend constexpr bool operator<(Constant, Zero) { return !is_positive(); }
-    friend constexpr bool operator<=(Constant, Zero) { return !is_positive(); }
-    friend constexpr bool operator>(Constant, Zero) { return is_positive(); }
-    friend constexpr bool operator>=(Constant, Zero) { return is_positive(); }
+    AU_DEVICE_FUNC friend constexpr bool operator==(Constant, Zero) { return false; }
+    AU_DEVICE_FUNC friend constexpr bool operator!=(Constant, Zero) { return true; }
+    AU_DEVICE_FUNC friend constexpr bool operator<(Constant, Zero) { return !is_positive(); }
+    AU_DEVICE_FUNC friend constexpr bool operator<=(Constant, Zero) { return !is_positive(); }
+    AU_DEVICE_FUNC friend constexpr bool operator>(Constant, Zero) { return is_positive(); }
+    AU_DEVICE_FUNC friend constexpr bool operator>=(Constant, Zero) { return is_positive(); }
 
-    friend constexpr bool operator==(Zero, Constant) { return false; }
-    friend constexpr bool operator!=(Zero, Constant) { return true; }
-    friend constexpr bool operator<(Zero, Constant) { return is_positive(); }
-    friend constexpr bool operator<=(Zero, Constant) { return is_positive(); }
-    friend constexpr bool operator>(Zero, Constant) { return !is_positive(); }
-    friend constexpr bool operator>=(Zero, Constant) { return !is_positive(); }
+    AU_DEVICE_FUNC friend constexpr bool operator==(Zero, Constant) { return false; }
+    AU_DEVICE_FUNC friend constexpr bool operator!=(Zero, Constant) { return true; }
+    AU_DEVICE_FUNC friend constexpr bool operator<(Zero, Constant) { return is_positive(); }
+    AU_DEVICE_FUNC friend constexpr bool operator<=(Zero, Constant) { return is_positive(); }
+    AU_DEVICE_FUNC friend constexpr bool operator>(Zero, Constant) { return !is_positive(); }
+    AU_DEVICE_FUNC friend constexpr bool operator>=(Zero, Constant) { return !is_positive(); }
 
  private:
-    static constexpr bool is_positive() { return IsPositive<detail::MagT<Unit>>::value; }
+    AU_DEVICE_FUNC static constexpr bool is_positive() { return IsPositive<detail::MagT<Unit>>::value; }
 };
 
 // Make a constant from the given unit.
@@ -149,11 +150,11 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
 // Note that the argument is a _unit slot_, and thus can also accept things like `QuantityMaker` and
 // `SymbolFor` in addition to regular units.
 template <typename UnitSlot>
-constexpr Constant<AssociatedUnit<UnitSlot>> make_constant(UnitSlot) {
+AU_DEVICE_FUNC constexpr Constant<AssociatedUnit<UnitSlot>> make_constant(UnitSlot) {
     return {};
 }
 
-constexpr Zero make_constant(Zero) { return {}; }
+AU_DEVICE_FUNC constexpr Zero make_constant(Zero) { return {}; }
 
 // Support using `Constant` in a unit slot.
 template <typename Unit>
@@ -165,35 +166,35 @@ struct AssociatedUnitImpl<Constant<Unit>> : stdx::type_identity<Unit> {};
 // every combination of Constant.  We decided that supporting many common use cases was worth this
 // tradeoff.
 template <typename U1, typename U2>
-constexpr bool operator==(Constant<U1>, Constant<U2>) {
+AU_DEVICE_FUNC constexpr bool operator==(Constant<U1>, Constant<U2>) {
     return UnitRatio<U1, U2>{} == mag<1>();
 }
 template <typename U1, typename U2>
-constexpr bool operator<(Constant<U1>, Constant<U2>) {
+AU_DEVICE_FUNC constexpr bool operator<(Constant<U1>, Constant<U2>) {
     using SignU2 = Sign<detail::MagT<U2>>;
     using AbsU2 = decltype(U2{} * SignU2{});
     return UnitRatio<U1, AbsU2>{} < SignU2{};
 }
 template <typename U1, typename U2>
-constexpr bool operator!=(Constant<U1> lhs, Constant<U2> rhs) {
+AU_DEVICE_FUNC constexpr bool operator!=(Constant<U1> lhs, Constant<U2> rhs) {
     return !(lhs == rhs);
 }
 template <typename U1, typename U2>
-constexpr bool operator<=(Constant<U1> lhs, Constant<U2> rhs) {
+AU_DEVICE_FUNC constexpr bool operator<=(Constant<U1> lhs, Constant<U2> rhs) {
     return (lhs < rhs) || (lhs == rhs);
 }
 template <typename U1, typename U2>
-constexpr bool operator>(Constant<U1> lhs, Constant<U2> rhs) {
+AU_DEVICE_FUNC constexpr bool operator>(Constant<U1> lhs, Constant<U2> rhs) {
     return !(lhs <= rhs);
 }
 template <typename U1, typename U2>
-constexpr bool operator>=(Constant<U1> lhs, Constant<U2> rhs) {
+AU_DEVICE_FUNC constexpr bool operator>=(Constant<U1> lhs, Constant<U2> rhs) {
     return !(lhs < rhs);
 }
 
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 template <typename U1, typename U2>
-constexpr std::strong_ordering operator<=>(Constant<U1>, Constant<U2>) {
+AU_DEVICE_FUNC constexpr std::strong_ordering operator<=>(Constant<U1>, Constant<U2>) {
     using SignU2 = Sign<detail::MagT<U2>>;
     using AbsU2 = decltype(U2{} * SignU2{});
     return UnitRatio<U1, AbsU2>{} <=> SignU2{};
@@ -208,7 +209,7 @@ constexpr std::strong_ordering operator<=>(Constant<U1>, Constant<U2>) {
 
 // Mod (%) for `Constant`.
 template <typename U1, typename U2>
-constexpr auto operator%(Constant<U1>, Constant<U2>) {
+AU_DEVICE_FUNC constexpr auto operator%(Constant<U1>, Constant<U2>) {
     // This slightly complicated dance tends to produce more intuitive, human-friendly labels.
     //
     // The basic idea for `%` with `Constant` is to perform the operation in the constants' common
@@ -227,38 +228,38 @@ constexpr auto operator%(Constant<U1>, Constant<U2>) {
 
 // Arithmetic operators mixing `Constant` with `Zero`.
 template <typename U>
-constexpr Zero operator%(Zero, Constant<U>) {
+AU_DEVICE_FUNC constexpr Zero operator%(Zero, Constant<U>) {
     return {};
 }
 
 // Addition (+) for `Constant`.
 template <typename U1, typename U2>
-constexpr auto operator+(Constant<U1>, Constant<U2>) {
+AU_DEVICE_FUNC constexpr auto operator+(Constant<U1>, Constant<U2>) {
     return make_constant(UnitSum<U1, U2>{});
 }
 
 // Subtraction (-) for `Constant`.
 template <typename U1, typename U2>
-constexpr auto operator-(Constant<U1>, Constant<U2>) {
+AU_DEVICE_FUNC constexpr auto operator-(Constant<U1>, Constant<U2>) {
     using NegU2 = decltype(U2{} * Magnitude<Negative>{});
     return make_constant(UnitSum<U1, NegU2>{});
 }
 
 // Arithmetic operators mixing `Constant` with `Zero`.
 template <typename U>
-constexpr Constant<U> operator+(Constant<U>, Zero) {
+AU_DEVICE_FUNC constexpr Constant<U> operator+(Constant<U>, Zero) {
     return {};
 }
 template <typename U>
-constexpr Constant<U> operator+(Zero, Constant<U>) {
+AU_DEVICE_FUNC constexpr Constant<U> operator+(Zero, Constant<U>) {
     return {};
 }
 template <typename U>
-constexpr Constant<U> operator-(Constant<U>, Zero) {
+AU_DEVICE_FUNC constexpr Constant<U> operator-(Constant<U>, Zero) {
     return {};
 }
 template <typename U>
-constexpr auto operator-(Zero, Constant<U>) {
+AU_DEVICE_FUNC constexpr auto operator-(Zero, Constant<U>) {
     return -Constant<U>{};
 }
 

--- a/au/constant.hh
+++ b/au/constant.hh
@@ -142,7 +142,9 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
     AU_DEVICE_FUNC friend constexpr bool operator>=(Zero, Constant) { return !is_positive(); }
 
  private:
-    AU_DEVICE_FUNC static constexpr bool is_positive() { return IsPositive<detail::MagT<Unit>>::value; }
+    AU_DEVICE_FUNC static constexpr bool is_positive() {
+        return IsPositive<detail::MagT<Unit>>::value;
+    }
 };
 
 // Make a constant from the given unit.

--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -16,6 +16,7 @@
 
 #include <limits>
 
+#include "au/config.hh"
 #include "au/conversion_strategy.hh"
 #include "au/magnitude.hh"
 #include "au/operators.hh"
@@ -52,32 +53,36 @@ struct RiskSet {
     static_assert(RiskFlags <= 3u, "Invalid risk flags");
 
     template <uint8_t OtherFlags>
-    constexpr RiskSet<RiskFlags | OtherFlags> operator|(RiskSet<OtherFlags>) const {
+    AU_DEVICE_FUNC constexpr RiskSet<RiskFlags | OtherFlags> operator|(RiskSet<OtherFlags>) const {
         return {};
     }
 
-    constexpr uint8_t flags() const { return RiskFlags; }
+    AU_DEVICE_FUNC constexpr uint8_t flags() const { return RiskFlags; }
 
-    friend constexpr CheckTheseRisks<RiskSet<RiskFlags>> check_for(RiskSet) { return {}; }
-    friend constexpr CheckTheseRisks<RiskSet<3u - RiskFlags>> ignore(RiskSet) { return {}; }
+    friend AU_DEVICE_FUNC constexpr CheckTheseRisks<RiskSet<RiskFlags>> check_for(RiskSet) {
+        return {};
+    }
+    friend AU_DEVICE_FUNC constexpr CheckTheseRisks<RiskSet<3u - RiskFlags>> ignore(RiskSet) {
+        return {};
+    }
 };
 
 template <uint8_t RiskFlags>
 struct CheckTheseRisks<RiskSet<RiskFlags>> {
-    constexpr bool should_check(ConversionRisk risk) const {
+    AU_DEVICE_FUNC constexpr bool should_check(ConversionRisk risk) const {
         return (RiskFlags & static_cast<uint8_t>(risk)) != 0u;
     }
 
     // Remove risks from the checked set.
     template <uint8_t OtherFlags>
-    constexpr CheckTheseRisks<RiskSet<RiskFlags & ~OtherFlags>> but_ignoring(
+    AU_DEVICE_FUNC constexpr CheckTheseRisks<RiskSet<RiskFlags & ~OtherFlags>> but_ignoring(
         RiskSet<OtherFlags>) const {
         return {};
     }
 
     // Add risks to the checked set.
     template <uint8_t OtherFlags>
-    constexpr CheckTheseRisks<RiskSet<RiskFlags | OtherFlags>> but_also_checking_for(
+    AU_DEVICE_FUNC constexpr CheckTheseRisks<RiskSet<RiskFlags | OtherFlags>> but_also_checking_for(
         RiskSet<OtherFlags>) const {
         return {};
     }
@@ -122,7 +127,7 @@ struct SettingPureRealFromMixedReal
                         std::is_same<Rep, RealPart<Rep>>> {};
 
 template <typename T>
-constexpr bool meets_threshold(T x) {
+AU_DEVICE_FUNC constexpr bool meets_threshold(T x) {
     constexpr auto threshold_result = get_value_result<T>(OVERFLOW_THRESHOLD);
     static_assert(threshold_result.outcome == MagRepresentationOutcome::ERR_CANNOT_FIT ||
                       threshold_result.outcome == MagRepresentationOutcome::OK,
@@ -208,7 +213,8 @@ struct ImplicitRepPermitted
           Rep> {};
 
 template <typename Rep, typename SourceUnitSlot, typename TargetUnitSlot>
-constexpr bool implicit_rep_permitted_from_source_to_target(SourceUnitSlot, TargetUnitSlot) {
+AU_DEVICE_FUNC constexpr bool implicit_rep_permitted_from_source_to_target(SourceUnitSlot,
+                                                                           TargetUnitSlot) {
     using SourceUnit = AssociatedUnit<SourceUnitSlot>;
     using TargetUnit = AssociatedUnit<TargetUnitSlot>;
     static_assert(HasSameDimension<SourceUnit, TargetUnit>::value,

--- a/au/cuda/cuda_test.cu
+++ b/au/cuda/cuda_test.cu
@@ -12,21 +12,546 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Comprehensive CUDA compilation test for Au library.
+// This file exercises all public APIs to ensure AU_DEVICE_FUNC is applied everywhere needed.
+//
+// NOTE: This test is designed to FAIL TO COMPILE if AU_DEVICE_FUNC is missing from any
+// function that users would call from device code. Each section tests a specific header.
+
 #include "au/au.hh"
+#include "au/constants/speed_of_light.hh"
+#include "au/units/hertz.hh"
+#include "au/units/meters.hh"
+#include "au/units/radians.hh"
+#include "au/units/seconds.hh"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+using namespace au;
 
-namespace au {
-namespace {
+// =============================================================================
+// SECTION 1: au/zero.hh - Zero type
+// =============================================================================
+// =============================================================================
 
-using ::testing::Eq;
-
-TEST(CudaCompilation, Vacuous) {
-    // This test intentionally does nothing.
-    // Its purpose is to verify that Au headers compile successfully with nvcc.
-    EXPECT_THAT(1, Eq(1));
+__device__ bool test_zero_arithmetic() {
+    auto sum = ZERO + ZERO;
+    auto diff = ZERO - ZERO;
+    return (sum == ZERO) && (diff == ZERO);
 }
 
-}  // namespace
-}  // namespace au
+__device__ bool test_zero_comparisons() {
+    return (ZERO == ZERO) && !(ZERO != ZERO) && !(ZERO < ZERO) && (ZERO <= ZERO) &&
+           !(ZERO > ZERO) && (ZERO >= ZERO);
+}
+
+__device__ int test_zero_conversions() {
+    int i = ZERO;
+    double d = ZERO;
+    float f = ZERO;
+    return static_cast<int>(i + d + f);
+}
+
+// =============================================================================
+// SECTION 2: au/quantity.hh - Quantity type
+// =============================================================================
+
+__device__ double test_quantity_make_quantity() {
+    auto q = make_quantity<Meters>(5.0);
+    return q.in(meters);
+}
+
+__device__ double test_quantity_construction_from_zero() {
+    Quantity<Meters, double> q = ZERO;
+    return q.in(meters);
+}
+
+__device__ double test_quantity_construction_implicit() {
+    QuantityD<Meters> q1 = meters(5.0);
+    QuantityD<Centi<Meters>> q2 = q1;  // Implicit conversion (widening)
+    return q2.in(centi(meters));
+}
+
+__device__ double test_quantity_as_same_unit() {
+    auto q = meters(5.0);
+    return q.as<float>(meters).in(meters);
+}
+
+__device__ double test_quantity_as_different_unit() {
+    auto q = meters(5.0);
+    return q.as(centi(meters)).in(centi(meters));
+}
+
+__device__ double test_quantity_as_rep_and_unit() {
+    auto q = meters(5.0);
+    return q.as<float>(centi(meters)).in(centi(meters));
+}
+
+__device__ double test_quantity_in_same_unit() {
+    auto q = meters(5.0);
+    return q.in(meters);
+}
+
+__device__ double test_quantity_in_different_unit() {
+    auto q = meters(5.0);
+    return q.in(centi(meters));
+}
+
+__device__ double test_quantity_in_rep_and_unit() {
+    auto q = meters(5.0);
+    return q.in<float>(centi(meters));
+}
+
+// NOTE: coerce_as and coerce_in are deliberately not supported on device code because they are
+// deprecated and will be removed in a future release.
+
+__device__ double test_quantity_data_in() {
+    auto q = meters(5.0);
+    return q.data_in(meters);
+}
+
+__device__ void test_quantity_data_in_mutable() {
+    auto q = meters(5.0);
+    q.data_in(meters) = 10.0;
+}
+
+__device__ bool test_quantity_comparison_same_type() {
+    auto a = meters(5.0);
+    auto b = meters(3.0);
+    return (a == a) && (a != b) && (b < a) && (b <= a) && (a > b) && (a >= b);
+}
+
+__device__ bool test_quantity_comparison_different_types() {
+    auto a = meters(1.0);
+    auto b = centi(meters)(100.0);
+    return (a == b);
+}
+
+__device__ bool test_quantity_comparison_with_zero() {
+    auto q = meters(0.0);
+    return (q == ZERO) && !(q != ZERO) && !(q < ZERO) && (q <= ZERO) && !(q > ZERO) && (q >= ZERO);
+}
+
+__device__ double test_quantity_addition_same_type() {
+    auto a = meters(5.0);
+    auto b = meters(3.0);
+    return (a + b).in(meters);
+}
+
+__device__ double test_quantity_addition_different_types() {
+    auto a = meters(1.0);
+    auto b = centi(meters)(50.0);
+    return (a + b).in(centi(meters));
+}
+
+__device__ double test_quantity_subtraction_same_type() {
+    auto a = meters(5.0);
+    auto b = meters(3.0);
+    return (a - b).in(meters);
+}
+
+__device__ double test_quantity_subtraction_different_types() {
+    auto a = meters(1.0);
+    auto b = centi(meters)(50.0);
+    return (a - b).in(centi(meters));
+}
+
+__device__ double test_quantity_scalar_multiplication() {
+    auto q = meters(5.0);
+    return (q * 2.0).in(meters);
+}
+
+__device__ double test_quantity_scalar_multiplication_reverse() {
+    auto q = meters(5.0);
+    return (2.0 * q).in(meters);
+}
+
+__device__ double test_quantity_scalar_division() {
+    auto q = meters(10.0);
+    return (q / 2.0).in(meters);
+}
+
+__device__ double test_quantity_quantity_multiplication() {
+    auto d = meters(5.0);
+    auto t = seconds(2.0);
+    auto result = d * t;
+    return result.in(meters * seconds);
+}
+
+__device__ double test_quantity_quantity_division() {
+    auto d = meters(10.0);
+    auto t = seconds(2.0);
+    auto v = d / t;
+    return v.in(meters / second);
+}
+
+__device__ double test_quantity_compound_assignment_add() {
+    auto q = meters(5.0);
+    q += meters(3.0);
+    return q.in(meters);
+}
+
+__device__ double test_quantity_compound_assignment_sub() {
+    auto q = meters(5.0);
+    q -= meters(3.0);
+    return q.in(meters);
+}
+
+__device__ double test_quantity_compound_assignment_mul() {
+    auto q = meters(5.0);
+    q *= 2.0;
+    return q.in(meters);
+}
+
+__device__ double test_quantity_compound_assignment_div() {
+    auto q = meters(10.0);
+    q /= 2.0;
+    return q.in(meters);
+}
+
+__device__ double test_quantity_unary_plus() {
+    auto q = meters(5.0);
+    return (+q).in(meters);
+}
+
+__device__ double test_quantity_unary_minus() {
+    auto q = meters(5.0);
+    return (-q).in(meters);
+}
+
+__device__ int test_quantity_modulo() {
+    auto a = meters(10);
+    auto b = meters(3);
+    return (a % b).in(meters);
+}
+
+__device__ double test_quantity_min() {
+    auto a = meters(5.0);
+    auto b = meters(3.0);
+    return min(a, b).in(meters);
+}
+
+__device__ double test_quantity_max() {
+    auto a = meters(5.0);
+    auto b = meters(3.0);
+    return max(a, b).in(meters);
+}
+
+__device__ double test_quantity_clamp() {
+    auto v = meters(10.0);
+    auto lo = meters(2.0);
+    auto hi = meters(8.0);
+    return clamp(v, lo, hi).in(meters);
+}
+
+__device__ double test_quantity_maker_operations() {
+    auto velocity_maker = meters / second;
+    auto v = velocity_maker(5.0);
+    return v.in(meters / second);
+}
+
+__device__ double test_quantity_maker_product() {
+    auto area_maker = meters * meters;
+    auto a = area_maker(25.0);
+    return a.in(meters * meters);
+}
+
+__device__ double test_as_raw_number() {
+    auto q = make_quantity<UnitProduct<>>(5.0);  // dimensionless
+    return as_raw_number(q);
+}
+
+__device__ double test_rep_cast() {
+    auto q = meters(5.5);
+    auto q_int = rep_cast<int>(q);
+    return static_cast<double>(q_int.in(meters));
+}
+
+__device__ double test_unblock_int_div() {
+    auto d = meters(10);
+    auto t = seconds(3);
+    return (d / unblock_int_div(t)).in(meters / second);
+}
+
+// =============================================================================
+// SECTION 3: au/quantity_point.hh - QuantityPoint type
+// =============================================================================
+
+__device__ double test_quantity_point_construction() {
+    auto p = meters_pt(5.0);
+    return p.in(meters_pt);
+}
+
+__device__ double test_quantity_point_from_zero() {
+    QuantityPointD<Meters> p = meters_pt(0.0);
+    return p.in(meters_pt);
+}
+
+__device__ double test_quantity_point_as() {
+    auto p = meters_pt(5.0);
+    return p.as(centi(meters_pt)).in(centi(meters_pt));
+}
+
+__device__ double test_quantity_point_as_rep() {
+    auto p = meters_pt(5.0);
+    return p.as<float>(centi(meters_pt)).in(centi(meters_pt));
+}
+
+__device__ double test_quantity_point_in() {
+    auto p = meters_pt(5.0);
+    return p.in(centi(meters_pt));
+}
+
+__device__ double test_quantity_point_in_rep() {
+    auto p = meters_pt(5.0);
+    return p.in<float>(centi(meters_pt));
+}
+
+__device__ double test_quantity_point_data_in() {
+    auto p = meters_pt(5.0);
+    return p.data_in(meters_pt);
+}
+
+__device__ bool test_quantity_point_comparison() {
+    auto a = meters_pt(5.0);
+    auto b = meters_pt(3.0);
+    return (a == a) && (a != b) && (b < a) && (b <= a) && (a > b) && (a >= b);
+}
+
+__device__ double test_quantity_point_difference() {
+    auto a = meters_pt(5.0);
+    auto b = meters_pt(3.0);
+    return (a - b).in(meters);
+}
+
+__device__ double test_quantity_point_add_quantity() {
+    auto p = meters_pt(5.0);
+    auto q = meters(3.0);
+    return (p + q).in(meters_pt);
+}
+
+__device__ double test_quantity_point_sub_quantity() {
+    auto p = meters_pt(5.0);
+    auto q = meters(3.0);
+    return (p - q).in(meters_pt);
+}
+
+__device__ double test_quantity_point_compound_add() {
+    auto p = meters_pt(5.0);
+    p += meters(3.0);
+    return p.in(meters_pt);
+}
+
+__device__ double test_quantity_point_compound_sub() {
+    auto p = meters_pt(5.0);
+    p -= meters(3.0);
+    return p.in(meters_pt);
+}
+
+__device__ double test_quantity_point_min() {
+    auto a = meters_pt(5.0);
+    auto b = meters_pt(3.0);
+    return min(a, b).in(meters_pt);
+}
+
+__device__ double test_quantity_point_max() {
+    auto a = meters_pt(5.0);
+    auto b = meters_pt(3.0);
+    return max(a, b).in(meters_pt);
+}
+
+__device__ double test_quantity_point_clamp() {
+    auto v = meters_pt(10.0);
+    auto lo = meters_pt(2.0);
+    auto hi = meters_pt(8.0);
+    return clamp(v, lo, hi).in(meters_pt);
+}
+
+// =============================================================================
+// SECTION 4: au/magnitude.hh - Magnitude operations
+// =============================================================================
+// NOTE: Magnitude operations are primarily compile-time utilities and require
+// extensive AU_DEVICE_FUNC decoration throughout magnitude.hh. These are not
+// typically called from device code, so we skip testing them for now.
+// To enable these tests, magnitude.hh needs systematic AU_DEVICE_FUNC decoration.
+
+// =============================================================================
+// SECTION 5: au/unit_of_measure.hh - Unit operations
+// =============================================================================
+// NOTE: Unit operations are primarily compile-time utilities and require
+// extensive AU_DEVICE_FUNC decoration throughout unit_of_measure.hh. These are
+// not typically called from device code, so we skip testing them for now.
+// To enable these tests, unit_of_measure.hh needs systematic AU_DEVICE_FUNC decoration.
+
+// =============================================================================
+// SECTION 6: au/constant.hh - Constants
+// =============================================================================
+
+__device__ double test_constant_as() {
+    return SPEED_OF_LIGHT.as<double>().in(meters / second);
+}
+
+__device__ double test_constant_in() {
+    return SPEED_OF_LIGHT.in<double>(meters / second);
+}
+
+__device__ bool test_constant_comparison_with_zero() {
+    return (SPEED_OF_LIGHT != ZERO) && (SPEED_OF_LIGHT > ZERO);
+}
+
+__device__ double test_make_constant() {
+    auto c = make_constant(meters / second);
+    return c.in<double>(meters / second);
+}
+
+// =============================================================================
+// SECTION 7: au/math.hh - Math functions
+// =============================================================================
+// NOTE: Most math.hh functions call <cmath> functions (sin, cos, sqrt, etc.)
+// which are NOT constexpr and require special handling for CUDA device code.
+// These functions would need to call CUDA's device math intrinsics instead.
+// For now, we test only the functions that don't depend on <cmath>.
+
+__device__ double test_math_int_pow() {
+    auto q = meters(2.0);
+    return int_pow<3>(q).in(meters * meters * meters);
+}
+
+// TODO: Add tests for these functions once math.hh has CUDA-compatible implementations:
+// - abs, sqrt, cbrt (call std::abs, std::sqrt, std::cbrt)
+// - sin, cos, tan (call std::sin, std::cos, std::tan)
+// - arcsin, arccos, arctan, arctan2 (call std::asin, std::acos, std::atan, std::atan2)
+// - hypot (calls std::hypot)
+// - fmod, remainder (call std::fmod, std::remainder)
+// - copysign (calls std::copysign)
+// - round_in/as, floor_in/as, ceil_in/as (call std::round, std::floor, std::ceil)
+// - isnan, isinf (call std::isnan, std::isinf)
+// - mean (uses division which works, but need to test)
+
+// =============================================================================
+// SECTION 8: au/operators.hh - Comparison operator functors
+// =============================================================================
+
+__device__ bool test_operators_equal() {
+    return detail::Equal{}(5, 5);
+}
+
+__device__ bool test_operators_not_equal() {
+    return detail::NotEqual{}(5, 3);
+}
+
+__device__ bool test_operators_less() {
+    return detail::Less{}(3, 5);
+}
+
+__device__ bool test_operators_less_equal() {
+    return detail::LessEqual{}(3, 5);
+}
+
+__device__ bool test_operators_greater() {
+    return detail::Greater{}(5, 3);
+}
+
+__device__ bool test_operators_greater_equal() {
+    return detail::GreaterEqual{}(5, 3);
+}
+
+__device__ double test_operators_plus() {
+    return detail::plus(meters(3.0), meters(2.0)).in(meters);
+}
+
+__device__ double test_operators_minus() {
+    return detail::minus(meters(5.0), meters(2.0)).in(meters);
+}
+
+// =============================================================================
+// SECTION 9: au/stdx/functional.hh - Identity
+// =============================================================================
+
+__device__ double test_stdx_identity() {
+    return stdx::identity{}(5.0);
+}
+
+// =============================================================================
+// SECTION 10: au/stdx/utility.hh - Safe integer comparisons
+// =============================================================================
+
+__device__ bool test_stdx_cmp_equal() {
+    return stdx::cmp_equal(5, 5);
+}
+
+__device__ bool test_stdx_cmp_not_equal() {
+    return stdx::cmp_not_equal(5, 3);
+}
+
+__device__ bool test_stdx_cmp_less() {
+    return stdx::cmp_less(3, 5);
+}
+
+__device__ bool test_stdx_cmp_greater() {
+    return stdx::cmp_greater(5, 3);
+}
+
+__device__ bool test_stdx_cmp_less_equal() {
+    return stdx::cmp_less_equal(3, 5);
+}
+
+__device__ bool test_stdx_cmp_greater_equal() {
+    return stdx::cmp_greater_equal(5, 3);
+}
+
+__device__ bool test_stdx_in_range() {
+    return stdx::in_range<unsigned char>(100);
+}
+
+// =============================================================================
+// SECTION 11: au/prefix.hh - SI prefixes
+// =============================================================================
+
+__device__ double test_prefix_kilo() {
+    auto q = kilo(meters)(5.0);
+    return q.in(meters);
+}
+
+__device__ double test_prefix_milli() {
+    auto q = milli(meters)(5000.0);
+    return q.in(meters);
+}
+
+__device__ double test_prefix_centi() {
+    auto q = centi(meters)(500.0);
+    return q.in(meters);
+}
+
+__device__ double test_prefix_micro() {
+    auto q = micro(meters)(5000000.0);
+    return q.in(meters);
+}
+
+// =============================================================================
+// SECTION 12: Conversion risk checking
+// =============================================================================
+
+__device__ bool test_will_conversion_overflow() {
+    auto q = meters(1e308);
+    return will_conversion_overflow(q, centi(meters));
+}
+
+__device__ bool test_will_conversion_truncate() {
+    auto q = meters(5.5);
+    return will_conversion_truncate<int>(q, meters);
+}
+
+__device__ bool test_is_conversion_lossy() {
+    auto q = meters(5.5);
+    return is_conversion_lossy<int>(q, meters);
+}
+
+// =============================================================================
+// Host-side sanity check
+// =============================================================================
+
+bool host_test() {
+    auto q = meters(5.0);
+    auto t = seconds(2.0);
+    auto v = q / t;
+    return v.in(meters / second) == 2.5;
+}

--- a/au/cuda/cuda_test.cu
+++ b/au/cuda/cuda_test.cu
@@ -385,13 +385,9 @@ __device__ double test_quantity_point_clamp() {
 // SECTION 6: au/constant.hh - Constants
 // =============================================================================
 
-__device__ double test_constant_as() {
-    return SPEED_OF_LIGHT.as<double>().in(meters / second);
-}
+__device__ double test_constant_as() { return SPEED_OF_LIGHT.as<double>().in(meters / second); }
 
-__device__ double test_constant_in() {
-    return SPEED_OF_LIGHT.in<double>(meters / second);
-}
+__device__ double test_constant_in() { return SPEED_OF_LIGHT.in<double>(meters / second); }
 
 __device__ bool test_constant_comparison_with_zero() {
     return (SPEED_OF_LIGHT != ZERO) && (SPEED_OF_LIGHT > ZERO);
@@ -430,29 +426,17 @@ __device__ double test_math_int_pow() {
 // SECTION 8: au/operators.hh - Comparison operator functors
 // =============================================================================
 
-__device__ bool test_operators_equal() {
-    return detail::Equal{}(5, 5);
-}
+__device__ bool test_operators_equal() { return detail::Equal{}(5, 5); }
 
-__device__ bool test_operators_not_equal() {
-    return detail::NotEqual{}(5, 3);
-}
+__device__ bool test_operators_not_equal() { return detail::NotEqual{}(5, 3); }
 
-__device__ bool test_operators_less() {
-    return detail::Less{}(3, 5);
-}
+__device__ bool test_operators_less() { return detail::Less{}(3, 5); }
 
-__device__ bool test_operators_less_equal() {
-    return detail::LessEqual{}(3, 5);
-}
+__device__ bool test_operators_less_equal() { return detail::LessEqual{}(3, 5); }
 
-__device__ bool test_operators_greater() {
-    return detail::Greater{}(5, 3);
-}
+__device__ bool test_operators_greater() { return detail::Greater{}(5, 3); }
 
-__device__ bool test_operators_greater_equal() {
-    return detail::GreaterEqual{}(5, 3);
-}
+__device__ bool test_operators_greater_equal() { return detail::GreaterEqual{}(5, 3); }
 
 __device__ double test_operators_plus() {
     return detail::plus(meters(3.0), meters(2.0)).in(meters);
@@ -466,41 +450,25 @@ __device__ double test_operators_minus() {
 // SECTION 9: au/stdx/functional.hh - Identity
 // =============================================================================
 
-__device__ double test_stdx_identity() {
-    return stdx::identity{}(5.0);
-}
+__device__ double test_stdx_identity() { return stdx::identity{}(5.0); }
 
 // =============================================================================
 // SECTION 10: au/stdx/utility.hh - Safe integer comparisons
 // =============================================================================
 
-__device__ bool test_stdx_cmp_equal() {
-    return stdx::cmp_equal(5, 5);
-}
+__device__ bool test_stdx_cmp_equal() { return stdx::cmp_equal(5, 5); }
 
-__device__ bool test_stdx_cmp_not_equal() {
-    return stdx::cmp_not_equal(5, 3);
-}
+__device__ bool test_stdx_cmp_not_equal() { return stdx::cmp_not_equal(5, 3); }
 
-__device__ bool test_stdx_cmp_less() {
-    return stdx::cmp_less(3, 5);
-}
+__device__ bool test_stdx_cmp_less() { return stdx::cmp_less(3, 5); }
 
-__device__ bool test_stdx_cmp_greater() {
-    return stdx::cmp_greater(5, 3);
-}
+__device__ bool test_stdx_cmp_greater() { return stdx::cmp_greater(5, 3); }
 
-__device__ bool test_stdx_cmp_less_equal() {
-    return stdx::cmp_less_equal(3, 5);
-}
+__device__ bool test_stdx_cmp_less_equal() { return stdx::cmp_less_equal(3, 5); }
 
-__device__ bool test_stdx_cmp_greater_equal() {
-    return stdx::cmp_greater_equal(5, 3);
-}
+__device__ bool test_stdx_cmp_greater_equal() { return stdx::cmp_greater_equal(5, 3); }
 
-__device__ bool test_stdx_in_range() {
-    return stdx::in_range<unsigned char>(100);
-}
+__device__ bool test_stdx_in_range() { return stdx::in_range<unsigned char>(100); }
 
 // =============================================================================
 // SECTION 11: au/prefix.hh - SI prefixes

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -22,6 +22,7 @@
 #include <compare>
 #endif
 
+#include "au/config.hh"
 #include "au/fwd.hh"
 #include "au/packs.hh"
 #include "au/power_aliases.hh"
@@ -130,7 +131,7 @@ constexpr T get_value(Magnitude<BPs...>);
 
 // Let `Zero` "act like" a `Magnitude` for purposes of `get_value`.
 template <typename T>
-constexpr T get_value(Zero) {
+AU_DEVICE_FUNC constexpr T get_value(Zero) {
     return T{0};
 }
 
@@ -139,7 +140,7 @@ template <std::uintmax_t N>
 struct Prime {
     static_assert(detail::is_prime(N), "Prime<N> requires that N is prime");
 
-    static constexpr std::uintmax_t value() { return N; }
+    static AU_DEVICE_FUNC constexpr std::uintmax_t value() { return N; }
 };
 
 // A base type for pi.
@@ -150,7 +151,9 @@ struct Pi {
     // architectures at all, that's enough to give confidence in this value.
     //
     // Source for value: http://www.pi-world-ranking-list.com/lists/details/hogg.html
-    static constexpr long double value() { return 3.14159265358979323846264338327950288419716939L; }
+    static AU_DEVICE_FUNC constexpr long double value() {
+        return 3.14159265358979323846264338327950288419716939L;
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -739,7 +742,7 @@ using Widen = std::conditional_t<
     T>;
 
 template <typename T>
-constexpr MagRepresentationOrError<T> checked_int_pow(T base, std::uintmax_t exp) {
+AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> checked_int_pow(T base, std::uintmax_t exp) {
     MagRepresentationOrError<T> result = {MagRepresentationOutcome::OK, T{1}};
     while (exp > 0u) {
         if (exp % 2u == 1u) {
@@ -767,7 +770,7 @@ using IsKnownToBeInteger = stdx::bool_constant<(std::numeric_limits<T>::is_speci
 
 template <typename T>
 struct NontrivialRootForInt {
-    constexpr MagRepresentationOrError<T> operator()(T, std::uintmax_t) const {
+    AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> operator()(T, std::uintmax_t) const {
         // There exist input values where a valid answer exists.  If this were a fully general root
         // finding function, we would want to support them.  However, those situations can't arise
         // in this instance.  We would never take a non-trivial root that returns an integer,
@@ -788,7 +791,7 @@ struct NontrivialRootImpl
 };
 
 template <typename T>
-constexpr MagRepresentationOrError<T> root(T x, std::uintmax_t n) {
+AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> root(T x, std::uintmax_t n) {
     // The "zeroth root" would be mathematically undefined.
     if (n == 0) {
         return {MagRepresentationOutcome::ERR_INVALID_ROOT};
@@ -809,7 +812,7 @@ constexpr MagRepresentationOrError<T> root(T x, std::uintmax_t n) {
 
 template <typename T>
 struct GeneralNontrivialRoot {
-    constexpr MagRepresentationOrError<T> operator()(T x, std::uintmax_t n) const {
+    AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> operator()(T x, std::uintmax_t n) const {
         // Handle negative numbers: only odd roots are allowed.
         if (x < 0) {
             if (n % 2 == 0) {
@@ -888,7 +891,7 @@ template <typename T, std::uintmax_t N, std::uintmax_t D, typename B, SignOfExpo
 struct BasePowerValueImpl;
 
 template <typename T, std::intmax_t N, std::uintmax_t D, typename B>
-constexpr MagRepresentationOrError<Widen<T>> base_power_value(B base) {
+AU_DEVICE_FUNC constexpr MagRepresentationOrError<Widen<T>> base_power_value(B base) {
     return BasePowerValueImpl<T,
                               static_cast<std::uintmax_t>(N < 0 ? -N : N),
                               D,
@@ -899,7 +902,7 @@ constexpr MagRepresentationOrError<Widen<T>> base_power_value(B base) {
 
 template <typename T, std::uintmax_t N, std::uintmax_t D, typename B>
 struct BasePowerValueImpl<T, N, D, B, SignOfExponent::NEGATIVE_SIGN> {
-    constexpr MagRepresentationOrError<Widen<T>> operator()(B base) const {
+    AU_DEVICE_FUNC constexpr MagRepresentationOrError<Widen<T>> operator()(B base) const {
         const auto inverse_result =
             BasePowerValueImpl<T, N, D, B, SignOfExponent::POSITIVE_SIGN>{}(base);
         if (inverse_result.outcome != MagRepresentationOutcome::OK) {
@@ -914,7 +917,7 @@ struct BasePowerValueImpl<T, N, D, B, SignOfExponent::NEGATIVE_SIGN> {
 
 template <typename T, std::uintmax_t N, std::uintmax_t D, typename B>
 struct BasePowerValueImpl<T, N, D, B, SignOfExponent::POSITIVE_SIGN> {
-    constexpr MagRepresentationOrError<Widen<T>> operator()(B base) const {
+    AU_DEVICE_FUNC constexpr MagRepresentationOrError<Widen<T>> operator()(B base) const {
         const auto power_result = checked_int_pow(static_cast<Widen<T>>(base), N);
         if (power_result.outcome != MagRepresentationOutcome::OK) {
             return {power_result.outcome};
@@ -924,7 +927,7 @@ struct BasePowerValueImpl<T, N, D, B, SignOfExponent::POSITIVE_SIGN> {
 };
 
 template <typename T, std::size_t N>
-constexpr MagRepresentationOrError<T> product(const MagRepresentationOrError<T> (&values)[N]) {
+AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> product(const MagRepresentationOrError<T> (&values)[N]) {
     for (const auto &x : values) {
         if (x.outcome != MagRepresentationOutcome::OK) {
             return x;
@@ -942,7 +945,7 @@ constexpr MagRepresentationOrError<T> product(const MagRepresentationOrError<T> 
 }
 
 template <std::size_t N>
-constexpr bool all(const bool (&values)[N]) {
+AU_DEVICE_FUNC constexpr bool all(const bool (&values)[N]) {
     for (const auto &x : values) {
         if (!x) {
             return false;
@@ -968,7 +971,7 @@ using RealPart = typename RealPartImpl<T>::type;
 template <typename Target, typename Enable = void>
 struct SafeCastingChecker {
     template <typename T>
-    constexpr bool operator()(T x) {
+    AU_DEVICE_FUNC constexpr bool operator()(T x) {
         return stdx::cmp_less_equal(std::numeric_limits<RealPart<Target>>::lowest(), x) &&
                stdx::cmp_greater_equal(std::numeric_limits<RealPart<Target>>::max(), x);
     }
@@ -977,7 +980,7 @@ struct SafeCastingChecker {
 template <typename Target>
 struct SafeCastingChecker<Target, std::enable_if_t<std::is_integral<Target>::value>> {
     template <typename T>
-    constexpr bool operator()(T x) {
+    AU_DEVICE_FUNC constexpr bool operator()(T x) {
         return std::is_integral<T>::value &&
                stdx::cmp_less_equal(std::numeric_limits<RealPart<Target>>::lowest(), x) &&
                stdx::cmp_greater_equal(std::numeric_limits<RealPart<Target>>::max(), x);
@@ -985,13 +988,13 @@ struct SafeCastingChecker<Target, std::enable_if_t<std::is_integral<Target>::val
 };
 
 template <typename T, typename InputT>
-constexpr bool safe_to_cast_to(InputT x) {
+AU_DEVICE_FUNC constexpr bool safe_to_cast_to(InputT x) {
     return SafeCastingChecker<T>{}(x);
 }
 
 template <typename T, typename MagT>
 struct GetValueResultImplForNonIntegerInIntegralType {
-    constexpr MagRepresentationOrError<T> operator()() {
+    AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> operator()() {
         return {MagRepresentationOutcome::ERR_NON_INTEGER_IN_INTEGER_TYPE};
     }
 };
@@ -1000,7 +1003,7 @@ template <typename T, typename MagT>
 struct GetValueResultImplForDefaultCase;
 template <typename T, typename... BPs>
 struct GetValueResultImplForDefaultCase<T, Magnitude<BPs...>> {
-    constexpr MagRepresentationOrError<T> operator()() {
+    AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> operator()() {
         // Force the expression to be evaluated in a constexpr context.
         constexpr auto widened_result = product(
             {base_power_value<RealPart<T>,
@@ -1024,14 +1027,14 @@ struct GetValueResultImpl
           GetValueResultImplForDefaultCase<T, MagT>> {};
 
 template <typename T, typename... BPs>
-constexpr MagRepresentationOrError<T> get_value_result(Magnitude<BPs...>) {
+AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> get_value_result(Magnitude<BPs...>) {
     constexpr auto result = GetValueResultImpl<T, Magnitude<BPs...>>{}();
     return result;
 }
 
 // This simple overload avoids edge cases with creating and passing zero-sized arrays.
 template <typename T>
-constexpr MagRepresentationOrError<T> get_value_result(Magnitude<>) {
+AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> get_value_result(Magnitude<>) {
     return {MagRepresentationOutcome::OK, static_cast<T>(1)};
 }
 
@@ -1051,7 +1054,7 @@ constexpr bool is_exactly_lowest_of_signed_integral(Magnitude<BPs...>) {
 }
 
 template <typename T, typename... BPs>
-constexpr MagRepresentationOrError<T> get_value_result(Magnitude<Negative, BPs...> m) {
+AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> get_value_result(Magnitude<Negative, BPs...> m) {
     if (std::is_unsigned<T>::value) {
         return {MagRepresentationOutcome::ERR_NEGATIVE_NUMBER_IN_UNSIGNED_TYPE};
     }
@@ -1076,7 +1079,7 @@ constexpr bool representable_in(Magnitude<BPs...> m) {
 }
 
 template <typename T, typename... BPs>
-constexpr T get_value(Magnitude<BPs...> m) {
+AU_DEVICE_FUNC constexpr T get_value(Magnitude<BPs...> m) {
     using namespace detail;
 
     constexpr auto result = get_value_result<T>(m);

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -927,7 +927,8 @@ struct BasePowerValueImpl<T, N, D, B, SignOfExponent::POSITIVE_SIGN> {
 };
 
 template <typename T, std::size_t N>
-AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> product(const MagRepresentationOrError<T> (&values)[N]) {
+AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> product(
+    const MagRepresentationOrError<T> (&values)[N]) {
     for (const auto &x : values) {
         if (x.outcome != MagRepresentationOutcome::OK) {
             return x;
@@ -1054,7 +1055,8 @@ constexpr bool is_exactly_lowest_of_signed_integral(Magnitude<BPs...>) {
 }
 
 template <typename T, typename... BPs>
-AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> get_value_result(Magnitude<Negative, BPs...> m) {
+AU_DEVICE_FUNC constexpr MagRepresentationOrError<T> get_value_result(
+    Magnitude<Negative, BPs...> m) {
     if (std::is_unsigned<T>::value) {
         return {MagRepresentationOutcome::ERR_NEGATIVE_NUMBER_IN_UNSIGNED_TYPE};
     }

--- a/au/math.hh
+++ b/au/math.hh
@@ -19,6 +19,7 @@
 #include <limits>
 #include <type_traits>
 
+#include "au/config.hh"
 #include "au/constant.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
@@ -63,7 +64,7 @@ auto in_radians(Quantity<U, R> q) {
 }
 
 template <typename T>
-constexpr T int_pow_impl(T x, int exp) {
+AU_DEVICE_FUNC constexpr T int_pow_impl(T x, int exp) {
     if (exp < 0) {
         return T{1} / int_pow_impl(x, -exp);
     }
@@ -163,7 +164,7 @@ auto cbrt(Quantity<U, R> q) {
 
 // Clamp the first quantity to within the range of the second two.
 template <typename UV, typename ULo, typename UHi, typename RV, typename RLo, typename RHi>
-constexpr auto clamp(Quantity<UV, RV> v, Quantity<ULo, RLo> lo, Quantity<UHi, RHi> hi) {
+AU_DEVICE_FUNC constexpr auto clamp(Quantity<UV, RV> v, Quantity<ULo, RLo> lo, Quantity<UHi, RHi> hi) {
     using U = CommonUnit<UV, ULo, UHi>;
     using R = std::common_type_t<RV, RLo, RHi>;
     using ResultT = Quantity<U, R>;
@@ -172,7 +173,7 @@ constexpr auto clamp(Quantity<UV, RV> v, Quantity<ULo, RLo> lo, Quantity<UHi, RH
 
 // Clamp the first point to within the range of the second two.
 template <typename UV, typename ULo, typename UHi, typename RV, typename RLo, typename RHi>
-constexpr auto clamp(QuantityPoint<UV, RV> v,
+AU_DEVICE_FUNC constexpr auto clamp(QuantityPoint<UV, RV> v,
                      QuantityPoint<ULo, RLo> lo,
                      QuantityPoint<UHi, RHi> hi) {
     using U = CommonPointUnit<UV, ULo, UHi>;
@@ -189,19 +190,19 @@ auto hypot(Quantity<U1, R1> x, Quantity<U2, R2> y) {
 
 // Copysign where the magnitude has units.
 template <typename U, typename R, typename T>
-constexpr auto copysign(Quantity<U, R> mag, T sgn) {
+AU_DEVICE_FUNC constexpr auto copysign(Quantity<U, R> mag, T sgn) {
     return make_quantity<U>(std::copysign(mag.in(U{}), sgn));
 }
 
 // Copysign where the sign has units.
 template <typename T, typename U, typename R>
-constexpr auto copysign(T mag, Quantity<U, R> sgn) {
+AU_DEVICE_FUNC constexpr auto copysign(T mag, Quantity<U, R> sgn) {
     return std::copysign(mag, sgn.in(U{}));
 }
 
 // Copysign where both the magnitude and sign have units (disambiguates between the above).
 template <typename U1, typename R1, typename U2, typename R2>
-constexpr auto copysign(Quantity<U1, R1> mag, Quantity<U2, R2> sgn) {
+AU_DEVICE_FUNC constexpr auto copysign(Quantity<U1, R1> mag, Quantity<U2, R2> sgn) {
     return make_quantity<U1>(std::copysign(mag.in(U1{}), sgn.in(U2{})));
 }
 
@@ -221,7 +222,7 @@ auto fmod(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
 
 // Raise a Quantity to an integer power.
 template <int Exp, typename U, typename R>
-constexpr auto int_pow(Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_pow(Quantity<U, R> q) {
     static_assert((!std::is_integral<R>::value) || (Exp >= 0),
                   "Negative exponent on integral represented units are not supported.");
 
@@ -234,7 +235,7 @@ constexpr auto int_pow(Quantity<U, R> q) {
 // This is the "explicit Rep" format, which is semantically equivalent to a `static_cast`.
 //
 template <typename TargetRep, typename TargetUnits, typename U, typename R>
-constexpr auto inverse_in(TargetUnits target_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto inverse_in(TargetUnits target_units, Quantity<U, R> q) {
     using Rep = std::common_type_t<TargetRep, R>;
     constexpr auto UNITY = make_constant(UnitProduct<>{});
     return static_cast<TargetRep>(UNITY.in<Rep>(associated_unit(target_units) * U{}) / q.in(U{}));
@@ -248,7 +249,7 @@ constexpr auto inverse_in(TargetUnits target_units, Quantity<U, R> q) {
 // in this case, the library will know to divide into 1'000'000 instead of dividing into 1.)
 //
 template <typename TargetUnits, typename U, typename R>
-constexpr auto inverse_in(TargetUnits target_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto inverse_in(TargetUnits target_units, Quantity<U, R> q) {
     // The policy here is similar to our overflow policy, in that we try to avoid "bad outcomes"
     // when users store values less than 1000.  (The thinking, here as there, is that values _more_
     // than 1000 would tend to be stored in the next SI-prefixed unit up, e.g., 1 km instead of 1000
@@ -285,7 +286,7 @@ constexpr auto inverse_in(TargetUnits target_units, Quantity<U, R> q) {
 // (See `inverse_in()` comment above for how this inverse is "smart".)
 //
 template <typename TargetUnits, typename U, typename R>
-constexpr auto inverse_as(TargetUnits target_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto inverse_as(TargetUnits target_units, Quantity<U, R> q) {
     return make_quantity<AssociatedUnit<TargetUnits>>(inverse_in(target_units, q));
 }
 
@@ -295,7 +296,7 @@ constexpr auto inverse_as(TargetUnits target_units, Quantity<U, R> q) {
 // This is the "explicit Rep" format, which is semantically equivalent to a `static_cast`.
 //
 template <typename TargetRep, typename TargetUnits, typename U, typename R>
-constexpr auto inverse_as(TargetUnits target_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto inverse_as(TargetUnits target_units, Quantity<U, R> q) {
     return make_quantity<AssociatedUnit<TargetUnits>>(inverse_in<TargetRep>(target_units, q));
 }
 
@@ -303,13 +304,13 @@ constexpr auto inverse_as(TargetUnits target_units, Quantity<U, R> q) {
 // Check whether the value stored is (positive or negative) infinity.
 //
 template <typename U, typename R>
-constexpr bool isinf(Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr bool isinf(Quantity<U, R> q) {
     return std::isinf(q.in(U{}));
 }
 
 // Overload of `isinf` for `QuantityPoint`.
 template <typename U, typename R>
-constexpr bool isinf(QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr bool isinf(QuantityPoint<U, R> p) {
     return std::isinf(p.in(U{}));
 }
 
@@ -317,13 +318,13 @@ constexpr bool isinf(QuantityPoint<U, R> p) {
 // Check whether the value stored is "not a number" (NaN).
 //
 template <typename U, typename R>
-constexpr bool isnan(Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr bool isnan(Quantity<U, R> q) {
     return std::isnan(q.in(U{}));
 }
 
 // Overload of `isnan` for `QuantityPoint`.
 template <typename U, typename R>
-constexpr bool isnan(QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr bool isnan(QuantityPoint<U, R> p) {
     return std::isnan(p.in(U{}));
 }
 
@@ -338,13 +339,13 @@ constexpr bool isnan(QuantityPoint<U, R> p) {
 //
 #if defined(__cpp_lib_interpolate) && __cpp_lib_interpolate >= 201902L
 template <typename U1, typename R1, typename U2, typename R2, typename T>
-constexpr auto lerp(Quantity<U1, R1> q1, Quantity<U2, R2> q2, T t) {
+AU_DEVICE_FUNC constexpr auto lerp(Quantity<U1, R1> q1, Quantity<U2, R2> q2, T t) {
     using U = CommonUnit<U1, U2>;
     return make_quantity<U>(std::lerp(q1.in(U{}), q2.in(U{}), as_raw_number(t)));
 }
 
 template <typename U1, typename R1, typename U2, typename R2, typename T>
-constexpr auto lerp(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2, T t) {
+AU_DEVICE_FUNC constexpr auto lerp(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2, T t) {
     using U = CommonPointUnit<U1, U2>;
     return make_quantity_point<U>(std::lerp(p1.in(U{}), p2.in(U{}), as_raw_number(t)));
 }
@@ -354,7 +355,7 @@ namespace detail {
 // We can't use lambdas in `constexpr` contexts until C++17, so we make a manual function object.
 struct StdMaxByValue {
     template <typename T>
-    constexpr auto operator()(T a, T b) const {
+    AU_DEVICE_FUNC constexpr auto operator()(T a, T b) const {
         return std::max(a, b);
     }
 };
@@ -364,7 +365,7 @@ struct StdMaxByValue {
 //
 // Unlike std::max, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto max(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr auto max(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return detail::using_common_type(q1, q2, detail::StdMaxByValue{});
 }
 
@@ -372,13 +373,13 @@ constexpr auto max(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
 //
 // Unlike std::max, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto max(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+AU_DEVICE_FUNC constexpr auto max(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     return detail::using_common_point_unit(p1, p2, detail::StdMaxByValue{});
 }
 
 // Overload to resolve ambiguity with `std::max` for identical `QuantityPoint` types.
 template <typename U, typename R>
-constexpr auto max(QuantityPoint<U, R> a, QuantityPoint<U, R> b) {
+AU_DEVICE_FUNC constexpr auto max(QuantityPoint<U, R> a, QuantityPoint<U, R> b) {
     return std::max(a, b);
 }
 
@@ -386,7 +387,7 @@ namespace detail {
 // We can't use lambdas in `constexpr` contexts until C++17, so we make a manual function object.
 struct StdMinByValue {
     template <typename T>
-    constexpr auto operator()(T a, T b) const {
+    AU_DEVICE_FUNC constexpr auto operator()(T a, T b) const {
         return std::min(a, b);
     }
 };
@@ -396,7 +397,7 @@ struct StdMinByValue {
 //
 // Unlike std::min, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto min(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr auto min(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return detail::using_common_type(q1, q2, detail::StdMinByValue{});
 }
 
@@ -404,18 +405,18 @@ constexpr auto min(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
 //
 // Unlike std::min, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto min(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+AU_DEVICE_FUNC constexpr auto min(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     return detail::using_common_point_unit(p1, p2, detail::StdMinByValue{});
 }
 
 // Overload to resolve ambiguity with `std::min` for identical `QuantityPoint` types.
 template <typename U, typename R>
-constexpr auto min(QuantityPoint<U, R> a, QuantityPoint<U, R> b) {
+AU_DEVICE_FUNC constexpr auto min(QuantityPoint<U, R> a, QuantityPoint<U, R> b) {
     return std::min(a, b);
 }
 
 template <typename U0, typename R0, typename... Us, typename... Rs>
-constexpr auto mean(Quantity<U0, R0> q0, Quantity<Us, Rs>... qs) {
+AU_DEVICE_FUNC constexpr auto mean(Quantity<U0, R0> q0, Quantity<Us, Rs>... qs) {
     static_assert(sizeof...(qs) > 0, "mean() requires at least two inputs");
     using R = std::common_type_t<R0, Rs...>;
     using Common = Quantity<CommonUnit<U0, Us...>, R>;
@@ -429,7 +430,7 @@ constexpr auto mean(Quantity<U0, R0> q0, Quantity<Us, Rs>... qs) {
 }
 
 template <typename U0, typename R0, typename... Us, typename... Rs>
-constexpr auto mean(QuantityPoint<U0, R0> p0, QuantityPoint<Us, Rs>... ps) {
+AU_DEVICE_FUNC constexpr auto mean(QuantityPoint<U0, R0> p0, QuantityPoint<Us, Rs>... ps) {
     static_assert(sizeof...(ps) > 0, "mean() requires at least two inputs");
     using U = CommonPointUnit<U0, Us...>;
     using R = std::common_type_t<R0, Rs...>;
@@ -486,7 +487,7 @@ auto round_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
 }
 // c) Version for Constant.
 template <typename OutputRep, typename RoundingUnits, typename U>
-constexpr auto round_in(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto round_in(RoundingUnits rounding_units, Constant<U> c) {
     return get_value<OutputRep>(mag_round(unit_ratio(c, rounding_units)));
 }
 
@@ -507,7 +508,7 @@ auto round_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
 }
 // c) Version for Constant.
 template <typename RoundingUnits, typename U>
-constexpr auto round_as(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto round_as(RoundingUnits rounding_units, Constant<U> c) {
     return mag_round(unit_ratio(c, rounding_units)) * make_constant(rounding_units);
 }
 
@@ -564,7 +565,7 @@ auto floor_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
 }
 // c) Version for Constant.
 template <typename OutputRep, typename RoundingUnits, typename U>
-constexpr auto floor_in(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto floor_in(RoundingUnits rounding_units, Constant<U> c) {
     return get_value<OutputRep>(mag_floor(unit_ratio(c, rounding_units)));
 }
 
@@ -585,7 +586,7 @@ auto floor_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
 }
 // c) Version for Constant.
 template <typename RoundingUnits, typename U>
-constexpr auto floor_as(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto floor_as(RoundingUnits rounding_units, Constant<U> c) {
     return mag_floor(unit_ratio(c, rounding_units)) * make_constant(rounding_units);
 }
 
@@ -642,7 +643,7 @@ auto ceil_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
 }
 // c) Version for Constant.
 template <typename OutputRep, typename RoundingUnits, typename U>
-constexpr auto ceil_in(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto ceil_in(RoundingUnits rounding_units, Constant<U> c) {
     return get_value<OutputRep>(mag_ceil(unit_ratio(c, rounding_units)));
 }
 
@@ -663,7 +664,7 @@ auto ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
 }
 // c) Version for Constant.
 template <typename RoundingUnits, typename U>
-constexpr auto ceil_as(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto ceil_as(RoundingUnits rounding_units, Constant<U> c) {
     return mag_ceil(unit_ratio(c, rounding_units)) * make_constant(rounding_units);
 }
 
@@ -692,7 +693,7 @@ auto ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
 //
 // Common implementation helper:
 template <typename RoundingUnits, template <class, class> class QType, typename U, typename R>
-constexpr auto int_round_as_impl(RoundingUnits, QType<U, R> val) {
+AU_DEVICE_FUNC constexpr auto int_round_as_impl(RoundingUnits, QType<U, R> val) {
     static_assert(std::is_integral<R>::value, "int_round_as requires integral Rep type");
 
     constexpr auto target = AppropriateAssociatedUnit<QType, RoundingUnits>{};
@@ -702,17 +703,17 @@ constexpr auto int_round_as_impl(RoundingUnits, QType<U, R> val) {
 }
 // (a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_round_as(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_round_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_round_as_impl(rounding_units, q);
 }
 // (b) Version for QuantityPoint.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_round_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_round_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_round_as_impl(rounding_units, p);
 }
 // (c) Version for Constant.
 template <typename RoundingUnits, typename U>
-constexpr auto int_round_as(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto int_round_as(RoundingUnits rounding_units, Constant<U> c) {
     return round_as(rounding_units, c);  // For `Constant`, identical to `round_as`.
 }
 
@@ -728,7 +729,7 @@ template <typename OutputRep,
           class QType,
           typename U,
           typename R>
-constexpr auto int_round_as_explicit_rep_impl(RoundingUnits, QType<U, R> val) {
+AU_DEVICE_FUNC constexpr auto int_round_as_explicit_rep_impl(RoundingUnits, QType<U, R> val) {
     static_assert(std::is_integral<OutputRep>::value, "int_round_as output must be integral");
 
     constexpr auto target = AppropriateAssociatedUnit<QType, RoundingUnits>{};
@@ -739,12 +740,12 @@ constexpr auto int_round_as_explicit_rep_impl(RoundingUnits, QType<U, R> val) {
 }
 // (a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_round_as(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_round_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_round_as_explicit_rep_impl<OutputRep>(rounding_units, q);
 }
 // (b) Version for QuantityPoint.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_round_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_round_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_round_as_explicit_rep_impl<OutputRep>(rounding_units, p);
 }
 
@@ -755,12 +756,12 @@ constexpr auto int_round_as(RoundingUnits rounding_units, QuantityPoint<U, R> p)
 //
 // (a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_round_in(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_round_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_round_as(rounding_units, q).in(rounding_units);
 }
 // (b) Version for QuantityPoint.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_round_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_round_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_round_as(rounding_units, p).in(associated_unit_for_points(rounding_units));
 }
 
@@ -771,17 +772,17 @@ constexpr auto int_round_in(RoundingUnits rounding_units, QuantityPoint<U, R> p)
 //
 // (a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_round_in(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_round_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_round_as<OutputRep>(rounding_units, q).in(rounding_units);
 }
 // (b) Version for QuantityPoint.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_round_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_round_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_round_as<OutputRep>(rounding_units, p).in(rounding_units);
 }
 // (c) Version for Constant.
 template <typename OutputRep, typename RoundingUnits, typename U>
-constexpr auto int_round_in(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto int_round_in(RoundingUnits rounding_units, Constant<U> c) {
     return round_in<OutputRep>(rounding_units, c);  // For `Constant`, identical to `round_in`.
 }
 
@@ -792,7 +793,7 @@ constexpr auto int_round_in(RoundingUnits rounding_units, Constant<U> c) {
 //
 // Common implementation helper:
 template <typename RoundingUnits, template <class, class> class QType, typename U, typename R>
-constexpr auto int_floor_as_impl(RoundingUnits, QType<U, R> val) {
+AU_DEVICE_FUNC constexpr auto int_floor_as_impl(RoundingUnits, QType<U, R> val) {
     static_assert(std::is_integral<R>::value, "int_floor_as requires integral Rep type");
 
     constexpr auto target = AppropriateAssociatedUnit<QType, RoundingUnits>{};
@@ -802,17 +803,17 @@ constexpr auto int_floor_as_impl(RoundingUnits, QType<U, R> val) {
 }
 // (a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_floor_as(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_floor_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_floor_as_impl(rounding_units, q);
 }
 // (b) Version for QuantityPoint.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_floor_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_floor_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_floor_as_impl(rounding_units, p);
 }
 // (c) Version for Constant.
 template <typename RoundingUnits, typename U>
-constexpr auto int_floor_as(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto int_floor_as(RoundingUnits rounding_units, Constant<U> c) {
     return floor_as(rounding_units, c);  // For `Constant`, identical to `floor_as`.
 }
 
@@ -828,7 +829,7 @@ template <typename OutputRep,
           class QType,
           typename U,
           typename R>
-constexpr auto int_floor_as_explicit_rep_impl(RoundingUnits, QType<U, R> val) {
+AU_DEVICE_FUNC constexpr auto int_floor_as_explicit_rep_impl(RoundingUnits, QType<U, R> val) {
     static_assert(std::is_integral<OutputRep>::value, "int_floor_as output must be integral");
 
     constexpr auto target = AppropriateAssociatedUnit<QType, RoundingUnits>{};
@@ -838,12 +839,12 @@ constexpr auto int_floor_as_explicit_rep_impl(RoundingUnits, QType<U, R> val) {
 }
 // (a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_floor_as(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_floor_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_floor_as_explicit_rep_impl<OutputRep>(rounding_units, q);
 }
 // (b) Version for QuantityPoint.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_floor_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_floor_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_floor_as_explicit_rep_impl<OutputRep>(rounding_units, p);
 }
 
@@ -854,12 +855,12 @@ constexpr auto int_floor_as(RoundingUnits rounding_units, QuantityPoint<U, R> p)
 //
 // (a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_floor_in(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_floor_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_floor_as(rounding_units, q).in(rounding_units);
 }
 // (b) Version for QuantityPoint.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_floor_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_floor_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_floor_as(rounding_units, p).in(associated_unit_for_points(rounding_units));
 }
 
@@ -870,17 +871,17 @@ constexpr auto int_floor_in(RoundingUnits rounding_units, QuantityPoint<U, R> p)
 //
 // (a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_floor_in(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_floor_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_floor_as<OutputRep>(rounding_units, q).in(rounding_units);
 }
 // (b) Version for QuantityPoint.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_floor_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_floor_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_floor_as<OutputRep>(rounding_units, p).in(rounding_units);
 }
 // (c) Version for Constant.
 template <typename OutputRep, typename RoundingUnits, typename U>
-constexpr auto int_floor_in(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto int_floor_in(RoundingUnits rounding_units, Constant<U> c) {
     return floor_in<OutputRep>(rounding_units, c);  // For `Constant`, identical to `floor_in`.
 }
 
@@ -891,7 +892,7 @@ constexpr auto int_floor_in(RoundingUnits rounding_units, Constant<U> c) {
 //
 // Common implementation helper:
 template <typename RoundingUnits, template <class, class> class QType, typename U, typename R>
-constexpr auto int_ceil_as_impl(RoundingUnits, QType<U, R> val) {
+AU_DEVICE_FUNC constexpr auto int_ceil_as_impl(RoundingUnits, QType<U, R> val) {
     static_assert(std::is_integral<R>::value, "int_ceil_as requires integral Rep type");
 
     constexpr auto target = AppropriateAssociatedUnit<QType, RoundingUnits>{};
@@ -901,17 +902,17 @@ constexpr auto int_ceil_as_impl(RoundingUnits, QType<U, R> val) {
 }
 // (a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_ceil_as(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_ceil_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_ceil_as_impl(rounding_units, q);
 }
 // (b) Version for QuantityPoint.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_ceil_as_impl(rounding_units, p);
 }
 // (c) Version for Constant.
 template <typename RoundingUnits, typename U>
-constexpr auto int_ceil_as(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto int_ceil_as(RoundingUnits rounding_units, Constant<U> c) {
     return ceil_as(rounding_units, c);  // For `Constant`, identical to `ceil_as`.
 }
 
@@ -927,7 +928,7 @@ template <typename OutputRep,
           class QType,
           typename U,
           typename R>
-constexpr auto int_ceil_as_explicit_rep_impl(RoundingUnits, QType<U, R> val) {
+AU_DEVICE_FUNC constexpr auto int_ceil_as_explicit_rep_impl(RoundingUnits, QType<U, R> val) {
     static_assert(std::is_integral<OutputRep>::value, "int_ceil_as output must be integral");
 
     constexpr auto target = AppropriateAssociatedUnit<QType, RoundingUnits>{};
@@ -937,12 +938,12 @@ constexpr auto int_ceil_as_explicit_rep_impl(RoundingUnits, QType<U, R> val) {
 }
 // (a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_ceil_as(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_ceil_as(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_ceil_as_explicit_rep_impl<OutputRep>(rounding_units, q);
 }
 // (b) Version for QuantityPoint.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_ceil_as_explicit_rep_impl<OutputRep>(rounding_units, p);
 }
 
@@ -953,12 +954,12 @@ constexpr auto int_ceil_as(RoundingUnits rounding_units, QuantityPoint<U, R> p) 
 //
 // (a) Version for Quantity.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_ceil_in(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_ceil_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_ceil_as(rounding_units, q).in(rounding_units);
 }
 // (b) Version for QuantityPoint.
 template <typename RoundingUnits, typename U, typename R>
-constexpr auto int_ceil_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_ceil_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_ceil_as(rounding_units, p).in(associated_unit_for_points(rounding_units));
 }
 
@@ -969,17 +970,17 @@ constexpr auto int_ceil_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) 
 //
 // (a) Version for Quantity.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_ceil_in(RoundingUnits rounding_units, Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto int_ceil_in(RoundingUnits rounding_units, Quantity<U, R> q) {
     return int_ceil_as<OutputRep>(rounding_units, q).in(rounding_units);
 }
 // (b) Version for QuantityPoint.
 template <typename OutputRep, typename RoundingUnits, typename U, typename R>
-constexpr auto int_ceil_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
+AU_DEVICE_FUNC constexpr auto int_ceil_in(RoundingUnits rounding_units, QuantityPoint<U, R> p) {
     return int_ceil_as<OutputRep>(rounding_units, p).in(rounding_units);
 }
 // (c) Version for Constant.
 template <typename OutputRep, typename RoundingUnits, typename U>
-constexpr auto int_ceil_in(RoundingUnits rounding_units, Constant<U> c) {
+AU_DEVICE_FUNC constexpr auto int_ceil_in(RoundingUnits rounding_units, Constant<U> c) {
     return ceil_in<OutputRep>(rounding_units, c);  // For `Constant`, identical to `ceil_in`.
 }
 

--- a/au/math.hh
+++ b/au/math.hh
@@ -164,7 +164,9 @@ auto cbrt(Quantity<U, R> q) {
 
 // Clamp the first quantity to within the range of the second two.
 template <typename UV, typename ULo, typename UHi, typename RV, typename RLo, typename RHi>
-AU_DEVICE_FUNC constexpr auto clamp(Quantity<UV, RV> v, Quantity<ULo, RLo> lo, Quantity<UHi, RHi> hi) {
+AU_DEVICE_FUNC constexpr auto clamp(Quantity<UV, RV> v,
+                                    Quantity<ULo, RLo> lo,
+                                    Quantity<UHi, RHi> hi) {
     using U = CommonUnit<UV, ULo, UHi>;
     using R = std::common_type_t<RV, RLo, RHi>;
     using ResultT = Quantity<U, R>;
@@ -174,8 +176,8 @@ AU_DEVICE_FUNC constexpr auto clamp(Quantity<UV, RV> v, Quantity<ULo, RLo> lo, Q
 // Clamp the first point to within the range of the second two.
 template <typename UV, typename ULo, typename UHi, typename RV, typename RLo, typename RHi>
 AU_DEVICE_FUNC constexpr auto clamp(QuantityPoint<UV, RV> v,
-                     QuantityPoint<ULo, RLo> lo,
-                     QuantityPoint<UHi, RHi> hi) {
+                                    QuantityPoint<ULo, RLo> lo,
+                                    QuantityPoint<UHi, RHi> hi) {
     using U = CommonPointUnit<UV, ULo, UHi>;
     using R = std::common_type_t<RV, RLo, RHi>;
     using ResultT = QuantityPoint<U, R>;

--- a/au/operators.hh
+++ b/au/operators.hh
@@ -18,6 +18,7 @@
 #include <compare>
 #endif
 
+#include "au/config.hh"
 #include "au/stdx/type_traits.hh"
 #include "au/stdx/utility.hh"
 
@@ -61,17 +62,17 @@ using ComparisonCategory =
 
 struct Equal {
     template <typename T, typename U>
-    constexpr bool operator()(const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool operator()(const T &a, const U &b) const {
         return op_impl(ComparisonCategory<T, U>{}, a, b);
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a == b;
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
         return stdx::cmp_equal(a, b);
     }
 };
@@ -79,17 +80,17 @@ constexpr auto equal = Equal{};
 
 struct NotEqual {
     template <typename T, typename U>
-    constexpr bool operator()(const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool operator()(const T &a, const U &b) const {
         return op_impl(ComparisonCategory<T, U>{}, a, b);
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a != b;
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
         return stdx::cmp_not_equal(a, b);
     }
 };
@@ -97,17 +98,17 @@ constexpr auto not_equal = NotEqual{};
 
 struct Greater {
     template <typename T, typename U>
-    constexpr bool operator()(const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool operator()(const T &a, const U &b) const {
         return op_impl(ComparisonCategory<T, U>{}, a, b);
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a > b;
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
         return stdx::cmp_greater(a, b);
     }
 };
@@ -115,17 +116,17 @@ constexpr auto greater = Greater{};
 
 struct Less {
     template <typename T, typename U>
-    constexpr bool operator()(const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool operator()(const T &a, const U &b) const {
         return op_impl(ComparisonCategory<T, U>{}, a, b);
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a < b;
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
         return stdx::cmp_less(a, b);
     }
 };
@@ -133,17 +134,17 @@ constexpr auto less = Less{};
 
 struct GreaterEqual {
     template <typename T, typename U>
-    constexpr bool operator()(const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool operator()(const T &a, const U &b) const {
         return op_impl(ComparisonCategory<T, U>{}, a, b);
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a >= b;
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
         return stdx::cmp_greater_equal(a, b);
     }
 };
@@ -151,17 +152,17 @@ constexpr auto greater_equal = GreaterEqual{};
 
 struct LessEqual {
     template <typename T, typename U>
-    constexpr bool operator()(const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool operator()(const T &a, const U &b) const {
         return op_impl(ComparisonCategory<T, U>{}, a, b);
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(DefaultComparison, const T &a, const U &b) const {
         return a <= b;
     }
 
     template <typename T, typename U>
-    constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr bool op_impl(CompareBuiltInIntegers, const T &a, const U &b) const {
         return stdx::cmp_less_equal(a, b);
     }
 };
@@ -170,7 +171,7 @@ constexpr auto less_equal = LessEqual{};
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 struct ThreeWayCompare {
     template <typename T, typename U>
-    constexpr auto operator()(const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr auto operator()(const T &a, const U &b) const {
         // Note that we do not need special treatment for the case where `T` and `U` are both
         // integral types, because the C++ language already prohibits narrowing conversions (such as
         // `int` to `uint`) for `operator<=>`.  We can rely on this implicit warning to induce users
@@ -187,7 +188,7 @@ constexpr auto three_way_compare = ThreeWayCompare{};
 
 struct Plus {
     template <typename T, typename U>
-    constexpr auto operator()(const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr auto operator()(const T &a, const U &b) const {
         return a + b;
     }
 };
@@ -195,7 +196,7 @@ constexpr auto plus = Plus{};
 
 struct Minus {
     template <typename T, typename U>
-    constexpr auto operator()(const T &a, const U &b) const {
+    AU_DEVICE_FUNC constexpr auto operator()(const T &a, const U &b) const {
         return a - b;
     }
 };

--- a/au/overflow_boundary.hh
+++ b/au/overflow_boundary.hh
@@ -17,6 +17,7 @@
 #include <limits>
 #include <type_traits>
 
+#include "au/config.hh"
 #include "au/abstract_operations.hh"
 #include "au/magnitude.hh"
 #include "au/operators.hh"
@@ -102,7 +103,7 @@ struct MaxValueChecker;
 // `would_value_overflow<Op>(x)` checks whether the value `x` would exceed the bounds of the
 // operation at any stage.
 template <typename Op>
-constexpr bool would_value_overflow(const OpInput<Op> &x) {
+AU_DEVICE_FUNC constexpr bool would_value_overflow(const OpInput<Op> &x) {
     return MinValueChecker<Op>::is_too_small(x) || MaxValueChecker<Op>::is_too_large(x);
 }
 
@@ -782,22 +783,26 @@ struct CanOverflowAbove : stdx::bool_constant<(MaxGood<Op>::value() < MaxPossibl
 
 template <typename Op, bool IsOverflowPossible>
 struct MinValueCheckerImpl {
-    static constexpr bool is_too_small(const OpInput<Op> &x) { return x < MinGood<Op>::value(); }
+    static AU_DEVICE_FUNC constexpr bool is_too_small(const OpInput<Op> &x) {
+        return x < MinGood<Op>::value();
+    }
 };
 template <typename Op>
 struct MinValueCheckerImpl<Op, false> {
-    static constexpr bool is_too_small(const OpInput<Op> &) { return false; }
+    static AU_DEVICE_FUNC constexpr bool is_too_small(const OpInput<Op> &) { return false; }
 };
 template <typename Op>
 struct MinValueChecker : MinValueCheckerImpl<Op, CanOverflowBelow<Op>::value> {};
 
 template <typename Op, bool IsOverflowPossible>
 struct MaxValueCheckerImpl {
-    static constexpr bool is_too_large(const OpInput<Op> &x) { return x > MaxGood<Op>::value(); }
+    static AU_DEVICE_FUNC constexpr bool is_too_large(const OpInput<Op> &x) {
+        return x > MaxGood<Op>::value();
+    }
 };
 template <typename Op>
 struct MaxValueCheckerImpl<Op, false> {
-    static constexpr bool is_too_large(const OpInput<Op> &) { return false; }
+    static AU_DEVICE_FUNC constexpr bool is_too_large(const OpInput<Op> &) { return false; }
 };
 template <typename Op>
 struct MaxValueChecker : MaxValueCheckerImpl<Op, CanOverflowAbove<Op>::value> {};

--- a/au/overflow_boundary.hh
+++ b/au/overflow_boundary.hh
@@ -17,8 +17,8 @@
 #include <limits>
 #include <type_traits>
 
-#include "au/config.hh"
 #include "au/abstract_operations.hh"
+#include "au/config.hh"
 #include "au/magnitude.hh"
 #include "au/operators.hh"
 #include "au/stdx/type_traits.hh"

--- a/au/prefix.hh
+++ b/au/prefix.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "au/config.hh"
 #include "au/fwd.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
@@ -75,33 +76,33 @@ template <template <class U> class Prefix>
 struct PrefixApplier {
     // Applying a Prefix to a Unit instance, creates an instance of the Prefixed Unit.
     template <typename U>
-    constexpr auto operator()(U) const {
+    AU_DEVICE_FUNC constexpr auto operator()(U) const {
         return Prefix<U>{};
     }
 
     // Applying a Prefix to a QuantityMaker instance, creates a maker for the Prefixed Unit.
     template <typename U>
-    constexpr auto operator()(QuantityMaker<U>) const {
+    AU_DEVICE_FUNC constexpr auto operator()(QuantityMaker<U>) const {
         return QuantityMaker<Prefix<U>>{};
     }
 
     // Applying a Prefix to a QuantityPointMaker instance, changes it to make the Prefixed Unit.
     template <typename U>
-    constexpr auto operator()(QuantityPointMaker<U>) const {
+    AU_DEVICE_FUNC constexpr auto operator()(QuantityPointMaker<U>) const {
         return QuantityPointMaker<Prefix<U>>{};
     }
 
     // Applying a Prefix to a SingularNameFor instance, creates a singularly-named instance of the
     // Prefixed Unit.
     template <typename U>
-    constexpr auto operator()(SingularNameFor<U>) const {
+    AU_DEVICE_FUNC constexpr auto operator()(SingularNameFor<U>) const {
         return SingularNameFor<Prefix<U>>{};
     }
 
     // Applying a Prefix to a SymbolFor instance, creates a symbolically-named instance of the
     // Prefixed unit.
     template <typename U>
-    constexpr auto operator()(SymbolFor<U>) const {
+    AU_DEVICE_FUNC constexpr auto operator()(SymbolFor<U>) const {
         return SymbolFor<Prefix<U>>{};
     }
 };

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -20,6 +20,7 @@
 #include <compare>
 #endif
 
+#include "au/config.hh"
 #include "au/conversion_policy.hh"
 #include "au/conversion_strategy.hh"
 #include "au/fwd.hh"
@@ -37,12 +38,12 @@ namespace au {
 // Make a Quantity of the given Unit, which has this value as measured in the Unit.
 //
 template <typename UnitT, typename T>
-constexpr auto make_quantity(T value) {
+AU_DEVICE_FUNC constexpr auto make_quantity(T value) {
     return QuantityMaker<UnitT>{}(value);
 }
 
 template <typename Unit, typename T>
-constexpr auto make_quantity_unless_unitless(T value) {
+AU_DEVICE_FUNC constexpr auto make_quantity_unless_unitless(T value) {
     return std::conditional_t<IsUnitlessUnit<Unit>::value, stdx::identity, QuantityMaker<Unit>>{}(
         value);
 }
@@ -96,7 +97,7 @@ struct CorrespondingQuantity<const T &> : CorrespondingQuantity<T> {};
 // `as_quantity()` is SFINAE-friendly: we can use it to constrain templates to types `T` which are
 // exactly equivalent to some Quantity type.
 template <typename T>
-constexpr auto as_quantity(T &&x) -> detail::CorrespondingQuantityType<T> {
+AU_DEVICE_FUNC constexpr auto as_quantity(T &&x) -> detail::CorrespondingQuantityType<T> {
     using Q = CorrespondingQuantity<T>;
     static_assert(IsUnit<typename Q::Unit>{}, "No Quantity corresponding to type");
 
@@ -113,11 +114,11 @@ constexpr auto as_quantity(T &&x) -> detail::CorrespondingQuantityType<T> {
 //
 // Identity for non-`Quantity` types.
 template <typename U, typename R, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
-constexpr R as_raw_number(Quantity<U, R> q, RiskPolicyT policy = RiskPolicyT{}) {
+AU_DEVICE_FUNC constexpr R as_raw_number(Quantity<U, R> q, RiskPolicyT policy = RiskPolicyT{}) {
     return q.in(UnitProduct<>{}, policy);
 }
 template <typename T>
-constexpr T as_raw_number(T x) {
+AU_DEVICE_FUNC constexpr T as_raw_number(T x) {
     return x;
 }
 
@@ -158,7 +159,8 @@ class Quantity {
     template <typename OtherUnit,
               typename OtherRep,
               typename Enable = EnableIfImplicitOkIs<true, OtherUnit, OtherRep>>
-    constexpr Quantity(Quantity<OtherUnit, OtherRep> other)  // NOLINT(runtime/explicit)
+    AU_DEVICE_FUNC constexpr Quantity(
+        Quantity<OtherUnit, OtherRep> other)  // NOLINT(runtime/explicit)
         : value_{other.template in_impl<detail::UseImplicitConversion, Rep>(
               UnitT{}, check_for(ALL_RISKS))} {}
 
@@ -175,26 +177,26 @@ class Quantity {
               typename OtherRep,
               typename RiskPolicyT,
               std::enable_if_t<IsConversionRiskPolicy<RiskPolicyT>::value, int> = 0>
-    constexpr Quantity(Quantity<OtherUnit, OtherRep> other, RiskPolicyT policy)
+    AU_DEVICE_FUNC constexpr Quantity(Quantity<OtherUnit, OtherRep> other, RiskPolicyT policy)
         : value_{other.template in<Rep>(UnitT{}, policy)} {}
 
     // Construct this Quantity with a value of exactly Zero.
-    constexpr Quantity(Zero) : value_{0} {}
+    AU_DEVICE_FUNC constexpr Quantity(Zero) : value_{0} {}
 
-    constexpr Quantity() noexcept = default;
+    AU_DEVICE_FUNC constexpr Quantity() noexcept = default;
 
     // Implicit construction from any exactly-equivalent type.
     template <
         typename T,
         std::enable_if_t<std::is_convertible<detail::CorrespondingQuantityType<T>, Quantity>::value,
                          int> = 0>
-    constexpr Quantity(T &&x) : Quantity{as_quantity(std::forward<T>(x))} {}
+    AU_DEVICE_FUNC constexpr Quantity(T &&x) : Quantity{as_quantity(std::forward<T>(x))} {}
 
     // `q.as<Rep>()`, or `q.as<Rep>(risk_policy)`
     template <typename NewRep,
               typename RiskPolicyT = decltype(check_for(ALL_RISKS)),
               std::enable_if_t<IsConversionRiskPolicy<RiskPolicyT>::value, int> = 0>
-    constexpr auto as(RiskPolicyT policy = RiskPolicyT{}) const {
+    AU_DEVICE_FUNC constexpr auto as(RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity<Unit>(in_impl<detail::UseStaticCast, NewRep>(Unit{}, policy));
     }
 
@@ -203,14 +205,14 @@ class Quantity {
               typename NewUnitSlot,
               typename RiskPolicyT = decltype(ignore(ALL_RISKS)),
               std::enable_if_t<!IsConversionRiskPolicy<NewUnitSlot>::value, int> = 0>
-    constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
+    AU_DEVICE_FUNC constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity<AssociatedUnit<NewUnitSlot>>(
             in_impl<detail::UseStaticCast, NewRep>(u, policy));
     }
 
     // `q.as(new_unit)`, or `q.as(new_unit, risk_policy)`
     template <typename NewUnitSlot, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
-    constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
+    AU_DEVICE_FUNC constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity<AssociatedUnit<NewUnitSlot>>(
             in_impl<detail::UseStaticCast, Rep>(u, policy));
     }
@@ -219,13 +221,13 @@ class Quantity {
     template <typename NewRep,
               typename NewUnitSlot,
               typename RiskPolicyT = decltype(ignore(ALL_RISKS))>
-    constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
+    AU_DEVICE_FUNC constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<detail::UseStaticCast, NewRep>(u, policy);
     }
 
     // `q.in(new_unit)`, or `q.in(new_unit, risk_policy)`
     template <typename NewUnitSlot, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
-    constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
+    AU_DEVICE_FUNC constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<detail::UseStaticCast, Rep>(u, policy);
     }
 
@@ -255,14 +257,14 @@ class Quantity {
     //
     // Mutable access:
     template <typename UnitSlot>
-    constexpr Rep &data_in(UnitSlot) {
+    AU_DEVICE_FUNC constexpr Rep &data_in(UnitSlot) {
         static_assert(AreUnitsQuantityEquivalent<AssociatedUnit<UnitSlot>, Unit>::value,
                       "Can only access value via Quantity-equivalent unit");
         return value_;
     }
     // Const access:
     template <typename UnitSlot>
-    constexpr const Rep &data_in(UnitSlot) const {
+    AU_DEVICE_FUNC constexpr const Rep &data_in(UnitSlot) const {
         static_assert(AreUnitsQuantityEquivalent<AssociatedUnit<UnitSlot>, Unit>::value,
                       "Can only access value via Quantity-equivalent unit");
         return value_;
@@ -276,76 +278,92 @@ class Quantity {
     friend struct QuantityMaker<UnitT>;
 
     // Comparison operators.
-    friend constexpr bool operator==(Quantity a, Quantity b) { return Eq{}(a.value_, b.value_); }
-    friend constexpr bool operator!=(Quantity a, Quantity b) { return Ne{}(a.value_, b.value_); }
-    friend constexpr bool operator<(Quantity a, Quantity b) { return Lt{}(a.value_, b.value_); }
-    friend constexpr bool operator<=(Quantity a, Quantity b) { return Le{}(a.value_, b.value_); }
-    friend constexpr bool operator>(Quantity a, Quantity b) { return Gt{}(a.value_, b.value_); }
-    friend constexpr bool operator>=(Quantity a, Quantity b) { return Ge{}(a.value_, b.value_); }
+    friend AU_DEVICE_FUNC constexpr bool operator==(Quantity a, Quantity b) {
+        return Eq{}(a.value_, b.value_);
+    }
+    friend AU_DEVICE_FUNC constexpr bool operator!=(Quantity a, Quantity b) {
+        return Ne{}(a.value_, b.value_);
+    }
+    friend AU_DEVICE_FUNC constexpr bool operator<(Quantity a, Quantity b) {
+        return Lt{}(a.value_, b.value_);
+    }
+    friend AU_DEVICE_FUNC constexpr bool operator<=(Quantity a, Quantity b) {
+        return Le{}(a.value_, b.value_);
+    }
+    friend AU_DEVICE_FUNC constexpr bool operator>(Quantity a, Quantity b) {
+        return Gt{}(a.value_, b.value_);
+    }
+    friend AU_DEVICE_FUNC constexpr bool operator>=(Quantity a, Quantity b) {
+        return Ge{}(a.value_, b.value_);
+    }
 
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
     using Twc = detail::SignAwareComparison<Sign, detail::ThreeWayCompare>;
-    friend constexpr auto operator<=>(Quantity a, Quantity b) { return Twc{}(a.value_, b.value_); }
+    friend AU_DEVICE_FUNC constexpr auto operator<=>(Quantity a, Quantity b) {
+        return Twc{}(a.value_, b.value_);
+    }
 #endif
 
     // Addition and subtraction for like quantities.
-    friend constexpr Quantity<UnitT, decltype(std::declval<RepT>() + std::declval<RepT>())>
+    friend AU_DEVICE_FUNC constexpr Quantity<UnitT,
+                                             decltype(std::declval<RepT>() + std::declval<RepT>())>
     operator+(Quantity a, Quantity b) {
         return make_quantity<UnitT>(a.value_ + b.value_);
     }
-    friend constexpr Quantity<UnitT, decltype(std::declval<RepT>() - std::declval<RepT>())>
+    friend AU_DEVICE_FUNC constexpr Quantity<UnitT,
+                                             decltype(std::declval<RepT>() - std::declval<RepT>())>
     operator-(Quantity a, Quantity b) {
         return make_quantity<UnitT>(a.value_ - b.value_);
     }
 
     // Scalar multiplication.
     template <typename T, typename = std::enable_if_t<IsProductValidRep<RepT, T>::value>>
-    friend constexpr auto operator*(Quantity a, T s) {
+    friend AU_DEVICE_FUNC constexpr auto operator*(Quantity a, T s) {
         return make_quantity<UnitT>(a.value_ * s);
     }
     template <typename T, typename = std::enable_if_t<IsProductValidRep<T, RepT>::value>>
-    friend constexpr auto operator*(T s, Quantity a) {
+    friend AU_DEVICE_FUNC constexpr auto operator*(T s, Quantity a) {
         return make_quantity<UnitT>(s * a.value_);
     }
 
     // Scalar division.
     template <typename T, typename = std::enable_if_t<IsQuotientValidRep<RepT, T>::value>>
-    friend constexpr auto operator/(Quantity a, T s) {
+    friend AU_DEVICE_FUNC constexpr auto operator/(Quantity a, T s) {
         return make_quantity<UnitT>(a.value_ / s);
     }
     template <typename T, typename = std::enable_if_t<IsQuotientValidRep<T, RepT>::value>>
-    friend constexpr auto operator/(T s, Quantity a) {
+    friend AU_DEVICE_FUNC constexpr auto operator/(T s, Quantity a) {
         warn_if_integer_division<UnitProduct<>, T>();
         return make_quantity<decltype(pow<-1>(unit))>(s / a.value_);
     }
 
     // Multiplication for dimensioned quantities.
     template <typename OtherUnit, typename OtherRep>
-    constexpr auto operator*(Quantity<OtherUnit, OtherRep> q) const {
+    AU_DEVICE_FUNC constexpr auto operator*(Quantity<OtherUnit, OtherRep> q) const {
         return make_quantity_unless_unitless<UnitProduct<Unit, OtherUnit>>(value_ *
                                                                            q.in(OtherUnit{}));
     }
 
     // Division for dimensioned quantities.
     template <typename OtherUnit, typename OtherRep>
-    constexpr auto operator/(Quantity<OtherUnit, OtherRep> q) const {
+    AU_DEVICE_FUNC constexpr auto operator/(Quantity<OtherUnit, OtherRep> q) const {
         warn_if_integer_division<OtherUnit, OtherRep>();
         return make_quantity_unless_unitless<UnitQuotient<Unit, OtherUnit>>(value_ /
                                                                             q.in(OtherUnit{}));
     }
 
     // Short-hand addition and subtraction assignment.
-    constexpr Quantity &operator+=(Quantity other) {
+    AU_DEVICE_FUNC constexpr Quantity &operator+=(Quantity other) {
         value_ += other.value_;
         return *this;
     }
-    constexpr Quantity &operator-=(Quantity other) {
+    AU_DEVICE_FUNC constexpr Quantity &operator-=(Quantity other) {
         value_ -= other.value_;
         return *this;
     }
 
     template <typename T>
-    constexpr void perform_shorthand_checks() {
+    AU_DEVICE_FUNC constexpr void perform_shorthand_checks() {
         static_assert(
             IsValidRep<T>::value,
             "This overload is only for scalar mult/div-assignment with raw numeric types");
@@ -357,7 +375,7 @@ class Quantity {
 
     // Short-hand multiplication assignment.
     template <typename T>
-    constexpr Quantity &operator*=(T s) {
+    AU_DEVICE_FUNC constexpr Quantity &operator*=(T s) {
         perform_shorthand_checks<T>();
 
         value_ *= s;
@@ -366,7 +384,7 @@ class Quantity {
 
     // Short-hand division assignment.
     template <typename T>
-    constexpr Quantity &operator/=(T s) {
+    AU_DEVICE_FUNC constexpr Quantity &operator/=(T s) {
         perform_shorthand_checks<T>();
 
         value_ /= s;
@@ -374,15 +392,17 @@ class Quantity {
     }
 
     // Modulo operator (defined only for integral rep).
-    friend constexpr Quantity operator%(Quantity a, Quantity b) { return {a.value_ % b.value_}; }
+    friend AU_DEVICE_FUNC constexpr Quantity operator%(Quantity a, Quantity b) {
+        return {a.value_ % b.value_};
+    }
 
     // Unary plus and minus.
-    constexpr Quantity operator+() const { return {+value_}; }
-    constexpr Quantity operator-() const { return {-value_}; }
+    AU_DEVICE_FUNC constexpr Quantity operator+() const { return {+value_}; }
+    AU_DEVICE_FUNC constexpr Quantity operator-() const { return {-value_}; }
 
     // Automatic conversion to Rep for Unitless type.
     template <typename U = UnitT, typename = std::enable_if_t<IsUnitlessUnit<U>::value>>
-    constexpr operator Rep() const {
+    AU_DEVICE_FUNC constexpr operator Rep() const {
         return value_;
     }
 
@@ -391,7 +411,7 @@ class Quantity {
         typename T,
         std::enable_if_t<std::is_convertible<Quantity, detail::CorrespondingQuantityType<T>>::value,
                          int> = 0>
-    constexpr operator T() const {
+    AU_DEVICE_FUNC constexpr operator T() const {
         return CorrespondingQuantity<T>::construct_from_value(
             detail::CorrespondingQuantityType<T>{*this}.in(
                 typename CorrespondingQuantity<T>::Unit{}));
@@ -407,23 +427,23 @@ class Quantity {
         ENUM_VALUES_ARE_UNUSED
     };
 
-    constexpr Quantity(NTTP val) : value_{static_cast<Rep>(val)} {
+    AU_DEVICE_FUNC constexpr Quantity(NTTP val) : value_{static_cast<Rep>(val)} {
         static_assert(std::is_integral<Rep>::value,
                       "NTTP functionality only works when rep is built-in integral type");
     }
 
-    constexpr operator NTTP() const {
+    AU_DEVICE_FUNC constexpr operator NTTP() const {
         static_assert(std::is_integral<Rep>::value,
                       "NTTP functionality only works when rep is built-in integral type");
         return static_cast<NTTP>(value_);
     }
 
     template <typename C, C x = C::ENUM_VALUES_ARE_UNUSED>
-    constexpr operator C() const = delete;
+    AU_DEVICE_FUNC constexpr operator C() const = delete;
     // If you got here ^^^, then you need to do your unit conversion **manually**.  Check the type
     // of the template parameter, and convert it to that same unit and rep.
 
-    friend constexpr Quantity from_nttp(NTTP val) { return val; }
+    friend AU_DEVICE_FUNC constexpr Quantity from_nttp(NTTP val) { return val; }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Hidden friends for select math functions.
@@ -437,16 +457,16 @@ class Quantity {
     // Note, too, that we use the Walter Brown implementation for min/max, where min prefers `a`,
     // max prefers `b`, and they never return the same input (although this matters less when we're
     // returning by value).
-    friend constexpr Quantity min(Quantity a, Quantity b) { return b < a ? b : a; }
-    friend constexpr Quantity max(Quantity a, Quantity b) { return b < a ? a : b; }
-    friend constexpr Quantity clamp(Quantity v, Quantity lo, Quantity hi) {
+    friend AU_DEVICE_FUNC constexpr Quantity min(Quantity a, Quantity b) { return b < a ? b : a; }
+    friend AU_DEVICE_FUNC constexpr Quantity max(Quantity a, Quantity b) { return b < a ? a : b; }
+    friend AU_DEVICE_FUNC constexpr Quantity clamp(Quantity v, Quantity lo, Quantity hi) {
         return (v < lo) ? lo : ((hi < v) ? hi : v);
     }
 
 #if defined(__cpp_lib_interpolate) && __cpp_lib_interpolate >= 201902L
     // `std::lerp` requires C++20 support.
     template <typename T>
-    friend constexpr auto lerp(Quantity a, Quantity b, T t) {
+    friend AU_DEVICE_FUNC constexpr auto lerp(Quantity a, Quantity b, T t) {
         return make_quantity<UnitT>(std::lerp(a.in(unit), b.in(unit), as_raw_number(t)));
     }
 #endif
@@ -456,7 +476,7 @@ class Quantity {
 
  private:
     template <typename OtherUnit, typename OtherRep>
-    static constexpr void warn_if_integer_division() {
+    static AU_DEVICE_FUNC constexpr void warn_if_integer_division() {
         constexpr bool uses_integer_division =
             (std::is_integral<Rep>::value && std::is_integral<OtherRep>::value);
         constexpr bool are_units_quantity_equivalent =
@@ -472,7 +492,7 @@ class Quantity {
               typename OtherRep,
               typename OtherUnitSlot,
               typename RiskPolicyT>
-    constexpr OtherRep in_impl(OtherUnitSlot, RiskPolicyT) const {
+    AU_DEVICE_FUNC constexpr OtherRep in_impl(OtherUnitSlot, RiskPolicyT) const {
         using OtherUnit = AssociatedUnit<OtherUnitSlot>;
         static_assert(IsUnit<OtherUnit>::value, "Invalid type passed to unit slot");
 
@@ -512,7 +532,7 @@ class Quantity {
         return Op::apply_to(value_);
     }
 
-    constexpr Quantity(Rep value) : value_{value} {}
+    AU_DEVICE_FUNC constexpr Quantity(Rep value) : value_{value} {}
 
     Rep value_{};
 };
@@ -545,13 +565,13 @@ class AlwaysDivisibleQuantity;
 
 // Unblock integer divisoin for a `Quantity`.
 template <typename U, typename R>
-constexpr AlwaysDivisibleQuantity<U, R> unblock_int_div(Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr AlwaysDivisibleQuantity<U, R> unblock_int_div(Quantity<U, R> q) {
     return AlwaysDivisibleQuantity<U, R>{q};
 }
 
 // Unblock integer division for any non-`Quantity` type.
 template <typename R>
-constexpr AlwaysDivisibleQuantity<UnitProduct<>, R> unblock_int_div(R x) {
+AU_DEVICE_FUNC constexpr AlwaysDivisibleQuantity<UnitProduct<>, R> unblock_int_div(R x) {
     return AlwaysDivisibleQuantity<UnitProduct<>, R>{make_quantity<UnitProduct<>>(x)};
 }
 
@@ -560,24 +580,24 @@ class AlwaysDivisibleQuantity {
  public:
     // Divide a `Quantity` by this always-divisible quantity type.
     template <typename U2, typename R2>
-    friend constexpr auto operator/(Quantity<U2, R2> q2, AlwaysDivisibleQuantity q) {
+    friend AU_DEVICE_FUNC constexpr auto operator/(Quantity<U2, R2> q2, AlwaysDivisibleQuantity q) {
         return make_quantity<UnitQuotient<U2, U>>(q2.in(U2{}) / q.q_.in(U{}));
     }
 
     // Divide any non-`Quantity` by this always-divisible quantity type.
     template <typename T>
-    friend constexpr auto operator/(T x, AlwaysDivisibleQuantity q) {
+    friend AU_DEVICE_FUNC constexpr auto operator/(T x, AlwaysDivisibleQuantity q) {
         return make_quantity<UnitInverse<U>>(x / q.q_.in(U{}));
     }
 
     template <typename UU, typename RR>
-    friend constexpr AlwaysDivisibleQuantity<UU, RR> unblock_int_div(Quantity<UU, RR> q);
+    friend AU_DEVICE_FUNC constexpr AlwaysDivisibleQuantity<UU, RR> unblock_int_div(Quantity<UU, RR> q);
 
     template <typename RR>
-    friend constexpr AlwaysDivisibleQuantity<UnitProduct<>, RR> unblock_int_div(RR x);
+    friend AU_DEVICE_FUNC constexpr AlwaysDivisibleQuantity<UnitProduct<>, RR> unblock_int_div(RR x);
 
  private:
-    constexpr AlwaysDivisibleQuantity(Quantity<U, R> q) : q_{q} {}
+    AU_DEVICE_FUNC constexpr AlwaysDivisibleQuantity(Quantity<U, R> q) : q_{q} {}
 
     Quantity<U, R> q_;
 };
@@ -588,7 +608,7 @@ class AlwaysDivisibleQuantity {
 // dividing them.  When they have different dimension, the operation is undefined, and we'll get a
 // compiler error.
 template <typename U1, typename R1, typename U2, typename R2>
-constexpr auto divide_using_common_unit(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr auto divide_using_common_unit(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     using U = CommonUnit<U1, U2>;
     return q1.as(U{}) / q2.as(U{});
 }
@@ -598,7 +618,7 @@ constexpr auto divide_using_common_unit(Quantity<U1, R1> q1, Quantity<U2, R2> q2
 // Only defined whenever (R1{} % R2{}) is defined (i.e., for integral Reps), _and_
 // `CommonUnit<U1, U2>` is also defined.  We convert to that common unit to perform the operation.
 template <typename U1, typename R1, typename U2, typename R2>
-constexpr auto operator%(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr auto operator%(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     using U = CommonUnit<U1, U2>;
     return make_quantity<U>(q1.in(U{}) % q2.in(U{}));
 }
@@ -613,7 +633,7 @@ struct AreQuantityTypesEquivalent<Quantity<U1, R1>, Quantity<U2, R2>>
 
 // Cast Quantity to a different underlying type.
 template <typename NewRep, typename Unit, typename Rep>
-constexpr auto rep_cast(Quantity<Unit, Rep> q) {
+AU_DEVICE_FUNC constexpr auto rep_cast(Quantity<Unit, Rep> q) {
     return q.template as<NewRep>(Unit{});
 }
 
@@ -621,7 +641,7 @@ constexpr auto rep_cast(Quantity<Unit, Rep> q) {
 //
 // Casting Zero to any "Rep" is trivial, because it has no Rep, and is already consistent with all.
 template <typename NewRep>
-constexpr auto rep_cast(Zero z) {
+AU_DEVICE_FUNC constexpr auto rep_cast(Zero z) {
     return z;
 }
 
@@ -631,49 +651,49 @@ struct QuantityMaker {
     static constexpr auto unit = Unit{};
 
     template <typename T>
-    constexpr Quantity<Unit, T> operator()(T value) const {
+    AU_DEVICE_FUNC constexpr Quantity<Unit, T> operator()(T value) const {
         return {value};
     }
 
     template <typename U, typename R>
-    constexpr void operator()(Quantity<U, R>) const {
+    AU_DEVICE_FUNC constexpr void operator()(Quantity<U, R>) const {
         constexpr bool is_not_already_a_quantity = detail::AlwaysFalse<U, R>::value;
         static_assert(is_not_already_a_quantity, "Input to QuantityMaker is already a Quantity");
     }
 
     template <typename U, typename R>
-    constexpr void operator()(QuantityPoint<U, R>) const {
+    AU_DEVICE_FUNC constexpr void operator()(QuantityPoint<U, R>) const {
         constexpr bool is_not_a_quantity_point = detail::AlwaysFalse<U, R>::value;
         static_assert(is_not_a_quantity_point, "Input to QuantityMaker is a QuantityPoint");
     }
 
     template <typename... BPs>
-    constexpr auto operator*(Magnitude<BPs...> m) const {
+    AU_DEVICE_FUNC constexpr auto operator*(Magnitude<BPs...> m) const {
         return QuantityMaker<decltype(unit * m)>{};
     }
 
     template <typename... BPs>
-    constexpr auto operator/(Magnitude<BPs...> m) const {
+    AU_DEVICE_FUNC constexpr auto operator/(Magnitude<BPs...> m) const {
         return QuantityMaker<decltype(unit / m)>{};
     }
 
     template <typename DivisorUnit>
-    constexpr auto operator/(SingularNameFor<DivisorUnit>) const {
+    AU_DEVICE_FUNC constexpr auto operator/(SingularNameFor<DivisorUnit>) const {
         return QuantityMaker<UnitQuotient<Unit, DivisorUnit>>{};
     }
 
     template <typename MultiplierUnit>
-    friend constexpr auto operator*(SingularNameFor<MultiplierUnit>, QuantityMaker) {
+    friend AU_DEVICE_FUNC constexpr auto operator*(SingularNameFor<MultiplierUnit>, QuantityMaker) {
         return QuantityMaker<UnitProduct<MultiplierUnit, Unit>>{};
     }
 
     template <typename OtherUnit>
-    constexpr auto operator*(QuantityMaker<OtherUnit>) const {
+    AU_DEVICE_FUNC constexpr auto operator*(QuantityMaker<OtherUnit>) const {
         return QuantityMaker<UnitProduct<Unit, OtherUnit>>{};
     }
 
     template <typename OtherUnit>
-    constexpr auto operator/(QuantityMaker<OtherUnit>) const {
+    AU_DEVICE_FUNC constexpr auto operator/(QuantityMaker<OtherUnit>) const {
         return QuantityMaker<UnitQuotient<Unit, OtherUnit>>{};
     }
 };
@@ -684,12 +704,12 @@ template <typename U>
 struct AppropriateAssociatedUnitImpl<Quantity, U> : AssociatedUnitImpl<U> {};
 
 template <int Exp, typename Unit>
-constexpr auto pow(QuantityMaker<Unit>) {
+AU_DEVICE_FUNC constexpr auto pow(QuantityMaker<Unit>) {
     return QuantityMaker<UnitPower<Unit, Exp>>{};
 }
 
 template <int N, typename Unit>
-constexpr auto root(QuantityMaker<Unit>) {
+AU_DEVICE_FUNC constexpr auto root(QuantityMaker<Unit>) {
     return QuantityMaker<UnitPower<Unit, 1, N>>{};
 }
 
@@ -698,7 +718,7 @@ constexpr auto root(QuantityMaker<Unit>) {
 
 // Check conversion for overflow (no change of rep).
 template <typename U, typename R, typename TargetUnitSlot>
-constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot) {
+AU_DEVICE_FUNC constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot) {
     using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
                                                   R,
                                                   R,
@@ -708,7 +728,7 @@ constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot) {
 
 // Check conversion for overflow (new rep).
 template <typename TargetRep, typename U, typename R, typename TargetUnitSlot>
-constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot) {
+AU_DEVICE_FUNC constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot) {
     using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
                                                   R,
                                                   TargetRep,
@@ -718,7 +738,7 @@ constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot) {
 
 // Check conversion for truncation (no change of rep).
 template <typename U, typename R, typename TargetUnitSlot>
-constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot) {
+AU_DEVICE_FUNC constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot) {
     using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
                                                   R,
                                                   R,
@@ -728,7 +748,7 @@ constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot) {
 
 // Check conversion for truncation (new rep).
 template <typename TargetRep, typename U, typename R, typename TargetUnitSlot>
-constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot) {
+AU_DEVICE_FUNC constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot) {
     using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
                                                   R,
                                                   TargetRep,
@@ -738,13 +758,13 @@ constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot) {
 
 // Check for any lossiness in conversion (no change of rep).
 template <typename U, typename R, typename TargetUnitSlot>
-constexpr bool is_conversion_lossy(Quantity<U, R> q, TargetUnitSlot target_unit) {
+AU_DEVICE_FUNC constexpr bool is_conversion_lossy(Quantity<U, R> q, TargetUnitSlot target_unit) {
     return will_conversion_truncate(q, target_unit) || will_conversion_overflow(q, target_unit);
 }
 
 // Check for any lossiness in conversion (new rep).
 template <typename TargetRep, typename U, typename R, typename TargetUnitSlot>
-constexpr bool is_conversion_lossy(Quantity<U, R> q, TargetUnitSlot target_unit) {
+AU_DEVICE_FUNC constexpr bool is_conversion_lossy(Quantity<U, R> q, TargetUnitSlot target_unit) {
     return will_conversion_truncate<TargetRep>(q, target_unit) ||
            will_conversion_overflow<TargetRep>(q, target_unit);
 }
@@ -764,7 +784,7 @@ namespace detail {
 // We would have liked this to just be a simple lambda, but some old compilers sometimes struggle
 // with understanding that the lambda implementation of this can be constexpr.
 template <typename TargetUnit, typename U, typename R>
-constexpr auto cast_to_common_type(Quantity<U, R> q) {
+AU_DEVICE_FUNC constexpr auto cast_to_common_type(Quantity<U, R> q) {
     // When we perform a unit conversion to U, we need to make sure the library permits this
     // conversion *implicitly* for a rep R.  The form `rep_cast<R>(q).as(U{})` achieves
     // this.  First, we cast the Rep to R (which will typically be the wider of the input Reps).
@@ -774,7 +794,7 @@ constexpr auto cast_to_common_type(Quantity<U, R> q) {
 }
 
 template <typename T, typename U, typename Func>
-constexpr auto using_common_type(T t, U u, Func f) {
+AU_DEVICE_FUNC constexpr auto using_common_type(T t, U u, Func f) {
     using C = std::common_type_t<T, U>;
     static_assert(
         std::is_same<typename C::Rep, std::common_type_t<typename T::Rep, typename U::Rep>>::value,
@@ -784,7 +804,7 @@ constexpr auto using_common_type(T t, U u, Func f) {
 }
 
 template <typename Op, typename U1, typename U2, typename R1, typename R2>
-constexpr auto convert_and_compare(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr auto convert_and_compare(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     using U = CommonUnit<U1, U2>;
     using ComRep1 = detail::CommonTypeButPreserveIntSignedness<R1, R2>;
     using ComRep2 = detail::CommonTypeButPreserveIntSignedness<R2, R1>;
@@ -796,105 +816,121 @@ constexpr auto convert_and_compare(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
 
 // Comparison functions for compatible Quantity types.
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr bool operator==(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr bool operator==(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return detail::convert_and_compare<detail::Equal>(q1, q2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr bool operator!=(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr bool operator!=(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return detail::convert_and_compare<detail::NotEqual>(q1, q2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr bool operator<(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr bool operator<(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return detail::convert_and_compare<detail::Less>(q1, q2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr bool operator<=(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr bool operator<=(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return detail::convert_and_compare<detail::LessEqual>(q1, q2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr bool operator>(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr bool operator>(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return detail::convert_and_compare<detail::Greater>(q1, q2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr bool operator>=(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr bool operator>=(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return detail::convert_and_compare<detail::GreaterEqual>(q1, q2);
 }
 
 // Addition and subtraction functions for compatible Quantity types.
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto operator+(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr auto operator+(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return detail::using_common_type(q1, q2, detail::plus);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto operator-(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
+AU_DEVICE_FUNC constexpr auto operator-(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
     return detail::using_common_type(q1, q2, detail::minus);
 }
 
 // Mixed-type operations with a left-Quantity, and right-Quantity-equivalent.
 template <typename U, typename R, typename QLike>
-constexpr auto operator+(Quantity<U, R> q1, QLike q2) -> decltype(q1 + as_quantity(q2)) {
+AU_DEVICE_FUNC constexpr auto operator+(Quantity<U, R> q1, QLike q2)
+    -> decltype(q1 + as_quantity(q2)) {
     return q1 + as_quantity(q2);
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator-(Quantity<U, R> q1, QLike q2) -> decltype(q1 - as_quantity(q2)) {
+AU_DEVICE_FUNC constexpr auto operator-(Quantity<U, R> q1, QLike q2)
+    -> decltype(q1 - as_quantity(q2)) {
     return q1 - as_quantity(q2);
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator==(Quantity<U, R> q1, QLike q2) -> decltype(q1 == as_quantity(q2)) {
+AU_DEVICE_FUNC constexpr auto operator==(Quantity<U, R> q1, QLike q2)
+    -> decltype(q1 == as_quantity(q2)) {
     return q1 == as_quantity(q2);
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator!=(Quantity<U, R> q1, QLike q2) -> decltype(q1 != as_quantity(q2)) {
+AU_DEVICE_FUNC constexpr auto operator!=(Quantity<U, R> q1, QLike q2)
+    -> decltype(q1 != as_quantity(q2)) {
     return q1 != as_quantity(q2);
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator<(Quantity<U, R> q1, QLike q2) -> decltype(q1 < as_quantity(q2)) {
+AU_DEVICE_FUNC constexpr auto operator<(Quantity<U, R> q1, QLike q2)
+    -> decltype(q1 < as_quantity(q2)) {
     return q1 < as_quantity(q2);
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator<=(Quantity<U, R> q1, QLike q2) -> decltype(q1 <= as_quantity(q2)) {
+AU_DEVICE_FUNC constexpr auto operator<=(Quantity<U, R> q1, QLike q2)
+    -> decltype(q1 <= as_quantity(q2)) {
     return q1 <= as_quantity(q2);
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator>(Quantity<U, R> q1, QLike q2) -> decltype(q1 > as_quantity(q2)) {
+AU_DEVICE_FUNC constexpr auto operator>(Quantity<U, R> q1, QLike q2)
+    -> decltype(q1 > as_quantity(q2)) {
     return q1 > as_quantity(q2);
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator>=(Quantity<U, R> q1, QLike q2) -> decltype(q1 >= as_quantity(q2)) {
+AU_DEVICE_FUNC constexpr auto operator>=(Quantity<U, R> q1, QLike q2)
+    -> decltype(q1 >= as_quantity(q2)) {
     return q1 >= as_quantity(q2);
 }
 
 // Mixed-type operations with a left-Quantity-equivalent, and right-Quantity.
 template <typename U, typename R, typename QLike>
-constexpr auto operator+(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q1) + q2) {
+AU_DEVICE_FUNC constexpr auto operator+(QLike q1, Quantity<U, R> q2)
+    -> decltype(as_quantity(q1) + q2) {
     return as_quantity(q1) + q2;
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator-(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q1) - q2) {
+AU_DEVICE_FUNC constexpr auto operator-(QLike q1, Quantity<U, R> q2)
+    -> decltype(as_quantity(q1) - q2) {
     return as_quantity(q1) - q2;
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator==(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q1) == q2) {
+AU_DEVICE_FUNC constexpr auto operator==(QLike q1, Quantity<U, R> q2)
+    -> decltype(as_quantity(q1) == q2) {
     return as_quantity(q1) == q2;
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator!=(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q1) != q2) {
+AU_DEVICE_FUNC constexpr auto operator!=(QLike q1, Quantity<U, R> q2)
+    -> decltype(as_quantity(q1) != q2) {
     return as_quantity(q1) != q2;
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator<(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q1) < q2) {
+AU_DEVICE_FUNC constexpr auto operator<(QLike q1, Quantity<U, R> q2)
+    -> decltype(as_quantity(q1) < q2) {
     return as_quantity(q1) < q2;
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator<=(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q1) <= q2) {
+AU_DEVICE_FUNC constexpr auto operator<=(QLike q1, Quantity<U, R> q2)
+    -> decltype(as_quantity(q1) <= q2) {
     return as_quantity(q1) <= q2;
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator>(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q1) > q2) {
+AU_DEVICE_FUNC constexpr auto operator>(QLike q1, Quantity<U, R> q2)
+    -> decltype(as_quantity(q1) > q2) {
     return as_quantity(q1) > q2;
 }
 template <typename U, typename R, typename QLike>
-constexpr auto operator>=(QLike q1, Quantity<U, R> q2) -> decltype(as_quantity(q1) >= q2) {
+AU_DEVICE_FUNC constexpr auto operator>=(QLike q1, Quantity<U, R> q2)
+    -> decltype(as_quantity(q1) >= q2) {
     return as_quantity(q1) >= q2;
 }
 
@@ -902,7 +938,7 @@ namespace detail {
 template <typename Op>
 struct SignAwareComparison<Magnitude<>, Op> {
     template <typename T1, typename T2>
-    constexpr auto operator()(const T1 &lhs, const T2 &rhs) const {
+    AU_DEVICE_FUNC constexpr auto operator()(const T1 &lhs, const T2 &rhs) const {
         return Op{}(lhs, rhs);
     }
 };
@@ -910,7 +946,7 @@ struct SignAwareComparison<Magnitude<>, Op> {
 template <typename Op>
 struct SignAwareComparison<Magnitude<Negative>, Op> {
     template <typename T1, typename T2>
-    constexpr auto operator()(const T1 &lhs, const T2 &rhs) const {
+    AU_DEVICE_FUNC constexpr auto operator()(const T1 &lhs, const T2 &rhs) const {
         return Op{}(rhs, lhs);
     }
 };
@@ -918,7 +954,8 @@ struct SignAwareComparison<Magnitude<Negative>, Op> {
 
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 template <typename U1, typename R1, typename U2, typename R2>
-constexpr auto operator<=>(const Quantity<U1, R1> &lhs, const Quantity<U2, R2> &rhs) {
+AU_DEVICE_FUNC constexpr auto operator<=>(const Quantity<U1, R1> &lhs,
+                                          const Quantity<U2, R2> &rhs) {
     return detail::convert_and_compare<detail::ThreeWayCompare>(lhs, rhs);
 }
 #endif

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -591,10 +591,12 @@ class AlwaysDivisibleQuantity {
     }
 
     template <typename UU, typename RR>
-    friend AU_DEVICE_FUNC constexpr AlwaysDivisibleQuantity<UU, RR> unblock_int_div(Quantity<UU, RR> q);
+    friend AU_DEVICE_FUNC constexpr AlwaysDivisibleQuantity<UU, RR> unblock_int_div(
+        Quantity<UU, RR> q);
 
     template <typename RR>
-    friend AU_DEVICE_FUNC constexpr AlwaysDivisibleQuantity<UnitProduct<>, RR> unblock_int_div(RR x);
+    friend AU_DEVICE_FUNC constexpr AlwaysDivisibleQuantity<UnitProduct<>, RR> unblock_int_div(
+        RR x);
 
  private:
     AU_DEVICE_FUNC constexpr AlwaysDivisibleQuantity(Quantity<U, R> q) : q_{q} {}

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -18,6 +18,7 @@
 #include <compare>
 #endif
 
+#include "au/config.hh"
 #include "au/constant.hh"
 #include "au/fwd.hh"
 #include "au/quantity.hh"
@@ -42,7 +43,7 @@ namespace au {
 
 // Make a Quantity of the given Unit, which has this value as measured in the Unit.
 template <typename UnitT, typename T>
-constexpr auto make_quantity_point(T value) {
+AU_DEVICE_FUNC constexpr auto make_quantity_point(T value) {
     return QuantityPointMaker<UnitT>{}(value);
 }
 
@@ -59,7 +60,7 @@ struct IntermediateRep;
 // "origin" of another unit of the same Dimension _is_ meaningful.  This type trait provides access
 // to that difference.
 template <typename U1, typename U2>
-constexpr auto origin_displacement(U1, U2) {
+AU_DEVICE_FUNC constexpr auto origin_displacement(U1, U2) {
     return make_constant(detail::ComputeOriginDisplacementUnit<AssociatedUnitForPoints<U1>,
                                                                AssociatedUnitForPoints<U2>>{});
 }
@@ -107,12 +108,12 @@ class QuantityPoint {
     // The default constructor produces a QuantityPoint whose value is default constructed.  It
     // exists to give you an object you can assign to.  The main motivating factor for including
     // this is to support `std::atomic`, which requires its types to be default-constructible.
-    constexpr QuantityPoint() noexcept : x_{} {}
+    AU_DEVICE_FUNC constexpr QuantityPoint() noexcept : x_{} {}
 
     template <typename OtherUnit,
               typename OtherRep,
               typename Enable = EnableIfImplicitOkIs<true, OtherUnit, OtherRep>>
-    constexpr QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other)  // NOLINT(runtime/explicit)
+    AU_DEVICE_FUNC constexpr QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other)  // NOLINT(runtime/explicit)
         : QuantityPoint{other.template as<Rep>(unit)} {}
 
     template <typename OtherUnit,
@@ -127,7 +128,7 @@ class QuantityPoint {
               typename OtherRep,
               typename RiskPolicyT,
               std::enable_if_t<IsConversionRiskPolicy<RiskPolicyT>::value, int> = 0>
-    constexpr QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other, RiskPolicyT policy)
+    AU_DEVICE_FUNC constexpr QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other, RiskPolicyT policy)
         : QuantityPoint{other.template as<Rep>(Unit{}, policy)} {}
 
     // The notion of "0" is *not* unambiguous for point types, because different scales can make
@@ -138,7 +139,7 @@ class QuantityPoint {
     template <typename NewRep,
               typename RiskPolicyT = decltype(check_for(ALL_RISKS)),
               std::enable_if_t<IsConversionRiskPolicy<RiskPolicyT>::value, int> = 0>
-    constexpr auto as(RiskPolicyT policy = RiskPolicyT{}) const {
+    AU_DEVICE_FUNC constexpr auto as(RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity_point<Unit>(in_impl<NewRep>(Unit{}, policy));
     }
 
@@ -147,23 +148,23 @@ class QuantityPoint {
               typename NewUnit,
               typename RiskPolicyT = decltype(ignore(ALL_RISKS)),
               std::enable_if_t<!IsConversionRiskPolicy<NewUnit>::value, int> = 0>
-    constexpr auto as(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
+    AU_DEVICE_FUNC constexpr auto as(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity_point<AssociatedUnitForPoints<NewUnit>>(in_impl<NewRep>(u, policy));
     }
 
     // `p.as(new_unit)`, or `p.as(new_unit, risk_policy)`
     template <typename NewUnit, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
-    constexpr auto as(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
+    AU_DEVICE_FUNC constexpr auto as(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity_point<AssociatedUnitForPoints<NewUnit>>(in_impl<Rep>(u, policy));
     }
 
     template <typename NewRep, typename NewUnit, typename RiskPolicyT = decltype(ignore(ALL_RISKS))>
-    constexpr NewRep in(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
+    AU_DEVICE_FUNC constexpr NewRep in(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<NewRep>(u, policy);
     }
 
     template <typename NewUnit, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
-    constexpr Rep in(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
+    AU_DEVICE_FUNC constexpr Rep in(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<Rep>(u, policy);
     }
 
@@ -193,45 +194,45 @@ class QuantityPoint {
     //
     // Mutable access:
     template <typename UnitSlot>
-    constexpr Rep &data_in(UnitSlot) {
+    AU_DEVICE_FUNC constexpr Rep &data_in(UnitSlot) {
         static_assert(AreUnitsPointEquivalent<AssociatedUnitForPoints<UnitSlot>, Unit>::value,
                       "Can only access value via Point-equivalent unit");
         return x_.data_in(AssociatedUnitForPoints<UnitSlot>{});
     }
     // Const access:
     template <typename UnitSlot>
-    constexpr const Rep &data_in(UnitSlot) const {
+    AU_DEVICE_FUNC constexpr const Rep &data_in(UnitSlot) const {
         static_assert(AreUnitsPointEquivalent<AssociatedUnitForPoints<UnitSlot>, Unit>::value,
                       "Can only access value via Point-equivalent unit");
         return x_.data_in(AssociatedUnitForPoints<UnitSlot>{});
     }
 
     // Comparison operators.
-    constexpr friend bool operator==(QuantityPoint a, QuantityPoint b) { return a.x_ == b.x_; }
-    constexpr friend bool operator!=(QuantityPoint a, QuantityPoint b) { return a.x_ != b.x_; }
-    constexpr friend bool operator>=(QuantityPoint a, QuantityPoint b) { return a.x_ >= b.x_; }
-    constexpr friend bool operator>(QuantityPoint a, QuantityPoint b) { return a.x_ > b.x_; }
-    constexpr friend bool operator<=(QuantityPoint a, QuantityPoint b) { return a.x_ <= b.x_; }
-    constexpr friend bool operator<(QuantityPoint a, QuantityPoint b) { return a.x_ < b.x_; }
+    AU_DEVICE_FUNC constexpr friend bool operator==(QuantityPoint a, QuantityPoint b) { return a.x_ == b.x_; }
+    AU_DEVICE_FUNC constexpr friend bool operator!=(QuantityPoint a, QuantityPoint b) { return a.x_ != b.x_; }
+    AU_DEVICE_FUNC constexpr friend bool operator>=(QuantityPoint a, QuantityPoint b) { return a.x_ >= b.x_; }
+    AU_DEVICE_FUNC constexpr friend bool operator>(QuantityPoint a, QuantityPoint b) { return a.x_ > b.x_; }
+    AU_DEVICE_FUNC constexpr friend bool operator<=(QuantityPoint a, QuantityPoint b) { return a.x_ <= b.x_; }
+    AU_DEVICE_FUNC constexpr friend bool operator<(QuantityPoint a, QuantityPoint b) { return a.x_ < b.x_; }
 
     // Subtraction between two QuantityPoint types.
-    constexpr friend auto operator-(QuantityPoint a, QuantityPoint b) { return a.x_ - b.x_; }
+    AU_DEVICE_FUNC constexpr friend auto operator-(QuantityPoint a, QuantityPoint b) { return a.x_ - b.x_; }
 
     // Left and right addition of a Diff.
-    constexpr friend auto operator+(Diff d, QuantityPoint p) { return QuantityPoint{d + p.x_}; }
-    constexpr friend auto operator+(QuantityPoint p, Diff d) { return QuantityPoint{p.x_ + d}; }
+    AU_DEVICE_FUNC constexpr friend auto operator+(Diff d, QuantityPoint p) { return QuantityPoint{d + p.x_}; }
+    AU_DEVICE_FUNC constexpr friend auto operator+(QuantityPoint p, Diff d) { return QuantityPoint{p.x_ + d}; }
 
     // Right subtraction of a Diff.
-    constexpr friend auto operator-(QuantityPoint p, Diff d) { return QuantityPoint{p.x_ - d}; }
+    AU_DEVICE_FUNC constexpr friend auto operator-(QuantityPoint p, Diff d) { return QuantityPoint{p.x_ - d}; }
 
     // Short-hand addition assignment.
-    constexpr QuantityPoint &operator+=(Diff diff) {
+    AU_DEVICE_FUNC constexpr QuantityPoint &operator+=(Diff diff) {
         x_ += diff;
         return *this;
     }
 
     // Short-hand subtraction assignment.
-    constexpr QuantityPoint &operator-=(Diff diff) {
+    AU_DEVICE_FUNC constexpr QuantityPoint &operator-=(Diff diff) {
         x_ -= diff;
         return *this;
     }
@@ -245,7 +246,7 @@ class QuantityPoint {
 
  private:
     template <typename OtherRep, typename OtherPointUnitSlot, typename RiskPolicyT>
-    constexpr OtherRep in_impl(OtherPointUnitSlot, RiskPolicyT policy) const {
+    AU_DEVICE_FUNC constexpr OtherRep in_impl(OtherPointUnitSlot, RiskPolicyT policy) const {
         using OtherUnit = AssociatedUnitForPoints<OtherPointUnitSlot>;
         using OriginDisplacementUnit = detail::ComputeOriginDisplacementUnit<Unit, OtherUnit>;
         using Common = CommonUnit<Unit, OtherUnit, OriginDisplacementUnit>;
@@ -257,7 +258,7 @@ class QuantityPoint {
         return intermediate_result.template in<OtherRep>(OtherUnit{}, policy);
     }
 
-    constexpr explicit QuantityPoint(Diff x) : x_{x} {}
+    AU_DEVICE_FUNC constexpr explicit QuantityPoint(Diff x) : x_{x} {}
 
     Diff x_;
 };
@@ -267,30 +268,30 @@ struct QuantityPointMaker {
     static constexpr auto unit = Unit{};
 
     template <typename T>
-    constexpr auto operator()(T value) const {
+    AU_DEVICE_FUNC constexpr auto operator()(T value) const {
         return QuantityPoint<Unit, T>{make_quantity<Unit>(value)};
     }
 
     template <typename U, typename R>
-    constexpr void operator()(Quantity<U, R>) const {
+    AU_DEVICE_FUNC constexpr void operator()(Quantity<U, R>) const {
         constexpr bool is_not_a_quantity = detail::AlwaysFalse<U, R>::value;
         static_assert(is_not_a_quantity, "Input to QuantityPointMaker is a Quantity");
     }
 
     template <typename U, typename R>
-    constexpr void operator()(QuantityPoint<U, R>) const {
+    AU_DEVICE_FUNC constexpr void operator()(QuantityPoint<U, R>) const {
         constexpr bool is_not_already_a_quantity_point = detail::AlwaysFalse<U, R>::value;
         static_assert(is_not_already_a_quantity_point,
                       "Input to QuantityPointMaker is already a QuantityPoint");
     }
 
     template <typename... BPs>
-    constexpr auto operator*(Magnitude<BPs...> m) const {
+    AU_DEVICE_FUNC constexpr auto operator*(Magnitude<BPs...> m) const {
         return QuantityPointMaker<decltype(unit * m)>{};
     }
 
     template <typename... BPs>
-    constexpr auto operator/(Magnitude<BPs...> m) const {
+    AU_DEVICE_FUNC constexpr auto operator/(Magnitude<BPs...> m) const {
         return QuantityPointMaker<decltype(unit / m)>{};
     }
 };
@@ -326,20 +327,20 @@ struct AreQuantityPointTypesEquivalent<QuantityPoint<U1, R1>, QuantityPoint<U2, 
 
 // Cast QuantityPoint to a different underlying type.
 template <typename NewRep, typename Unit, typename Rep>
-constexpr auto rep_cast(QuantityPoint<Unit, Rep> q) {
+AU_DEVICE_FUNC constexpr auto rep_cast(QuantityPoint<Unit, Rep> q) {
     return q.template as<NewRep>(Unit{});
 }
 
 namespace detail {
 template <typename X, typename Y, typename Func>
-constexpr auto using_common_point_unit(X x, Y y, Func f) {
+AU_DEVICE_FUNC constexpr auto using_common_point_unit(X x, Y y, Func f) {
     using R = std::common_type_t<typename X::Rep, typename Y::Rep>;
     constexpr auto u = CommonPointUnit<typename X::Unit, typename Y::Unit>{};
     return f(rep_cast<R>(x).as(u), rep_cast<R>(y).as(u));
 }
 
 template <typename Op, typename U1, typename U2, typename R1, typename R2>
-constexpr auto convert_and_compare(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+AU_DEVICE_FUNC constexpr auto convert_and_compare(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     using U = CommonPointUnit<U1, U2>;
     using ComRep1 = detail::CommonTypeButPreserveIntSignedness<R1, R2>;
     using ComRep2 = detail::CommonTypeButPreserveIntSignedness<R2, R1>;
@@ -351,27 +352,27 @@ constexpr auto convert_and_compare(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R
 
 // Comparison functions for compatible QuantityPoint types.
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto operator<(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+AU_DEVICE_FUNC constexpr auto operator<(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     return detail::convert_and_compare<detail::Less>(p1, p2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto operator>(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+AU_DEVICE_FUNC constexpr auto operator>(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     return detail::convert_and_compare<detail::Greater>(p1, p2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto operator<=(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+AU_DEVICE_FUNC constexpr auto operator<=(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     return detail::convert_and_compare<detail::LessEqual>(p1, p2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto operator>=(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+AU_DEVICE_FUNC constexpr auto operator>=(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     return detail::convert_and_compare<detail::GreaterEqual>(p1, p2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto operator==(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+AU_DEVICE_FUNC constexpr auto operator==(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     return detail::convert_and_compare<detail::Equal>(p1, p2);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto operator!=(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+AU_DEVICE_FUNC constexpr auto operator!=(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     return detail::convert_and_compare<detail::NotEqual>(p1, p2);
 }
 
@@ -388,35 +389,35 @@ namespace detail {
 // This utility should be used for every overload below which combines a `QuantityPoint` with a
 // `Quantity`.
 template <typename Target, typename U>
-constexpr auto borrow_origin(U u) {
+AU_DEVICE_FUNC constexpr auto borrow_origin(U u) {
     return Target{} * unit_ratio(u, Target{});
 }
 }  // namespace detail
 
 // Addition and subtraction functions for compatible QuantityPoint types.
 template <typename UnitP, typename UnitQ, typename RepP, typename RepQ>
-constexpr auto operator+(QuantityPoint<UnitP, RepP> p, Quantity<UnitQ, RepQ> q) {
+AU_DEVICE_FUNC constexpr auto operator+(QuantityPoint<UnitP, RepP> p, Quantity<UnitQ, RepQ> q) {
     constexpr auto new_unit_q = detail::borrow_origin<UnitP>(UnitQ{});
     return detail::using_common_point_unit(p, q.as(new_unit_q), detail::plus);
 }
 template <typename UnitQ, typename UnitP, typename RepQ, typename RepP>
-constexpr auto operator+(Quantity<UnitQ, RepQ> q, QuantityPoint<UnitP, RepP> p) {
+AU_DEVICE_FUNC constexpr auto operator+(Quantity<UnitQ, RepQ> q, QuantityPoint<UnitP, RepP> p) {
     constexpr auto new_unit_q = detail::borrow_origin<UnitP>(UnitQ{});
     return detail::using_common_point_unit(q.as(new_unit_q), p, detail::plus);
 }
 template <typename UnitP, typename UnitQ, typename R1, typename RepQ>
-constexpr auto operator-(QuantityPoint<UnitP, R1> p, Quantity<UnitQ, RepQ> q) {
+AU_DEVICE_FUNC constexpr auto operator-(QuantityPoint<UnitP, R1> p, Quantity<UnitQ, RepQ> q) {
     constexpr auto new_unit_q = detail::borrow_origin<UnitP>(UnitQ{});
     return detail::using_common_point_unit(p, q.as(new_unit_q), detail::minus);
 }
 template <typename U1, typename U2, typename R1, typename R2>
-constexpr auto operator-(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+AU_DEVICE_FUNC constexpr auto operator-(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
     return detail::using_common_point_unit(p1, p2, detail::minus);
 }
 
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 template <typename U1, typename R1, typename U2, typename R2>
-constexpr auto operator<=>(const QuantityPoint<U1, R1> &lhs, const QuantityPoint<U2, R2> &rhs) {
+AU_DEVICE_FUNC constexpr auto operator<=>(const QuantityPoint<U1, R1> &lhs, const QuantityPoint<U2, R2> &rhs) {
     return detail::convert_and_compare<detail::ThreeWayCompare>(lhs, rhs);
 }
 #endif

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -113,7 +113,8 @@ class QuantityPoint {
     template <typename OtherUnit,
               typename OtherRep,
               typename Enable = EnableIfImplicitOkIs<true, OtherUnit, OtherRep>>
-    AU_DEVICE_FUNC constexpr QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other)  // NOLINT(runtime/explicit)
+    AU_DEVICE_FUNC constexpr QuantityPoint(
+        QuantityPoint<OtherUnit, OtherRep> other)  // NOLINT(runtime/explicit)
         : QuantityPoint{other.template as<Rep>(unit)} {}
 
     template <typename OtherUnit,
@@ -128,7 +129,8 @@ class QuantityPoint {
               typename OtherRep,
               typename RiskPolicyT,
               std::enable_if_t<IsConversionRiskPolicy<RiskPolicyT>::value, int> = 0>
-    AU_DEVICE_FUNC constexpr QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other, RiskPolicyT policy)
+    AU_DEVICE_FUNC constexpr QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other,
+                                           RiskPolicyT policy)
         : QuantityPoint{other.template as<Rep>(Unit{}, policy)} {}
 
     // The notion of "0" is *not* unambiguous for point types, because different scales can make
@@ -208,22 +210,42 @@ class QuantityPoint {
     }
 
     // Comparison operators.
-    AU_DEVICE_FUNC constexpr friend bool operator==(QuantityPoint a, QuantityPoint b) { return a.x_ == b.x_; }
-    AU_DEVICE_FUNC constexpr friend bool operator!=(QuantityPoint a, QuantityPoint b) { return a.x_ != b.x_; }
-    AU_DEVICE_FUNC constexpr friend bool operator>=(QuantityPoint a, QuantityPoint b) { return a.x_ >= b.x_; }
-    AU_DEVICE_FUNC constexpr friend bool operator>(QuantityPoint a, QuantityPoint b) { return a.x_ > b.x_; }
-    AU_DEVICE_FUNC constexpr friend bool operator<=(QuantityPoint a, QuantityPoint b) { return a.x_ <= b.x_; }
-    AU_DEVICE_FUNC constexpr friend bool operator<(QuantityPoint a, QuantityPoint b) { return a.x_ < b.x_; }
+    AU_DEVICE_FUNC constexpr friend bool operator==(QuantityPoint a, QuantityPoint b) {
+        return a.x_ == b.x_;
+    }
+    AU_DEVICE_FUNC constexpr friend bool operator!=(QuantityPoint a, QuantityPoint b) {
+        return a.x_ != b.x_;
+    }
+    AU_DEVICE_FUNC constexpr friend bool operator>=(QuantityPoint a, QuantityPoint b) {
+        return a.x_ >= b.x_;
+    }
+    AU_DEVICE_FUNC constexpr friend bool operator>(QuantityPoint a, QuantityPoint b) {
+        return a.x_ > b.x_;
+    }
+    AU_DEVICE_FUNC constexpr friend bool operator<=(QuantityPoint a, QuantityPoint b) {
+        return a.x_ <= b.x_;
+    }
+    AU_DEVICE_FUNC constexpr friend bool operator<(QuantityPoint a, QuantityPoint b) {
+        return a.x_ < b.x_;
+    }
 
     // Subtraction between two QuantityPoint types.
-    AU_DEVICE_FUNC constexpr friend auto operator-(QuantityPoint a, QuantityPoint b) { return a.x_ - b.x_; }
+    AU_DEVICE_FUNC constexpr friend auto operator-(QuantityPoint a, QuantityPoint b) {
+        return a.x_ - b.x_;
+    }
 
     // Left and right addition of a Diff.
-    AU_DEVICE_FUNC constexpr friend auto operator+(Diff d, QuantityPoint p) { return QuantityPoint{d + p.x_}; }
-    AU_DEVICE_FUNC constexpr friend auto operator+(QuantityPoint p, Diff d) { return QuantityPoint{p.x_ + d}; }
+    AU_DEVICE_FUNC constexpr friend auto operator+(Diff d, QuantityPoint p) {
+        return QuantityPoint{d + p.x_};
+    }
+    AU_DEVICE_FUNC constexpr friend auto operator+(QuantityPoint p, Diff d) {
+        return QuantityPoint{p.x_ + d};
+    }
 
     // Right subtraction of a Diff.
-    AU_DEVICE_FUNC constexpr friend auto operator-(QuantityPoint p, Diff d) { return QuantityPoint{p.x_ - d}; }
+    AU_DEVICE_FUNC constexpr friend auto operator-(QuantityPoint p, Diff d) {
+        return QuantityPoint{p.x_ - d};
+    }
 
     // Short-hand addition assignment.
     AU_DEVICE_FUNC constexpr QuantityPoint &operator+=(Diff diff) {
@@ -340,7 +362,8 @@ AU_DEVICE_FUNC constexpr auto using_common_point_unit(X x, Y y, Func f) {
 }
 
 template <typename Op, typename U1, typename U2, typename R1, typename R2>
-AU_DEVICE_FUNC constexpr auto convert_and_compare(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
+AU_DEVICE_FUNC constexpr auto convert_and_compare(QuantityPoint<U1, R1> p1,
+                                                  QuantityPoint<U2, R2> p2) {
     using U = CommonPointUnit<U1, U2>;
     using ComRep1 = detail::CommonTypeButPreserveIntSignedness<R1, R2>;
     using ComRep2 = detail::CommonTypeButPreserveIntSignedness<R2, R1>;
@@ -417,7 +440,8 @@ AU_DEVICE_FUNC constexpr auto operator-(QuantityPoint<U1, R1> p1, QuantityPoint<
 
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 template <typename U1, typename R1, typename U2, typename R2>
-AU_DEVICE_FUNC constexpr auto operator<=>(const QuantityPoint<U1, R1> &lhs, const QuantityPoint<U2, R2> &rhs) {
+AU_DEVICE_FUNC constexpr auto operator<=>(const QuantityPoint<U1, R1> &lhs,
+                                          const QuantityPoint<U2, R2> &rhs) {
     return detail::convert_and_compare<detail::ThreeWayCompare>(lhs, rhs);
 }
 #endif

--- a/au/stdx/utility.hh
+++ b/au/stdx/utility.hh
@@ -84,12 +84,16 @@ struct CmpEqualImpl<T, U, std::enable_if_t<std::is_signed<T>::value == std::is_s
 
 template <typename T, typename U>
 struct CmpEqualImpl<T, U, std::enable_if_t<std::is_signed<T>::value && !std::is_signed<U>::value>> {
-    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) { return t < 0 ? false : std::make_unsigned_t<T>(t) == u; }
+    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) {
+        return t < 0 ? false : std::make_unsigned_t<T>(t) == u;
+    }
 };
 
 template <typename T, typename U>
 struct CmpEqualImpl<T, U, std::enable_if_t<!std::is_signed<T>::value && std::is_signed<U>::value>> {
-    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) { return u < 0 ? false : t == std::make_unsigned_t<U>(u); }
+    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) {
+        return u < 0 ? false : t == std::make_unsigned_t<U>(u);
+    }
 };
 
 template <typename T, typename U>
@@ -99,12 +103,16 @@ struct CmpLessImpl<T, U, std::enable_if_t<std::is_signed<T>::value == std::is_si
 
 template <typename T, typename U>
 struct CmpLessImpl<T, U, std::enable_if_t<std::is_signed<T>::value && !std::is_signed<U>::value>> {
-    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) { return t < 0 ? true : std::make_unsigned_t<T>(t) < u; }
+    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) {
+        return t < 0 ? true : std::make_unsigned_t<T>(t) < u;
+    }
 };
 
 template <typename T, typename U>
 struct CmpLessImpl<T, U, std::enable_if_t<!std::is_signed<T>::value && std::is_signed<U>::value>> {
-    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) { return u < 0 ? false : t < std::make_unsigned_t<U>(u); }
+    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) {
+        return u < 0 ? false : t < std::make_unsigned_t<U>(u);
+    }
 };
 
 }  // namespace stdx

--- a/au/stdx/utility.hh
+++ b/au/stdx/utility.hh
@@ -17,6 +17,8 @@
 #include <limits>
 #include <type_traits>
 
+#include "au/config.hh"
+
 namespace au {
 namespace stdx {
 
@@ -26,13 +28,13 @@ namespace stdx {
 template <typename T, typename U, typename Enable = void>
 struct CmpEqualImpl;
 template <class T, class U>
-constexpr bool cmp_equal(T t, U u) noexcept {
+AU_DEVICE_FUNC constexpr bool cmp_equal(T t, U u) noexcept {
     return CmpEqualImpl<T, U>{}(t, u);
 }
 
 // Source: adapted from (https://en.cppreference.com/w/cpp/utility/intcmp).
 template <class T, class U>
-constexpr bool cmp_not_equal(T t, U u) noexcept {
+AU_DEVICE_FUNC constexpr bool cmp_not_equal(T t, U u) noexcept {
     return !cmp_equal(t, u);
 }
 
@@ -42,31 +44,31 @@ constexpr bool cmp_not_equal(T t, U u) noexcept {
 template <typename T, typename U, typename Enable = void>
 struct CmpLessImpl;
 template <class T, class U>
-constexpr bool cmp_less(T t, U u) noexcept {
+AU_DEVICE_FUNC constexpr bool cmp_less(T t, U u) noexcept {
     return CmpLessImpl<T, U>{}(t, u);
 }
 
 // Source: adapted from (https://en.cppreference.com/w/cpp/utility/intcmp).
 template <class T, class U>
-constexpr bool cmp_greater(T t, U u) noexcept {
+AU_DEVICE_FUNC constexpr bool cmp_greater(T t, U u) noexcept {
     return cmp_less(u, t);
 }
 
 // Source: adapted from (https://en.cppreference.com/w/cpp/utility/intcmp).
 template <class T, class U>
-constexpr bool cmp_less_equal(T t, U u) noexcept {
+AU_DEVICE_FUNC constexpr bool cmp_less_equal(T t, U u) noexcept {
     return !cmp_greater(t, u);
 }
 
 // Source: adapted from (https://en.cppreference.com/w/cpp/utility/intcmp).
 template <class T, class U>
-constexpr bool cmp_greater_equal(T t, U u) noexcept {
+AU_DEVICE_FUNC constexpr bool cmp_greater_equal(T t, U u) noexcept {
     return !cmp_less(t, u);
 }
 
 // Source: adapted from (https://en.cppreference.com/w/cpp/utility/in_range).
 template <class R, class T>
-constexpr bool in_range(T t) noexcept {
+AU_DEVICE_FUNC constexpr bool in_range(T t) noexcept {
     return cmp_greater_equal(t, std::numeric_limits<R>::min()) &&
            cmp_less_equal(t, std::numeric_limits<R>::max());
 }
@@ -77,32 +79,32 @@ constexpr bool in_range(T t) noexcept {
 
 template <typename T, typename U>
 struct CmpEqualImpl<T, U, std::enable_if_t<std::is_signed<T>::value == std::is_signed<U>::value>> {
-    constexpr bool operator()(T t, U u) { return t == u; }
+    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) { return t == u; }
 };
 
 template <typename T, typename U>
 struct CmpEqualImpl<T, U, std::enable_if_t<std::is_signed<T>::value && !std::is_signed<U>::value>> {
-    constexpr bool operator()(T t, U u) { return t < 0 ? false : std::make_unsigned_t<T>(t) == u; }
+    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) { return t < 0 ? false : std::make_unsigned_t<T>(t) == u; }
 };
 
 template <typename T, typename U>
 struct CmpEqualImpl<T, U, std::enable_if_t<!std::is_signed<T>::value && std::is_signed<U>::value>> {
-    constexpr bool operator()(T t, U u) { return u < 0 ? false : t == std::make_unsigned_t<U>(u); }
+    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) { return u < 0 ? false : t == std::make_unsigned_t<U>(u); }
 };
 
 template <typename T, typename U>
 struct CmpLessImpl<T, U, std::enable_if_t<std::is_signed<T>::value == std::is_signed<U>::value>> {
-    constexpr bool operator()(T t, U u) { return t < u; }
+    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) { return t < u; }
 };
 
 template <typename T, typename U>
 struct CmpLessImpl<T, U, std::enable_if_t<std::is_signed<T>::value && !std::is_signed<U>::value>> {
-    constexpr bool operator()(T t, U u) { return t < 0 ? true : std::make_unsigned_t<T>(t) < u; }
+    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) { return t < 0 ? true : std::make_unsigned_t<T>(t) < u; }
 };
 
 template <typename T, typename U>
 struct CmpLessImpl<T, U, std::enable_if_t<!std::is_signed<T>::value && std::is_signed<U>::value>> {
-    constexpr bool operator()(T t, U u) { return u < 0 ? false : t < std::make_unsigned_t<U>(u); }
+    AU_DEVICE_FUNC constexpr bool operator()(T t, U u) { return u < 0 ? false : t < std::make_unsigned_t<U>(u); }
 };
 
 }  // namespace stdx

--- a/au/truncation_risk.hh
+++ b/au/truncation_risk.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "au/config.hh"
 #include "au/abstract_operations.hh"
 
 namespace au {
@@ -31,7 +32,7 @@ struct TruncationRiskClass {
 
 template <typename T>
 struct NoTruncationRisk : TruncationRiskClass<0> {
-    static constexpr bool would_value_truncate(const T &) { return false; }
+    static AU_DEVICE_FUNC constexpr bool would_value_truncate(const T &) { return false; }
 };
 
 template <typename T, typename M>
@@ -45,12 +46,12 @@ using ValueIsNotInteger = ValueTimesRatioIsNotInteger<T, Magnitude<>>;
 
 template <typename T>
 struct ValueIsNotZero : TruncationRiskClass<20> {
-    static constexpr bool would_value_truncate(const T &x) { return x != T{0}; }
+    static AU_DEVICE_FUNC constexpr bool would_value_truncate(const T &x) { return x != T{0}; }
 };
 
 template <typename T>
 struct CannotAssessTruncationRiskFor : TruncationRiskClass<1000> {
-    static constexpr bool would_value_truncate(const T &) { return true; }
+    static AU_DEVICE_FUNC constexpr bool would_value_truncate(const T &) { return true; }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -282,12 +283,12 @@ struct TruncationRiskForImpl<OpSequenceImpl<Op, Ops...>>
 
 template <typename T, typename M>
 struct ValueTimesRatioIsNotIntegerImplForIntWhereDenominatorDoesNotFit {
-    static constexpr bool would_value_truncate(const T &value) { return value != T{0}; }
+    static AU_DEVICE_FUNC constexpr bool would_value_truncate(const T &value) { return value != T{0}; }
 };
 
 template <typename T, typename M>
 struct ValueTimesRatioIsNotIntegerImplForIntWhereDenominatorFits {
-    static constexpr bool would_value_truncate(const T &value) {
+    static AU_DEVICE_FUNC constexpr bool would_value_truncate(const T &value) {
         return (value % get_value<RealPart<T>>(Denominator<M>{})) != T{0};
     }
 };
@@ -301,7 +302,7 @@ struct ValueTimesRatioIsNotIntegerImplForInt
 
 template <typename T, typename M>
 struct ValueTimesRatioIsNotIntegerImplForFloatGeneric {
-    static constexpr bool would_value_truncate(const T &value) {
+    static AU_DEVICE_FUNC constexpr bool would_value_truncate(const T &value) {
         const auto result = value * get_value<RealPart<T>>(M{});
         return std::trunc(result) != result;
     }
@@ -309,7 +310,7 @@ struct ValueTimesRatioIsNotIntegerImplForFloatGeneric {
 
 template <typename T, typename M>
 struct ValueTimesRatioIsNotIntegerImplForFloatDivideByInteger {
-    static constexpr bool would_value_truncate(const T &value) {
+    static AU_DEVICE_FUNC constexpr bool would_value_truncate(const T &value) {
         const auto result = value / get_value<RealPart<T>>(MagInverse<M>{});
         return std::trunc(result) != result;
     }

--- a/au/truncation_risk.hh
+++ b/au/truncation_risk.hh
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include "au/config.hh"
 #include "au/abstract_operations.hh"
+#include "au/config.hh"
 
 namespace au {
 namespace detail {
@@ -283,7 +283,9 @@ struct TruncationRiskForImpl<OpSequenceImpl<Op, Ops...>>
 
 template <typename T, typename M>
 struct ValueTimesRatioIsNotIntegerImplForIntWhereDenominatorDoesNotFit {
-    static AU_DEVICE_FUNC constexpr bool would_value_truncate(const T &value) { return value != T{0}; }
+    static AU_DEVICE_FUNC constexpr bool would_value_truncate(const T &value) {
+        return value != T{0};
+    }
 };
 
 template <typename T, typename M>

--- a/au/zero.hh
+++ b/au/zero.hh
@@ -21,6 +21,7 @@
 #include <compare>
 #endif
 
+#include "au/config.hh"
 #include "au/fwd.hh"
 
 namespace au {
@@ -40,13 +41,13 @@ namespace au {
 struct Zero {
     // Implicit conversion to arithmetic types.
     template <typename T, typename Enable = std::enable_if_t<std::is_arithmetic<T>::value>>
-    constexpr operator T() const {
+    AU_DEVICE_FUNC constexpr operator T() const {
         return 0;
     }
 
     // Implicit conversion to chrono durations.
     template <typename Rep, typename Period>
-    constexpr operator std::chrono::duration<Rep, Period>() const {
+    AU_DEVICE_FUNC constexpr operator std::chrono::duration<Rep, Period>() const {
         return std::chrono::duration<Rep, Period>{0};
     }
 };
@@ -58,23 +59,23 @@ struct Zero {
 static constexpr auto ZERO = Zero{};
 
 // Addition, subtraction, and comparison of Zero are well defined.
-inline constexpr Zero operator+(Zero, Zero) { return ZERO; }
-inline constexpr Zero operator-(Zero, Zero) { return ZERO; }
-inline constexpr bool operator==(Zero, Zero) { return true; }
-inline constexpr bool operator>=(Zero, Zero) { return true; }
-inline constexpr bool operator<=(Zero, Zero) { return true; }
-inline constexpr bool operator!=(Zero, Zero) { return false; }
-inline constexpr bool operator>(Zero, Zero) { return false; }
-inline constexpr bool operator<(Zero, Zero) { return false; }
+inline AU_DEVICE_FUNC constexpr Zero operator+(Zero, Zero) { return ZERO; }
+inline AU_DEVICE_FUNC constexpr Zero operator-(Zero, Zero) { return ZERO; }
+inline AU_DEVICE_FUNC constexpr bool operator==(Zero, Zero) { return true; }
+inline AU_DEVICE_FUNC constexpr bool operator>=(Zero, Zero) { return true; }
+inline AU_DEVICE_FUNC constexpr bool operator<=(Zero, Zero) { return true; }
+inline AU_DEVICE_FUNC constexpr bool operator!=(Zero, Zero) { return false; }
+inline AU_DEVICE_FUNC constexpr bool operator>(Zero, Zero) { return false; }
+inline AU_DEVICE_FUNC constexpr bool operator<(Zero, Zero) { return false; }
 
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
-inline constexpr auto operator<=>(Zero, Zero) { return 0 <=> 0; }
+inline AU_DEVICE_FUNC constexpr auto operator<=>(Zero, Zero) { return 0 <=> 0; }
 #endif
 
 // Implementation helper for "a type where value() returns 0".
 template <typename T>
 struct ValueOfZero {
-    static constexpr T value() { return ZERO; }
+    static AU_DEVICE_FUNC constexpr T value() { return ZERO; }
 };
 
 }  // namespace au


### PR DESCRIPTION
Enable Au types to be used in CUDA and HIP device code by adding
the `AU_DEVICE_FUNC` macro, which expands to `__host__ __device__`
when compiling with nvcc or hipcc, and to nothing otherwise.  We would
much rather not use macros generally, but in this case, I don't know of
any feasible alternatives.  Supporting CUDA with Au is such a huge value
add, and the macro is a small price to pay in the grand scheme of
things.

This doesn't _complete_ our support.  We will also need to add
`__device__` annotations for all of our variables (e.g., `meters`,
`kilo`, etc.).

Helps #671.