### PR TITLE
Update `min`/`max` to common implementation

### DIFF
--- a/au/math.hh
+++ b/au/math.hh
@@ -38,8 +38,6 @@ using std::fmod;
 using std::hypot;
 using std::isinf;
 using std::isnan;
-using std::max;
-using std::min;
 using std::remainder;
 using std::sin;
 using std::sqrt;
@@ -355,10 +353,14 @@ AU_DEVICE_FUNC constexpr auto lerp(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R
 
 namespace detail {
 // We can't use lambdas in `constexpr` contexts until C++17, so we make a manual function object.
-struct StdMaxByValue {
-    template <typename T>
-    AU_DEVICE_FUNC constexpr auto operator()(T a, T b) const {
-        return std::max(a, b);
+struct MaxByValue {
+    template <template <class, class> class Q, typename U1, typename R1, typename U2, typename R2>
+    AU_DEVICE_FUNC constexpr auto operator()(Q<U1, R1> q1, Q<U2, R2> q2) const {
+        using U = AppropriateCommonUnit<Q, U1, U2>;
+        using R = std::common_type_t<R1, R2>;
+        const auto qc1 = q1.template as<R>(U{});
+        const auto qc2 = q2.template as<R>(U{});
+        return (qc2 < qc1) ? qc1 : qc2;
     }
 };
 }  // namespace detail
@@ -368,7 +370,7 @@ struct StdMaxByValue {
 // Unlike std::max, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
 AU_DEVICE_FUNC constexpr auto max(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
-    return detail::using_common_type(q1, q2, detail::StdMaxByValue{});
+    return detail::MaxByValue{}(q1, q2);
 }
 
 // The maximum of two point values of the same dimension.
@@ -376,21 +378,28 @@ AU_DEVICE_FUNC constexpr auto max(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
 // Unlike std::max, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
 AU_DEVICE_FUNC constexpr auto max(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
-    return detail::using_common_point_unit(p1, p2, detail::StdMaxByValue{});
+    return detail::MaxByValue{}(p1, p2);
 }
 
-// Overload to resolve ambiguity with `std::max` for identical `QuantityPoint` types.
+// Overload to resolve ambiguity for identical `QuantityPoint` types.
+//
+// This only happens in very rare cases: where both `au::max` and `std::max` are visible, and we
+// make an unqualified `max` call.
 template <typename U, typename R>
 AU_DEVICE_FUNC constexpr auto max(QuantityPoint<U, R> a, QuantityPoint<U, R> b) {
-    return std::max(a, b);
+    return detail::MaxByValue{}(a, b);
 }
 
 namespace detail {
 // We can't use lambdas in `constexpr` contexts until C++17, so we make a manual function object.
-struct StdMinByValue {
-    template <typename T>
-    AU_DEVICE_FUNC constexpr auto operator()(T a, T b) const {
-        return std::min(a, b);
+struct MinByValue {
+    template <template <class, class> class Q, typename U1, typename R1, typename U2, typename R2>
+    AU_DEVICE_FUNC constexpr auto operator()(Q<U1, R1> q1, Q<U2, R2> q2) const {
+        using U = AppropriateCommonUnit<Q, U1, U2>;
+        using R = std::common_type_t<R1, R2>;
+        const auto qc1 = q1.template as<R>(U{});
+        const auto qc2 = q2.template as<R>(U{});
+        return (qc2 < qc1) ? qc2 : qc1;
     }
 };
 }  // namespace detail
@@ -400,7 +409,7 @@ struct StdMinByValue {
 // Unlike std::min, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
 AU_DEVICE_FUNC constexpr auto min(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
-    return detail::using_common_type(q1, q2, detail::StdMinByValue{});
+    return detail::MinByValue{}(q1, q2);
 }
 
 // The minimum of two point values of the same dimension.
@@ -408,13 +417,16 @@ AU_DEVICE_FUNC constexpr auto min(Quantity<U1, R1> q1, Quantity<U2, R2> q2) {
 // Unlike std::min, returns by value rather than by reference, because the types might differ.
 template <typename U1, typename U2, typename R1, typename R2>
 AU_DEVICE_FUNC constexpr auto min(QuantityPoint<U1, R1> p1, QuantityPoint<U2, R2> p2) {
-    return detail::using_common_point_unit(p1, p2, detail::StdMinByValue{});
+    return detail::MinByValue{}(p1, p2);
 }
 
-// Overload to resolve ambiguity with `std::min` for identical `QuantityPoint` types.
+// Overload to resolve ambiguity for identical `QuantityPoint` types.
+//
+// This only happens in very rare cases: where both `au::min` and `std::min` are visible, and we
+// make an unqualified `min` call.
 template <typename U, typename R>
 AU_DEVICE_FUNC constexpr auto min(QuantityPoint<U, R> a, QuantityPoint<U, R> b) {
-    return std::min(a, b);
+    return detail::MinByValue{}(a, b);
 }
 
 template <typename U0, typename R0, typename... Us, typename... Rs>

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -454,15 +454,6 @@ TEST(Max, SupportsConstexprForSameExactQuantityPointType) {
     EXPECT_THAT(result, Eq(meters_pt(2)));
 }
 
-TEST(Max, SameAsStdMaxForNumericTypes) {
-    const auto a = 2;
-    const auto b = 3;
-
-    const auto &max_result = max(a, b);
-
-    EXPECT_THAT(&b, Eq(&max_result));
-}
-
 TEST(Max, SupportsZeroForFirstArgument) {
     constexpr auto positive_result = max(ZERO, meters(8));
     EXPECT_THAT(positive_result, SameTypeAndValue(meters(8)));
@@ -517,15 +508,6 @@ TEST(Min, ReturnsByValueForSameExactQuantityPointType) {
 TEST(Min, SupportsConstexprForSameExactQuantityPointType) {
     constexpr auto result = min(meters_pt(1), meters_pt(2));
     EXPECT_THAT(result, Eq(meters_pt(1)));
-}
-
-TEST(Min, SameAsStdMinForNumericTypes) {
-    const auto a = 2;
-    const auto b = 3;
-
-    const auto &min_result = min(a, b);
-
-    EXPECT_THAT(&a, Eq(&min_result));
 }
 
 TEST(Min, SupportsZeroForFirstArgument) {

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -583,17 +583,17 @@ TEST(Min, SupportsZeroForSecondArgument) {
 
 // Hidden friend overload (same unit, same rep).
 TEST(Max, PrefersSecondArgForSameTypeQuantity) {
-    using LN = LabeledNumber<int>;
-    const auto a = meters(LN{5, 'a'});
-    const auto b = meters(LN{5, 'b'});
+    using Ln = LabeledNumber<int>;
+    const auto a = meters(Ln{5, 'a'});
+    const auto b = meters(Ln{5, 'b'});
     EXPECT_THAT(max(a, b).data_in(meters).label, Eq('b'));
 }
 
 // Same-type QuantityPoint disambiguation overload (goes through MaxByValue).
 TEST(Max, PrefersSecondArgForSameTypeQuantityPoint) {
-    using LN = LabeledNumber<int>;
-    const auto a = meters_pt(LN{5, 'a'});
-    const auto b = meters_pt(LN{5, 'b'});
+    using Ln = LabeledNumber<int>;
+    const auto a = meters_pt(Ln{5, 'a'});
+    const auto b = meters_pt(Ln{5, 'b'});
     EXPECT_THAT(max(a, b).data_in(meters_pt).label, Eq('b'));
 }
 
@@ -606,17 +606,17 @@ TEST(Max, PrefersSecondArgWithZero) {
 
 // Hidden friend overload (same unit, same rep).
 TEST(Min, PrefersFirstArgForSameTypeQuantity) {
-    using LN = LabeledNumber<int>;
-    const auto a = meters(LN{5, 'a'});
-    const auto b = meters(LN{5, 'b'});
+    using Ln = LabeledNumber<int>;
+    const auto a = meters(Ln{5, 'a'});
+    const auto b = meters(Ln{5, 'b'});
     EXPECT_THAT(min(a, b).data_in(Meters{}).label, Eq('a'));
 }
 
 // Same-type QuantityPoint disambiguation overload (goes through MinByValue).
 TEST(Min, PrefersFirstArgForSameTypeQuantityPoint) {
-    using LN = LabeledNumber<int>;
-    const auto a = meters_pt(LN{5, 'a'});
-    const auto b = meters_pt(LN{5, 'b'});
+    using Ln = LabeledNumber<int>;
+    const auto a = meters_pt(Ln{5, 'a'});
+    const auto b = meters_pt(Ln{5, 'b'});
     EXPECT_THAT(min(a, b).data_in(Meters{}).label, Eq('a'));
 }
 

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -92,6 +92,61 @@ auto IsConstantWithUnitMatching(InnerMatcher m) {
 
 }  // namespace
 
+// A number that carries a char label, but ignores it in comparisons.  This lets us distinguish
+// two "equal" values, so we can test that min prefers the first arg and max prefers the second when
+// both args are equivalent.
+//
+// We have to add a fairly large number of operators just to get this to compile as a rep.
+template <typename T>
+struct LabeledNumber {
+    constexpr LabeledNumber() : value{}, label{'\0'} {}
+    constexpr LabeledNumber(T v, char l) : value{v}, label{l} {}
+    constexpr LabeledNumber(T v) : value{v}, label{'\0'} {}
+
+    T value;
+    char label;
+
+    friend constexpr LabeledNumber operator+(LabeledNumber a, LabeledNumber b) {
+        return {static_cast<T>(a.value + b.value), a.label};
+    }
+    friend constexpr LabeledNumber operator-(LabeledNumber a, LabeledNumber b) {
+        return {static_cast<T>(a.value - b.value), a.label};
+    }
+    friend constexpr LabeledNumber operator-(LabeledNumber a) { return {static_cast<T>(-a.value)}; }
+    friend constexpr LabeledNumber operator*(LabeledNumber a, LabeledNumber b) {
+        return {static_cast<T>(a.value * b.value), a.label};
+    }
+    friend constexpr LabeledNumber operator/(LabeledNumber a, LabeledNumber b) {
+        return {static_cast<T>(a.value / b.value), a.label};
+    }
+    friend constexpr bool operator<(LabeledNumber a, LabeledNumber b) { return a.value < b.value; }
+    friend constexpr bool operator<=(LabeledNumber a, LabeledNumber b) {
+        return a.value <= b.value;
+    }
+    friend constexpr bool operator>(LabeledNumber a, LabeledNumber b) { return a.value > b.value; }
+    friend constexpr bool operator>=(LabeledNumber a, LabeledNumber b) {
+        return a.value >= b.value;
+    }
+    friend constexpr bool operator==(LabeledNumber a, LabeledNumber b) {
+        return a.value == b.value;
+    }
+    friend constexpr bool operator!=(LabeledNumber a, LabeledNumber b) {
+        return a.value != b.value;
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, LabeledNumber n) {
+        return os << n.value << " [" << n.label << "]";
+    }
+};
+
+}  // namespace au
+
+template <typename T, typename U>
+struct std::common_type<au::LabeledNumber<T>, au::LabeledNumber<U>>
+    : au::stdx::type_identity<au::LabeledNumber<std::common_type_t<T, U>>> {};
+
+namespace au {
+
 TEST(Abs, AlwaysReturnsNonnegativeVersionOfInput) {
     EXPECT_THAT(abs(meters(-1)), Eq(meters(1)));
     EXPECT_THAT(abs(meters(0)), Eq(meters(0)));
@@ -524,6 +579,52 @@ TEST(Min, SupportsZeroForSecondArgument) {
 
     constexpr auto negative_result = min(meters(-8), ZERO);
     EXPECT_THAT(negative_result, SameTypeAndValue(meters(-8)));
+}
+
+// Hidden friend overload (same unit, same rep).
+TEST(Max, PrefersSecondArgForSameTypeQuantity) {
+    using LN = LabeledNumber<int>;
+    const auto a = meters(LN{5, 'a'});
+    const auto b = meters(LN{5, 'b'});
+    EXPECT_THAT(max(a, b).data_in(meters).label, Eq('b'));
+}
+
+// Same-type QuantityPoint disambiguation overload (goes through MaxByValue).
+TEST(Max, PrefersSecondArgForSameTypeQuantityPoint) {
+    using LN = LabeledNumber<int>;
+    const auto a = meters_pt(LN{5, 'a'});
+    const auto b = meters_pt(LN{5, 'b'});
+    EXPECT_THAT(max(a, b).data_in(meters_pt).label, Eq('b'));
+}
+
+// ZERO converts to the Quantity type and hits the hidden friend.
+TEST(Max, PrefersSecondArgWithZero) {
+    const auto x = meters(LabeledNumber<int>{0, 'x'});
+    EXPECT_THAT(max(ZERO, x).data_in(meters).label, Eq('x'));
+    EXPECT_THAT(max(x, ZERO).data_in(meters).label, Eq('\0'));
+}
+
+// Hidden friend overload (same unit, same rep).
+TEST(Min, PrefersFirstArgForSameTypeQuantity) {
+    using LN = LabeledNumber<int>;
+    const auto a = meters(LN{5, 'a'});
+    const auto b = meters(LN{5, 'b'});
+    EXPECT_THAT(min(a, b).data_in(Meters{}).label, Eq('a'));
+}
+
+// Same-type QuantityPoint disambiguation overload (goes through MinByValue).
+TEST(Min, PrefersFirstArgForSameTypeQuantityPoint) {
+    using LN = LabeledNumber<int>;
+    const auto a = meters_pt(LN{5, 'a'});
+    const auto b = meters_pt(LN{5, 'b'});
+    EXPECT_THAT(min(a, b).data_in(Meters{}).label, Eq('a'));
+}
+
+// ZERO converts to the Quantity type and hits the hidden friend.
+TEST(Min, PrefersFirstArgWithZero) {
+    const auto x = meters(LabeledNumber<int>{0, 'x'});
+    EXPECT_THAT(min(ZERO, x).data_in(meters).label, Eq('\0'));
+    EXPECT_THAT(min(x, ZERO).data_in(meters).label, Eq('x'));
 }
 
 TEST(IntPow, OutputRepMatchesInputRep) {

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -704,6 +704,8 @@ template <typename U>
 struct AssociatedUnitImpl<QuantityMaker<U>> : stdx::type_identity<U> {};
 template <typename U>
 struct AppropriateAssociatedUnitImpl<Quantity, U> : AssociatedUnitImpl<U> {};
+template <typename... Us>
+struct AppropriateCommonUnitImpl<Quantity, Us...> : ComputeCommonUnit<Us...> {};
 
 template <int Exp, typename Unit>
 AU_DEVICE_FUNC constexpr auto pow(QuantityMaker<Unit>) {

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -322,6 +322,8 @@ template <typename U>
 struct AssociatedUnitForPointsImpl<QuantityPointMaker<U>> : stdx::type_identity<U> {};
 template <typename U>
 struct AppropriateAssociatedUnitImpl<QuantityPoint, U> : AssociatedUnitForPointsImpl<U> {};
+template <typename... Us>
+struct AppropriateCommonUnitImpl<QuantityPoint, Us...> : ComputeCommonPointUnit<Us...> {};
 
 // Provide nicer error messages when users try passing a `QuantityPoint` to a unit slot.
 template <typename U, typename R>

--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -205,6 +205,11 @@ using CommonPointUnit = typename ComputeCommonPointUnit<Us...>::type;
 template <typename... Us>
 using CommonPointUnitT = CommonPointUnit<Us...>;
 
+template <template <class, class> class QType, typename... Us>
+struct AppropriateCommonUnitImpl;
+template <template <class, class> class QType, typename... Us>
+using AppropriateCommonUnit = typename AppropriateCommonUnitImpl<QType, Us...>::type;
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Type traits (instance-based interface).
 

--- a/au/unit_of_measure_test.cc
+++ b/au/unit_of_measure_test.cc
@@ -464,6 +464,21 @@ TEST(AppropriateAssociatedUnit, GivesAssociatedUnitForPointsForQuantityPoint) {
                        Kelvins>();
 }
 
+TEST(AppropriateCommonUnit, GivesCommonUnitForQuantity) {
+    StaticAssertTypeEq<AppropriateCommonUnit<Quantity, Feet, Inches>,
+                       CommonUnit<Feet, Inches>>();
+}
+
+TEST(AppropriateCommonUnit, GivesCommonPointUnitForQuantityPoint) {
+    StaticAssertTypeEq<AppropriateCommonUnit<QuantityPoint, Kelvins, Fahrenheit>,
+                       CommonPointUnit<Kelvins, Fahrenheit>>();
+}
+
+TEST(AppropriateCommonUnit, HandlesMoreThanTwoUnits) {
+    StaticAssertTypeEq<AppropriateCommonUnit<Quantity, Feet, Inches, Yards>,
+                       CommonUnit<Feet, Inches, Yards>>();
+}
+
 TEST(UnitInverse, CommutesWithProduct) {
     StaticAssertTypeEq<UnitInverse<UnitProduct<Feet, Minutes>>,
                        UnitProduct<UnitInverse<Feet>, UnitInverse<Minutes>>>();

--- a/au/unit_of_measure_test.cc
+++ b/au/unit_of_measure_test.cc
@@ -465,8 +465,7 @@ TEST(AppropriateAssociatedUnit, GivesAssociatedUnitForPointsForQuantityPoint) {
 }
 
 TEST(AppropriateCommonUnit, GivesCommonUnitForQuantity) {
-    StaticAssertTypeEq<AppropriateCommonUnit<Quantity, Feet, Inches>,
-                       CommonUnit<Feet, Inches>>();
+    StaticAssertTypeEq<AppropriateCommonUnit<Quantity, Feet, Inches>, CommonUnit<Feet, Inches>>();
 }
 
 TEST(AppropriateCommonUnit, GivesCommonPointUnitForQuantityPoint) {


### PR DESCRIPTION
Walter Brown has given talks pointing out the design flaw in `std::min`
and `std::max` (which Stepanov has acknowledged): in cases where they
compare equal, `min` should return the first argument and `max` the
second.  We are already doing this for our hidden friend implementation
inside `Quantity`, so now we do it for the rest of them.  This also lets
us get rid of the `using std::min` and `using std::max` declarations,
and the corresponding tests.

The reason we do this now, as part of the Eigen/vector/matrix push, is
because `using_common_type` is going to become problematic, and we would
like to simply delete it.  This lets us get rid of users that exist
outside of `quantity.hh`, which would be an awkward situation if there
are no users _inside_ of `quantity.hh`.  And it's not a hugely valuable
utility anyway; it's easy to recreate the common unit/rep logic directly
(as we now do).

To help with these implementations, we add a new utility, too.
`AppropriateCommonUnit<Q, Us...>` produces `CommonUnit<Us...>` when `Q`
is `Quantity`, and `CommonPointUnit<Us...>` when `Q` is `QuantityPoint`.
Since we didn't document the existing `AppropriateAssociatedUnit`
utility, we don't document this either.  Yes, it's in `au::`, but it's a
very "in the weeds" utility that I'm ambivalent about advertising.

Helps #484.