### PR TITLE
Make operations return natural type

### DIFF
--- a/au/abstract_operations.hh
+++ b/au/abstract_operations.hh
@@ -49,20 +49,12 @@ struct ImplicitConversion;
 // `MultiplyTypeBy<T, M>` represents an operation that multiplies a value of type `T` by the
 // magnitude `M`.
 //
-// Note that this operation does *not* model integer promotion.  It will always force the result to
-// be `T`.  To model integer promotion, form a compound operation with `OpSequence` that includes
-// appropriate `StaticCast`.
-//
 template <typename T, typename M>
 struct MultiplyTypeBy;
 
 //
 // `DivideTypeByInteger<T, M>` represents an operation that divides a value of type `T` by the
 // magnitude `M`.
-//
-// Note that this operation does *not* model integer promotion.  It will always force the result to
-// be `T`.  To model integer promotion, form a compound operation with `OpSequence` that includes
-// appropriate `StaticCast`.
 //
 template <typename T, typename M>
 struct DivideTypeByInteger;
@@ -119,14 +111,25 @@ struct ImplicitConversion {
 template <typename T, typename M>
 struct OpInputImpl<MultiplyTypeBy<T, M>> : stdx::type_identity<T> {};
 template <typename T, typename M>
-struct OpOutputImpl<MultiplyTypeBy<T, M>> : stdx::type_identity<T> {};
+struct OpOutputImpl<MultiplyTypeBy<T, M>>
+    : stdx::type_identity<decltype(std::declval<T>() * std::declval<RealPart<T>>())> {};
+
+// Identity magnitude preserves type.
+template <typename T>
+struct OpOutputImpl<MultiplyTypeBy<T, Magnitude<>>> : stdx::type_identity<T> {};
 
 // `MultiplyTypeBy<T, M>` operation:
 template <typename T, typename Mag>
 struct MultiplyTypeBy {
-    static AU_DEVICE_FUNC constexpr T apply_to(T value) {
-        return static_cast<T>(value * get_value<RealPart<T>>(Mag{}));
+    static AU_DEVICE_FUNC constexpr OpOutput<MultiplyTypeBy<T, Mag>> apply_to(T value) {
+        return value * get_value<RealPart<T>>(Mag{});
     }
+};
+
+// Specialization for identity magnitude: just return the value unchanged.
+template <typename T>
+struct MultiplyTypeBy<T, Magnitude<>> {
+    static AU_DEVICE_FUNC constexpr T apply_to(T value) { return value; }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -136,13 +139,14 @@ struct MultiplyTypeBy {
 template <typename T, typename M>
 struct OpInputImpl<DivideTypeByInteger<T, M>> : stdx::type_identity<T> {};
 template <typename T, typename M>
-struct OpOutputImpl<DivideTypeByInteger<T, M>> : stdx::type_identity<T> {};
+struct OpOutputImpl<DivideTypeByInteger<T, M>>
+    : stdx::type_identity<decltype(std::declval<T>() / std::declval<RealPart<T>>())> {};
 
 template <typename T, typename M, MagRepresentationOutcome MagOutcome>
 struct DivideTypeByIntegerImpl {
-    static AU_DEVICE_FUNC constexpr T apply_to(T value) {
+    static AU_DEVICE_FUNC constexpr OpOutput<DivideTypeByInteger<T, M>> apply_to(T value) {
         static_assert(MagOutcome == MagRepresentationOutcome::OK, "Internal library error");
-        return static_cast<T>(value / get_value<RealPart<T>>(M{}));
+        return value / get_value<RealPart<T>>(M{});
     }
 };
 

--- a/au/abstract_operations.hh
+++ b/au/abstract_operations.hh
@@ -153,7 +153,9 @@ struct DivideTypeByIntegerImpl {
 template <typename T, typename M>
 struct DivideTypeByIntegerImpl<T, M, MagRepresentationOutcome::ERR_CANNOT_FIT> {
     // If a number is too big to fit in the type, then dividing by it should produce 0.
-    static AU_DEVICE_FUNC constexpr T apply_to(T) { return T{0}; }
+    static AU_DEVICE_FUNC constexpr OpOutput<DivideTypeByInteger<T, M>> apply_to(T) {
+        return OpOutput<DivideTypeByInteger<T, M>>{0};
+    }
 };
 
 template <typename T, typename M>

--- a/au/abstract_operations_test.cc
+++ b/au/abstract_operations_test.cc
@@ -93,7 +93,7 @@ TEST(DivideTypeByInteger, IntegerTypeCanBeDividedByIntegerMag) {
 
 TEST(DivideTypeByInteger, IntegerTypeDividedByIntegerTooBigToRepresentGivesZero) {
     EXPECT_THAT((DivideTypeByInteger<uint8_t, decltype(mag<256>())>::apply_to(uint8_t{1})),
-                SameTypeAndValue(uint8_t{0}));
+                SameTypeAndValue(PromotedType<uint8_t>{0}));
 }
 
 TEST(DivideTypeByInteger, IntegerTypeDividedByIntegerMagGreaterThanDividendGivesZero) {

--- a/au/abstract_operations_test.cc
+++ b/au/abstract_operations_test.cc
@@ -59,14 +59,15 @@ TEST(MultiplyTypeBy, InputTypeIsTypeParameter) {
                        uint32_t>();
 }
 
-TEST(MultiplyTypeBy, OutputTypeIsTypeParameter) {
-    StaticAssertTypeEq<OpOutput<MultiplyTypeBy<int16_t, decltype(mag<2>())>>, int16_t>();
+TEST(MultiplyTypeBy, OutputTypeIsResultOfMultiplication) {
+    StaticAssertTypeEq<OpOutput<MultiplyTypeBy<int16_t, decltype(mag<2>())>>,
+                       PromotedType<int16_t>>();
     StaticAssertTypeEq<OpOutput<MultiplyTypeBy<double, decltype(mag<3>() / mag<4>())>>, double>();
 }
 
 TEST(MultiplyTypeBy, IntegerTypeCanBeMultipliedByIntegerMag) {
     EXPECT_THAT((MultiplyTypeBy<int16_t, decltype(mag<2>())>::apply_to(int16_t{3})),
-                SameTypeAndValue(int16_t{6}));
+                SameTypeAndValue(PromotedType<int16_t>{6}));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -78,15 +79,16 @@ TEST(DivideTypeByInteger, InputTypeIsTypeParameter) {
                        uint32_t>();
 }
 
-TEST(DivideTypeByInteger, OutputTypeIsTypeParameter) {
-    StaticAssertTypeEq<OpOutput<DivideTypeByInteger<int16_t, decltype(mag<2>())>>, int16_t>();
+TEST(DivideTypeByInteger, OutputTypeIsResultOfDivision) {
+    StaticAssertTypeEq<OpOutput<DivideTypeByInteger<int16_t, decltype(mag<2>())>>,
+                       PromotedType<int16_t>>();
     StaticAssertTypeEq<OpOutput<DivideTypeByInteger<double, decltype(mag<3>() / mag<4>())>>,
                        double>();
 }
 
 TEST(DivideTypeByInteger, IntegerTypeCanBeDividedByIntegerMag) {
     EXPECT_THAT((DivideTypeByInteger<uint16_t, decltype(mag<3>())>::apply_to(uint16_t{16})),
-                SameTypeAndValue(uint16_t{5}));
+                SameTypeAndValue(PromotedType<uint16_t>{5}));
 }
 
 TEST(DivideTypeByInteger, IntegerTypeDividedByIntegerTooBigToRepresentGivesZero) {
@@ -96,7 +98,7 @@ TEST(DivideTypeByInteger, IntegerTypeDividedByIntegerTooBigToRepresentGivesZero)
 
 TEST(DivideTypeByInteger, IntegerTypeDividedByIntegerMagGreaterThanDividendGivesZero) {
     EXPECT_THAT((DivideTypeByInteger<uint8_t, decltype(mag<2>())>::apply_to(uint8_t{1})),
-                SameTypeAndValue(uint8_t{0}));
+                SameTypeAndValue(PromotedType<uint8_t>{0}));
 
     EXPECT_THAT((DivideTypeByInteger<int, decltype(mag<2025>())>::apply_to(int{2024})),
                 SameTypeAndValue(int{0}));

--- a/au/overflow_boundary_test.cc
+++ b/au/overflow_boundary_test.cc
@@ -55,12 +55,12 @@ struct ImplicitLimits {
 };
 
 template <typename T, typename M>
-MultiplyTypeBy<T, M> multiply_type_by(M) {
+constexpr MultiplyTypeBy<T, M> multiply_type_by(M) {
     return MultiplyTypeBy<T, M>{};
 }
 
 template <typename T, typename M>
-DivideTypeByInteger<T, M> divide_type_by_integer(M) {
+constexpr DivideTypeByInteger<T, M> divide_type_by_integer(M) {
     return DivideTypeByInteger<T, M>{};
 }
 
@@ -87,6 +87,12 @@ auto max_good_value(Op, Limits) {
 template <typename... Ops>
 auto op_sequence(Ops...) {
     return OpSequence<Ops...>{};
+}
+
+// Helper to create a StaticCast from the output of an operation to a destination type.
+template <typename Dest, typename Op>
+auto static_cast_output_type_to(Op) {
+    return StaticCast<OpOutput<Op>, Dest>{};
 }
 
 template <typename Op>
@@ -1530,14 +1536,14 @@ TEST(OpSequence, MinGoodForSequenceOfSingleOpIsMinGoodForThatOp) {
 }
 
 TEST(OpSequence, MinGoodForDivideThenNarrowIsLimitsOfTypeIfDivisorIsBigEnough) {
-    EXPECT_THAT(min_good_value(op_sequence(divide_type_by_integer<int16_t>(mag<1000>()),
-                                           StaticCast<int16_t, int8_t>{})),
+    constexpr auto div_op = divide_type_by_integer<int16_t>(mag<1000>());
+    EXPECT_THAT(min_good_value(op_sequence(div_op, static_cast_output_type_to<int8_t>(div_op))),
                 SameTypeAndValue(std::numeric_limits<int16_t>::min()));
 }
 
 TEST(OpSequence, MinGoodForDivideThenNarrowIsScaledUpDestinationBoundIfDivisorIsSmallEnough) {
-    EXPECT_THAT(min_good_value(op_sequence(divide_type_by_integer<int16_t>(mag<10>()),
-                                           StaticCast<int16_t, int8_t>{})),
+    constexpr auto div_op = divide_type_by_integer<int16_t>(mag<10>());
+    EXPECT_THAT(min_good_value(op_sequence(div_op, static_cast_output_type_to<int8_t>(div_op))),
                 SameTypeAndValue(int16_t{-1280}));
 }
 
@@ -1550,11 +1556,12 @@ TEST(OpSequence, MinGoodOfStaticCastSequenceIsMostConstrainingType) {
 }
 
 TEST(OpSequence, MinGoodIsZeroIfUnsignedTypeFoundOnBothSidesOfNegativeMultiplication) {
+    constexpr auto mul_op = multiply_type_by<int16_t>(-mag<1>() / mag<234>());
     EXPECT_THAT(min_good_value(op_sequence(StaticCast<int64_t, float>{},
                                            StaticCast<float, uint32_t>{},
                                            StaticCast<uint32_t, int16_t>{},
-                                           multiply_type_by<int16_t>(-mag<1>() / mag<234>()),
-                                           StaticCast<int16_t, double>{},
+                                           mul_op,
+                                           static_cast_output_type_to<double>(mul_op),
                                            StaticCast<double, uint8_t>{},
                                            StaticCast<uint8_t, int32_t>{})),
                 SameTypeAndValue(int64_t{0}));
@@ -1576,14 +1583,14 @@ TEST(OpSequence, MaxGoodForSequenceOfSingleOpIsMaxGoodForThatOp) {
 }
 
 TEST(OpSequence, MaxGoodForDivideThenNarrowIsLimitsOfTypeIfDivisorIsBigEnough) {
-    EXPECT_THAT(max_good_value(op_sequence(divide_type_by_integer<uint16_t>(mag<1000>()),
-                                           StaticCast<uint16_t, uint8_t>{})),
+    constexpr auto div_op = divide_type_by_integer<uint16_t>(mag<1000>());
+    EXPECT_THAT(max_good_value(op_sequence(div_op, static_cast_output_type_to<uint8_t>(div_op))),
                 SameTypeAndValue(std::numeric_limits<uint16_t>::max()));
 }
 
 TEST(OpSequence, MaxGoodForDivideThenNarrowIsScaledDownDestinationBoundIfDivisorIsSmallEnough) {
-    EXPECT_THAT(max_good_value(op_sequence(divide_type_by_integer<uint16_t>(mag<10>()),
-                                           StaticCast<uint16_t, uint8_t>{})),
+    constexpr auto div_op = divide_type_by_integer<uint16_t>(mag<10>());
+    EXPECT_THAT(max_good_value(op_sequence(div_op, static_cast_output_type_to<uint8_t>(div_op))),
                 SameTypeAndValue(uint16_t{2550}));
 }
 
@@ -1596,11 +1603,12 @@ TEST(OpSequence, MaxGoodOfStaticCastSequenceIsMostConstrainingType) {
 }
 
 TEST(OpSequence, MaxGoodIsZeroIfUnsignedTypeFoundOnBothSidesOfNegativeMultiplication) {
+    constexpr auto div_op = divide_type_by_integer<int16_t>(-mag<234>());
     EXPECT_THAT(max_good_value(op_sequence(StaticCast<int64_t, float>{},
                                            StaticCast<float, uint32_t>{},
                                            StaticCast<uint32_t, int16_t>{},
-                                           divide_type_by_integer<int16_t>(-mag<234>()),
-                                           StaticCast<int16_t, double>{},
+                                           div_op,
+                                           static_cast_output_type_to<double>(div_op),
                                            StaticCast<double, uint8_t>{},
                                            StaticCast<uint8_t, int32_t>{})),
                 SameTypeAndValue(int64_t{0}));

--- a/au/utility/type_traits.hh
+++ b/au/utility/type_traits.hh
@@ -197,12 +197,17 @@ struct CommonTypeButPreserveIntSignednessImpl
 // `PromotedType<T>` implementation.
 
 template <typename T>
-struct PromotedTypeImpl {
+struct PromotedArithmeticTypeImpl {
     using type = decltype(std::declval<T>() * std::declval<T>());
 
-    static_assert(std::is_same<type, typename PromotedTypeImpl<type>::type>::value,
+    static_assert(std::is_same<type, typename PromotedArithmeticTypeImpl<type>::type>::value,
                   "We explicitly assume that promoted types are not again promotable");
 };
+
+template <typename T>
+struct PromotedTypeImpl : std::conditional_t<std::is_arithmetic<T>::value,
+                                             PromotedArithmeticTypeImpl<T>,
+                                             stdx::type_identity<T>> {};
 
 }  // namespace detail
 }  // namespace au


### PR DESCRIPTION
From the beginning of the library, using "implicit rep" for a conversion
has meant "keep the same rep".  But this is actually incorrect!

The core design goal of a units library is "same program, only safer".
We shouldn't force users to change the bits and bytes flowing through
their program in order to get unit safety.  When we apply this principle
to unit conversions, we see that the right answer is to produce whatever
you would get from a hand-rolled unit conversion on the underlying type.

The most prominent example where this differs in today's code is in the
case of _integer promotion_.  We currently force the result back to the
initial type, but that's not what a manual conversion would result in.
Suppose `int16_t{20}` represents a quantity of meters.  Then converting
it to centimeters means multiplying by `int16_t{100}`, which results in
`int{2000}`, not `int16_t{2000}`.  Therefore, that's also what we should
produce: `QuantityI<Centi<Meters>>`, not `QuantityI16<Centi<Meters>>`.

The main usability risk is our overflow checks, which often prevent
assigning an integer-backed quantity to a smaller integer type.  But
actually, we already solved this issue.  If that initial integer type is
_exactly the promoted type_ of the destination, we bypass our overflow
checks and permit the assignment.

Besides promotable integers, the other main category where fixing
implicit rep matters is in libraries such as Eigen, which often return
expression templates that differ from the inputs.  This isn't just an
efficiency thing, but it's necessary for certain cases to even compile:
if the _input rep_ is already an expression template, then the output
will be a _different_ expression template type, which is _not even
convertible_ to the input type.

Incidentally, Eigen types also struggle with our notion of
`PromotedType` generally.  The cleanest fix here is to restrict the
notion of "promotable" types to the arithmetic types that are our only
actual use case, so we do that here as well.

Helps #484.  After this PR, implicit rep conversions are still
constrained to return their initial type, but we're one step closer to
fixing that.  A follow-on PR will update the _operation sequence_ for
implicit-rep conversions to remove that final casting step.