### PR TITLE
Add `_mag` UDLs

### DIFF
--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -121,6 +121,14 @@ constexpr const auto &mag_label(MagT = MagT{});
 template <std::uintmax_t N>
 constexpr auto mag();
 
+// A user-defined literal for Magnitude, which is equivalent to `mag<N>()`.
+//
+// To use, add `using namespace ::au::au_literals;`.
+namespace au_literals {
+template <char... Cs>
+constexpr auto operator""_mag();
+}  // namespace au_literals
+
 // Check whether a Magnitude is representable in type T.
 template <typename T, typename... BPs>
 constexpr bool representable_in(Magnitude<BPs...> m);
@@ -659,6 +667,30 @@ template <std::uintmax_t N>
 AU_DEVICE_FUNC constexpr auto mag() {
     return detail::PrimeFactorization<N>{};
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// User-defined literal for magnitude.
+
+namespace detail {
+template <char... Cs>
+constexpr std::uintmax_t parse_magnitude_integer() {
+    constexpr char digits[] = {Cs...};
+    std::uintmax_t result = 0u;
+    for (std::size_t i = 0u; i < sizeof...(Cs); ++i) {
+        if (digits[i] >= '0' && digits[i] <= '9') {
+            result = result * 10u + static_cast<std::uintmax_t>(digits[i] - '0');
+        }
+    }
+    return result;
+}
+}  // namespace detail
+
+namespace au_literals {
+template <char... Cs>
+constexpr auto operator""_mag() {
+    return mag<detail::parse_magnitude_integer<Cs...>()>();
+}
+}  // namespace au_literals
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `integer_part()` implementation.

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -672,8 +672,25 @@ AU_DEVICE_FUNC constexpr auto mag() {
 // User-defined literal for magnitude.
 
 namespace detail {
+constexpr bool is_valid_magnitude_digit(char c) {
+    return (c >= '0' && c <= '9') || c == '\'';
+}
+
+template <char... Cs>
+constexpr bool all_valid_magnitude_digits() {
+    constexpr char digits[] = {Cs...};
+    for (std::size_t i = 0u; i < sizeof...(Cs); ++i) {
+        if (!is_valid_magnitude_digit(digits[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 template <char... Cs>
 constexpr std::uintmax_t parse_magnitude_integer() {
+    static_assert(all_valid_magnitude_digits<Cs...>(),
+                  "_mag literals must contain only decimal digits (and optional ' separators)");
     constexpr char digits[] = {Cs...};
     std::uintmax_t result = 0u;
     for (std::size_t i = 0u; i < sizeof...(Cs); ++i) {

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -672,9 +672,7 @@ AU_DEVICE_FUNC constexpr auto mag() {
 // User-defined literal for magnitude.
 
 namespace detail {
-constexpr bool is_valid_magnitude_digit(char c) {
-    return (c >= '0' && c <= '9') || c == '\'';
-}
+constexpr bool is_valid_magnitude_digit(char c) { return (c >= '0' && c <= '9') || c == '\''; }
 
 template <char... Cs>
 constexpr bool all_valid_magnitude_digits() {

--- a/au/magnitude_test.cc
+++ b/au/magnitude_test.cc
@@ -998,6 +998,23 @@ TEST(CommonMagnitude, CommonMagOfNegAndNegIsNeg) {
 
 }  // namespace
 
+namespace au_literals {
+
+TEST(MagnitudeUDL, ProducesSameTypeAndValueAsMagFunction) {
+    EXPECT_THAT(1_mag, SameTypeAndValue(mag<1>()));
+    EXPECT_THAT(2_mag, SameTypeAndValue(mag<2>()));
+    EXPECT_THAT(18_mag, SameTypeAndValue(mag<18>()));
+    EXPECT_THAT(123_mag, SameTypeAndValue(mag<123>()));
+    EXPECT_THAT(1'000'000_mag, SameTypeAndValue(mag<1'000'000>()));
+}
+
+TEST(MagnitudeUDL, WorksInConstexprContext) {
+    constexpr auto m = 42_mag;
+    EXPECT_THAT(m, SameTypeAndValue(mag<42>()));
+}
+
+}  // namespace au_literals
+
 namespace detail {
 
 MATCHER(CannotFit, "") {

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -11,13 +11,15 @@ a corollary, any unit can be scaled by a `Magnitude` to make a new unit of the s
 
 ## Forming magnitudes
 
-There are 3 **valid** ways for end users to form a `Magnitude` instance.
+There are 4 **valid** ways for end users to form a `Magnitude` instance.
 
 1. :heavy_check_mark: Using the `mag<N>()` helper to form the canonical representation of the
    integer `N`.
-2. :heavy_check_mark: Writing `Magnitude<MyConstant>{}`, where `MyConstant` is a valid _irrational
+2. :heavy_check_mark: Using the `_mag` user-defined literal.  For example, `123_mag` is equivalent
+   to `mag<123>()`.  (Requires `using namespace ::au::au_literals;`.)
+3. :heavy_check_mark: Writing `Magnitude<MyConstant>{}`, where `MyConstant` is a valid _irrational
    magnitude base_.  (See the _custom bases_ section below for more details.)
-3. :heavy_check_mark: Forming products, quotients, powers, and roots of other valid `Magnitude`
+4. :heavy_check_mark: Forming products, quotients, powers, and roots of other valid `Magnitude`
    instances.
 
 The following is a **valid, but dis-preferred way** to form a `Magnitude`.
@@ -36,7 +38,7 @@ The following are **not valid** ways to form a `Magnitude`.
     - **Explanation:** Do not supply integer bases manually.  Integers are represented by their
       prime factorization, which is performed automatically.  Instead, form integers, rationals, and
       their powers only by starting with valid `Magnitude` instances, and performing arithmetic
-      operations as in option 3 above.
+      operations as in option 4 above.
 
 Below, we give more details on several concepts mentioned above.
 
@@ -51,6 +53,21 @@ integer `N`.
 
     `mag<N>()` automatically performs the prime factorization of `N`, and constructs a well-formed
     `Magnitude`.
+
+### `_mag` literal
+
+`_mag` is a user-defined literal (UDL) that provides a more concise alternative to `mag<N>()`.  For
+example, `123_mag` produces the exact same type and value as `mag<123>()`.  It also supports digit
+separators: `1'000'000_mag` is equivalent to `mag<1000000>()`.
+
+To use it, add the following to your file:
+
+```cpp
+using namespace ::au::au_literals;
+```
+
+As with any `using namespace` directive, avoid placing this at file scope in a header file; prefer
+`.cc` files, or scope it to a function or block.
 
 ### Custom bases
 


### PR DESCRIPTION
Using the templated version lets us return a separate type for each
number, exactly as we need!  This should be a nice readable alternative.