### PR TITLE
Add AU_DEVICE_VAR for constexpr variables

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -479,6 +479,63 @@
         ]
       }
     },
+    "@@rules_cuda+//cuda:extensions.bzl%toolchain": {
+      "general": {
+        "bzlTransitiveDigest": "b0hrJK2gVyb2xnrbLB1VjPzOneob4RJVz2EoVKrVvaM=",
+        "usagesDigest": "Th2MmlBaZwBX6KmdXRVIggryaD6qHya0eRxekTDzcjI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "cuda": {
+            "repoRuleId": "@@rules_cuda+//cuda/private:repositories.bzl%cuda_toolkit",
+            "attributes": {
+              "components_mapping": {},
+              "nvcc_version": "",
+              "toolkit_path": "",
+              "version": ""
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "cc_compatibility_proxy",
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cuda+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cuda+",
+            "rules_cc",
+            "rules_cc+"
+          ]
+        ]
+      }
+    },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "OlvsB0HsvxbR8ZN+J9Vf00X/+WVz/Y/5Xrq2LgcVfdo=",

--- a/au/config.hh
+++ b/au/config.hh
@@ -17,11 +17,14 @@
 //
 // Device/GPU support (CUDA, HIP)
 //
-// The AU_DEVICE_FUNC macro marks functions as callable from both host and device.
+// AU_DEVICE_FUNC: marks functions as callable from both host and device.
+// AU_DEVICE_VAR: marks constexpr variables as accessible from device code.
 //
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 #define AU_DEVICE_FUNC __host__ __device__
+#define AU_DEVICE_VAR __device__
 #else
 #define AU_DEVICE_FUNC
+#define AU_DEVICE_VAR
 #endif

--- a/au/config.hh
+++ b/au/config.hh
@@ -20,23 +20,11 @@
 // AU_DEVICE_FUNC: marks functions as callable from both host and device.
 // AU_DEVICE_VAR: marks constexpr variables as accessible from device code.
 //
-// Note: AU_DEVICE_FUNC uses __CUDACC__ / __HIPCC__ (compiler detection) because functions need
-// the annotation during both host and device compilation passes.
-//
-// AU_DEVICE_VAR uses __CUDA_ARCH__ / __HIP_DEVICE_COMPILE__ (device pass detection) because
-// __device__ on a variable makes it device-only, which would break host code. By only applying
-// __device__ during the device compilation pass, the same variable is visible to both host and
-// device code.
-//
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 #define AU_DEVICE_FUNC __host__ __device__
-#else
-#define AU_DEVICE_FUNC
-#endif
-
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 #define AU_DEVICE_VAR __device__
 #else
+#define AU_DEVICE_FUNC
 #define AU_DEVICE_VAR
 #endif

--- a/au/config.hh
+++ b/au/config.hh
@@ -20,11 +20,23 @@
 // AU_DEVICE_FUNC: marks functions as callable from both host and device.
 // AU_DEVICE_VAR: marks constexpr variables as accessible from device code.
 //
+// Note: AU_DEVICE_FUNC uses __CUDACC__ / __HIPCC__ (compiler detection) because functions need
+// the annotation during both host and device compilation passes.
+//
+// AU_DEVICE_VAR uses __CUDA_ARCH__ / __HIP_DEVICE_COMPILE__ (device pass detection) because
+// __device__ on a variable makes it device-only, which would break host code. By only applying
+// __device__ during the device compilation pass, the same variable is visible to both host and
+// device code.
+//
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
 #define AU_DEVICE_FUNC __host__ __device__
-#define AU_DEVICE_VAR __device__
 #else
 #define AU_DEVICE_FUNC
+#endif
+
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#define AU_DEVICE_VAR __device__
+#else
 #define AU_DEVICE_VAR
 #endif

--- a/au/constants/avogadro_constant.hh
+++ b/au/constants/avogadro_constant.hh
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "au/config.hh"
 #include "au/constant.hh"
 #include "au/units/moles.hh"
 
@@ -32,6 +33,6 @@ struct AvogadroConstantUnit : decltype(inverse(Moles{}) * mag<602'214'076>() * p
 };
 }  // namespace detail
 
-constexpr auto AVOGADRO_CONSTANT = make_constant(detail::AvogadroConstantUnit{});
+AU_DEVICE_VAR constexpr auto AVOGADRO_CONSTANT = make_constant(detail::AvogadroConstantUnit{});
 
 }  // namespace au

--- a/au/constants/boltzmann_constant.hh
+++ b/au/constants/boltzmann_constant.hh
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "au/config.hh"
 #include "au/constant.hh"
 #include "au/units/joules.hh"
 #include "au/units/kelvins.hh"
@@ -34,6 +35,6 @@ struct BoltzmannConstantUnit
 };
 }  // namespace detail
 
-constexpr auto BOLTZMANN_CONSTANT = make_constant(detail::BoltzmannConstantUnit{});
+AU_DEVICE_VAR constexpr auto BOLTZMANN_CONSTANT = make_constant(detail::BoltzmannConstantUnit{});
 
 }  // namespace au

--- a/au/constants/cesium_hyperfine_transition_frequency.hh
+++ b/au/constants/cesium_hyperfine_transition_frequency.hh
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "au/config.hh"
 #include "au/constant.hh"
 #include "au/units/hertz.hh"
 
@@ -32,7 +33,7 @@ struct CesiumHyperfineTransitionFrequencyUnit : decltype(Hertz{} * mag<9'192'631
 };
 }  // namespace detail
 
-constexpr auto CESIUM_HYPERFINE_TRANSITION_FREQUENCY =
+AU_DEVICE_VAR constexpr auto CESIUM_HYPERFINE_TRANSITION_FREQUENCY =
     make_constant(detail::CesiumHyperfineTransitionFrequencyUnit{});
 
 }  // namespace au

--- a/au/constants/elementary_charge.hh
+++ b/au/constants/elementary_charge.hh
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "au/config.hh"
 #include "au/constant.hh"
 #include "au/units/coulombs.hh"
 
@@ -32,6 +33,6 @@ struct ElementaryChargeUnit : decltype(Coulombs{} * mag<1'602'176'634>() * pow<-
 };
 }  // namespace detail
 
-constexpr auto ELEMENTARY_CHARGE = make_constant(detail::ElementaryChargeUnit{});
+AU_DEVICE_VAR constexpr auto ELEMENTARY_CHARGE = make_constant(detail::ElementaryChargeUnit{});
 
 }  // namespace au

--- a/au/constants/luminous_efficacy_540_terahertz.hh
+++ b/au/constants/luminous_efficacy_540_terahertz.hh
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "au/config.hh"
 #include "au/constant.hh"
 #include "au/units/lumens.hh"
 #include "au/units/watts.hh"
@@ -33,7 +34,7 @@ struct LuminousEfficacy540TerahertzUnit : decltype((Lumens{} / Watts{}) * mag<68
 };
 }  // namespace detail
 
-constexpr auto LUMINOUS_EFFICACY_540_TERAHERTZ =
+AU_DEVICE_VAR constexpr auto LUMINOUS_EFFICACY_540_TERAHERTZ =
     make_constant(detail::LuminousEfficacy540TerahertzUnit{});
 
 }  // namespace au

--- a/au/constants/planck_constant.hh
+++ b/au/constants/planck_constant.hh
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "au/config.hh"
 #include "au/constant.hh"
 #include "au/units/joules.hh"
 #include "au/units/seconds.hh"
@@ -34,6 +35,6 @@ struct PlanckConstantUnit
 };
 }  // namespace detail
 
-constexpr auto PLANCK_CONSTANT = make_constant(detail::PlanckConstantUnit{});
+AU_DEVICE_VAR constexpr auto PLANCK_CONSTANT = make_constant(detail::PlanckConstantUnit{});
 
 }  // namespace au

--- a/au/constants/reduced_planck_constant.hh
+++ b/au/constants/reduced_planck_constant.hh
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "au/config.hh"
 #include "au/constant.hh"
 #include "au/units/joules.hh"
 #include "au/units/seconds.hh"
@@ -34,6 +35,7 @@ struct ReducedPlanckConstantUnit : decltype(Joules{} * Seconds{} * mag<662'607'0
 };
 }  // namespace detail
 
-constexpr auto REDUCED_PLANCK_CONSTANT = make_constant(detail::ReducedPlanckConstantUnit{});
+AU_DEVICE_VAR constexpr auto REDUCED_PLANCK_CONSTANT =
+    make_constant(detail::ReducedPlanckConstantUnit{});
 
 }  // namespace au

--- a/au/constants/speed_of_light.hh
+++ b/au/constants/speed_of_light.hh
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "au/config.hh"
 #include "au/constant.hh"
 #include "au/units/meters.hh"
 #include "au/units/seconds.hh"
@@ -33,6 +34,6 @@ struct SpeedOfLightUnit : decltype(Meters{} / Seconds{} * mag<299'792'458>()),
 };
 }  // namespace detail
 
-constexpr auto SPEED_OF_LIGHT = make_constant(detail::SpeedOfLightUnit{});
+AU_DEVICE_VAR constexpr auto SPEED_OF_LIGHT = make_constant(detail::SpeedOfLightUnit{});
 
 }  // namespace au

--- a/au/constants/standard_gravity.hh
+++ b/au/constants/standard_gravity.hh
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "au/config.hh"
 #include "au/constant.hh"
 #include "au/units/standard_gravity.hh"
 
 namespace au {
 
-constexpr auto STANDARD_GRAVITY = make_constant(StandardGravity{});
+AU_DEVICE_VAR constexpr auto STANDARD_GRAVITY = make_constant(StandardGravity{});
 
 }  // namespace au

--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -88,14 +88,16 @@ struct CheckTheseRisks<RiskSet<RiskFlags>> {
     }
 };
 
-constexpr auto OVERFLOW_RISK = RiskSet<static_cast<uint8_t>(ConversionRisk::Overflow)>{};
-constexpr auto TRUNCATION_RISK = RiskSet<static_cast<uint8_t>(ConversionRisk::Truncation)>{};
+AU_DEVICE_VAR constexpr auto OVERFLOW_RISK =
+    RiskSet<static_cast<uint8_t>(ConversionRisk::Overflow)>{};
+AU_DEVICE_VAR constexpr auto TRUNCATION_RISK =
+    RiskSet<static_cast<uint8_t>(ConversionRisk::Truncation)>{};
 
 }  // namespace detail
 
-constexpr auto OVERFLOW_RISK = detail::OVERFLOW_RISK;
-constexpr auto TRUNCATION_RISK = detail::TRUNCATION_RISK;
-constexpr auto ALL_RISKS = OVERFLOW_RISK | TRUNCATION_RISK;
+AU_DEVICE_VAR constexpr auto OVERFLOW_RISK = detail::OVERFLOW_RISK;
+AU_DEVICE_VAR constexpr auto TRUNCATION_RISK = detail::TRUNCATION_RISK;
+AU_DEVICE_VAR constexpr auto ALL_RISKS = OVERFLOW_RISK | TRUNCATION_RISK;
 
 // `IsConversionRiskPolicy<T>` checks whether `T` is a conversion risk policy type.  For now, this
 // boils down to being a specialization of `CheckTheseRisks` on some `RiskSet`.

