### PR TITLE
Reflect CUDA support in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ https://github.com/aurora-opensource/au/actions/workflows/msvc-2022-x64.yml)
 [![MSVC 2025 x64](
 https://github.com/aurora-opensource/au/actions/workflows/msvc-2025-x64.yml/badge.svg?branch=main&event=push)](
 https://github.com/aurora-opensource/au/actions/workflows/msvc-2025-x64.yml)
+<br>
+[![cuda-ubuntu](
+https://github.com/aurora-opensource/au/actions/workflows/cuda-ubuntu.yml/badge.svg?branch=main&event=push)](
+https://github.com/aurora-opensource/au/actions/workflows/cuda-ubuntu.yml)
 
 # Au: A C++14-compatible units library, by Aurora
 
@@ -55,8 +59,9 @@ surface" that protects conversions against overflow, unit-aware rounding and inv
 many more.
 
 Forged in the crucible of Aurora's diverse, demanding use cases, Au has a proven track record of
-usability and reliability. This **includes embedded support**: Aurora's embedded teams have been
-first class customers since the library's inception.
+usability and reliability. This **includes embedded and GPU support**: Aurora's embedded teams have
+been first class customers since the library's inception, and Au now also works out of the box with
+CUDA.
 
 To learn more about our place in the C++ units library ecosystem, see our [detailed library
 comparison](https://aurora-opensource.github.io/au/main/alternatives/).

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -1208,6 +1208,12 @@ features.
                 <li>Only one user-facing macro for C++20 backwards compatibility</li>
             </ul>
         </td>
-        <td class="best">Zero user-facing macros; only two internal macros</td>
+        <td class="good">
+            <ul>
+                <li class="check">No user-facing macros</li>
+                <li>Internal macros only where no viable alternative exists (CUDA/HIP support,
+                    C++ feature detection)</li>
+            </ul>
+        </td>
     </tr>
 </table>

--- a/docs/supported-compilers.md
+++ b/docs/supported-compilers.md
@@ -75,6 +75,7 @@ Here are the configurations that have Best Effort Support status.
 |----------|----------|--------|
 | Windows Server 2022 | MSVC 2022 x64 | [![MSVC 2022 x64]( https://github.com/aurora-opensource/au/actions/workflows/msvc-2022-x64.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/msvc-2022-x64.yml) |
 | Windows Server 2025 | MSVC 2025 x64 | [![MSVC 2025 x64]( https://github.com/aurora-opensource/au/actions/workflows/msvc-2025-x64.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/msvc-2025-x64.yml) |
+| Ubuntu | CUDA (nvcc) | [![cuda-ubuntu]( https://github.com/aurora-opensource/au/actions/workflows/cuda-ubuntu.yml/badge.svg?branch=main&event=push)]( https://github.com/aurora-opensource/au/actions/workflows/cuda-ubuntu.yml) |
 
 ### Assumed support
 


### PR DESCRIPTION
This doc update is intentionally light.  Since CUDA should "just work"
out of the box, a full doc page wouldn't pull its weight.  We simply
advertise on the README (including a badge), mention nvcc as "best
effort" on our compilers page, and quit tooting our own horn about
macros on the alternatives page.  Fixes #671.