### PR TITLE
Add a `View<T>` type to wrap reps

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -594,6 +594,26 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "view",
+    hdrs = ["view.hh"],
+    deps = [
+        ":magnitude",
+        ":stdx",
+    ],
+)
+
+cc_test(
+    name = "view_test",
+    size = "small",
+    srcs = ["view_test.cc"],
+    deps = [
+        ":testing",
+        ":view",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_test(
     name = "quantity_chrono_policy_correspondence_test",
     size = "small",

--- a/au/view.hh
+++ b/au/view.hh
@@ -144,8 +144,8 @@ struct RealPartImpl<View<R>> : RealPartImpl<R> {};
 
 // ScalarOfTrait for View delegates to the underlying type.
 template <typename R>
-struct ScalarOfTrait<View<R>, std::enable_if_t<
-    stdx::experimental::is_detected<ScalarOf, R>::value>> : ScalarOfTrait<R> {};
+struct ScalarOfTrait<View<R>, std::enable_if_t<stdx::experimental::is_detected<ScalarOf, R>::value>>
+    : ScalarOfTrait<R> {};
 
 // Helper to create a view of a value.
 template <typename R>

--- a/au/view.hh
+++ b/au/view.hh
@@ -1,0 +1,156 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+
+#include "au/magnitude.hh"
+#include "au/stdx/type_traits.hh"
+
+namespace au {
+
+template <typename R>
+class View;
+
+template <typename R>
+constexpr View<R> make_view(R &ref);
+
+// A non-owning mutable view of a value.
+//
+// View<R> wraps a pointer to R, providing reference-like semantics:
+// - Reading: implicit conversion to R
+// - Writing: assignment writes through
+// - Arithmetic: operations dereference and return values (not views)
+// - Element access: returns View of the element type (preserves mutability)
+//
+// This enables `Quantity<U, View<R>>` to act as a mutable view of a Quantity's rep.
+template <typename R>
+class View {
+ public:
+    constexpr explicit View(R &ref) : ptr_{&ref} {}
+
+    constexpr View(const View &) = default;
+
+    // Reading: implicit conversion to underlying type.
+    constexpr operator R() const { return *ptr_; }
+
+    // Writing: assign through to the underlying value.
+    constexpr View &operator=(const R &value) {
+        *ptr_ = value;
+        return *this;
+    }
+
+    // Copy assignment writes through rather than rebinding.
+    constexpr View &operator=(const View &other) {
+        *ptr_ = *other.ptr_;
+        return *this;
+    }
+
+    // Element access: always return View to preserve mutability through the pointer.
+    template <typename I>
+    constexpr auto operator[](I i) const {
+        return make_view((*ptr_)[i]);
+    }
+
+    template <typename... Is>
+    constexpr auto operator()(Is... is) const {
+        return make_view((*ptr_)(is...));
+    }
+
+    // Arithmetic: dereference and return values.
+    friend constexpr R operator+(View a, View b) { return *a.ptr_ + *b.ptr_; }
+    friend constexpr R operator+(View a, const R &b) { return *a.ptr_ + b; }
+    friend constexpr R operator+(const R &a, View b) { return a + *b.ptr_; }
+
+    friend constexpr R operator-(View a, View b) { return *a.ptr_ - *b.ptr_; }
+    friend constexpr R operator-(View a, const R &b) { return *a.ptr_ - b; }
+    friend constexpr R operator-(const R &a, View b) { return a - *b.ptr_; }
+
+    // Scalar multiplication/division.
+    template <typename T>
+    friend constexpr auto operator*(View a, T s) -> decltype(std::declval<R>() * s) {
+        return *a.ptr_ * s;
+    }
+    template <typename T>
+    friend constexpr auto operator*(T s, View a) -> decltype(s * std::declval<R>()) {
+        return s * *a.ptr_;
+    }
+    template <typename T>
+    friend constexpr auto operator/(View a, T s) -> decltype(std::declval<R>() / s) {
+        return *a.ptr_ / s;
+    }
+    template <typename T>
+    friend constexpr auto operator/(T s, View a) -> decltype(s / std::declval<R>()) {
+        return s / *a.ptr_;
+    }
+
+    // Compound assignment.
+    constexpr View &operator+=(const R &other) {
+        *ptr_ += other;
+        return *this;
+    }
+    constexpr View &operator-=(const R &other) {
+        *ptr_ -= other;
+        return *this;
+    }
+    template <typename T>
+    constexpr View &operator*=(T s) {
+        *ptr_ *= s;
+        return *this;
+    }
+    template <typename T>
+    constexpr View &operator/=(T s) {
+        *ptr_ /= s;
+        return *this;
+    }
+
+ private:
+    R *ptr_;
+};
+
+// Type trait to detect View types.
+template <typename T>
+struct IsView : std::false_type {};
+template <typename R>
+struct IsView<View<R>> : std::true_type {};
+
+namespace detail {
+
+// Get underlying type, stripping View wrapper if present.
+template <typename T>
+struct UnderlyingTypeImpl : stdx::type_identity<T> {};
+template <typename R>
+struct UnderlyingTypeImpl<View<R>> : stdx::type_identity<R> {};
+template <typename T>
+using UnderlyingType = typename UnderlyingTypeImpl<T>::type;
+
+// RealPart for View delegates to the underlying type (legacy fallback path).
+template <typename R>
+struct RealPartImpl<View<R>> : RealPartImpl<R> {};
+
+}  // namespace detail
+
+// ScalarOfTrait for View delegates to the underlying type.
+template <typename R>
+struct ScalarOfTrait<View<R>, std::enable_if_t<
+    stdx::experimental::is_detected<ScalarOf, R>::value>> : ScalarOfTrait<R> {};
+
+// Helper to create a view of a value.
+template <typename R>
+constexpr View<R> make_view(R &ref) {
+    return View<R>{ref};
+}
+
+}  // namespace au

--- a/au/view_test.cc
+++ b/au/view_test.cc
@@ -74,6 +74,7 @@ TEST(View, AdditionDereferencesAndReturnsValue) {
     View<double> va{a};
     View<double> vb{b};
 
+    StaticAssertTypeEq<decltype(va + vb), double>();
     EXPECT_THAT(va + vb, Eq(4.0));
     EXPECT_THAT(va + 10.0, Eq(11.5));
     EXPECT_THAT(10.0 + va, Eq(11.5));

--- a/au/view_test.cc
+++ b/au/view_test.cc
@@ -56,7 +56,7 @@ TEST(View, CopyAssignmentWritesThroughRatherThanRebinding) {
 TEST(View, ElementAccessReturnsViewOfElement) {
     std::array<double, 3> arr = {1.0, 2.0, 3.0};
     View<std::array<double, 3>> v{arr};
-    auto elem = v[1];
+    auto elem = v[1u];
     StaticAssertTypeEq<decltype(elem), View<double>>();
     EXPECT_THAT(static_cast<double>(elem), Eq(2.0));
 }
@@ -64,8 +64,8 @@ TEST(View, ElementAccessReturnsViewOfElement) {
 TEST(View, ElementAccessWritesThrough) {
     std::array<double, 3> arr = {1.0, 2.0, 3.0};
     View<std::array<double, 3>> v{arr};
-    v[1] = 42.0;
-    EXPECT_THAT(arr[1], Eq(42.0));
+    v[1u] = 42.0;
+    EXPECT_THAT(arr[1u], Eq(42.0));
 }
 
 TEST(View, AdditionDereferencesAndReturnsValue) {

--- a/au/view_test.cc
+++ b/au/view_test.cc
@@ -1,0 +1,187 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/view.hh"
+
+#include <array>
+
+#include "au/testing.hh"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace au {
+
+using ::testing::Eq;
+using ::testing::IsFalse;
+using ::testing::IsTrue;
+using ::testing::StaticAssertTypeEq;
+
+TEST(View, ImplicitlyConvertsToUnderlyingValue) {
+    double x = 3.5;
+    View<double> v{x};
+    double result = v;
+    EXPECT_THAT(result, Eq(3.5));
+}
+
+TEST(View, AssignmentWritesThroughToUnderlying) {
+    double x = 1.0;
+    View<double> v{x};
+    v = 2.5;
+    EXPECT_THAT(x, Eq(2.5));
+}
+
+TEST(View, CopyAssignmentWritesThroughRatherThanRebinding) {
+    double x = 1.0;
+    double y = 2.0;
+    View<double> vx{x};
+    View<double> vy{y};
+    vx = vy;
+    EXPECT_THAT(x, Eq(2.0));
+
+    y = 99.0;
+    EXPECT_THAT(static_cast<double>(vx), Eq(2.0));
+}
+
+TEST(View, ElementAccessReturnsViewOfElement) {
+    std::array<double, 3> arr = {1.0, 2.0, 3.0};
+    View<std::array<double, 3>> v{arr};
+    auto elem = v[1];
+    StaticAssertTypeEq<decltype(elem), View<double>>();
+    EXPECT_THAT(static_cast<double>(elem), Eq(2.0));
+}
+
+TEST(View, ElementAccessWritesThrough) {
+    std::array<double, 3> arr = {1.0, 2.0, 3.0};
+    View<std::array<double, 3>> v{arr};
+    v[1] = 42.0;
+    EXPECT_THAT(arr[1], Eq(42.0));
+}
+
+TEST(View, AdditionDereferencesAndReturnsValue) {
+    double a = 1.5;
+    double b = 2.5;
+    View<double> va{a};
+    View<double> vb{b};
+
+    EXPECT_THAT(va + vb, Eq(4.0));
+    EXPECT_THAT(va + 10.0, Eq(11.5));
+    EXPECT_THAT(10.0 + va, Eq(11.5));
+}
+
+TEST(View, SubtractionDereferencesAndReturnsValue) {
+    double a = 5.0;
+    double b = 2.0;
+    View<double> va{a};
+    View<double> vb{b};
+
+    EXPECT_THAT(va - vb, Eq(3.0));
+    EXPECT_THAT(va - 1.0, Eq(4.0));
+    EXPECT_THAT(10.0 - va, Eq(5.0));
+}
+
+TEST(View, ScalarMultiplicationWorks) {
+    double x = 3.0;
+    View<double> v{x};
+
+    EXPECT_THAT(v * 2.0, Eq(6.0));
+    EXPECT_THAT(2.0 * v, Eq(6.0));
+}
+
+TEST(View, ScalarDivisionWorks) {
+    double x = 6.0;
+    View<double> v{x};
+
+    EXPECT_THAT(v / 2.0, Eq(3.0));
+    EXPECT_THAT(12.0 / v, Eq(2.0));
+}
+
+TEST(View, CompoundAdditionWritesThrough) {
+    double x = 1.0;
+    View<double> v{x};
+    v += 2.5;
+    EXPECT_THAT(x, Eq(3.5));
+}
+
+TEST(View, CompoundSubtractionWritesThrough) {
+    double x = 5.0;
+    View<double> v{x};
+    v -= 1.5;
+    EXPECT_THAT(x, Eq(3.5));
+}
+
+TEST(View, CompoundMultiplicationWritesThrough) {
+    double x = 3.0;
+    View<double> v{x};
+    v *= 4.0;
+    EXPECT_THAT(x, Eq(12.0));
+}
+
+TEST(View, CompoundDivisionWritesThrough) {
+    double x = 12.0;
+    View<double> v{x};
+    v /= 3.0;
+    EXPECT_THAT(x, Eq(4.0));
+}
+
+TEST(View, ArithmeticDoesNotModifyUnderlying) {
+    double a = 3.0;
+    double b = 2.0;
+    View<double> va{a};
+    View<double> vb{b};
+
+    EXPECT_THAT(va + vb, Eq(5.0));
+    EXPECT_THAT(a, Eq(3.0));
+    EXPECT_THAT(b, Eq(2.0));
+}
+
+TEST(MakeView, CreatesViewOfValue) {
+    int x = 42;
+    auto v = make_view(x);
+    StaticAssertTypeEq<decltype(v), View<int>>();
+    EXPECT_THAT(static_cast<int>(v), Eq(42));
+}
+
+TEST(IsView, TrueForViewTypes) {
+    EXPECT_THAT(IsView<View<double>>::value, IsTrue());
+    EXPECT_THAT(IsView<View<int>>::value, IsTrue());
+}
+
+TEST(IsView, FalseForNonViewTypes) {
+    EXPECT_THAT(IsView<double>::value, IsFalse());
+    EXPECT_THAT(IsView<int>::value, IsFalse());
+}
+
+TEST(UnderlyingType, StripsViewWrapper) {
+    StaticAssertTypeEq<detail::UnderlyingType<View<double>>, double>();
+    StaticAssertTypeEq<detail::UnderlyingType<View<int>>, int>();
+}
+
+TEST(UnderlyingType, PassesThroughNonViewTypes) {
+    StaticAssertTypeEq<detail::UnderlyingType<double>, double>();
+    StaticAssertTypeEq<detail::UnderlyingType<int>, int>();
+}
+
+struct HasScalar {
+    using Scalar = float;
+};
+
+TEST(ScalarOfTrait, ViewDelegatesToUnderlyingType) {
+    StaticAssertTypeEq<ScalarOf<View<HasScalar>>, float>();
+}
+
+TEST(RealPartImpl, ViewDelegatesToUnderlyingType) {
+    StaticAssertTypeEq<detail::RealPart<View<double>>, double>();
+}
+
+}  // namespace au

--- a/au/view_test.cc
+++ b/au/view_test.cc
@@ -74,10 +74,9 @@ TEST(View, AdditionDereferencesAndReturnsValue) {
     View<double> va{a};
     View<double> vb{b};
 
-    StaticAssertTypeEq<decltype(va + vb), double>();
-    EXPECT_THAT(va + vb, Eq(4.0));
-    EXPECT_THAT(va + 10.0, Eq(11.5));
-    EXPECT_THAT(10.0 + va, Eq(11.5));
+    EXPECT_THAT(va + vb, SameTypeAndValue(4.0));
+    EXPECT_THAT(va + 10.0, SameTypeAndValue(11.5));
+    EXPECT_THAT(10.0 + va, SameTypeAndValue(11.5));
 }
 
 TEST(View, SubtractionDereferencesAndReturnsValue) {
@@ -86,25 +85,25 @@ TEST(View, SubtractionDereferencesAndReturnsValue) {
     View<double> va{a};
     View<double> vb{b};
 
-    EXPECT_THAT(va - vb, Eq(3.0));
-    EXPECT_THAT(va - 1.0, Eq(4.0));
-    EXPECT_THAT(10.0 - va, Eq(5.0));
+    EXPECT_THAT(va - vb, SameTypeAndValue(3.0));
+    EXPECT_THAT(va - 1.0, SameTypeAndValue(4.0));
+    EXPECT_THAT(10.0 - va, SameTypeAndValue(5.0));
 }
 
 TEST(View, ScalarMultiplicationWorks) {
     double x = 3.0;
     View<double> v{x};
 
-    EXPECT_THAT(v * 2.0, Eq(6.0));
-    EXPECT_THAT(2.0 * v, Eq(6.0));
+    EXPECT_THAT(v * 2.0, SameTypeAndValue(6.0));
+    EXPECT_THAT(2.0 * v, SameTypeAndValue(6.0));
 }
 
 TEST(View, ScalarDivisionWorks) {
     double x = 6.0;
     View<double> v{x};
 
-    EXPECT_THAT(v / 2.0, Eq(3.0));
-    EXPECT_THAT(12.0 / v, Eq(2.0));
+    EXPECT_THAT(v / 2.0, SameTypeAndValue(3.0));
+    EXPECT_THAT(12.0 / v, SameTypeAndValue(2.0));
 }
 
 TEST(View, CompoundAdditionWritesThrough) {


### PR DESCRIPTION
This paves the way for the `q.mutable_view()[i]` implementation in our
vector/matrix support design.  Assignment writes through to the
underlying value; other operations convert easily to the underlying
type.  Importantly, it also includes `operator[]` and `operator()`, so
that we can create a quantity whose rep is a view onto a matrix type.
This will let us edit individual matrix elements in a unit-safe way,
through the view.

Helps #484.