--- a/au/cuda/cuda_test.cu
+++ b/au/cuda/cuda_test.cu
@@ -518,18 +518,18 @@ __device__ bool test_is_conversion_lossy() {
 // =============================================================================
 
 __device__ int test_risk_policy_overflow_risk() {
-    auto q = meters(5.5);
-    return q.as<int>(meters, ignore(OVERFLOW_RISK)).in(meters);
+    auto q = giga(hertz)(1);
+    return q.in(hertz, ignore(OVERFLOW_RISK));
 }
 
 __device__ int test_risk_policy_truncation_risk() {
-    auto q = meters(5.5);
-    return q.as<int>(meters, ignore(TRUNCATION_RISK)).in(meters);
+    auto q = meters(500);
+    return q.in(kilo(meters), ignore(TRUNCATION_RISK));
 }
 
 __device__ int test_risk_policy_all_risks() {
-    auto q = meters(5.5);
-    return q.as<int>(meters, ignore(ALL_RISKS)).in(meters);
+    auto q = giga(hertz)(1);
+    return q.in(hertz * mag<3>() / mag<2>(), ignore(ALL_RISKS));
 }
 
 // =============================================================================

--- a/au/cuda/cuda_test.cu
+++ b/au/cuda/cuda_test.cu
@@ -533,12 +533,44 @@ __device__ int test_risk_policy_all_risks() {
 }
 
 // =============================================================================
-// Host-side sanity check
+// Host-side tests
 // =============================================================================
+// These tests verify that AU_DEVICE_VAR-annotated variables are accessible from host code.
+// This is critical because __device__ alone would make variables device-only.
+// By gating AU_DEVICE_VAR on __CUDA_ARCH__, we ensure variables work in both passes.
 
-bool host_test() {
+bool host_test_quantity_operations() {
     auto q = meters(5.0);
     auto t = seconds(2.0);
     auto v = q / t;
     return v.in(meters / second) == 2.5;
+}
+
+bool host_test_prefixes() {
+    auto q1 = kilo(meters)(5.0);
+    auto q2 = milli(meters)(5000.0);
+    auto q3 = centi(meters)(500.0);
+    auto q4 = micro(meters)(5000000.0);
+    return q1.in(meters) == 5000.0 && q2.in(meters) == 5.0 && q3.in(meters) == 5.0 &&
+           q4.in(meters) == 5.0;
+}
+
+bool host_test_constants() { return SPEED_OF_LIGHT.in<double>(meters / second) > 0.0; }
+
+bool host_test_risk_policies() {
+    auto q1 = giga(hertz)(1);
+    auto result1 = q1.in(hertz, ignore(OVERFLOW_RISK));
+
+    auto q2 = meters(500);
+    auto result2 = q2.in(kilo(meters), ignore(TRUNCATION_RISK));
+
+    auto q3 = giga(hertz)(1);
+    auto result3 = q3.in(hertz * mag<3>() / mag<2>(), ignore(ALL_RISKS));
+
+    return result1 > 0 && result2 >= 0 && result3 > 0;
+}
+
+bool host_test_zero() {
+    auto sum = ZERO + ZERO;
+    return sum == ZERO;
 }

--- a/au/cuda/cuda_test.cu
+++ b/au/cuda/cuda_test.cu
@@ -519,17 +519,17 @@ __device__ bool test_is_conversion_lossy() {
 
 __device__ int test_risk_policy_overflow_risk() {
     auto q = meters(5.5);
-    return q.as<int>(meters, OVERFLOW_RISK).in(meters);
+    return q.as<int>(meters, ignore(OVERFLOW_RISK)).in(meters);
 }
 
 __device__ int test_risk_policy_truncation_risk() {
     auto q = meters(5.5);
-    return q.as<int>(meters, TRUNCATION_RISK).in(meters);
+    return q.as<int>(meters, ignore(TRUNCATION_RISK)).in(meters);
 }
 
 __device__ int test_risk_policy_all_risks() {
     auto q = meters(5.5);
-    return q.as<int>(meters, ALL_RISKS).in(meters);
+    return q.as<int>(meters, ignore(ALL_RISKS)).in(meters);
 }
 
 // =============================================================================

--- a/au/cuda/cuda_test.cu
+++ b/au/cuda/cuda_test.cu
@@ -514,6 +514,25 @@ __device__ bool test_is_conversion_lossy() {
 }
 
 // =============================================================================
+// SECTION 13: Risk policy constants
+// =============================================================================
+
+__device__ int test_risk_policy_overflow_risk() {
+    auto q = meters(5.5);
+    return q.as<int>(meters, OVERFLOW_RISK).in(meters);
+}
+
+__device__ int test_risk_policy_truncation_risk() {
+    auto q = meters(5.5);
+    return q.as<int>(meters, TRUNCATION_RISK).in(meters);
+}
+
+__device__ int test_risk_policy_all_risks() {
+    auto q = meters(5.5);
+    return q.as<int>(meters, ALL_RISKS).in(meters);
+}
+
+// =============================================================================
 // Host-side sanity check
 // =============================================================================
 

--- a/au/cuda/cuda_test.cu
+++ b/au/cuda/cuda_test.cu
@@ -574,3 +574,20 @@ bool host_test_zero() {
     auto sum = ZERO + ZERO;
     return sum == ZERO;
 }
+
+// Taking the address of AU_DEVICE_VAR variables forces the compiler to materialize them.
+// If AU_DEVICE_VAR were simply `__device__`, this would fail to compile from host code
+// because __device__ variables only exist in device memory.
+bool host_test_address_of_device_var() {
+    const void *p1 = &kilo;
+    const void *p2 = &SPEED_OF_LIGHT;
+    const void *p3 = &ZERO;
+    return p1 != nullptr && p2 != nullptr && p3 != nullptr;
+}
+
+__device__ bool device_test_address_of_device_var() {
+    const void *p1 = &kilo;
+    const void *p2 = &SPEED_OF_LIGHT;
+    const void *p3 = &ZERO;
+    return p1 != nullptr && p2 != nullptr && p3 != nullptr;
+}

--- a/au/cuda/cuda_test.cu
+++ b/au/cuda/cuda_test.cu
@@ -578,19 +578,16 @@ bool host_test_zero() {
 // Taking the address of AU_DEVICE_VAR variables forces the compiler to materialize them.
 // If AU_DEVICE_VAR were simply `__device__`, this would fail to compile from host code
 // because __device__ variables only exist in device memory.
-// We return the pointer to prevent the compiler from optimizing away the address-taking.
-const void *host_test_address_of_device_var() {
+bool host_test_address_of_device_var() {
     const void *p1 = &kilo;
     const void *p2 = &SPEED_OF_LIGHT;
     const void *p3 = &ZERO;
-    // Return one of the pointers to prevent optimization
-    return (p1 < p2) ? ((p2 < p3) ? p3 : p2) : ((p1 < p3) ? p3 : p1);
+    return p1 != nullptr && p2 != nullptr && p3 != nullptr;
 }
 
-__device__ const void *device_test_address_of_device_var() {
+__device__ bool device_test_address_of_device_var() {
     const void *p1 = &kilo;
     const void *p2 = &SPEED_OF_LIGHT;
     const void *p3 = &ZERO;
-    // Return one of the pointers to prevent optimization
-    return (p1 < p2) ? ((p2 < p3) ? p3 : p2) : ((p1 < p3) ? p3 : p1);
+    return p1 != nullptr && p2 != nullptr && p3 != nullptr;
 }

--- a/au/cuda/cuda_test.cu
+++ b/au/cuda/cuda_test.cu
@@ -575,14 +575,22 @@ bool host_test_zero() {
     return sum == ZERO;
 }
 
-// These tests verify AU_DEVICE_VAR variables are accessible from both host and device code.
-// Using volatile pointers prevents the compiler from optimizing away the address-of operations.
-// If AU_DEVICE_VAR were simply `__device__`, host_test would fail to compile because
-// __device__ variables only exist in device memory.
-const void *volatile host_address_of_kilo = &kilo;
-const void *volatile host_address_of_speed_of_light = &SPEED_OF_LIGHT;
-const void *volatile host_address_of_zero = &ZERO;
+// Taking the address of AU_DEVICE_VAR variables forces the compiler to materialize them.
+// If AU_DEVICE_VAR were simply `__device__`, this would fail to compile from host code
+// because __device__ variables only exist in device memory.
+// We return the pointer to prevent the compiler from optimizing away the address-taking.
+const void *host_test_address_of_device_var() {
+    const void *p1 = &kilo;
+    const void *p2 = &SPEED_OF_LIGHT;
+    const void *p3 = &ZERO;
+    // Return one of the pointers to prevent optimization
+    return (p1 < p2) ? ((p2 < p3) ? p3 : p2) : ((p1 < p3) ? p3 : p1);
+}
 
-__device__ const void *volatile device_address_of_kilo = &kilo;
-__device__ const void *volatile device_address_of_speed_of_light = &SPEED_OF_LIGHT;
-__device__ const void *volatile device_address_of_zero = &ZERO;
+__device__ const void *device_test_address_of_device_var() {
+    const void *p1 = &kilo;
+    const void *p2 = &SPEED_OF_LIGHT;
+    const void *p3 = &ZERO;
+    // Return one of the pointers to prevent optimization
+    return (p1 < p2) ? ((p2 < p3) ? p3 : p2) : ((p1 < p3) ? p3 : p1);
+}

--- a/au/cuda/cuda_test.cu
+++ b/au/cuda/cuda_test.cu
@@ -575,22 +575,14 @@ bool host_test_zero() {
     return sum == ZERO;
 }
 
-// Taking the address of AU_DEVICE_VAR variables forces the compiler to materialize them.
-// If AU_DEVICE_VAR were simply `__device__`, this would fail to compile from host code
-// because __device__ variables only exist in device memory.
-// We return the pointer to prevent the compiler from optimizing away the address-taking.
-const void *host_test_address_of_device_var() {
-    const void *p1 = &kilo;
-    const void *p2 = &SPEED_OF_LIGHT;
-    const void *p3 = &ZERO;
-    // Return one of the pointers to prevent optimization
-    return (p1 < p2) ? ((p2 < p3) ? p3 : p2) : ((p1 < p3) ? p3 : p1);
-}
+// These tests verify AU_DEVICE_VAR variables are accessible from both host and device code.
+// Using volatile pointers prevents the compiler from optimizing away the address-of operations.
+// If AU_DEVICE_VAR were simply `__device__`, host_test would fail to compile because
+// __device__ variables only exist in device memory.
+const void *volatile host_address_of_kilo = &kilo;
+const void *volatile host_address_of_speed_of_light = &SPEED_OF_LIGHT;
+const void *volatile host_address_of_zero = &ZERO;
 
-__device__ const void *device_test_address_of_device_var() {
-    const void *p1 = &kilo;
-    const void *p2 = &SPEED_OF_LIGHT;
-    const void *p3 = &ZERO;
-    // Return one of the pointers to prevent optimization
-    return (p1 < p2) ? ((p2 < p3) ? p3 : p2) : ((p1 < p3) ? p3 : p1);
-}
+__device__ const void *volatile device_address_of_kilo = &kilo;
+__device__ const void *volatile device_address_of_speed_of_light = &SPEED_OF_LIGHT;
+__device__ const void *volatile device_address_of_zero = &ZERO;

--- a/au/cuda/cuda_test.cu
+++ b/au/cuda/cuda_test.cu
@@ -578,16 +578,19 @@ bool host_test_zero() {
 // Taking the address of AU_DEVICE_VAR variables forces the compiler to materialize them.
 // If AU_DEVICE_VAR were simply `__device__`, this would fail to compile from host code
 // because __device__ variables only exist in device memory.
-bool host_test_address_of_device_var() {
+// We return the pointer to prevent the compiler from optimizing away the address-taking.
+const void *host_test_address_of_device_var() {
     const void *p1 = &kilo;
     const void *p2 = &SPEED_OF_LIGHT;
     const void *p3 = &ZERO;
-    return p1 != nullptr && p2 != nullptr && p3 != nullptr;
+    // Return one of the pointers to prevent optimization
+    return (p1 < p2) ? ((p2 < p3) ? p3 : p2) : ((p1 < p3) ? p3 : p1);
 }
 
-__device__ bool device_test_address_of_device_var() {
+__device__ const void *device_test_address_of_device_var() {
     const void *p1 = &kilo;
     const void *p2 = &SPEED_OF_LIGHT;
     const void *p3 = &ZERO;
-    return p1 != nullptr && p2 != nullptr && p3 != nullptr;
+    // Return one of the pointers to prevent optimization
+    return (p1 < p2) ? ((p2 < p3) ? p3 : p2) : ((p1 < p3) ? p3 : p1);
 }

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -656,7 +656,7 @@ struct PrimeFactorizationImpl {
 }  // namespace detail
 
 template <std::uintmax_t N>
-constexpr auto mag() {
+AU_DEVICE_FUNC constexpr auto mag() {
     return detail::PrimeFactorization<N>{};
 }
 

--- a/au/prefix.hh
+++ b/au/prefix.hh
@@ -118,7 +118,7 @@ struct Quetta : decltype(U{} * pow<30>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Quetta<U>::LabelT Quetta<U>::label;
-constexpr auto quetta = PrefixApplier<Quetta>{};
+AU_DEVICE_VAR constexpr auto quetta = PrefixApplier<Quetta>{};
 
 template <typename U>
 struct Ronna : decltype(U{} * pow<27>(mag<10>())) {
@@ -128,7 +128,7 @@ struct Ronna : decltype(U{} * pow<27>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Ronna<U>::LabelT Ronna<U>::label;
-constexpr auto ronna = PrefixApplier<Ronna>{};
+AU_DEVICE_VAR constexpr auto ronna = PrefixApplier<Ronna>{};
 
 template <typename U>
 struct Yotta : decltype(U{} * pow<24>(mag<10>())) {
@@ -138,7 +138,7 @@ struct Yotta : decltype(U{} * pow<24>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Yotta<U>::LabelT Yotta<U>::label;
-constexpr auto yotta = PrefixApplier<Yotta>{};
+AU_DEVICE_VAR constexpr auto yotta = PrefixApplier<Yotta>{};
 
 template <typename U>
 struct Zetta : decltype(U{} * pow<21>(mag<10>())) {
@@ -148,7 +148,7 @@ struct Zetta : decltype(U{} * pow<21>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Zetta<U>::LabelT Zetta<U>::label;
-constexpr auto zetta = PrefixApplier<Zetta>{};
+AU_DEVICE_VAR constexpr auto zetta = PrefixApplier<Zetta>{};
 
 template <typename U>
 struct Exa : decltype(U{} * pow<18>(mag<10>())) {
@@ -158,7 +158,7 @@ struct Exa : decltype(U{} * pow<18>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Exa<U>::LabelT Exa<U>::label;
-constexpr auto exa = PrefixApplier<Exa>{};
+AU_DEVICE_VAR constexpr auto exa = PrefixApplier<Exa>{};
 
 template <typename U>
 struct Peta : decltype(U{} * pow<15>(mag<10>())) {
@@ -168,7 +168,7 @@ struct Peta : decltype(U{} * pow<15>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Peta<U>::LabelT Peta<U>::label;
-constexpr auto peta = PrefixApplier<Peta>{};
+AU_DEVICE_VAR constexpr auto peta = PrefixApplier<Peta>{};
 
 template <typename U>
 struct Tera : decltype(U{} * pow<12>(mag<10>())) {
@@ -178,7 +178,7 @@ struct Tera : decltype(U{} * pow<12>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Tera<U>::LabelT Tera<U>::label;
-constexpr auto tera = PrefixApplier<Tera>{};
+AU_DEVICE_VAR constexpr auto tera = PrefixApplier<Tera>{};
 
 template <typename U>
 struct Giga : decltype(U{} * pow<9>(mag<10>())) {
@@ -188,7 +188,7 @@ struct Giga : decltype(U{} * pow<9>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Giga<U>::LabelT Giga<U>::label;
-constexpr auto giga = PrefixApplier<Giga>{};
+AU_DEVICE_VAR constexpr auto giga = PrefixApplier<Giga>{};
 
 template <typename U>
 struct Mega : decltype(U{} * pow<6>(mag<10>())) {
@@ -198,7 +198,7 @@ struct Mega : decltype(U{} * pow<6>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Mega<U>::LabelT Mega<U>::label;
-constexpr auto mega = PrefixApplier<Mega>{};
+AU_DEVICE_VAR constexpr auto mega = PrefixApplier<Mega>{};
 
 template <typename U>
 struct Kilo : decltype(U{} * pow<3>(mag<10>())) {
@@ -208,7 +208,7 @@ struct Kilo : decltype(U{} * pow<3>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Kilo<U>::LabelT Kilo<U>::label;
-constexpr auto kilo = PrefixApplier<Kilo>{};
+AU_DEVICE_VAR constexpr auto kilo = PrefixApplier<Kilo>{};
 
 template <typename U>
 struct Hecto : decltype(U{} * pow<2>(mag<10>())) {
@@ -218,7 +218,7 @@ struct Hecto : decltype(U{} * pow<2>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Hecto<U>::LabelT Hecto<U>::label;
-constexpr auto hecto = PrefixApplier<Hecto>{};
+AU_DEVICE_VAR constexpr auto hecto = PrefixApplier<Hecto>{};
 
 template <typename U>
 struct Deka : decltype(U{} * pow<1>(mag<10>())) {
@@ -228,7 +228,7 @@ struct Deka : decltype(U{} * pow<1>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Deka<U>::LabelT Deka<U>::label;
-constexpr auto deka = PrefixApplier<Deka>{};
+AU_DEVICE_VAR constexpr auto deka = PrefixApplier<Deka>{};
 
 template <typename U>
 struct Deci : decltype(U{} * pow<-1>(mag<10>())) {
@@ -238,7 +238,7 @@ struct Deci : decltype(U{} * pow<-1>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Deci<U>::LabelT Deci<U>::label;
-constexpr auto deci = PrefixApplier<Deci>{};
+AU_DEVICE_VAR constexpr auto deci = PrefixApplier<Deci>{};
 
 template <typename U>
 struct Centi : decltype(U{} * pow<-2>(mag<10>())) {
@@ -248,7 +248,7 @@ struct Centi : decltype(U{} * pow<-2>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Centi<U>::LabelT Centi<U>::label;
-constexpr auto centi = PrefixApplier<Centi>{};
+AU_DEVICE_VAR constexpr auto centi = PrefixApplier<Centi>{};
 
 template <typename U>
 struct Milli : decltype(U{} * pow<-3>(mag<10>())) {
@@ -258,7 +258,7 @@ struct Milli : decltype(U{} * pow<-3>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Milli<U>::LabelT Milli<U>::label;
-constexpr auto milli = PrefixApplier<Milli>{};
+AU_DEVICE_VAR constexpr auto milli = PrefixApplier<Milli>{};
 
 template <typename U>
 struct Micro : decltype(U{} * pow<-6>(mag<10>())) {
@@ -268,7 +268,7 @@ struct Micro : decltype(U{} * pow<-6>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Micro<U>::LabelT Micro<U>::label;
-constexpr auto micro = PrefixApplier<Micro>{};
+AU_DEVICE_VAR constexpr auto micro = PrefixApplier<Micro>{};
 
 template <typename U>
 struct Nano : decltype(U{} * pow<-9>(mag<10>())) {
@@ -278,7 +278,7 @@ struct Nano : decltype(U{} * pow<-9>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Nano<U>::LabelT Nano<U>::label;
-constexpr auto nano = PrefixApplier<Nano>{};
+AU_DEVICE_VAR constexpr auto nano = PrefixApplier<Nano>{};
 
 template <typename U>
 struct Pico : decltype(U{} * pow<-12>(mag<10>())) {
@@ -288,7 +288,7 @@ struct Pico : decltype(U{} * pow<-12>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Pico<U>::LabelT Pico<U>::label;
-constexpr auto pico = PrefixApplier<Pico>{};
+AU_DEVICE_VAR constexpr auto pico = PrefixApplier<Pico>{};
 
 template <typename U>
 struct Femto : decltype(U{} * pow<-15>(mag<10>())) {
@@ -298,7 +298,7 @@ struct Femto : decltype(U{} * pow<-15>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Femto<U>::LabelT Femto<U>::label;
-constexpr auto femto = PrefixApplier<Femto>{};
+AU_DEVICE_VAR constexpr auto femto = PrefixApplier<Femto>{};
 
 template <typename U>
 struct Atto : decltype(U{} * pow<-18>(mag<10>())) {
@@ -308,7 +308,7 @@ struct Atto : decltype(U{} * pow<-18>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Atto<U>::LabelT Atto<U>::label;
-constexpr auto atto = PrefixApplier<Atto>{};
+AU_DEVICE_VAR constexpr auto atto = PrefixApplier<Atto>{};
 
 template <typename U>
 struct Zepto : decltype(U{} * pow<-21>(mag<10>())) {
@@ -318,7 +318,7 @@ struct Zepto : decltype(U{} * pow<-21>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Zepto<U>::LabelT Zepto<U>::label;
-constexpr auto zepto = PrefixApplier<Zepto>{};
+AU_DEVICE_VAR constexpr auto zepto = PrefixApplier<Zepto>{};
 
 template <typename U>
 struct Yocto : decltype(U{} * pow<-24>(mag<10>())) {
@@ -328,7 +328,7 @@ struct Yocto : decltype(U{} * pow<-24>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Yocto<U>::LabelT Yocto<U>::label;
-constexpr auto yocto = PrefixApplier<Yocto>{};
+AU_DEVICE_VAR constexpr auto yocto = PrefixApplier<Yocto>{};
 
 template <typename U>
 struct Ronto : decltype(U{} * pow<-27>(mag<10>())) {
@@ -338,7 +338,7 @@ struct Ronto : decltype(U{} * pow<-27>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Ronto<U>::LabelT Ronto<U>::label;
-constexpr auto ronto = PrefixApplier<Ronto>{};
+AU_DEVICE_VAR constexpr auto ronto = PrefixApplier<Ronto>{};
 
 template <typename U>
 struct Quecto : decltype(U{} * pow<-30>(mag<10>())) {
@@ -348,7 +348,7 @@ struct Quecto : decltype(U{} * pow<-30>(mag<10>())) {
 };
 template <typename U>
 constexpr typename Quecto<U>::LabelT Quecto<U>::label;
-constexpr auto quecto = PrefixApplier<Quecto>{};
+AU_DEVICE_VAR constexpr auto quecto = PrefixApplier<Quecto>{};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Binary Prefixes.
@@ -361,7 +361,7 @@ struct Yobi : decltype(U{} * pow<80>(mag<2>())) {
 };
 template <typename U>
 constexpr typename Yobi<U>::LabelT Yobi<U>::label;
-constexpr auto yobi = PrefixApplier<Yobi>{};
+AU_DEVICE_VAR constexpr auto yobi = PrefixApplier<Yobi>{};
 
 template <typename U>
 struct Zebi : decltype(U{} * pow<70>(mag<2>())) {
@@ -371,7 +371,7 @@ struct Zebi : decltype(U{} * pow<70>(mag<2>())) {
 };
 template <typename U>
 constexpr typename Zebi<U>::LabelT Zebi<U>::label;
-constexpr auto zebi = PrefixApplier<Zebi>{};
+AU_DEVICE_VAR constexpr auto zebi = PrefixApplier<Zebi>{};
 
 template <typename U>
 struct Exbi : decltype(U{} * pow<60>(mag<2>())) {
@@ -381,7 +381,7 @@ struct Exbi : decltype(U{} * pow<60>(mag<2>())) {
 };
 template <typename U>
 constexpr typename Exbi<U>::LabelT Exbi<U>::label;
-constexpr auto exbi = PrefixApplier<Exbi>{};
+AU_DEVICE_VAR constexpr auto exbi = PrefixApplier<Exbi>{};
 
 template <typename U>
 struct Pebi : decltype(U{} * pow<50>(mag<2>())) {
@@ -391,7 +391,7 @@ struct Pebi : decltype(U{} * pow<50>(mag<2>())) {
 };
 template <typename U>
 constexpr typename Pebi<U>::LabelT Pebi<U>::label;
-constexpr auto pebi = PrefixApplier<Pebi>{};
+AU_DEVICE_VAR constexpr auto pebi = PrefixApplier<Pebi>{};
 
 template <typename U>
 struct Tebi : decltype(U{} * pow<40>(mag<2>())) {
@@ -401,7 +401,7 @@ struct Tebi : decltype(U{} * pow<40>(mag<2>())) {
 };
 template <typename U>
 constexpr typename Tebi<U>::LabelT Tebi<U>::label;
-constexpr auto tebi = PrefixApplier<Tebi>{};
+AU_DEVICE_VAR constexpr auto tebi = PrefixApplier<Tebi>{};
 
 template <typename U>
 struct Gibi : decltype(U{} * pow<30>(mag<2>())) {
@@ -411,7 +411,7 @@ struct Gibi : decltype(U{} * pow<30>(mag<2>())) {
 };
 template <typename U>
 constexpr typename Gibi<U>::LabelT Gibi<U>::label;
-constexpr auto gibi = PrefixApplier<Gibi>{};
+AU_DEVICE_VAR constexpr auto gibi = PrefixApplier<Gibi>{};
 
 template <typename U>
 struct Mebi : decltype(U{} * pow<20>(mag<2>())) {
@@ -421,7 +421,7 @@ struct Mebi : decltype(U{} * pow<20>(mag<2>())) {
 };
 template <typename U>
 constexpr typename Mebi<U>::LabelT Mebi<U>::label;
-constexpr auto mebi = PrefixApplier<Mebi>{};
+AU_DEVICE_VAR constexpr auto mebi = PrefixApplier<Mebi>{};
 
 template <typename U>
 struct Kibi : decltype(U{} * pow<10>(mag<2>())) {
@@ -431,6 +431,6 @@ struct Kibi : decltype(U{} * pow<10>(mag<2>())) {
 };
 template <typename U>
 constexpr typename Kibi<U>::LabelT Kibi<U>::label;
-constexpr auto kibi = PrefixApplier<Kibi>{};
+AU_DEVICE_VAR constexpr auto kibi = PrefixApplier<Kibi>{};
 
 }  // namespace au

--- a/au/units/amperes.hh
+++ b/au/units/amperes.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/amperes_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -33,11 +33,11 @@ constexpr const char AmperesLabel<T>::label[];
 struct Amperes : UnitImpl<Current>, AmperesLabel<void> {
     using AmperesLabel<void>::label;
 };
-constexpr auto ampere = SingularNameFor<Amperes>{};
-constexpr auto amperes = QuantityMaker<Amperes>{};
+AU_DEVICE_VAR constexpr auto ampere = SingularNameFor<Amperes>{};
+AU_DEVICE_VAR constexpr auto amperes = QuantityMaker<Amperes>{};
 
 namespace symbols {
-constexpr auto A = SymbolFor<Amperes>{};
+AU_DEVICE_VAR constexpr auto A = SymbolFor<Amperes>{};
 }
 
 }  // namespace au

--- a/au/units/arcminutes.hh
+++ b/au/units/arcminutes.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/arcminutes_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,11 +39,11 @@ struct Arcminutes
       ArcminutesLabel<void> {
     using ArcminutesLabel<void>::label;
 };
-constexpr auto arcminute = SingularNameFor<Arcminutes>{};
-constexpr auto arcminutes = QuantityMaker<Arcminutes>{};
+AU_DEVICE_VAR constexpr auto arcminute = SingularNameFor<Arcminutes>{};
+AU_DEVICE_VAR constexpr auto arcminutes = QuantityMaker<Arcminutes>{};
 
 namespace symbols {
-constexpr auto am = SymbolFor<Arcminutes>{};
+AU_DEVICE_VAR constexpr auto am = SymbolFor<Arcminutes>{};
 }
 
 }  // namespace au

--- a/au/units/arcseconds.hh
+++ b/au/units/arcseconds.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/arcseconds_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,11 +39,11 @@ struct Arcseconds
       ArcsecondsLabel<void> {
     using ArcsecondsLabel<void>::label;
 };
-constexpr auto arcsecond = SingularNameFor<Arcseconds>{};
-constexpr auto arcseconds = QuantityMaker<Arcseconds>{};
+AU_DEVICE_VAR constexpr auto arcsecond = SingularNameFor<Arcseconds>{};
+AU_DEVICE_VAR constexpr auto arcseconds = QuantityMaker<Arcseconds>{};
 
 namespace symbols {
-constexpr auto as = SymbolFor<Arcseconds>{};
+AU_DEVICE_VAR constexpr auto as = SymbolFor<Arcseconds>{};
 }
 
 }  // namespace au

--- a/au/units/astronomical_units.hh
+++ b/au/units/astronomical_units.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/astronomical_units_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -45,10 +45,10 @@ struct AstronomicalUnits
       AstronomicalUnitsLabel<void> {
     using AstronomicalUnitsLabel<void>::label;
 };
-constexpr auto astronomical_unit = SingularNameFor<AstronomicalUnits>{};
-constexpr auto astronomical_units = QuantityMaker<AstronomicalUnits>{};
+AU_DEVICE_VAR constexpr auto astronomical_unit = SingularNameFor<AstronomicalUnits>{};
+AU_DEVICE_VAR constexpr auto astronomical_units = QuantityMaker<AstronomicalUnits>{};
 
 namespace symbols {
-constexpr auto AU = SymbolFor<AstronomicalUnits>{};
+AU_DEVICE_VAR constexpr auto AU = SymbolFor<AstronomicalUnits>{};
 }
 }  // namespace au

--- a/au/units/bars.hh
+++ b/au/units/bars.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/bars_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -40,10 +40,10 @@ struct Bars
       BarsLabel<void> {
     using BarsLabel<void>::label;
 };
-constexpr auto bar = SingularNameFor<Bars>{};
-constexpr auto bars = QuantityMaker<Bars>{};
+AU_DEVICE_VAR constexpr auto bar = SingularNameFor<Bars>{};
+AU_DEVICE_VAR constexpr auto bars = QuantityMaker<Bars>{};
 
 namespace symbols {
-constexpr auto bar = SymbolFor<Bars>{};
+AU_DEVICE_VAR constexpr auto bar = SymbolFor<Bars>{};
 }  // namespace symbols
 }  // namespace au

--- a/au/units/becquerel.hh
+++ b/au/units/becquerel.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/becquerel_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,9 +39,9 @@ struct Becquerel
       BecquerelLabel<void> {
     using BecquerelLabel<void>::label;
 };
-constexpr auto becquerel = QuantityMaker<Becquerel>{};
+AU_DEVICE_VAR constexpr auto becquerel = QuantityMaker<Becquerel>{};
 
 namespace symbols {
-constexpr auto Bq = SymbolFor<Becquerel>{};
+AU_DEVICE_VAR constexpr auto Bq = SymbolFor<Becquerel>{};
 }
 }  // namespace au

--- a/au/units/bits.hh
+++ b/au/units/bits.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/bits_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -33,10 +33,10 @@ constexpr const char BitsLabel<T>::label[];
 struct Bits : UnitImpl<Information>, BitsLabel<void> {
     using BitsLabel<void>::label;
 };
-constexpr auto bit = SingularNameFor<Bits>{};
-constexpr auto bits = QuantityMaker<Bits>{};
+AU_DEVICE_VAR constexpr auto bit = SingularNameFor<Bits>{};
+AU_DEVICE_VAR constexpr auto bits = QuantityMaker<Bits>{};
 
 namespace symbols {
-constexpr auto b = SymbolFor<Bits>{};
+AU_DEVICE_VAR constexpr auto b = SymbolFor<Bits>{};
 }
 }  // namespace au

--- a/au/units/bytes.hh
+++ b/au/units/bytes.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/bytes_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Bytes
       BytesLabel<void> {
     using BytesLabel<void>::label;
 };
-constexpr auto byte = SingularNameFor<Bytes>{};
-constexpr auto bytes = QuantityMaker<Bytes>{};
+AU_DEVICE_VAR constexpr auto byte = SingularNameFor<Bytes>{};
+AU_DEVICE_VAR constexpr auto bytes = QuantityMaker<Bytes>{};
 
 namespace symbols {
-constexpr auto B = SymbolFor<Bytes>{};
+AU_DEVICE_VAR constexpr auto B = SymbolFor<Bytes>{};
 }
 }  // namespace au

--- a/au/units/candelas.hh
+++ b/au/units/candelas.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/candelas_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -33,10 +33,10 @@ constexpr const char CandelasLabel<T>::label[];
 struct Candelas : UnitImpl<LuminousIntensity>, CandelasLabel<void> {
     using CandelasLabel<void>::label;
 };
-constexpr auto candela = SingularNameFor<Candelas>{};
-constexpr auto candelas = QuantityMaker<Candelas>{};
+AU_DEVICE_VAR constexpr auto candela = SingularNameFor<Candelas>{};
+AU_DEVICE_VAR constexpr auto candelas = QuantityMaker<Candelas>{};
 
 namespace symbols {
-constexpr auto cd = SymbolFor<Candelas>{};
+AU_DEVICE_VAR constexpr auto cd = SymbolFor<Candelas>{};
 }
 }  // namespace au

--- a/au/units/celsius.hh
+++ b/au/units/celsius.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/celsius_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
@@ -39,14 +39,14 @@ struct Celsius : UnitImpl<Temperature>, CelsiusLabel<void> {
         return make_quantity<Centi<UnitImpl<Temperature>>>(27315);
     }
 };
-constexpr auto celsius_qty = QuantityMaker<Celsius>{};
-constexpr auto celsius_pt = QuantityPointMaker<Celsius>{};
+AU_DEVICE_VAR constexpr auto celsius_qty = QuantityMaker<Celsius>{};
+AU_DEVICE_VAR constexpr auto celsius_pt = QuantityPointMaker<Celsius>{};
 
 [[deprecated(
     "`celsius()` is ambiguous.  Use `celsius_pt()` for _points_, or `celsius_qty()` for "
     "_quantities_")]] constexpr auto celsius = QuantityMaker<Celsius>{};
 
 namespace symbols {
-constexpr auto degC_qty = SymbolFor<Celsius>{};
+AU_DEVICE_VAR constexpr auto degC_qty = SymbolFor<Celsius>{};
 }
 }  // namespace au

--- a/au/units/celsius.hh
+++ b/au/units/celsius.hh
@@ -44,7 +44,7 @@ AU_DEVICE_VAR constexpr auto celsius_pt = QuantityPointMaker<Celsius>{};
 
 [[deprecated(
     "`celsius()` is ambiguous.  Use `celsius_pt()` for _points_, or `celsius_qty()` for "
-    "_quantities_")]] constexpr auto celsius = QuantityMaker<Celsius>{};
+    "_quantities_")]] AU_DEVICE_VAR constexpr auto celsius = QuantityMaker<Celsius>{};
 
 namespace symbols {
 AU_DEVICE_VAR constexpr auto degC_qty = SymbolFor<Celsius>{};

--- a/au/units/coulombs.hh
+++ b/au/units/coulombs.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/coulombs_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Coulombs
       CoulombsLabel<void> {
     using CoulombsLabel<void>::label;
 };
-constexpr auto coulomb = SingularNameFor<Coulombs>{};
-constexpr auto coulombs = QuantityMaker<Coulombs>{};
+AU_DEVICE_VAR constexpr auto coulomb = SingularNameFor<Coulombs>{};
+AU_DEVICE_VAR constexpr auto coulombs = QuantityMaker<Coulombs>{};
 
 namespace symbols {
-constexpr auto C = SymbolFor<Coulombs>{};
+AU_DEVICE_VAR constexpr auto C = SymbolFor<Coulombs>{};
 }
 }  // namespace au

--- a/au/units/days.hh
+++ b/au/units/days.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/days_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Days
       DaysLabel<void> {
     using DaysLabel<void>::label;
 };
-constexpr auto day = SingularNameFor<Days>{};
-constexpr auto days = QuantityMaker<Days>{};
+AU_DEVICE_VAR constexpr auto day = SingularNameFor<Days>{};
+AU_DEVICE_VAR constexpr auto days = QuantityMaker<Days>{};
 
 namespace symbols {
-constexpr auto d = SymbolFor<Days>{};
+AU_DEVICE_VAR constexpr auto d = SymbolFor<Days>{};
 }
 }  // namespace au

--- a/au/units/degrees.hh
+++ b/au/units/degrees.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/degrees_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Degrees
       DegreesLabel<void> {
     using DegreesLabel<void>::label;
 };
-constexpr auto degree = SingularNameFor<Degrees>{};
-constexpr auto degrees = QuantityMaker<Degrees>{};
+AU_DEVICE_VAR constexpr auto degree = SingularNameFor<Degrees>{};
+AU_DEVICE_VAR constexpr auto degrees = QuantityMaker<Degrees>{};
 
 namespace symbols {
-constexpr auto deg = SymbolFor<Degrees>{};
+AU_DEVICE_VAR constexpr auto deg = SymbolFor<Degrees>{};
 }
 }  // namespace au

--- a/au/units/fahrenheit.hh
+++ b/au/units/fahrenheit.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/fahrenheit_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/prefix.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
@@ -46,14 +46,14 @@ struct Fahrenheit
             45967);
     }
 };
-constexpr auto fahrenheit_qty = QuantityMaker<Fahrenheit>{};
-constexpr auto fahrenheit_pt = QuantityPointMaker<Fahrenheit>{};
+AU_DEVICE_VAR constexpr auto fahrenheit_qty = QuantityMaker<Fahrenheit>{};
+AU_DEVICE_VAR constexpr auto fahrenheit_pt = QuantityPointMaker<Fahrenheit>{};
 
 [[deprecated(
     "`fahrenheit()` is ambiguous.  Use `fahrenheit_pt()` for _points_, or `fahrenheit_qty()` for "
     "_quantities_")]] constexpr auto fahrenheit = QuantityMaker<Fahrenheit>{};
 
 namespace symbols {
-constexpr auto degF_qty = SymbolFor<Fahrenheit>{};
+AU_DEVICE_VAR constexpr auto degF_qty = SymbolFor<Fahrenheit>{};
 }
 }  // namespace au

--- a/au/units/fahrenheit.hh
+++ b/au/units/fahrenheit.hh
@@ -51,7 +51,7 @@ AU_DEVICE_VAR constexpr auto fahrenheit_pt = QuantityPointMaker<Fahrenheit>{};
 
 [[deprecated(
     "`fahrenheit()` is ambiguous.  Use `fahrenheit_pt()` for _points_, or `fahrenheit_qty()` for "
-    "_quantities_")]] constexpr auto fahrenheit = QuantityMaker<Fahrenheit>{};
+    "_quantities_")]] AU_DEVICE_VAR constexpr auto fahrenheit = QuantityMaker<Fahrenheit>{};
 
 namespace symbols {
 AU_DEVICE_VAR constexpr auto degF_qty = SymbolFor<Fahrenheit>{};

--- a/au/units/farads.hh
+++ b/au/units/farads.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/farads_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -43,10 +43,10 @@ struct Farads
       FaradsLabel<void> {
     using FaradsLabel<void>::label;
 };
-constexpr auto farad = SingularNameFor<Farads>{};
-constexpr auto farads = QuantityMaker<Farads>{};
+AU_DEVICE_VAR constexpr auto farad = SingularNameFor<Farads>{};
+AU_DEVICE_VAR constexpr auto farads = QuantityMaker<Farads>{};
 
 namespace symbols {
-constexpr auto F = SymbolFor<Farads>{};
+AU_DEVICE_VAR constexpr auto F = SymbolFor<Farads>{};
 }
 }  // namespace au

--- a/au/units/fathoms.hh
+++ b/au/units/fathoms.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/fathoms_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Fathoms
       FathomsLabel<void> {
     using FathomsLabel<void>::label;
 };
-constexpr auto fathom = SingularNameFor<Fathoms>{};
-constexpr auto fathoms = QuantityMaker<Fathoms>{};
+AU_DEVICE_VAR constexpr auto fathom = SingularNameFor<Fathoms>{};
+AU_DEVICE_VAR constexpr auto fathoms = QuantityMaker<Fathoms>{};
 
 namespace symbols {
-constexpr auto ftm = SymbolFor<Fathoms>{};
+AU_DEVICE_VAR constexpr auto ftm = SymbolFor<Fathoms>{};
 }
 }  // namespace au

--- a/au/units/feet.hh
+++ b/au/units/feet.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/feet_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Feet
       FeetLabel<void> {
     using FeetLabel<void>::label;
 };
-constexpr auto foot = SingularNameFor<Feet>{};
-constexpr auto feet = QuantityMaker<Feet>{};
+AU_DEVICE_VAR constexpr auto foot = SingularNameFor<Feet>{};
+AU_DEVICE_VAR constexpr auto feet = QuantityMaker<Feet>{};
 
 namespace symbols {
-constexpr auto ft = SymbolFor<Feet>{};
+AU_DEVICE_VAR constexpr auto ft = SymbolFor<Feet>{};
 }
 }  // namespace au

--- a/au/units/football_fields.hh
+++ b/au/units/football_fields.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/football_fields_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct FootballFields
       FootballFieldsLabel<void> {
     using FootballFieldsLabel<void>::label;
 };
-constexpr auto football_field = SingularNameFor<FootballFields>{};
-constexpr auto football_fields = QuantityMaker<FootballFields>{};
+AU_DEVICE_VAR constexpr auto football_field = SingularNameFor<FootballFields>{};
+AU_DEVICE_VAR constexpr auto football_fields = QuantityMaker<FootballFields>{};
 
 namespace symbols {
-constexpr auto ftbl_fld = SymbolFor<FootballFields>{};
+AU_DEVICE_VAR constexpr auto ftbl_fld = SymbolFor<FootballFields>{};
 }
 }  // namespace au

--- a/au/units/furlongs.hh
+++ b/au/units/furlongs.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/furlongs_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -40,10 +40,10 @@ struct Furlongs
       FurlongsLabel<void> {
     using FurlongsLabel<void>::label;
 };
-constexpr auto furlong = SingularNameFor<Furlongs>{};
-constexpr auto furlongs = QuantityMaker<Furlongs>{};
+AU_DEVICE_VAR constexpr auto furlong = SingularNameFor<Furlongs>{};
+AU_DEVICE_VAR constexpr auto furlongs = QuantityMaker<Furlongs>{};
 
 namespace symbols {
-constexpr auto fur = SymbolFor<Furlongs>{};
+AU_DEVICE_VAR constexpr auto fur = SymbolFor<Furlongs>{};
 }
 }  // namespace au

--- a/au/units/grams.hh
+++ b/au/units/grams.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/grams_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -33,10 +33,10 @@ constexpr const char GramsLabel<T>::label[];
 struct Grams : UnitImpl<Mass>, GramsLabel<void> {
     using GramsLabel<void>::label;
 };
-constexpr auto gram = SingularNameFor<Grams>{};
-constexpr auto grams = QuantityMaker<Grams>{};
+AU_DEVICE_VAR constexpr auto gram = SingularNameFor<Grams>{};
+AU_DEVICE_VAR constexpr auto grams = QuantityMaker<Grams>{};
 
 namespace symbols {
-constexpr auto g = SymbolFor<Grams>{};
+AU_DEVICE_VAR constexpr auto g = SymbolFor<Grams>{};
 }
 }  // namespace au

--- a/au/units/grays.hh
+++ b/au/units/grays.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/grays_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Grays
       GraysLabel<void> {
     using GraysLabel<void>::label;
 };
-constexpr auto gray = SingularNameFor<Grays>{};
-constexpr auto grays = QuantityMaker<Grays>{};
+AU_DEVICE_VAR constexpr auto gray = SingularNameFor<Grays>{};
+AU_DEVICE_VAR constexpr auto grays = QuantityMaker<Grays>{};
 
 namespace symbols {
-constexpr auto Gy = SymbolFor<Grays>{};
+AU_DEVICE_VAR constexpr auto Gy = SymbolFor<Grays>{};
 }
 }  // namespace au

--- a/au/units/henries.hh
+++ b/au/units/henries.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/henries_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -43,10 +43,10 @@ struct Henries
       HenriesLabel<void> {
     using HenriesLabel<void>::label;
 };
-constexpr auto henry = SingularNameFor<Henries>{};
-constexpr auto henries = QuantityMaker<Henries>{};
+AU_DEVICE_VAR constexpr auto henry = SingularNameFor<Henries>{};
+AU_DEVICE_VAR constexpr auto henries = QuantityMaker<Henries>{};
 
 namespace symbols {
-constexpr auto H = SymbolFor<Henries>{};
+AU_DEVICE_VAR constexpr auto H = SymbolFor<Henries>{};
 }
 }  // namespace au

--- a/au/units/hertz.hh
+++ b/au/units/hertz.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/hertz_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,9 +39,9 @@ struct Hertz
       HertzLabel<void> {
     using HertzLabel<void>::label;
 };
-constexpr auto hertz = QuantityMaker<Hertz>{};
+AU_DEVICE_VAR constexpr auto hertz = QuantityMaker<Hertz>{};
 
 namespace symbols {
-constexpr auto Hz = SymbolFor<Hertz>{};
+AU_DEVICE_VAR constexpr auto Hz = SymbolFor<Hertz>{};
 }
 }  // namespace au

--- a/au/units/hours.hh
+++ b/au/units/hours.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/hours_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Hours
       HoursLabel<void> {
     using HoursLabel<void>::label;
 };
-constexpr auto hour = SingularNameFor<Hours>{};
-constexpr auto hours = QuantityMaker<Hours>{};
+AU_DEVICE_VAR constexpr auto hour = SingularNameFor<Hours>{};
+AU_DEVICE_VAR constexpr auto hours = QuantityMaker<Hours>{};
 
 namespace symbols {
-constexpr auto h = SymbolFor<Hours>{};
+AU_DEVICE_VAR constexpr auto h = SymbolFor<Hours>{};
 }
 }  // namespace au

--- a/au/units/inches.hh
+++ b/au/units/inches.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/inches_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Inches
       InchesLabel<void> {
     using InchesLabel<void>::label;
 };
-constexpr auto inch = SingularNameFor<Inches>{};
-constexpr auto inches = QuantityMaker<Inches>{};
+AU_DEVICE_VAR constexpr auto inch = SingularNameFor<Inches>{};
+AU_DEVICE_VAR constexpr auto inches = QuantityMaker<Inches>{};
 
 namespace symbols {
-constexpr auto in = SymbolFor<Inches>{};
+AU_DEVICE_VAR constexpr auto in = SymbolFor<Inches>{};
 }
 }  // namespace au

--- a/au/units/joules.hh
+++ b/au/units/joules.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/joules_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -40,10 +40,10 @@ struct Joules
       JoulesLabel<void> {
     using JoulesLabel<void>::label;
 };
-constexpr auto joule = SingularNameFor<Joules>{};
-constexpr auto joules = QuantityMaker<Joules>{};
+AU_DEVICE_VAR constexpr auto joule = SingularNameFor<Joules>{};
+AU_DEVICE_VAR constexpr auto joules = QuantityMaker<Joules>{};
 
 namespace symbols {
-constexpr auto J = SymbolFor<Joules>{};
+AU_DEVICE_VAR constexpr auto J = SymbolFor<Joules>{};
 }
 }  // namespace au

--- a/au/units/katals.hh
+++ b/au/units/katals.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/katals_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Katals
       KatalsLabel<void> {
     using KatalsLabel<void>::label;
 };
-constexpr auto katal = SingularNameFor<Katals>{};
-constexpr auto katals = QuantityMaker<Katals>{};
+AU_DEVICE_VAR constexpr auto katal = SingularNameFor<Katals>{};
+AU_DEVICE_VAR constexpr auto katals = QuantityMaker<Katals>{};
 
 namespace symbols {
-constexpr auto kat = SymbolFor<Katals>{};
+AU_DEVICE_VAR constexpr auto kat = SymbolFor<Katals>{};
 }
 }  // namespace au

--- a/au/units/kelvins.hh
+++ b/au/units/kelvins.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/kelvins_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/unit_symbol.hh"
@@ -34,11 +34,11 @@ constexpr const char KelvinsLabel<T>::label[];
 struct Kelvins : UnitImpl<Temperature>, KelvinsLabel<void> {
     using KelvinsLabel<void>::label;
 };
-constexpr auto kelvin = SingularNameFor<Kelvins>{};
-constexpr auto kelvins = QuantityMaker<Kelvins>{};
-constexpr auto kelvins_pt = QuantityPointMaker<Kelvins>{};
+AU_DEVICE_VAR constexpr auto kelvin = SingularNameFor<Kelvins>{};
+AU_DEVICE_VAR constexpr auto kelvins = QuantityMaker<Kelvins>{};
+AU_DEVICE_VAR constexpr auto kelvins_pt = QuantityPointMaker<Kelvins>{};
 
 namespace symbols {
-constexpr auto K = SymbolFor<Kelvins>{};
+AU_DEVICE_VAR constexpr auto K = SymbolFor<Kelvins>{};
 }
 }  // namespace au

--- a/au/units/knots.hh
+++ b/au/units/knots.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/knots_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -40,10 +40,10 @@ struct Knots
       KnotsLabel<void> {
     using KnotsLabel<void>::label;
 };
-constexpr auto knot = SingularNameFor<Knots>{};
-constexpr auto knots = QuantityMaker<Knots>{};
+AU_DEVICE_VAR constexpr auto knot = SingularNameFor<Knots>{};
+AU_DEVICE_VAR constexpr auto knots = QuantityMaker<Knots>{};
 
 namespace symbols {
-constexpr auto kn = SymbolFor<Knots>{};
+AU_DEVICE_VAR constexpr auto kn = SymbolFor<Knots>{};
 }
 }  // namespace au

--- a/au/units/liters.hh
+++ b/au/units/liters.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/liters_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -40,10 +40,10 @@ struct Liters
       LitersLabel<void> {
     using LitersLabel<void>::label;
 };
-constexpr auto liter = SingularNameFor<Liters>{};
-constexpr auto liters = QuantityMaker<Liters>{};
+AU_DEVICE_VAR constexpr auto liter = SingularNameFor<Liters>{};
+AU_DEVICE_VAR constexpr auto liters = QuantityMaker<Liters>{};
 
 namespace symbols {
-constexpr auto L = SymbolFor<Liters>{};
+AU_DEVICE_VAR constexpr auto L = SymbolFor<Liters>{};
 }
 }  // namespace au

--- a/au/units/lumens.hh
+++ b/au/units/lumens.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/lumens_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Lumens
       LumensLabel<void> {
     using LumensLabel<void>::label;
 };
-constexpr auto lumen = SingularNameFor<Lumens>{};
-constexpr auto lumens = QuantityMaker<Lumens>{};
+AU_DEVICE_VAR constexpr auto lumen = SingularNameFor<Lumens>{};
+AU_DEVICE_VAR constexpr auto lumens = QuantityMaker<Lumens>{};
 
 namespace symbols {
-constexpr auto lm = SymbolFor<Lumens>{};
+AU_DEVICE_VAR constexpr auto lm = SymbolFor<Lumens>{};
 }
 }  // namespace au

--- a/au/units/lux.hh
+++ b/au/units/lux.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/lux_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -41,9 +41,9 @@ struct Lux
       LuxLabel<void> {
     using LuxLabel<void>::label;
 };
-constexpr auto lux = QuantityMaker<Lux>{};
+AU_DEVICE_VAR constexpr auto lux = QuantityMaker<Lux>{};
 
 namespace symbols {
-constexpr auto lx = SymbolFor<Lux>{};
+AU_DEVICE_VAR constexpr auto lx = SymbolFor<Lux>{};
 }
 }  // namespace au

--- a/au/units/meters.hh
+++ b/au/units/meters.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/meters_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/unit_symbol.hh"
@@ -34,11 +34,11 @@ constexpr const char MetersLabel<T>::label[];
 struct Meters : UnitImpl<Length>, MetersLabel<void> {
     using MetersLabel<void>::label;
 };
-constexpr auto meter = SingularNameFor<Meters>{};
-constexpr auto meters = QuantityMaker<Meters>{};
-constexpr auto meters_pt = QuantityPointMaker<Meters>{};
+AU_DEVICE_VAR constexpr auto meter = SingularNameFor<Meters>{};
+AU_DEVICE_VAR constexpr auto meters = QuantityMaker<Meters>{};
+AU_DEVICE_VAR constexpr auto meters_pt = QuantityPointMaker<Meters>{};
 
 namespace symbols {
-constexpr auto m = SymbolFor<Meters>{};
+AU_DEVICE_VAR constexpr auto m = SymbolFor<Meters>{};
 }
 }  // namespace au

--- a/au/units/miles.hh
+++ b/au/units/miles.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/miles_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -41,10 +41,10 @@ struct Miles
       MilesLabel<void> {
     using MilesLabel<void>::label;
 };
-constexpr auto mile = SingularNameFor<Miles>{};
-constexpr auto miles = QuantityMaker<Miles>{};
+AU_DEVICE_VAR constexpr auto mile = SingularNameFor<Miles>{};
+AU_DEVICE_VAR constexpr auto miles = QuantityMaker<Miles>{};
 
 namespace symbols {
-constexpr auto mi = SymbolFor<Miles>{};
+AU_DEVICE_VAR constexpr auto mi = SymbolFor<Miles>{};
 }
 }  // namespace au

--- a/au/units/minutes.hh
+++ b/au/units/minutes.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/minutes_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Minutes
       MinutesLabel<void> {
     using MinutesLabel<void>::label;
 };
-constexpr auto minute = SingularNameFor<Minutes>{};
-constexpr auto minutes = QuantityMaker<Minutes>{};
+AU_DEVICE_VAR constexpr auto minute = SingularNameFor<Minutes>{};
+AU_DEVICE_VAR constexpr auto minutes = QuantityMaker<Minutes>{};
 
 namespace symbols {
-constexpr auto min = SymbolFor<Minutes>{};
+AU_DEVICE_VAR constexpr auto min = SymbolFor<Minutes>{};
 }
 }  // namespace au

--- a/au/units/moles.hh
+++ b/au/units/moles.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/moles_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -33,10 +33,10 @@ constexpr const char MolesLabel<T>::label[];
 struct Moles : UnitImpl<AmountOfSubstance>, MolesLabel<void> {
     using MolesLabel<void>::label;
 };
-constexpr auto mole = SingularNameFor<Moles>{};
-constexpr auto moles = QuantityMaker<Moles>{};
+AU_DEVICE_VAR constexpr auto mole = SingularNameFor<Moles>{};
+AU_DEVICE_VAR constexpr auto moles = QuantityMaker<Moles>{};
 
 namespace symbols {
-constexpr auto mol = SymbolFor<Moles>{};
+AU_DEVICE_VAR constexpr auto mol = SymbolFor<Moles>{};
 }
 }  // namespace au

--- a/au/units/nautical_miles.hh
+++ b/au/units/nautical_miles.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/nautical_miles_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct NauticalMiles
       NauticalMilesLabel<void> {
     using NauticalMilesLabel<void>::label;
 };
-constexpr auto nautical_mile = SingularNameFor<NauticalMiles>{};
-constexpr auto nautical_miles = QuantityMaker<NauticalMiles>{};
+AU_DEVICE_VAR constexpr auto nautical_mile = SingularNameFor<NauticalMiles>{};
+AU_DEVICE_VAR constexpr auto nautical_miles = QuantityMaker<NauticalMiles>{};
 
 namespace symbols {
-constexpr auto nmi = SymbolFor<NauticalMiles>{};
+AU_DEVICE_VAR constexpr auto nmi = SymbolFor<NauticalMiles>{};
 }
 }  // namespace au

--- a/au/units/newtons.hh
+++ b/au/units/newtons.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/newtons_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -40,10 +40,10 @@ struct Newtons
       NewtonsLabel<void> {
     using NewtonsLabel<void>::label;
 };
-constexpr auto newton = SingularNameFor<Newtons>{};
-constexpr auto newtons = QuantityMaker<Newtons>{};
+AU_DEVICE_VAR constexpr auto newton = SingularNameFor<Newtons>{};
+AU_DEVICE_VAR constexpr auto newtons = QuantityMaker<Newtons>{};
 
 namespace symbols {
-constexpr auto N = SymbolFor<Newtons>{};
+AU_DEVICE_VAR constexpr auto N = SymbolFor<Newtons>{};
 }
 }  // namespace au

--- a/au/units/ohms.hh
+++ b/au/units/ohms.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/ohms_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -43,10 +43,10 @@ struct Ohms
       OhmsLabel<void> {
     using OhmsLabel<void>::label;
 };
-constexpr auto ohm = SingularNameFor<Ohms>{};
-constexpr auto ohms = QuantityMaker<Ohms>{};
+AU_DEVICE_VAR constexpr auto ohm = SingularNameFor<Ohms>{};
+AU_DEVICE_VAR constexpr auto ohms = QuantityMaker<Ohms>{};
 
 namespace symbols {
-constexpr auto ohm = SymbolFor<Ohms>{};
+AU_DEVICE_VAR constexpr auto ohm = SymbolFor<Ohms>{};
 }
 }  // namespace au

--- a/au/units/pascals.hh
+++ b/au/units/pascals.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/pascals_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/unit_symbol.hh"
@@ -42,10 +42,10 @@ struct Pascals
     using PascalsLabel<void>::label;
 };
 
-constexpr auto pascals = QuantityMaker<Pascals>{};
+AU_DEVICE_VAR constexpr auto pascals = QuantityMaker<Pascals>{};
 constexpr QuantityPointMaker<Pascals> pascals_pt{};
 
 namespace symbols {
-constexpr auto Pa = SymbolFor<Pascals>{};
+AU_DEVICE_VAR constexpr auto Pa = SymbolFor<Pascals>{};
 }
 }  // namespace au

--- a/au/units/pascals.hh
+++ b/au/units/pascals.hh
@@ -43,7 +43,7 @@ struct Pascals
 };
 
 AU_DEVICE_VAR constexpr auto pascals = QuantityMaker<Pascals>{};
-constexpr QuantityPointMaker<Pascals> pascals_pt{};
+AU_DEVICE_VAR constexpr auto pascals_pt = QuantityPointMaker<Pascals>{};
 
 namespace symbols {
 AU_DEVICE_VAR constexpr auto Pa = SymbolFor<Pascals>{};

--- a/au/units/percent.hh
+++ b/au/units/percent.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/percent_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,9 +39,9 @@ struct Percent
       PercentLabel<void> {
     using PercentLabel<void>::label;
 };
-constexpr auto percent = QuantityMaker<Percent>{};
+AU_DEVICE_VAR constexpr auto percent = QuantityMaker<Percent>{};
 
 namespace symbols {
-constexpr auto pct = SymbolFor<Percent>{};
+AU_DEVICE_VAR constexpr auto pct = SymbolFor<Percent>{};
 }
 }  // namespace au

--- a/au/units/pounds_force.hh
+++ b/au/units/pounds_force.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/pounds_force_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -46,10 +46,10 @@ struct PoundsForce
       PoundsForceLabel<void> {
     using PoundsForceLabel<void>::label;
 };
-constexpr auto pound_force = SingularNameFor<PoundsForce>{};
-constexpr auto pounds_force = QuantityMaker<PoundsForce>{};
+AU_DEVICE_VAR constexpr auto pound_force = SingularNameFor<PoundsForce>{};
+AU_DEVICE_VAR constexpr auto pounds_force = QuantityMaker<PoundsForce>{};
 
 namespace symbols {
-constexpr auto lbf = SymbolFor<PoundsForce>{};
+AU_DEVICE_VAR constexpr auto lbf = SymbolFor<PoundsForce>{};
 }
 }  // namespace au

--- a/au/units/pounds_mass.hh
+++ b/au/units/pounds_mass.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/pounds_mass_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -45,10 +45,10 @@ struct PoundsMass
       PoundsMassLabel<void> {
     using PoundsMassLabel<void>::label;
 };
-constexpr auto pound_mass = SingularNameFor<PoundsMass>{};
-constexpr auto pounds_mass = QuantityMaker<PoundsMass>{};
+AU_DEVICE_VAR constexpr auto pound_mass = SingularNameFor<PoundsMass>{};
+AU_DEVICE_VAR constexpr auto pounds_mass = QuantityMaker<PoundsMass>{};
 
 namespace symbols {
-constexpr auto lb = SymbolFor<PoundsMass>{};
+AU_DEVICE_VAR constexpr auto lb = SymbolFor<PoundsMass>{};
 }
 }  // namespace au

--- a/au/units/radians.hh
+++ b/au/units/radians.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/radians_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -33,10 +33,10 @@ constexpr const char RadiansLabel<T>::label[];
 struct Radians : UnitImpl<Angle>, RadiansLabel<void> {
     using RadiansLabel<void>::label;
 };
-constexpr auto radian = SingularNameFor<Radians>{};
-constexpr auto radians = QuantityMaker<Radians>{};
+AU_DEVICE_VAR constexpr auto radian = SingularNameFor<Radians>{};
+AU_DEVICE_VAR constexpr auto radians = QuantityMaker<Radians>{};
 
 namespace symbols {
-constexpr auto rad = SymbolFor<Radians>{};
+AU_DEVICE_VAR constexpr auto rad = SymbolFor<Radians>{};
 }
 }  // namespace au

--- a/au/units/rankine.hh
+++ b/au/units/rankine.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/rankine_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
 #include "au/unit_symbol.hh"
@@ -40,10 +40,10 @@ struct Rankine
       RankineLabel<void> {
     using RankineLabel<void>::label;
 };
-constexpr auto rankine = QuantityMaker<Rankine>{};
-constexpr auto rankine_pt = QuantityPointMaker<Rankine>{};
+AU_DEVICE_VAR constexpr auto rankine = QuantityMaker<Rankine>{};
+AU_DEVICE_VAR constexpr auto rankine_pt = QuantityPointMaker<Rankine>{};
 
 namespace symbols {
-constexpr auto degR = SymbolFor<Rankine>{};
+AU_DEVICE_VAR constexpr auto degR = SymbolFor<Rankine>{};
 }
 }  // namespace au

--- a/au/units/revolutions.hh
+++ b/au/units/revolutions.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/revolutions_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Revolutions
       RevolutionsLabel<void> {
     using RevolutionsLabel<void>::label;
 };
-constexpr auto revolution = SingularNameFor<Revolutions>{};
-constexpr auto revolutions = QuantityMaker<Revolutions>{};
+AU_DEVICE_VAR constexpr auto revolution = SingularNameFor<Revolutions>{};
+AU_DEVICE_VAR constexpr auto revolutions = QuantityMaker<Revolutions>{};
 
 namespace symbols {
-constexpr auto rev = SymbolFor<Revolutions>{};
+AU_DEVICE_VAR constexpr auto rev = SymbolFor<Revolutions>{};
 }
 }  // namespace au

--- a/au/units/seconds.hh
+++ b/au/units/seconds.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/seconds_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -33,10 +33,10 @@ constexpr const char SecondsLabel<T>::label[];
 struct Seconds : UnitImpl<Time>, SecondsLabel<void> {
     using SecondsLabel<void>::label;
 };
-constexpr auto second = SingularNameFor<Seconds>{};
-constexpr auto seconds = QuantityMaker<Seconds>{};
+AU_DEVICE_VAR constexpr auto second = SingularNameFor<Seconds>{};
+AU_DEVICE_VAR constexpr auto seconds = QuantityMaker<Seconds>{};
 
 namespace symbols {
-constexpr auto s = SymbolFor<Seconds>{};
+AU_DEVICE_VAR constexpr auto s = SymbolFor<Seconds>{};
 }
 }  // namespace au

--- a/au/units/siemens.hh
+++ b/au/units/siemens.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/siemens_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -43,10 +43,10 @@ struct Siemens
       SiemensLabel<void> {
     using SiemensLabel<void>::label;
 };
-constexpr auto siemen = SingularNameFor<Siemens>{};
-constexpr auto siemens = QuantityMaker<Siemens>{};
+AU_DEVICE_VAR constexpr auto siemen = SingularNameFor<Siemens>{};
+AU_DEVICE_VAR constexpr auto siemens = QuantityMaker<Siemens>{};
 
 namespace symbols {
-constexpr auto S = SymbolFor<Siemens>{};
+AU_DEVICE_VAR constexpr auto S = SymbolFor<Siemens>{};
 }
 }  // namespace au

--- a/au/units/slugs.hh
+++ b/au/units/slugs.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/slugs_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -48,10 +48,10 @@ struct Slugs
       SlugsLabel<void> {
     using SlugsLabel<void>::label;
 };
-constexpr auto slug = SingularNameFor<Slugs>{};
-constexpr auto slugs = QuantityMaker<Slugs>{};
+AU_DEVICE_VAR constexpr auto slug = SingularNameFor<Slugs>{};
+AU_DEVICE_VAR constexpr auto slugs = QuantityMaker<Slugs>{};
 
 namespace symbols {
-constexpr auto slug = SymbolFor<Slugs>{};
+AU_DEVICE_VAR constexpr auto slug = SymbolFor<Slugs>{};
 }
 }  // namespace au

--- a/au/units/standard_gravity.hh
+++ b/au/units/standard_gravity.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/standard_gravity_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -40,9 +40,9 @@ struct StandardGravity
       StandardGravityLabel<void> {
     using StandardGravityLabel<void>::label;
 };
-constexpr auto standard_gravity = QuantityMaker<StandardGravity>{};
+AU_DEVICE_VAR constexpr auto standard_gravity = QuantityMaker<StandardGravity>{};
 
 namespace symbols {
-constexpr auto g_0 = SymbolFor<StandardGravity>{};
+AU_DEVICE_VAR constexpr auto g_0 = SymbolFor<StandardGravity>{};
 }
 }  // namespace au

--- a/au/units/steradians.hh
+++ b/au/units/steradians.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/steradians_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -39,10 +39,10 @@ struct Steradians
       SteradiansLabel<void> {
     using SteradiansLabel<void>::label;
 };
-constexpr auto steradian = SingularNameFor<Steradians>{};
-constexpr auto steradians = QuantityMaker<Steradians>{};
+AU_DEVICE_VAR constexpr auto steradian = SingularNameFor<Steradians>{};
+AU_DEVICE_VAR constexpr auto steradians = QuantityMaker<Steradians>{};
 
 namespace symbols {
-constexpr auto sr = SymbolFor<Steradians>{};
+AU_DEVICE_VAR constexpr auto sr = SymbolFor<Steradians>{};
 }
 }  // namespace au

--- a/au/units/tesla.hh
+++ b/au/units/tesla.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/tesla_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -40,9 +40,9 @@ struct Tesla
       TeslaLabel<void> {
     using TeslaLabel<void>::label;
 };
-constexpr auto tesla = QuantityMaker<Tesla>{};
+AU_DEVICE_VAR constexpr auto tesla = QuantityMaker<Tesla>{};
 
 namespace symbols {
-constexpr auto T = SymbolFor<Tesla>{};
+AU_DEVICE_VAR constexpr auto T = SymbolFor<Tesla>{};
 }
 }  // namespace au

--- a/au/units/unos.hh
+++ b/au/units/unos.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/unos_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 
 namespace au {
@@ -32,6 +32,6 @@ constexpr const char UnosLabel<T>::label[];
 struct Unos : UnitProduct<>, UnosLabel<void> {
     using UnosLabel<void>::label;
 };
-constexpr auto unos = QuantityMaker<Unos>{};
+AU_DEVICE_VAR constexpr auto unos = QuantityMaker<Unos>{};
 
 }  // namespace au

--- a/au/units/us_gallons.hh
+++ b/au/units/us_gallons.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/us_gallons_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -45,11 +45,11 @@ struct USGallons
       USGallonsLabel<void> {
     using USGallonsLabel<void>::label;
 };
-constexpr auto us_gallon = SingularNameFor<USGallons>{};
-constexpr auto us_gallons = QuantityMaker<USGallons>{};
+AU_DEVICE_VAR constexpr auto us_gallon = SingularNameFor<USGallons>{};
+AU_DEVICE_VAR constexpr auto us_gallons = QuantityMaker<USGallons>{};
 
 namespace symbols {
-constexpr auto US_gal = SymbolFor<USGallons>{};
+AU_DEVICE_VAR constexpr auto US_gal = SymbolFor<USGallons>{};
 }
 
 }  // namespace au

