### PR TITLE
Add ASAN and UBSAN CI jobs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,6 +34,15 @@ build:gcc --config=gcc15
 # Compile with clang by default
 build --config=clang
 
+# Sanitizer configs.
+build:asan --copt=-fsanitize=address --linkopt=-fsanitize=address
+build:asan --copt=-fno-omit-frame-pointer
+build:asan --test_env=ASAN_OPTIONS=detect_stack_use_after_return=1
+build:ubsan --copt=-fsanitize=undefined --linkopt=-fsanitize=undefined
+build:ubsan --copt=-fno-omit-frame-pointer
+build:ubsan --copt=-fno-sanitize-recover=undefined
+build:ubsan --copt=-fno-sanitize=vptr --linkopt=-fno-sanitize=vptr
+
 # Show test output when there are errors.
 # Making this true by default significantly improves developer experience.
 test --test_output=errors

--- a/.github/workflows/asan-ubsan.yml
+++ b/.github/workflows/asan-ubsan.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 Aurora Operations, Inc.
+# Copyright 2026 Aurora Operations, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/asan-ubsan.yml
+++ b/.github/workflows/asan-ubsan.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: asan-ubsan
+name: sanitizers
 
 on:
   push:

--- a/.github/workflows/asan-ubsan.yml
+++ b/.github/workflows/asan-ubsan.yml
@@ -1,0 +1,38 @@
+# Copyright 2025 Aurora Operations, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: asan-ubsan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  asan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
+      - name: Test with ASAN (clang17)
+        run: bazel test --config=clang17 --config=asan --copt=-Werror --test_tag_filters=-no_asan --build_tag_filters=-no_asan //...:all
+
+  ubsan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
+      - name: Test with UBSAN (clang17)
+        run: bazel test --config=clang17 --config=ubsan --copt=-Werror --test_tag_filters=-no_ubsan --build_tag_filters=-no_ubsan //...:all

--- a/fuzz/BUILD.bazel
+++ b/fuzz/BUILD.bazel
@@ -41,6 +41,7 @@ cc_test(
     name = "quantity_runtime_conversion_checkers_test",
     size = "small",
     srcs = ["quantity_runtime_conversion_checkers_test.cc"],
+    tags = ["no_ubsan"],
     deps = [
         ":quantity_runtime_conversion_checkers",
         "//au",


### PR DESCRIPTION
First, we update our `.bazelrc` to add easy `--config=asan` and
`--config=ubsan` options.  Then, we add new workflows to run these
options.

We provide `no-*san` tags to opt out individual tests, and use the
`"no-ubsan"` tag for the fuzz tests.  That one can't run under UBSAN,
because we intentionally invoke undefined behavior for values that lead
to signed overflow.  This isn't production code, so it doesn't indicate
a problem with the library; rather, it's an offline testing utility.

This works: see results for [asan] and [ubsan].

[asan]: https://github.com/aurora-opensource/au/actions/runs/26915163746/job/79402977926?pr=678
[ubsan]: https://github.com/aurora-opensource/au/actions/runs/26915163746/job/79402977939?pr=678 

Helps #484.  Sanitizers are critical for supporting Eigen safely.