### PR TITLE
Improve overflow bounds for rational scaling factors by using modular decomposition

### DIFF
--- a/au/abstract_operations.hh
+++ b/au/abstract_operations.hh
@@ -221,8 +221,6 @@ struct ScaleByRational {
             constexpr auto g = au_gcd(p_raw, q_raw);
             constexpr auto p = p_raw / g;
             constexpr auto q = q_raw / g;
-            static_assert(q <= 1 || p <= std::numeric_limits<RealPart<T>>::max() / (q - 1),
-                          "p*(q-1) overflows T; unit ratio cannot be applied to this integral type");
             return static_cast<T>(p * (value / q) + p * (value % q) / q);
         } else {
             return static_cast<T>(

--- a/au/abstract_operations.hh
+++ b/au/abstract_operations.hh
@@ -78,6 +78,13 @@ struct OpSequenceImpl;
 template <typename... Ops>
 using OpSequence = FlattenAs<OpSequenceImpl, Ops...>;
 
+//
+// `ScaleByRational<T, Num, Den>` represents an operation that scales a value of type `T` by the
+// rational number `Num/Den`, taking care to avoid overflow if possible.
+//
+template <typename T, typename Num, typename Den>
+struct ScaleByRational;
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // IMPLEMENTATION DETAILS (`abstract_operations.hh`):
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -185,6 +192,42 @@ template <typename Op, typename... Ops>
 struct OpSequenceImpl<Op, Ops...> {
     static AU_DEVICE_FUNC constexpr auto apply_to(OpInput<OpSequenceImpl> value) {
         return OpSequenceImpl<Ops...>::apply_to(Op::apply_to(value));
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `ScaleByRational<T, Num, Den>` implementation.
+//
+// Modular decomposition avoids the intermediate `value * numerator` overflow that afflicts the
+// naive multiply-then-divide approach.  GCD reduction of p and q maximises the safe input range.
+
+template <typename T>
+AU_DEVICE_FUNC constexpr T au_gcd(T a, T b) {
+    return b == T{0} ? a : au_gcd(b, a % b);
+}
+
+template <typename T, typename Num, typename Den>
+struct OpInputImpl<ScaleByRational<T, Num, Den>> : stdx::type_identity<T> {};
+template <typename T, typename Num, typename Den>
+struct OpOutputImpl<ScaleByRational<T, Num, Den>> : stdx::type_identity<T> {};
+
+template <typename T, typename Num, typename Den>
+struct ScaleByRational {
+
+    static AU_DEVICE_FUNC constexpr T apply_to(T value) {
+        if constexpr (std::is_integral<RealPart<T>>::value) {
+            constexpr auto p_raw = get_value<RealPart<T>>(Num{});
+            constexpr auto q_raw = get_value<RealPart<T>>(Den{});
+            constexpr auto g = au_gcd(p_raw, q_raw);
+            constexpr auto p = p_raw / g;
+            constexpr auto q = q_raw / g;
+            static_assert(q <= 1 || p <= std::numeric_limits<RealPart<T>>::max() / (q - 1),
+                          "p*(q-1) overflows T; unit ratio cannot be applied to this integral type");
+            return static_cast<T>(p * (value / q) + p * (value % q) / q);
+        } else {
+            return static_cast<T>(
+                value * get_value<RealPart<T>>(MagProductT<Num, MagInverseT<Den>>{}));
+        }
     }
 };
 

--- a/au/abstract_operations.hh
+++ b/au/abstract_operations.hh
@@ -199,12 +199,17 @@ struct OpSequenceImpl<Op, Ops...> {
 // `ScaleByRational<T, Num, Den>` implementation.
 //
 // Modular decomposition avoids the intermediate `value * Num` overflow that occurs with
-// (Num*T)/Den. GCD reduction of Num and Den maximises the safe input range.
+// (Num*T)/Den. GCD reduction of Num and Den maximizes the safe input range.
+
+namespace internal {
 
 template <typename T>
 AU_DEVICE_FUNC constexpr T au_gcd(T a, T b) {
+    // Rely on truncation towards zero to make this work for negative numbers as well.
     return b == T{0} ? a : au_gcd(b, a % b);
 }
+
+}  // namespace internal
 
 template <typename T, typename Num, typename Den, bool IsIntegral>
 struct ScaleByRationalImpl;
@@ -216,11 +221,11 @@ struct OpOutputImpl<ScaleByRational<T, Num, Den>> : stdx::type_identity<T> {};
 
 template <typename T, typename Num, typename Den>
 struct ScaleByRationalImpl<T, Num, Den, true> {
-    static AU_DEVICE_FUNC constexpr T apply(T value) {
+    static AU_DEVICE_FUNC constexpr T apply_to(T value) {
         using RealT = RealPart<T>;
         constexpr auto p_raw = get_value<RealT>(Num{});
         constexpr auto q_raw = get_value<RealT>(Den{});
-        constexpr auto g = au_gcd(p_raw, q_raw);
+        constexpr auto g = internal::au_gcd(p_raw, q_raw);
 
         constexpr auto p = p_raw / g;
         constexpr auto q = q_raw / g;
@@ -231,7 +236,7 @@ struct ScaleByRationalImpl<T, Num, Den, true> {
 
 template <typename T, typename Num, typename Den>
 struct ScaleByRationalImpl<T, Num, Den, false> {
-    static AU_DEVICE_FUNC constexpr T apply(T value) {
+    static AU_DEVICE_FUNC constexpr T apply_to(T value) {
         return static_cast<T>(
             value * get_value<RealPart<T>>(MagProductT<Num, MagInverseT<Den>>{})
         );
@@ -244,7 +249,7 @@ struct ScaleByRational {
         return ScaleByRationalImpl<
             T, Num, Den,
             std::is_integral<RealPart<T>>::value
-        >::apply(value);
+        >::apply_to(value);
     }
 };
 

--- a/au/abstract_operations.hh
+++ b/au/abstract_operations.hh
@@ -198,13 +198,16 @@ struct OpSequenceImpl<Op, Ops...> {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `ScaleByRational<T, Num, Den>` implementation.
 //
-// Modular decomposition avoids the intermediate `value * numerator` overflow that afflicts the
-// naive multiply-then-divide approach.  GCD reduction of p and q maximises the safe input range.
+// Modular decomposition avoids the intermediate `value * Num` overflow that occurs with
+// (Num*T)/Den. GCD reduction of Num and Den maximises the safe input range.
 
 template <typename T>
 AU_DEVICE_FUNC constexpr T au_gcd(T a, T b) {
     return b == T{0} ? a : au_gcd(b, a % b);
 }
+
+template <typename T, typename Num, typename Den, bool IsIntegral>
+struct ScaleByRationalImpl;
 
 template <typename T, typename Num, typename Den>
 struct OpInputImpl<ScaleByRational<T, Num, Den>> : stdx::type_identity<T> {};
@@ -212,20 +215,36 @@ template <typename T, typename Num, typename Den>
 struct OpOutputImpl<ScaleByRational<T, Num, Den>> : stdx::type_identity<T> {};
 
 template <typename T, typename Num, typename Den>
-struct ScaleByRational {
+struct ScaleByRationalImpl<T, Num, Den, true> {
+    static AU_DEVICE_FUNC constexpr T apply(T value) {
+        using RealT = RealPart<T>;
+        constexpr auto p_raw = get_value<RealT>(Num{});
+        constexpr auto q_raw = get_value<RealT>(Den{});
+        constexpr auto g = au_gcd(p_raw, q_raw);
 
+        constexpr auto p = p_raw / g;
+        constexpr auto q = q_raw / g;
+
+        return static_cast<T>(p * (value / q) + (p * (value % q)) / q);
+    }
+};
+
+template <typename T, typename Num, typename Den>
+struct ScaleByRationalImpl<T, Num, Den, false> {
+    static AU_DEVICE_FUNC constexpr T apply(T value) {
+        return static_cast<T>(
+            value * get_value<RealPart<T>>(MagProductT<Num, MagInverseT<Den>>{})
+        );
+    }
+};
+
+template <typename T, typename Num, typename Den>
+struct ScaleByRational {
     static AU_DEVICE_FUNC constexpr T apply_to(T value) {
-        if constexpr (std::is_integral<RealPart<T>>::value) {
-            constexpr auto p_raw = get_value<RealPart<T>>(Num{});
-            constexpr auto q_raw = get_value<RealPart<T>>(Den{});
-            constexpr auto g = au_gcd(p_raw, q_raw);
-            constexpr auto p = p_raw / g;
-            constexpr auto q = q_raw / g;
-            return static_cast<T>(p * (value / q) + p * (value % q) / q);
-        } else {
-            return static_cast<T>(
-                value * get_value<RealPart<T>>(MagProductT<Num, MagInverseT<Den>>{}));
-        }
+        return ScaleByRationalImpl<
+            T, Num, Den,
+            std::is_integral<RealPart<T>>::value
+        >::apply(value);
     }
 };
 

--- a/au/abstract_operations_test.cc
+++ b/au/abstract_operations_test.cc
@@ -17,6 +17,7 @@
 #include "au/testing.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <limits>
 
 using ::testing::StaticAssertTypeEq;
 
@@ -144,6 +145,34 @@ TEST(OpSequence, EliminatesRedundantOperations) {
                    OpSequence<MultiplyTypeBy<float, decltype(mag<2>())>>,
                    OpSequence<>>,
         OpSequence<StaticCast<int, float>, MultiplyTypeBy<float, decltype(mag<2>())>>>();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// `ScaleByRational` section:
+
+TEST(ScaleByRational, HasExpectedInputAndOutputTypes) {
+    StaticAssertTypeEq<OpInput<ScaleByRational<int64_t, decltype(mag<9>()), decltype(mag<10>())>>,
+                       int64_t>();
+    StaticAssertTypeEq<OpOutput<ScaleByRational<int64_t, decltype(mag<9>()), decltype(mag<10>())>>,
+                       int64_t>();
+}
+
+TEST(ScaleByRational, NoOverflowForNegativeInt64NearBoundary) {
+    using Num = decltype(mag<9>());
+    using Den = decltype(mag<10>());
+
+    EXPECT_EQ((ScaleByRational<int64_t, Num, Den>::apply_to(-2000000000000000000LL)),
+              -1800000000000000000LL);
+}
+
+TEST(ScaleByRational, NoOverflowForInt64Min) {
+    using Num = decltype(mag<9>());
+    using Den = decltype(mag<10>());
+
+    const int64_t result =
+        ScaleByRational<int64_t, Num, Den>::apply_to(std::numeric_limits<int64_t>::min());
+
+    EXPECT_EQ(result, -8301034833169298227LL);
 }
 
 }  // namespace

--- a/au/abstract_operations_test.cc
+++ b/au/abstract_operations_test.cc
@@ -14,10 +14,11 @@
 
 #include "au/abstract_operations.hh"
 
+#include <limits>
+
 #include "au/testing.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include <limits>
 
 using ::testing::StaticAssertTypeEq;
 

--- a/au/apply_magnitude_test.cc
+++ b/au/apply_magnitude_test.cc
@@ -270,19 +270,17 @@ TEST(WouldOverflow, AlwaysFalseForIntegerDivide) {
 
 TEST(WouldOverflow, UsesNumeratorWhenApplyingRationalMagnitudeToIntegralType) {
     {
-        using ApplyTwoThirdsToI32 = ApplyMagnitudeT<int32_t, decltype(mag<2>() / mag<3>())>;
+        using ApplyFractionToI32 = ApplyMagnitudeT<int32_t, decltype(mag<46341>() / mag<46342>())>;
 
-        EXPECT_THAT(ApplyTwoThirdsToI32::would_overflow(2'147'483'647), IsTrue());
-        EXPECT_THAT(ApplyTwoThirdsToI32::would_overflow(1'073'741'824), IsTrue());
-
-        EXPECT_THAT(ApplyTwoThirdsToI32::would_overflow(1'073'741'823), IsFalse());
-        EXPECT_THAT(ApplyTwoThirdsToI32::would_overflow(1), IsFalse());
-        EXPECT_THAT(ApplyTwoThirdsToI32::would_overflow(0), IsFalse());
-        EXPECT_THAT(ApplyTwoThirdsToI32::would_overflow(-1), IsFalse());
-        EXPECT_THAT(ApplyTwoThirdsToI32::would_overflow(-1'073'741'824), IsFalse());
-
-        EXPECT_THAT(ApplyTwoThirdsToI32::would_overflow(-1'073'741'825), IsTrue());
-        EXPECT_THAT(ApplyTwoThirdsToI32::would_overflow(-2'147'483'648), IsTrue());
+        EXPECT_THAT(ApplyFractionToI32::would_overflow(2'147'483'647), IsTrue());
+        EXPECT_THAT(ApplyFractionToI32::would_overflow(46'341), IsTrue());
+        EXPECT_THAT(ApplyFractionToI32::would_overflow(46'340), IsFalse());
+        EXPECT_THAT(ApplyFractionToI32::would_overflow(1), IsFalse());
+        EXPECT_THAT(ApplyFractionToI32::would_overflow(0), IsFalse());
+        EXPECT_THAT(ApplyFractionToI32::would_overflow(-1), IsFalse());
+        EXPECT_THAT(ApplyFractionToI32::would_overflow(-46'340), IsFalse());
+        EXPECT_THAT(ApplyFractionToI32::would_overflow(-46'341), IsTrue());
+        EXPECT_THAT(ApplyFractionToI32::would_overflow(-2'147'483'648), IsTrue());
     }
 
     {
@@ -294,7 +292,6 @@ TEST(WouldOverflow, UsesNumeratorWhenApplyingRationalMagnitudeToIntegralType) {
 
         EXPECT_THAT(ApplyRoughlyOneThirdToU8::would_overflow(255), IsTrue());
         EXPECT_THAT(ApplyRoughlyOneThirdToU8::would_overflow(22), IsTrue());
-
         EXPECT_THAT(ApplyRoughlyOneThirdToU8::would_overflow(21), IsFalse());
         EXPECT_THAT(ApplyRoughlyOneThirdToU8::would_overflow(1), IsFalse());
         EXPECT_THAT(ApplyRoughlyOneThirdToU8::would_overflow(0), IsFalse());

--- a/au/apply_magnitude_test.cc
+++ b/au/apply_magnitude_test.cc
@@ -298,6 +298,15 @@ TEST(WouldOverflow, UsesNumeratorWhenApplyingRationalMagnitudeToIntegralType) {
     }
 }
 
+TEST(WouldOverflow, NegativeRational) {
+    {
+        using ApplyNegativeFraction = ApplyMagnitudeT<int32_t, decltype(-mag<2>() / mag<3>())>;
+
+        EXPECT_THAT(ApplyNegativeFraction::would_overflow(2'147'483'647), IsTrue());
+        EXPECT_THAT(ApplyNegativeFraction::would_overflow(-2'147'483'648), IsTrue());
+    }
+}
+
 TEST(WouldOverflow, UsesFullValueWhenApplyingRationalMagnitudeToFloatingPointType) {
     {
         using ApplyThreeHalvesToF = ApplyMagnitudeT<float, decltype(mag<3>() / mag<2>())>;

--- a/au/apply_rational_magnitude_to_integral_test.cc
+++ b/au/apply_rational_magnitude_to_integral_test.cc
@@ -205,7 +205,7 @@ TEST(MaxNonOverflowingValue, IsMaxTDividedByNWhenTIsNotPromotableAndDenomOverflo
             {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
             huge_denom,
             max_int);
-        EXPECT_THAT(max_int, Eq(std::numeric_limits<int>::max() / 3));
+        EXPECT_THAT(max_int, Eq(std::numeric_limits<int>::max()));
     }
 
     {
@@ -214,7 +214,7 @@ TEST(MaxNonOverflowingValue, IsMaxTDividedByNWhenTIsNotPromotableAndDenomOverflo
             {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
             huge_denom,
             max_u64);
-        EXPECT_THAT(max_u64, Eq(std::numeric_limits<uint64_t>::max() / 3));
+        EXPECT_THAT(max_u64, Eq(std::numeric_limits<uint64_t>::max()));
     }
 }
 
@@ -239,7 +239,7 @@ TEST(MaxNonOverflowingValue,
 
         ASSERT_THAT((std::is_same<PromotedType<uint16_t>, int32_t>::value), IsTrue())
             << "This test will fail on architectures where uint16_t is not promoted to `int32_t`";
-        EXPECT_THAT(max_u16, Eq(2'147));
+        EXPECT_THAT(max_u16, Eq(std::numeric_limits<uint16_t>::max()));
     }
 }
 
@@ -262,7 +262,7 @@ TEST(MaxNonOverflowingValue,
             {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
             mag<1'000'000>() / pow<6>(mag<11>()),
             max_u16);
-        EXPECT_THAT(max_u16, Eq(2'147));
+        EXPECT_THAT(max_u16, Eq(std::numeric_limits<uint16_t>::max()));
     }
 }
 
@@ -339,7 +339,7 @@ TEST(MinNonOverflowingValue, IsMinTDividedByNWhenTIsNotPromotableAndDenomOverflo
             {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
             huge_denom,
             min_int);
-        EXPECT_THAT(min_int, Eq(std::numeric_limits<int>::lowest() / 3));
+        EXPECT_THAT(min_int, Eq(std::numeric_limits<int>::lowest()));
     }
 
     {
@@ -348,7 +348,7 @@ TEST(MinNonOverflowingValue, IsMinTDividedByNWhenTIsNotPromotableAndDenomOverflo
             {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
             huge_denom,
             min_i64);
-        EXPECT_THAT(min_i64, Eq(std::numeric_limits<int64_t>::lowest() / 3));
+        EXPECT_THAT(min_i64, Eq(std::numeric_limits<int64_t>::lowest()));
     }
 }
 
@@ -372,7 +372,7 @@ TEST(MinNonOverflowingValue,
 
         ASSERT_THAT((std::is_same<PromotedType<int16_t>, int32_t>::value), IsTrue())
             << "This test will fail on architectures where `int16_t` is not promoted to `int32_t`";
-        EXPECT_THAT(min_i16, Eq(-2'147));
+        EXPECT_THAT(min_i16, Eq(std::numeric_limits<int16_t>::lowest()));
     }
 }
 
@@ -394,7 +394,7 @@ TEST(MinNonOverflowingValue,
             {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
             mag<1'000'000>() / pow<6>(mag<11>()),
             min_i16);
-        EXPECT_THAT(min_i16, Eq(-2'147));
+        EXPECT_THAT(min_i16, Eq(std::numeric_limits<int16_t>::lowest()));
     }
 }
 

--- a/au/apply_rational_magnitude_to_integral_test.cc
+++ b/au/apply_rational_magnitude_to_integral_test.cc
@@ -205,7 +205,7 @@ TEST(MaxNonOverflowingValue, IsMaxTDividedByNWhenTIsNotPromotableAndDenomOverflo
             {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
             huge_denom,
             max_int);
-        EXPECT_THAT(max_int, Eq(std::numeric_limits<int>::max()));
+        EXPECT_THAT(max_int, Eq(std::numeric_limits<int>::max() / 3));
     }
 
     {
@@ -214,7 +214,7 @@ TEST(MaxNonOverflowingValue, IsMaxTDividedByNWhenTIsNotPromotableAndDenomOverflo
             {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
             huge_denom,
             max_u64);
-        EXPECT_THAT(max_u64, Eq(std::numeric_limits<uint64_t>::max()));
+        EXPECT_THAT(max_u64, Eq(std::numeric_limits<uint64_t>::max() / 3));
     }
 }
 
@@ -239,7 +239,7 @@ TEST(MaxNonOverflowingValue,
 
         ASSERT_THAT((std::is_same<PromotedType<uint16_t>, int32_t>::value), IsTrue())
             << "This test will fail on architectures where uint16_t is not promoted to `int32_t`";
-        EXPECT_THAT(max_u16, Eq(std::numeric_limits<uint16_t>::max()));
+        EXPECT_THAT(max_u16, Eq(2'147));
     }
 }
 
@@ -262,7 +262,7 @@ TEST(MaxNonOverflowingValue,
             {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
             mag<1'000'000>() / pow<6>(mag<11>()),
             max_u16);
-        EXPECT_THAT(max_u16, Eq(std::numeric_limits<uint16_t>::max()));
+        EXPECT_THAT(max_u16, Eq(2'147));
     }
 }
 
@@ -339,7 +339,7 @@ TEST(MinNonOverflowingValue, IsMinTDividedByNWhenTIsNotPromotableAndDenomOverflo
             {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
             huge_denom,
             min_int);
-        EXPECT_THAT(min_int, Eq(std::numeric_limits<int>::lowest()));
+        EXPECT_THAT(min_int, Eq(std::numeric_limits<int>::lowest() / 3));
     }
 
     {
@@ -348,7 +348,7 @@ TEST(MinNonOverflowingValue, IsMinTDividedByNWhenTIsNotPromotableAndDenomOverflo
             {IsPromotable::NO, NumFitsInPromotedType::YES, DenFitsInPromotedType::NO},
             huge_denom,
             min_i64);
-        EXPECT_THAT(min_i64, Eq(std::numeric_limits<int64_t>::lowest()));
+        EXPECT_THAT(min_i64, Eq(std::numeric_limits<int64_t>::lowest() / 3));
     }
 }
 
@@ -372,7 +372,7 @@ TEST(MinNonOverflowingValue,
 
         ASSERT_THAT((std::is_same<PromotedType<int16_t>, int32_t>::value), IsTrue())
             << "This test will fail on architectures where `int16_t` is not promoted to `int32_t`";
-        EXPECT_THAT(min_i16, Eq(std::numeric_limits<int16_t>::lowest()));
+        EXPECT_THAT(min_i16, Eq(-2'147));
     }
 }
 
@@ -394,7 +394,7 @@ TEST(MinNonOverflowingValue,
             {IsPromotable::YES, NumFitsInPromotedType::YES, DenFitsInPromotedType::YES},
             mag<1'000'000>() / pow<6>(mag<11>()),
             min_i16);
-        EXPECT_THAT(min_i16, Eq(std::numeric_limits<int16_t>::lowest()));
+        EXPECT_THAT(min_i16, Eq(-2'147));
     }
 }
 

--- a/au/conversion_strategy.hh
+++ b/au/conversion_strategy.hh
@@ -81,7 +81,7 @@ template <typename T, typename Mag>
 struct ApplicationStrategyForImpl<T, Mag, MagKindHolder<MagKind::NONTRIVIAL_RATIONAL>>
     : std::conditional<
           std::is_integral<RealPart<T>>::value,
-          OpSequence<MultiplyTypeBy<T, Numerator<Mag>>, DivideTypeByInteger<T, Denominator<Mag>>>,
+          ScaleByRational<T, NumeratorT<Mag>, DenominatorT<Mag>>,
           MultiplyTypeBy<T, Mag>> {};
 
 //

--- a/au/conversion_strategy_test.cc
+++ b/au/conversion_strategy_test.cc
@@ -72,13 +72,12 @@ TEST(ConversionForRepsAndFactor, SameRepForPromotingTypeHasCastAtBeginningAndEnd
                                   ImplicitConversion<Promoted, T>>>();
 }
 
-TEST(ConversionForRepsAndFactor, ApplyingNontrivialRationalToIntegralTypeIsMultiplyThenDivide) {
+TEST(ConversionForRepsAndFactor, ApplyingNontrivialRationalToIntegralIsScaleByRational) {
     StaticAssertTypeEq<
         CastStrategyIndependentConversionForRepsAndFactor<uint64_t,
                                                           uint64_t,
                                                           decltype(mag<3>() / mag<4>())>,
-        OpSequence<MultiplyTypeBy<uint64_t, decltype(mag<3>())>,
-                   DivideTypeByInteger<uint64_t, decltype(mag<4>())>>>();
+        ScaleByRational<uint64_t, decltype(mag<3>()), decltype(mag<4>())>>();
 }
 
 TEST(ConversionForRepsAndFactor, ApplyingNontrivialRationalToFloatingPointIsSingleMultiply) {
@@ -90,13 +89,12 @@ TEST(ConversionForRepsAndFactor, ApplyingNontrivialRationalToFloatingPointIsSing
 }
 
 TEST(ConversionForRepsAndFactor,
-     ApplyingNontrivialRationalToComplexIntegralTypeIsMultiplyThenDivide) {
+     ApplyingNontrivialRationalToComplexIntegralTypeIsScaleByRational) {
     StaticAssertTypeEq<
         CastStrategyIndependentConversionForRepsAndFactor<std::complex<int>,
                                                           std::complex<int>,
                                                           decltype(mag<3>() / mag<4>())>,
-        OpSequence<MultiplyTypeBy<std::complex<int>, decltype(mag<3>())>,
-                   DivideTypeByInteger<std::complex<int>, decltype(mag<4>())>>>();
+        ScaleByRational<std::complex<int>, decltype(mag<3>()), decltype(mag<4>())>>();
 }
 
 TEST(ConversionForRepsAndFactor, WhenTargetIsPromotedTypeSkipFinalStaticCast) {

--- a/au/overflow_boundary.hh
+++ b/au/overflow_boundary.hh
@@ -750,6 +750,21 @@ struct IsMagnifyingOrNegativeRational {
          P_RESULT.value > Q_RESULT.value);
 };
 
+// Return true when the intermediate modular remainder Num * (value % Den)
+// overflows type T for some values within T's range.
+template <typename T, typename Num, typename Den>
+struct IsScaleByRationalIntermediateOverflowPossible {
+    using M = MagProductT<Num, MagInverseT<Den>>;
+    using P = NumeratorT<M>;
+    using Q = DenominatorT<M>;
+    static constexpr auto P_RESULT = get_value_result<T>(P{});
+    static constexpr auto Q_RESULT = get_value_result<T>(Q{});
+    static constexpr bool value =
+        (Q_RESULT.outcome != MagRepresentationOutcome::OK) ||
+        (Q_RESULT.value > T{1} && P_RESULT.outcome == MagRepresentationOutcome::OK &&
+         P_RESULT.value > std::numeric_limits<T>::max() / (Q_RESULT.value - T{1}));
+};
+
 template <typename T, typename Limits>
 struct ScaleByRationalAtLowerLimit {
     static constexpr T value() { return LowerLimit<T, Limits>::value(); }
@@ -758,6 +773,24 @@ struct ScaleByRationalAtLowerLimit {
 template <typename T, typename Limits>
 struct ScaleByRationalAtUpperLimit {
     static constexpr T value() { return UpperLimit<T, Limits>::value(); }
+};
+
+template <typename T, typename Num, typename Den, typename Limits>
+struct ScaleByRationalNarrowMinBound {
+    using M = MagProductT<Num, MagInverseT<Den>>;
+    using P = NumeratorT<M>;
+    static constexpr T value() {
+        return std::numeric_limits<T>::lowest() / get_value<T>(P{});
+    }
+};
+
+template <typename T, typename Num, typename Den, typename Limits>
+struct ScaleByRationalNarrowMaxBound {
+    using M = MagProductT<Num, MagInverseT<Den>>;
+    using P = NumeratorT<M>;
+    static constexpr T value() {
+        return std::numeric_limits<T>::max() / get_value<T>(P{});
+    }
 };
 
 template <typename T, typename Num, typename Den, typename Limits>
@@ -770,7 +803,9 @@ struct MinGoodImpl<ScaleByRational<T, Num, Den>, Limits> {
         IsMagnifyingOrNegativeRational<Num, Den>::value,
         typename MinGoodImpl<OpSequence<MultiplyTypeBy<RT, P>, DivideTypeByInteger<RT, Q>>,
                              Limits>::type,
-        ScaleByRationalAtLowerLimit<RT, Limits>>;
+        std::conditional_t<IsScaleByRationalIntermediateOverflowPossible<RT, Num, Den>::value,
+                           ScaleByRationalNarrowMinBound<RT, Num, Den, Limits>,
+                           ScaleByRationalAtLowerLimit<RT, Limits>>>;
 };
 
 template <typename T, typename Num, typename Den, typename Limits>
@@ -783,7 +818,9 @@ struct MaxGoodImpl<ScaleByRational<T, Num, Den>, Limits> {
         IsMagnifyingOrNegativeRational<Num, Den>::value,
         typename MaxGoodImpl<OpSequence<MultiplyTypeBy<RT, P>, DivideTypeByInteger<RT, Q>>,
                              Limits>::type,
-        ScaleByRationalAtUpperLimit<RT, Limits>>;
+        std::conditional_t<IsScaleByRationalIntermediateOverflowPossible<RT, Num, Den>::value,
+                           ScaleByRationalNarrowMaxBound<RT, Num, Den, Limits>,
+                           ScaleByRationalAtUpperLimit<RT, Limits>>>;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/au/overflow_boundary.hh
+++ b/au/overflow_boundary.hh
@@ -736,6 +736,57 @@ struct MaxGoodImpl<DivideTypeByInteger<T, M>, Limits>
     : MaxGoodImplForDivideTypeByIntegerUsingRealPart<RealPart<T>, M, Limits> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+// `ScaleByRational<T, Num, Den>` implementation.
+template <typename Num, typename Den>
+struct IsMagnifyingOrNegativeRational {
+    using M = MagProductT<Num, MagInverseT<Den>>;
+    using P = NumeratorT<M>;
+    using Q = DenominatorT<M>;
+    static constexpr auto P_RESULT = get_value_result<uintmax_t>(P{});
+    static constexpr auto Q_RESULT = get_value_result<uintmax_t>(Q{});
+    static constexpr bool value =
+        (P_RESULT.outcome != MagRepresentationOutcome::OK) ||
+        (Q_RESULT.outcome == MagRepresentationOutcome::OK &&
+         P_RESULT.value > Q_RESULT.value);
+};
+
+template <typename T, typename Limits>
+struct ScaleByRationalAtLowerLimit {
+    static constexpr T value() { return LowerLimit<T, Limits>::value(); }
+};
+
+template <typename T, typename Limits>
+struct ScaleByRationalAtUpperLimit {
+    static constexpr T value() { return UpperLimit<T, Limits>::value(); }
+};
+
+template <typename T, typename Num, typename Den, typename Limits>
+struct MinGoodImpl<ScaleByRational<T, Num, Den>, Limits> {
+    using RT = RealPart<T>;
+    using M = MagProductT<Num, MagInverseT<Den>>;
+    using P = NumeratorT<M>;
+    using Q = DenominatorT<M>;
+    using type = std::conditional_t<
+        IsMagnifyingOrNegativeRational<Num, Den>::value,
+        typename MinGoodImpl<OpSequence<MultiplyTypeBy<RT, P>, DivideTypeByInteger<RT, Q>>,
+                             Limits>::type,
+        ScaleByRationalAtLowerLimit<RT, Limits>>;
+};
+
+template <typename T, typename Num, typename Den, typename Limits>
+struct MaxGoodImpl<ScaleByRational<T, Num, Den>, Limits> {
+    using RT = RealPart<T>;
+    using M = MagProductT<Num, MagInverseT<Den>>;
+    using P = NumeratorT<M>;
+    using Q = DenominatorT<M>;
+    using type = std::conditional_t<
+        IsMagnifyingOrNegativeRational<Num, Den>::value,
+        typename MaxGoodImpl<OpSequence<MultiplyTypeBy<RT, P>, DivideTypeByInteger<RT, Q>>,
+                             Limits>::type,
+        ScaleByRationalAtUpperLimit<RT, Limits>>;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 // `OpSequence<Ops...>` implementation.
 
 //

--- a/au/overflow_boundary.hh
+++ b/au/overflow_boundary.hh
@@ -737,6 +737,7 @@ struct MaxGoodImpl<DivideTypeByInteger<T, M>, Limits>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `ScaleByRational<T, Num, Den>` implementation.
+
 template <typename Num, typename Den>
 struct IsMagnifyingOrNegativeRational {
     using M = MagProductT<Num, MagInverseT<Den>>;

--- a/au/truncation_risk.hh
+++ b/au/truncation_risk.hh
@@ -135,6 +135,10 @@ template <typename T, typename M>
 struct TruncationRiskForImpl<MultiplyTypeBy<T, M>>
     : TruncationRiskForMultiplyByAssumingScalar<RealPart<T>, M> {};
 
+template <typename T, typename Num, typename Den>
+struct TruncationRiskForImpl<ScaleByRational<T, Num, Den>>
+    : TruncationRiskForImpl<MultiplyTypeBy<T, MagProductT<Num, MagInverseT<Den>>>> {};
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `DivideTypeByInteger<T, M>` section:
 
@@ -215,6 +219,17 @@ struct UpdateRiskImpl<MultiplyTypeBy<T, M>, Risk<RealPart<T>>>
 template <template <class> class Risk, typename T, typename M>
 struct UpdateRiskImpl<DivideTypeByInteger<T, M>, Risk<RealPart<T>>>
     : stdx::type_identity<Risk<RealPart<T>>> {};
+
+template <template <class> class Risk, typename T, typename Num, typename Den>
+struct UpdateRiskImpl<ScaleByRational<T, Num, Den>, Risk<RealPart<T>>>
+    : stdx::type_identity<Risk<RealPart<T>>> {};
+
+template <typename T, typename Num, typename Den, typename M>
+struct UpdateRiskImpl<ScaleByRational<T, Num, Den>, ValueTimesRatioIsNotInteger<RealPart<T>, M>>
+    : std::conditional<IsRational<MagProductT<Num, MagInverseT<Den>>>::value,
+                       ReduceValueTimesRatioIsNotInteger<RealPart<T>,
+                                                        MagProductT<MagProductT<Num, MagInverseT<Den>>, M>>,
+                       ValueIsNotZero<RealPart<T>>> {};
 
 template <typename T, typename M1, typename M2>
 struct UpdateRiskImpl<MultiplyTypeBy<T, M1>, ValueTimesRatioIsNotInteger<RealPart<T>, M2>>

--- a/au/truncation_risk.hh
+++ b/au/truncation_risk.hh
@@ -225,11 +225,13 @@ struct UpdateRiskImpl<ScaleByRational<T, Num, Den>, Risk<RealPart<T>>>
     : stdx::type_identity<Risk<RealPart<T>>> {};
 
 template <typename T, typename Num, typename Den, typename M>
-struct UpdateRiskImpl<ScaleByRational<T, Num, Den>, ValueTimesRatioIsNotInteger<RealPart<T>, M>>
-    : std::conditional<IsRational<MagProductT<Num, MagInverseT<Den>>>::value,
-                       ReduceValueTimesRatioIsNotInteger<RealPart<T>,
-                                                        MagProductT<MagProductT<Num, MagInverseT<Den>>, M>>,
-                       ValueIsNotZero<RealPart<T>>> {};
+struct UpdateRiskImpl<ScaleByRational<T, Num, Den>, ValueTimesRatioIsNotInteger<RealPart<T>, M>> {
+    using ScaleMag = MagProductT<Num, MagInverseT<Den>>;
+    using type = typename std::conditional<IsRational<ScaleMag>::value,
+                                           ReduceValueTimesRatioIsNotInteger<RealPart<T>,
+                                                                             MagProductT<ScaleMag, M>>,
+                                           ValueIsNotZero<RealPart<T>>>::type;
+};
 
 template <typename T, typename M1, typename M2>
 struct UpdateRiskImpl<MultiplyTypeBy<T, M1>, ValueTimesRatioIsNotInteger<RealPart<T>, M2>>


### PR DESCRIPTION
Units variables of integral types with large magnitudes can overflow unnecessarily when applying the scaling factor $$\frac{P \cdot X}{Q}$$.

We can mitigate this for small values of P and Q (which should be most cases) by rewriting X as a quotient and remainder relative to Q, which gives us $$P \cdot \lfloor X / Q \rfloor + \frac{P \cdot (X \pmod Q)}{Q}$$. This eliminates overflow as long as $$P \cdot (Q - 1) \le \text{TypeMax}$$. Factoring out $$GCD(P, Q)$$ gives us an even larger range of non-overflowing factors P and Q. 

The practical result is that for reasonably sized factors and most larger factors, the entire type range becomes usable without overflow. There's also some truncation risk changes to accommodate the new operation.