--- a/au/units/us_pints.hh
+++ b/au/units/us_pints.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/us_pints_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -45,11 +45,11 @@ struct USPints
       USPintsLabel<void> {
     using USPintsLabel<void>::label;
 };
-constexpr auto us_pint = SingularNameFor<USPints>{};
-constexpr auto us_pints = QuantityMaker<USPints>{};
+AU_DEVICE_VAR constexpr auto us_pint = SingularNameFor<USPints>{};
+AU_DEVICE_VAR constexpr auto us_pints = QuantityMaker<USPints>{};
 
 namespace symbols {
-constexpr auto US_pt = SymbolFor<USPints>{};
+AU_DEVICE_VAR constexpr auto US_pt = SymbolFor<USPints>{};
 }
 
 }  // namespace au

--- a/au/units/us_quarts.hh
+++ b/au/units/us_quarts.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/us_quarts_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -45,11 +45,11 @@ struct USQuarts
       USQuartsLabel<void> {
     using USQuartsLabel<void>::label;
 };
-constexpr auto us_quart = SingularNameFor<USQuarts>{};
-constexpr auto us_quarts = QuantityMaker<USQuarts>{};
+AU_DEVICE_VAR constexpr auto us_quart = SingularNameFor<USQuarts>{};
+AU_DEVICE_VAR constexpr auto us_quarts = QuantityMaker<USQuarts>{};
 
 namespace symbols {
-constexpr auto US_qt = SymbolFor<USQuarts>{};
+AU_DEVICE_VAR constexpr auto US_qt = SymbolFor<USQuarts>{};
 }
 
 }  // namespace au

