### PR TITLE
Support element access on Quantity types

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -578,6 +578,7 @@ cc_library(
         ":truncation_risk",
         ":unit_of_measure",
         ":utility",
+        ":view",
         ":zero",
     ],
 )

--- a/au/CMakeLists.txt
+++ b/au/CMakeLists.txt
@@ -45,6 +45,7 @@ header_only_library(
     truncation_risk.hh
     unit_of_measure.hh
     unit_symbol.hh
+    view.hh
     wrapper_operations.hh
     zero.hh
     constants/avogadro_constant.hh
@@ -564,6 +565,15 @@ gtest_based_test(
   DEPS
     au
     testing
+)
+
+gtest_based_test(
+    NAME view_test
+    SRCS
+      view_test.cc
+    DEPS
+      au
+      testing
 )
 
 gtest_based_test(

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -287,7 +287,7 @@ class Quantity {
     }
 
     // Return a mutable view of this Quantity.
-    AU_DEVICE_FUNC constexpr Quantity<UnitT, View<RepT>> mutable_view() {
+    AU_DEVICE_FUNC constexpr Quantity<UnitT, View<RepT>> mutable_view() & {
         return make_quantity<UnitT>(make_view(value_));
     }
 

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -30,6 +30,7 @@
 #include "au/truncation_risk.hh"
 #include "au/unit_of_measure.hh"
 #include "au/utility/type_traits.hh"
+#include "au/view.hh"
 #include "au/zero.hh"
 
 namespace au {
@@ -184,6 +185,8 @@ class Quantity {
     AU_DEVICE_FUNC constexpr Quantity(Zero) : value_{0} {}
 
     AU_DEVICE_FUNC constexpr Quantity() noexcept = default;
+    AU_DEVICE_FUNC constexpr Quantity(const Quantity &) = default;
+    AU_DEVICE_FUNC constexpr Quantity(Quantity &&) = default;
 
     // Implicit construction from any exactly-equivalent type.
     template <
@@ -270,6 +273,24 @@ class Quantity {
         return value_;
     }
 
+    // Passthrough element access for vector/matrix rep types.
+    template <typename R = Rep, typename I>
+    AU_DEVICE_FUNC constexpr auto operator[](I i) const
+        -> decltype(make_quantity<UnitT>(std::declval<const R &>()[i])) {
+        return make_quantity<UnitT>(value_[i]);
+    }
+
+    template <typename R = Rep, typename... Is>
+    AU_DEVICE_FUNC constexpr auto operator()(Is... is) const
+        -> decltype(make_quantity<UnitT>(std::declval<const R &>()(is...))) {
+        return make_quantity<UnitT>(value_(is...));
+    }
+
+    // Return a mutable view of this Quantity.
+    AU_DEVICE_FUNC constexpr Quantity<UnitT, View<RepT>> mutable_view() {
+        return make_quantity<UnitT>(make_view(value_));
+    }
+
     // Permit this factory functor to access our private constructor.
     //
     // We allow this because it explicitly names the unit at the callsite, even if people refer to
@@ -352,12 +373,59 @@ class Quantity {
                                                                             q.in(OtherUnit{}));
     }
 
-    // Short-hand addition and subtraction assignment.
-    AU_DEVICE_FUNC constexpr Quantity &operator+=(Quantity other) {
+    // Copy and move assignment: lvalue-only.
+    //
+    // Ref-qualifying as `&` prevents silent no-ops like `q[0] = meters(10)`, where operator[]
+    // returns by value and the assignment would modify a temporary.  The `&&`-qualified overloads
+    // below re-enable rvalue assignment specifically for View reps, where it writes through.
+    AU_DEVICE_FUNC constexpr Quantity &operator=(const Quantity &) & = default;
+    AU_DEVICE_FUNC constexpr Quantity &operator=(Quantity &&) & = default;
+
+    // Cross-unit assignment: lvalue-only.
+    template <typename OtherUnit,
+              typename OtherRep,
+              typename Enable = EnableIfImplicitOkIs<true, OtherUnit, OtherRep>>
+    AU_DEVICE_FUNC constexpr Quantity &operator=(Quantity<OtherUnit, OtherRep> other) & {
+        value_ = other.template in_impl<detail::UseImplicitConversion, detail::UnderlyingType<Rep>>(
+            Unit{}, check_for(ALL_RISKS));
+        return *this;
+    }
+
+    // Rvalue assignment overloads for View reps (write-through semantics).
+    template <typename R = Rep, std::enable_if_t<IsView<R>::value, int> = 0>
+    AU_DEVICE_FUNC constexpr Quantity &operator=(const Quantity &other) && {
+        value_ = other.value_;
+        return *this;
+    }
+    template <typename OtherUnit,
+              typename OtherRep,
+              typename R = Rep,
+              typename Enable = EnableIfImplicitOkIs<true, OtherUnit, OtherRep>,
+              std::enable_if_t<IsView<R>::value, int> = 0>
+    AU_DEVICE_FUNC constexpr Quantity &operator=(Quantity<OtherUnit, OtherRep> other) && {
+        value_ = other.template in_impl<detail::UseImplicitConversion, detail::UnderlyingType<Rep>>(
+            Unit{}, check_for(ALL_RISKS));
+        return *this;
+    }
+
+    // Short-hand addition and subtraction assignment: lvalue-only by default.
+    AU_DEVICE_FUNC constexpr Quantity &operator+=(Quantity other) & {
         value_ += other.value_;
         return *this;
     }
-    AU_DEVICE_FUNC constexpr Quantity &operator-=(Quantity other) {
+    AU_DEVICE_FUNC constexpr Quantity &operator-=(Quantity other) & {
+        value_ -= other.value_;
+        return *this;
+    }
+
+    // Support short-hand addition and subtraction on rvalues for view rep types only.
+    template <typename R = Rep, std::enable_if_t<IsView<R>::value, int> = 0>
+    AU_DEVICE_FUNC constexpr Quantity &operator+=(Quantity other) && {
+        value_ += other.value_;
+        return *this;
+    }
+    template <typename R = Rep, std::enable_if_t<IsView<R>::value, int> = 0>
+    AU_DEVICE_FUNC constexpr Quantity &operator-=(Quantity other) && {
         value_ -= other.value_;
         return *this;
     }
@@ -373,18 +441,32 @@ class Quantity {
                       "We don't support compound mult/div of integral types by floating point");
     }
 
-    // Short-hand multiplication assignment.
+    // Short-hand multiplication assignment: most types lvalue-only; view types support rvalues.
     template <typename T>
-    AU_DEVICE_FUNC constexpr Quantity &operator*=(T s) {
+    AU_DEVICE_FUNC constexpr Quantity &operator*=(T s) & {
+        perform_shorthand_checks<T>();
+
+        value_ *= s;
+        return *this;
+    }
+    template <typename T, typename R = Rep, std::enable_if_t<IsView<R>::value, int> = 0>
+    AU_DEVICE_FUNC constexpr Quantity &operator*=(T s) && {
         perform_shorthand_checks<T>();
 
         value_ *= s;
         return *this;
     }
 
-    // Short-hand division assignment.
+    // Short-hand division assignment: most types lvalue-only; view types support rvalues.
     template <typename T>
-    AU_DEVICE_FUNC constexpr Quantity &operator/=(T s) {
+    AU_DEVICE_FUNC constexpr Quantity &operator/=(T s) & {
+        perform_shorthand_checks<T>();
+
+        value_ /= s;
+        return *this;
+    }
+    template <typename T, typename R = Rep, std::enable_if_t<IsView<R>::value, int> = 0>
+    AU_DEVICE_FUNC constexpr Quantity &operator/=(T s) && {
         perform_shorthand_checks<T>();
 
         value_ /= s;

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -1396,6 +1396,7 @@ TEST(QuantityMutableView, ElementAssignmentModifiesOriginal) {
 TEST(QuantityPassthrough, AssignmentToElementDoesNotCompile) {
     auto q = meters(make_vec(1.0, 2.0, 3.0));
     static_assert(!std::is_assignable<decltype(q[0]), decltype(meters(10.0))>::value, "");
+    static_assert(!std::is_assignable<decltype(q(0)), decltype(meters(10.0))>::value, "");
 }
 
 }  // namespace au

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -24,7 +24,7 @@
 
 namespace test_types {
 
-template <typename T, int N>
+template <typename T, std::size_t N>
 struct Vec {
     T data[N];
 
@@ -35,21 +35,21 @@ struct Vec {
 
     friend constexpr Vec operator+(Vec a, Vec b) {
         Vec r{};
-        for (int i = 0; i < N; ++i) {
+        for (auto i = 0u; i < N; ++i) {
             r.data[i] = a.data[i] + b.data[i];
         }
         return r;
     }
     friend constexpr Vec operator-(Vec a, Vec b) {
         Vec r{};
-        for (int i = 0; i < N; ++i) {
+        for (auto i = 0u; i < N; ++i) {
             r.data[i] = a.data[i] - b.data[i];
         }
         return r;
     }
     friend constexpr Vec operator*(Vec a, T s) {
         Vec r{};
-        for (int i = 0; i < N; ++i) {
+        for (auto i = 0u; i < N; ++i) {
             r.data[i] = a.data[i] * s;
         }
         return r;
@@ -57,7 +57,7 @@ struct Vec {
     friend constexpr Vec operator*(T s, Vec a) { return a * s; }
     friend constexpr Vec operator/(Vec a, T s) {
         Vec r{};
-        for (int i = 0; i < N; ++i) {
+        for (auto i = 0u; i < N; ++i) {
             r.data[i] = a.data[i] / s;
         }
         return r;
@@ -68,7 +68,7 @@ struct Vec {
 
 namespace au {
 
-template <typename T, int N>
+template <typename T, std::size_t N>
 struct ScalarOfTrait<test_types::Vec<T, N>> : stdx::type_identity<T> {};
 
 using ::testing::DoubleEq;

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -22,7 +22,54 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+namespace test_types {
+
+template <typename T, int N>
+struct Vec {
+    T data[N];
+
+    constexpr T &operator[](int i) { return data[i]; }
+    constexpr const T &operator[](int i) const { return data[i]; }
+    constexpr T &operator()(int i) { return data[i]; }
+    constexpr const T &operator()(int i) const { return data[i]; }
+
+    friend constexpr Vec operator+(Vec a, Vec b) {
+        Vec r{};
+        for (int i = 0; i < N; ++i) {
+            r.data[i] = a.data[i] + b.data[i];
+        }
+        return r;
+    }
+    friend constexpr Vec operator-(Vec a, Vec b) {
+        Vec r{};
+        for (int i = 0; i < N; ++i) {
+            r.data[i] = a.data[i] - b.data[i];
+        }
+        return r;
+    }
+    friend constexpr Vec operator*(Vec a, T s) {
+        Vec r{};
+        for (int i = 0; i < N; ++i) {
+            r.data[i] = a.data[i] * s;
+        }
+        return r;
+    }
+    friend constexpr Vec operator*(T s, Vec a) { return a * s; }
+    friend constexpr Vec operator/(Vec a, T s) {
+        Vec r{};
+        for (int i = 0; i < N; ++i) {
+            r.data[i] = a.data[i] / s;
+        }
+        return r;
+    }
+};
+
+}  // namespace test_types
+
 namespace au {
+
+template <typename T, int N>
+struct ScalarOfTrait<test_types::Vec<T, N>> : stdx::type_identity<T> {};
 
 using ::testing::DoubleEq;
 using ::testing::DoubleNear;
@@ -705,7 +752,8 @@ TEST(Quantity, ShortHandAdditionAssignmentWorks) {
 
 TEST(Quantity, ShortHandAdditionHasReferenceCharacter) {
     auto d = feet(1);
-    d += feet(1234) = feet(3);
+    auto e = feet(1234);
+    d += e = feet(3);
     EXPECT_THAT(d, Eq(feet(4)));
 }
 
@@ -717,7 +765,8 @@ TEST(Quantity, ShortHandSubtractionAssignmentWorks) {
 
 TEST(Quantity, ShortHandSubtractionHasReferenceCharacter) {
     auto d = feet(4);
-    d -= feet(1234) = feet(3);
+    auto e = feet(1234);
+    d -= e = feet(3);
     EXPECT_THAT(d, Eq(feet(1)));
 }
 
@@ -1257,6 +1306,96 @@ TEST(Zero, AssignableToArbitraryQuantities) {
 
     constexpr Quantity<Hours, int> zero_hours = ZERO;
     EXPECT_THAT(zero_hours, QuantityEquivalent(hours(0)));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Passthrough element access tests.
+
+template <typename... Ts>
+constexpr test_types::Vec<std::common_type_t<Ts...>, sizeof...(Ts)> make_vec(Ts... args) {
+    return {{static_cast<std::common_type_t<Ts...>>(args)...}};
+}
+
+TEST(QuantityPassthrough, OperatorBracketReturnsQuantityWithSameUnit) {
+    auto v = meters(make_vec(1.0, 2.0, 3.0));
+
+    EXPECT_THAT(v[0], SameTypeAndValue(meters(1.0)));
+    EXPECT_THAT(v[1], SameTypeAndValue(meters(2.0)));
+    EXPECT_THAT(v[2], SameTypeAndValue(meters(3.0)));
+}
+
+TEST(QuantityPassthrough, OperatorBracketWorksWithIntRep) {
+    auto arr = inches(make_vec(10, 20, 30, 40));
+
+    EXPECT_THAT(arr[0], SameTypeAndValue(inches(10)));
+    EXPECT_THAT(arr[1], SameTypeAndValue(inches(20)));
+    EXPECT_THAT(arr[2], SameTypeAndValue(inches(30)));
+    EXPECT_THAT(arr[3], SameTypeAndValue(inches(40)));
+}
+
+TEST(QuantityPassthrough, OperatorBracketReturnsCorrectType) {
+    auto v = meters(make_vec(1.0, 2.0));
+
+    auto elem = v[0];
+
+    StaticAssertTypeEq<decltype(elem), Quantity<Meters, double>>();
+}
+
+TEST(QuantityPassthrough, OperatorParenWorksForVectorSingleIndex) {
+    auto v = meters(make_vec(1.0, 2.0, 3.0));
+
+    EXPECT_THAT(v(0), SameTypeAndValue(meters(1.0)));
+    EXPECT_THAT(v(1), SameTypeAndValue(meters(2.0)));
+    EXPECT_THAT(v(2), SameTypeAndValue(meters(3.0)));
+}
+
+TEST(QuantityPassthrough, QuantityArithmeticWorksWithVectorRep) {
+    constexpr auto q1 = meters(make_vec(1.0, 2.0, 3.0));
+    constexpr auto q2 = meters(make_vec(4.0, 5.0, 6.0));
+
+    constexpr auto sum = q1 + q2;
+    EXPECT_THAT(sum[0], SameTypeAndValue(meters(5.0)));
+    EXPECT_THAT(sum[1], SameTypeAndValue(meters(7.0)));
+    EXPECT_THAT(sum[2], SameTypeAndValue(meters(9.0)));
+
+    constexpr auto diff = q2 - q1;
+    EXPECT_THAT(diff[0], SameTypeAndValue(meters(3.0)));
+    EXPECT_THAT(diff[1], SameTypeAndValue(meters(3.0)));
+    EXPECT_THAT(diff[2], SameTypeAndValue(meters(3.0)));
+
+    constexpr auto scaled = q1 * 2.0;
+    EXPECT_THAT(scaled[0], SameTypeAndValue(meters(2.0)));
+    EXPECT_THAT(scaled[1], SameTypeAndValue(meters(4.0)));
+    EXPECT_THAT(scaled[2], SameTypeAndValue(meters(6.0)));
+}
+
+TEST(QuantityMutableView, ReturnsQuantityOfView) {
+    auto q = meters(make_vec(1.0, 2.0, 3.0));
+
+    auto view = q.mutable_view();
+
+    StaticAssertTypeEq<decltype(view), Quantity<Meters, View<test_types::Vec<double, 3>>>>();
+}
+
+TEST(QuantityMutableView, ElementAccessReturnsQuantityOfView) {
+    auto q = meters(make_vec(1.0, 2.0, 3.0));
+
+    auto elem = q.mutable_view()[0];
+
+    StaticAssertTypeEq<decltype(elem), Quantity<Meters, View<double>>>();
+}
+
+TEST(QuantityMutableView, ElementAssignmentModifiesOriginal) {
+    auto q = meters(make_vec(1.0, 2.0, 3.0));
+
+    q.mutable_view()[0] = meters(10.0);
+
+    EXPECT_THAT(q[0], SameTypeAndValue(meters(10.0)));
+}
+
+TEST(QuantityPassthrough, AssignmentToElementDoesNotCompile) {
+    auto q = meters(make_vec(1.0, 2.0, 3.0));
+    static_assert(!std::is_assignable<decltype(q[0]), decltype(meters(10.0))>::value, "");
 }
 
 }  // namespace au


### PR DESCRIPTION
We support two styles: `[i]`, and `(i, j, ...)`.  In each case, we
construct a `Quantity` from the indexed underlying element.

The biggest "gotcha" that we _must_ avoid is the silent no-op of
expressions like `q[0] = meters(3)`.  Since `q[0]` is a temporary, this
statement modifies the temporary, and then discards it.

The principled solution is to ref-qualify all of our assignment operator
overloads.  The problem is that we don't have these overloads!  We have
been using automatically generated versions based on our copy
constructor.  So we make them, and ref-qualify them.  This suppresses
the copy and move constructor generation, so we explicitly add them back
as defaulted.

Next, we need to add rvalue qualified overloads _back_ for the _specific
cases_ where they make sense: namely, view types.  We also provide the
`.mutable_view()` member to make it easy to _get_ that view type.  The
name is a little bit clunky/unwieldy, but it does what it needs to: it
makes _very_ clear that this is a "view" (and thus warns about lifetime
issues), and also very clear that this view will let you mutate the
underlying value.  I cannot think of a better alternative that provides
this level of safety.

After this, we give the same treatment to the shorthand arithmetic
operators (`+=` and friends).

Finally, we add `view` and its test to CMake.  Apparently our CI jobs do
a good job of catching regressions for new targets, but maybe just when
they're _used_ instead of _added_?  That... makes sense, actually, since
I think it's based on what's in the `au` target.

Helps #484.  After this PR, many common vector and matrix use cases will
now work nicely!  That said, Eigen types would be very dangerous to use
until we finish fully delivering this feature.  (I think the risk is
very low of somebody happening to grab a version of main between this PR
and those other changes, _and_ using Eigen types with it.)