--- a/au/units/volts.hh
+++ b/au/units/volts.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/volts_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -43,10 +43,10 @@ struct Volts
       VoltsLabel<void> {
     using VoltsLabel<void>::label;
 };
-constexpr auto volt = SingularNameFor<Volts>{};
-constexpr auto volts = QuantityMaker<Volts>{};
+AU_DEVICE_VAR constexpr auto volt = SingularNameFor<Volts>{};
+AU_DEVICE_VAR constexpr auto volts = QuantityMaker<Volts>{};
 
 namespace symbols {
-constexpr auto V = SymbolFor<Volts>{};
+AU_DEVICE_VAR constexpr auto V = SymbolFor<Volts>{};
 }
 }  // namespace au

--- a/au/units/watts.hh
+++ b/au/units/watts.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/watts_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -40,10 +40,10 @@ struct Watts
       WattsLabel<void> {
     using WattsLabel<void>::label;
 };
-constexpr auto watt = SingularNameFor<Watts>{};
-constexpr auto watts = QuantityMaker<Watts>{};
+AU_DEVICE_VAR constexpr auto watt = SingularNameFor<Watts>{};
+AU_DEVICE_VAR constexpr auto watts = QuantityMaker<Watts>{};
 
 namespace symbols {
-constexpr auto W = SymbolFor<Watts>{};
+AU_DEVICE_VAR constexpr auto W = SymbolFor<Watts>{};
 }
 }  // namespace au

--- a/au/units/webers.hh
+++ b/au/units/webers.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/webers_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -43,10 +43,10 @@ struct Webers
       WebersLabel<void> {
     using WebersLabel<void>::label;
 };
-constexpr auto weber = SingularNameFor<Webers>{};
-constexpr auto webers = QuantityMaker<Webers>{};
+AU_DEVICE_VAR constexpr auto weber = SingularNameFor<Webers>{};
+AU_DEVICE_VAR constexpr auto webers = QuantityMaker<Webers>{};
 
 namespace symbols {
-constexpr auto Wb = SymbolFor<Webers>{};
+AU_DEVICE_VAR constexpr auto Wb = SymbolFor<Webers>{};
 }
 }  // namespace au

--- a/au/units/yards.hh
+++ b/au/units/yards.hh
@@ -16,7 +16,7 @@
 
 #include "au/units/yards_fwd.hh"
 // Keep corresponding `_fwd.hh` file on top.
-
+#include "au/config.hh"
 #include "au/quantity.hh"
 #include "au/unit_symbol.hh"
 
@@ -40,10 +40,10 @@ struct Yards
       YardsLabel<void> {
     using YardsLabel<void>::label;
 };
-constexpr auto yard = SingularNameFor<Yards>{};
-constexpr auto yards = QuantityMaker<Yards>{};
+AU_DEVICE_VAR constexpr auto yard = SingularNameFor<Yards>{};
+AU_DEVICE_VAR constexpr auto yards = QuantityMaker<Yards>{};
 
 namespace symbols {
-constexpr auto yd = SymbolFor<Yards>{};
+AU_DEVICE_VAR constexpr auto yd = SymbolFor<Yards>{};
 }
 }  // namespace au

--- a/au/zero.hh
+++ b/au/zero.hh
@@ -56,7 +56,7 @@ struct Zero {
 //
 // This exists purely for convenience, so people don't have to call the initializer.  i.e., it lets
 // us write `ZERO` instead of `Zero{}`.
-static constexpr auto ZERO = Zero{};
+AU_DEVICE_VAR constexpr auto ZERO = Zero{};
 
 // Addition, subtraction, and comparison of Zero are well defined.
 inline AU_DEVICE_FUNC constexpr Zero operator+(Zero, Zero) { return ZERO; }


### PR DESCRIPTION
This enables our core out-of-the-box callables --- quantity maker
instances like `meters`, prefix appliers like `kilo`, unit symbols like
`yd`, etc. --- to work in CUDA code.

60 of the files are simply unit files with mechanical updates to include
the header and use the macro.  9 more are the same, but for constants
rather than units.  The others are:

- `MODULE.bazel.lock` (generated file changes)
- `au/config.hh` adds the new macro
- `au/prefix.hh` applies it to the prefix appliers
- `au/conversion_policy.hh` applies it to the conversion policies
- `au/cuda/cuda_test.cu` gets new test cases for the conversion policies

Finally... we forgot to handle `mag<N>()` in the parent PR, and it's
already landed, so we cover it here.  The new conversion policy tests
use it, so now we have coverage for it.

Helps #671.  We will follow up with doc updates.