### PR TITLE
Change implicit rep to natural output type

### DIFF
--- a/au/constant.hh
+++ b/au/constant.hh
@@ -72,15 +72,15 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
 
         constexpr bool has_unacceptable_overflow =
             RiskPolicyT{}.should_check(detail::ConversionRisk::Overflow) &&
-            will_conversion_overflow(this_value, OtherUnit{});
+            will_conversion_overflow<T>(this_value, OtherUnit{});
         static_assert(!has_unacceptable_overflow, "Constant conversion known to overflow");
 
         constexpr bool has_unacceptable_truncation =
             RiskPolicyT{}.should_check(detail::ConversionRisk::Truncation) &&
-            will_conversion_truncate(this_value, OtherUnit{});
+            will_conversion_truncate<T>(this_value, OtherUnit{});
         static_assert(!has_unacceptable_truncation, "Constant conversion known to truncate");
 
-        return this_value.as(OtherUnit{}, ignore(ALL_RISKS));
+        return this_value.template as<T>(OtherUnit{}, ignore(ALL_RISKS));
     }
 
     // Get the value of this constant in the given unit and rep, ignoring safety checks.

--- a/au/constant_test.cc
+++ b/au/constant_test.cc
@@ -18,6 +18,8 @@
 
 #include "au/chrono_interop.hh"
 #include "au/testing.hh"
+#include "au/units/bits.hh"
+#include "au/units/bytes.hh"
 #include "au/units/degrees.hh"
 #include "au/units/feet.hh"
 #include "au/units/inches.hh"
@@ -311,6 +313,31 @@ TEST(Constant, ImplicitlyConvertsToAppropriateQuantityTypes) {
     {
         // constexpr Quantity<decltype(Meters{} / Seconds{}), int16_t> v = c;
         // (void)c;
+    }
+}
+
+TEST(Constant, OutputHasProvidedRep) {
+    constexpr auto X = make_constant(bytes * mag<10>());
+    EXPECT_THAT(X.as<uint8_t>(bits), SameTypeAndValue(bits(uint8_t{80})));
+    EXPECT_THAT(X.as<int8_t>(bits), SameTypeAndValue(bits(int8_t{80})));
+}
+
+TEST(Constant, InOutputTypeIsProvidedRep) {
+    constexpr auto X = make_constant(bytes * mag<10>());
+    EXPECT_THAT(X.in<uint8_t>(bits), SameTypeAndValue(uint8_t{80}));
+    EXPECT_THAT(X.in<int8_t>(bits), SameTypeAndValue(int8_t{80}));
+}
+
+TEST(Constant, OverflowCheckUsesExplicitRep) {
+    // 40 bytes = 320 bits: fits in int (the promoted type) but overflows uint8_t.
+    // The explicit-rep check in Constant::as correctly catches this.
+    constexpr auto X = make_constant(bytes * mag<40>());
+    EXPECT_THAT(X.can_store_value_in<uint8_t>(bits), IsFalse());
+    EXPECT_THAT(X.can_store_value_in<uint16_t>(bits), IsTrue());
+
+    // The following must not compile.  Uncomment inside the scope to check.
+    {
+        // X.as<uint8_t>(bits);
     }
 }
 

--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -178,11 +178,15 @@ struct ConversionRiskAcceptablyLow
 template <typename Rep, typename ScaleFactor, typename SourceRep>
 struct PermitAsCarveOutForIntegerPromotion
     : stdx::conjunction<std::is_same<Abs<ScaleFactor>, Magnitude<>>,
-                        std::is_same<SourceRep, PromotedType<Rep>>,
-                        stdx::disjunction<IsPositive<ScaleFactor>, std::is_signed<Rep>>,
                         std::is_integral<Rep>,
                         std::is_integral<SourceRep>,
+                        std::is_same<SourceRep, PromotedType<Rep>>,
+                        stdx::disjunction<IsPositive<ScaleFactor>, std::is_signed<Rep>>,
                         std::is_assignable<Rep &, SourceRep>> {};
+// `void` means "no explicit rep" (the implicit-rep `.in()`/`.as()` path).  The carve-out is
+// irrelevant there, but `in_impl` checks it unconditionally, so we need a valid instantiation.
+template <typename ScaleFactor, typename SourceRep>
+struct PermitAsCarveOutForIntegerPromotion<void, ScaleFactor, SourceRep> : std::false_type {};
 
 template <typename CastStrategy, typename Rep, typename ScaleFactor, typename SourceRep>
 struct PassesConversionRiskCheck

--- a/au/conversion_strategy.hh
+++ b/au/conversion_strategy.hh
@@ -22,8 +22,10 @@ namespace au {
 namespace detail {
 
 //
-// `ConversionForRepsAndFactor<OldRep, NewRep, Factor>` is the operation that takes a value of
-// `OldRep`, and produces the product of that value with magnitude `Factor` in the type `NewRep`.
+// `ConversionForRepsAndFactor<CastType, OldRep, NewRep, Factor>` is the operation that takes a
+// value of `OldRep`, and produces the product of that value with magnitude `Factor` in the type
+// `NewRep`, using casting operations according to `CastType` (`static_cast` or implicit
+// conversions).
 //
 template <typename CastType, typename OldRep, typename NewRep, typename Factor>
 struct ConversionForRepsAndFactorImpl;
@@ -79,10 +81,11 @@ struct ApplicationStrategyForImpl<T, Mag, MagKindHolder<MagKind::INTEGER_DIVIDE>
 
 template <typename T, typename Mag>
 struct ApplicationStrategyForImpl<T, Mag, MagKindHolder<MagKind::NONTRIVIAL_RATIONAL>>
-    : std::conditional<
-          std::is_integral<RealPart<T>>::value,
-          OpSequence<MultiplyTypeBy<T, Numerator<Mag>>, DivideTypeByInteger<T, Denominator<Mag>>>,
-          MultiplyTypeBy<T, Mag>> {};
+    : std::conditional<std::is_integral<RealPart<T>>::value,
+                       OpSequence<MultiplyTypeBy<T, Numerator<Mag>>,
+                                  DivideTypeByInteger<OpOutput<MultiplyTypeBy<T, Numerator<Mag>>>,
+                                                      Denominator<Mag>>>,
+                       MultiplyTypeBy<T, Mag>> {};
 
 //
 // `ConversionRep<OldRep, NewRep>` is the rep we should use when applying the conversion factor.
@@ -138,10 +141,15 @@ template <typename CastType, typename T, typename U>
 using CastSequence = typename CastSequenceImpl<CastType, T, U>::type;
 
 //
-// `FullConversionImpl<OldRep, ConversionRepT, NewRep, Factor>` should resolve to the most efficient
-// sequence of operations for a conversion from `OldRep` to `NewRep`, with a magnitude `Factor`,
-// where `ConversionRepT` is the promoted type of the common type of `OldRep` and `NewRep`.
+// `FullConversionImpl<CastType, OldRep, ConversionRepT, NewRep, Factor>` should resolve to the most
+// efficient sequence of operations for a conversion from `OldRep` to `NewRep`, with a magnitude
+// `Factor`, where `ConversionRepT` is the promoted type of the common type of `OldRep` and
+// `NewRep`.  `CastType` discriminates between `static_cast` and implicit conversions.
 //
+
+// Helper to get the output type after applying the conversion factor.
+template <typename Rep, typename Factor>
+using ApplicationOutputFor = OpOutput<ApplicationStrategyFor<Rep, Factor>>;
 
 template <typename CastType,
           typename OldRep,
@@ -149,28 +157,55 @@ template <typename CastType,
           typename NewRep,
           typename Factor>
 struct FullConversionImpl
-    : stdx::type_identity<OpSequence<CastSequence<CastType, OldRep, ConversionRepT>,
-                                     ApplicationStrategyFor<ConversionRepT, Factor>,
-                                     CastSequence<CastType, ConversionRepT, NewRep>>> {};
+    : stdx::type_identity<OpSequence<
+          CastSequence<CastType, OldRep, ConversionRepT>,
+          ApplicationStrategyFor<ConversionRepT, Factor>,
+          CastSequence<CastType, ApplicationOutputFor<ConversionRepT, Factor>, NewRep>>> {};
 
 template <typename CastType, typename OldRepIsConversionRep, typename NewRep, typename Factor>
 struct FullConversionImpl<CastType, OldRepIsConversionRep, OldRepIsConversionRep, NewRep, Factor>
-    : stdx::type_identity<OpSequence<ApplicationStrategyFor<OldRepIsConversionRep, Factor>,
-                                     CastSequence<CastType, OldRepIsConversionRep, NewRep>>> {};
+    : stdx::type_identity<OpSequence<
+          ApplicationStrategyFor<OldRepIsConversionRep, Factor>,
+          CastSequence<CastType, ApplicationOutputFor<OldRepIsConversionRep, Factor>, NewRep>>> {};
 
 template <typename CastType, typename OldRep, typename NewRepIsConversionRep, typename Factor>
 struct FullConversionImpl<CastType, OldRep, NewRepIsConversionRep, NewRepIsConversionRep, Factor>
     : stdx::type_identity<OpSequence<CastSequence<CastType, OldRep, NewRepIsConversionRep>,
                                      ApplicationStrategyFor<NewRepIsConversionRep, Factor>>> {};
 
+// When OldRep == ConversionRep == NewRep and the application output matches Rep, no cast needed.
 template <typename CastType, typename Rep, typename Factor>
 struct FullConversionImpl<CastType, Rep, Rep, Rep, Factor>
-    : stdx::type_identity<ApplicationStrategyFor<Rep, Factor>> {};
+    : std::conditional<std::is_same<ApplicationOutputFor<Rep, Factor>, Rep>::value,
+                       ApplicationStrategyFor<Rep, Factor>,
+                       OpSequence<ApplicationStrategyFor<Rep, Factor>,
+                                  CastSequence<CastType, ApplicationOutputFor<Rep, Factor>, Rep>>> {
+};
 
 // To implement `ConversionForRepsAndFactor`, delegate to `FullConversionImpl`.
 template <typename CastType, typename OldRep, typename NewRep, typename Factor>
 struct ConversionForRepsAndFactorImpl
     : FullConversionImpl<CastType, OldRep, ConversionRep<OldRep, NewRep>, NewRep, Factor> {};
+
+// Identity factor: just cast, no arithmetic.
+template <typename CastType, typename OldRep, typename NewRep>
+struct ConversionForRepsAndFactorImpl<CastType, OldRep, NewRep, Magnitude<>>
+    : stdx::type_identity<CastSequence<CastType, OldRep, NewRep>> {};
+
+// Specialization for `void`: apply the conversion factor with proper promotion,
+// but don't add a final cast to force a specific output type.
+template <typename CastType, typename OldRep, typename Factor>
+struct ConversionForRepsAndFactorImpl<CastType, OldRep, void, Factor>
+    : FullConversionImpl<CastType,
+                         OldRep,
+                         PromotedType<OldRep>,
+                         ApplicationOutputFor<PromotedType<OldRep>, Factor>,
+                         Factor> {};
+
+// Identity factor, implicit rep: no conversion at all.
+template <typename CastType, typename OldRep>
+struct ConversionForRepsAndFactorImpl<CastType, OldRep, void, Magnitude<>>
+    : FullConversionImpl<CastType, OldRep, OldRep, OldRep, Magnitude<>> {};
 
 }  // namespace detail
 }  // namespace au

--- a/au/conversion_strategy.hh
+++ b/au/conversion_strategy.hh
@@ -23,10 +23,11 @@ namespace detail {
 
 //
 // `ConversionForRepsAndFactor<CastType, OldRep, NewRep, Factor>` is the operation that takes a
-// value of `OldRep`, and produces the product of that value with magnitude `Factor` in the type
-// `NewRep`, using casting operations according to `CastType` (`static_cast` or implicit
-// conversions).
-//
+// value of `OldRep`, and produces the product of that value with magnitude `Factor`.
+// If `NewRep` is `void`, the operation omits the final cast and returns the “natural” result type
+// of applying the conversion factor (after any required promotion).
+// Otherwise, the result is cast to `NewRep`, using casting operations according to `CastType`
+// (`static_cast` or implicit conversions).
 template <typename CastType, typename OldRep, typename NewRep, typename Factor>
 struct ConversionForRepsAndFactorImpl;
 template <typename CastType, typename OldRep, typename NewRep, typename Factor>

--- a/au/conversion_strategy.hh
+++ b/au/conversion_strategy.hh
@@ -24,10 +24,13 @@ namespace detail {
 //
 // `ConversionForRepsAndFactor<CastType, OldRep, NewRep, Factor>` is the operation that takes a
 // value of `OldRep`, and produces the product of that value with magnitude `Factor`.
-// If `NewRep` is `void`, the operation omits the final cast and returns the “natural” result type
+//
+// If `NewRep` is `void`, the operation omits the final cast and returns the "natural" result type
 // of applying the conversion factor (after any required promotion).
+//
 // Otherwise, the result is cast to `NewRep`, using casting operations according to `CastType`
 // (`static_cast` or implicit conversions).
+//
 template <typename CastType, typename OldRep, typename NewRep, typename Factor>
 struct ConversionForRepsAndFactorImpl;
 template <typename CastType, typename OldRep, typename NewRep, typename Factor>

--- a/au/conversion_strategy.hh
+++ b/au/conversion_strategy.hh
@@ -190,7 +190,7 @@ struct ConversionForRepsAndFactorImpl
 // Identity factor: just cast, no arithmetic.
 template <typename CastType, typename OldRep, typename NewRep>
 struct ConversionForRepsAndFactorImpl<CastType, OldRep, NewRep, Magnitude<>>
-    : stdx::type_identity<CastSequence<CastType, OldRep, NewRep>> {};
+    : FullConversionImpl<CastType, OldRep, ConversionRep<OldRep, NewRep>, NewRep, Magnitude<>> {};
 
 // Specialization for `void`: apply the conversion factor with proper promotion,
 // but don't add a final cast to force a specific output type.

--- a/au/no_wconversion_test.cc
+++ b/au/no_wconversion_test.cc
@@ -139,4 +139,13 @@ TEST(Conversions, SupportIntMHzToU32Hz) {
     EXPECT_THAT(freq, SameTypeAndValue(hertz(40'000'000u)));
 }
 
+TEST(Quantity, CanAssignFromPromotedTypeToOriginalType) {
+    // `int8_t + int8_t` promotes to `int`, just as it would without Au.
+    // Assigning back narrows, which is the same `-Wconversion` behavior as raw integers.
+    auto x = feet(int8_t{10});
+    auto promoted = x + x;
+    x = promoted;
+    EXPECT_THAT(x, SameTypeAndValue(feet(int8_t{20})));
+}
+
 }  // namespace au

--- a/au/no_wconversion_test.cc
+++ b/au/no_wconversion_test.cc
@@ -144,6 +144,7 @@ TEST(Quantity, CanAssignFromPromotedTypeToOriginalType) {
     // Assigning back narrows, which is the same `-Wconversion` behavior as raw integers.
     auto x = feet(int8_t{10});
     auto promoted = x + x;
+    EXPECT_THAT(promoted, SameTypeAndValue(feet(int{20})));
     x = promoted;
     EXPECT_THAT(x, SameTypeAndValue(feet(int8_t{20})));
 }

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -214,7 +214,7 @@ class Quantity {
     template <typename NewUnitSlot, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
     AU_DEVICE_FUNC constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity<AssociatedUnit<NewUnitSlot>>(
-            in_impl<detail::UseStaticCast, Rep>(u, policy));
+            in_impl<detail::UseStaticCast, void>(u, policy));
     }
 
     // `q.in<Rep>(new_unit)`, or `q.in<Rep>(new_unit, risk_policy)`
@@ -228,7 +228,7 @@ class Quantity {
     // `q.in(new_unit)`, or `q.in(new_unit, risk_policy)`
     template <typename NewUnitSlot, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
     AU_DEVICE_FUNC constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
-        return in_impl<detail::UseStaticCast, Rep>(u, policy);
+        return in_impl<detail::UseStaticCast, void>(u, policy);
     }
 
     // "Forcing" conversions, which explicitly ignore safety checks for overflow and truncation.
@@ -492,7 +492,7 @@ class Quantity {
               typename OtherRep,
               typename OtherUnitSlot,
               typename RiskPolicyT>
-    AU_DEVICE_FUNC constexpr OtherRep in_impl(OtherUnitSlot, RiskPolicyT) const {
+    AU_DEVICE_FUNC constexpr auto in_impl(OtherUnitSlot, RiskPolicyT) const {
         using OtherUnit = AssociatedUnit<OtherUnitSlot>;
         static_assert(IsUnit<OtherUnit>::value, "Invalid type passed to unit slot");
 
@@ -501,7 +501,11 @@ class Quantity {
 
         constexpr bool should_check_overflow =
             RiskPolicyT{}.should_check(detail::ConversionRisk::Overflow);
-        constexpr bool is_overflow_risk_ok = detail::OverflowRiskAcceptablyLow<Op>::value;
+        constexpr bool is_overflow_risk_ok = stdx::disjunction<
+            detail::OverflowRiskAcceptablyLow<Op>,
+            detail::PermitAsCarveOutForIntegerPromotion<OtherRep,
+                                                        UnitRatio<Unit, OtherUnit>,
+                                                        Rep>>::value;
 
         constexpr bool should_check_truncation =
             RiskPolicyT{}.should_check(detail::ConversionRisk::Truncation);
@@ -720,17 +724,17 @@ AU_DEVICE_FUNC constexpr auto root(QuantityMaker<Unit>) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Runtime conversion checkers
 
-// Check conversion for overflow (no change of rep).
+// Check conversion for overflow (implicit rep).
 template <typename U, typename R, typename TargetUnitSlot>
 AU_DEVICE_FUNC constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot) {
     using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
                                                   R,
-                                                  R,
+                                                  void,
                                                   UnitRatio<U, AssociatedUnit<TargetUnitSlot>>>;
     return detail::would_value_overflow<Op>(q.in(U{}));
 }
 
-// Check conversion for overflow (new rep).
+// Check conversion for overflow (explicit rep).
 template <typename TargetRep, typename U, typename R, typename TargetUnitSlot>
 AU_DEVICE_FUNC constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetUnitSlot) {
     using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
@@ -740,17 +744,17 @@ AU_DEVICE_FUNC constexpr bool will_conversion_overflow(Quantity<U, R> q, TargetU
     return detail::would_value_overflow<Op>(q.in(U{}));
 }
 
-// Check conversion for truncation (no change of rep).
+// Check conversion for truncation (implicit rep).
 template <typename U, typename R, typename TargetUnitSlot>
 AU_DEVICE_FUNC constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot) {
     using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
                                                   R,
-                                                  R,
+                                                  void,
                                                   UnitRatio<U, AssociatedUnit<TargetUnitSlot>>>;
     return detail::TruncationRiskFor<Op>::would_value_truncate(q.in(U{}));
 }
 
-// Check conversion for truncation (new rep).
+// Check conversion for truncation (explicit rep).
 template <typename TargetRep, typename U, typename R, typename TargetUnitSlot>
 AU_DEVICE_FUNC constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetUnitSlot) {
     using Op = detail::ConversionForRepsAndFactor<detail::UseStaticCast,
@@ -760,7 +764,7 @@ AU_DEVICE_FUNC constexpr bool will_conversion_truncate(Quantity<U, R> q, TargetU
     return detail::TruncationRiskFor<Op>::would_value_truncate(q.in(U{}));
 }
 
-// Check for any lossiness in conversion (no change of rep).
+// Check for any lossiness in conversion (implicit rep).
 template <typename U, typename R, typename TargetUnitSlot>
 AU_DEVICE_FUNC constexpr bool is_conversion_lossy(Quantity<U, R> q, TargetUnitSlot target_unit) {
     return will_conversion_truncate(q, target_unit) || will_conversion_overflow(q, target_unit);

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -1160,10 +1160,8 @@ TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions
 
             std::string reason{};
             if (is_lossy) {
-                const bool truncates =
-                    will_conversion_truncate<uint16_t>(original, target_units);
-                const bool overflows =
-                    will_conversion_overflow<uint16_t>(original, target_units);
+                const bool truncates = will_conversion_truncate<uint16_t>(original, target_units);
+                const bool overflows = will_conversion_overflow<uint16_t>(original, target_units);
                 ASSERT_THAT(truncates || overflows, IsTrue());
                 reason = std::string{" ("} + [&] {
                     if (truncates && overflows) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -538,13 +538,6 @@ TEST(Quantity, AdditionAndSubtractionCommuteWithUnitTagging) {
     EXPECT_THAT(feet(a) - feet(b), SameTypeAndValue(feet(a - b)));
 }
 
-TEST(Quantity, CanAssignFromPromotedTypeToOriginalType) {
-    auto x = feet(int8_t{10});
-    auto promoted = x + x;
-    x = promoted;
-    EXPECT_THAT(x, SameTypeAndValue(feet(int8_t{20})));
-}
-
 TEST(Quantity, CanMultiplyArbitraryQuantities) {
     constexpr auto v = (feet / hour)(2);
     constexpr auto t = hours(3);

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -491,6 +491,13 @@ TEST(Quantity, AdditionAndSubtractionCommuteWithUnitTagging) {
     EXPECT_THAT(feet(a) - feet(b), SameTypeAndValue(feet(a - b)));
 }
 
+TEST(Quantity, CanAssignFromPromotedTypeToOriginalType) {
+    auto x = feet(int8_t{10});
+    auto promoted = x + x;
+    x = promoted;
+    EXPECT_THAT(x, SameTypeAndValue(feet(int8_t{20})));
+}
+
 TEST(Quantity, CanMultiplyArbitraryQuantities) {
     constexpr auto v = (feet / hour)(2);
     constexpr auto t = hours(3);
@@ -548,10 +555,9 @@ TEST(Quantity, SupportsConvertingUnitsForComplexQuantity) {
 }
 
 TEST(Quantity, ConvertingByNegativeOneCanBeDoneImplicitly) {
-    // Use `int8_t`, because it's a type that requires the special carve-out.
     constexpr auto neginches = inches * (-mag<1>());
     constexpr auto q = inches(int8_t{-10});
-    EXPECT_THAT(q.as(neginches), SameTypeAndValue(neginches(int8_t{10})));
+    EXPECT_THAT(q.as(neginches), SameTypeAndValue(neginches(detail::PromotedType<int8_t>{10})));
 }
 
 TEST(Quantity, AsCanExplicitlyOptOutOfOverflowRiskCheck) {
@@ -603,7 +609,7 @@ TEST(Quantity, InCanExplicitlyOptOutOfTruncationRiskCheckForExplicitRep) {
 }
 
 TEST(Quantity, IgnoringOverflowRiskCanProduceOverflow) {
-    EXPECT_THAT(seconds(uint8_t{1}).as(milli(seconds), ignore(OVERFLOW_RISK)),
+    EXPECT_THAT(seconds(uint8_t{1}).as<uint8_t>(milli(seconds), ignore(OVERFLOW_RISK)),
                 SameTypeAndValue(milli(seconds)(uint8_t{1'000 % 256})));
 }
 
@@ -1008,14 +1014,22 @@ TEST(WillConversionOverflow, SensitiveToTypeBoundariesForPureIntegerMultiply) {
     }
 
     {
-        auto will_m_to_mm_overflow_u8 = [](uint8_t x) {
+        auto will_m_to_mm_overflow_u8_implicit = [](uint8_t x) {
             return will_conversion_overflow(meters(x), milli(meters));
         };
+        auto will_m_to_mm_overflow_u8_explicit = [](uint8_t x) {
+            return will_conversion_overflow<uint8_t>(meters(x), milli(meters));
+        };
 
-        EXPECT_THAT(will_m_to_mm_overflow_u8(255), IsTrue());
+        // Implicit rep promotes to int, so no overflow.
+        EXPECT_THAT(will_m_to_mm_overflow_u8_implicit(255), IsFalse());
+        EXPECT_THAT(will_m_to_mm_overflow_u8_implicit(1), IsFalse());
+        EXPECT_THAT(will_m_to_mm_overflow_u8_implicit(0), IsFalse());
 
-        EXPECT_THAT(will_m_to_mm_overflow_u8(1), IsTrue());
-        EXPECT_THAT(will_m_to_mm_overflow_u8(0), IsFalse());
+        // Explicit uint8_t rep: 255 * 1000 and 1 * 1000 both overflow uint8_t.
+        EXPECT_THAT(will_m_to_mm_overflow_u8_explicit(255), IsTrue());
+        EXPECT_THAT(will_m_to_mm_overflow_u8_explicit(1), IsTrue());
+        EXPECT_THAT(will_m_to_mm_overflow_u8_explicit(0), IsFalse());
     }
 
     {
@@ -1129,7 +1143,7 @@ TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions
             const bool did_value_change = (original != round_trip);
 
             // Function under test:
-            const bool is_lossy = is_conversion_lossy(original, target_units);
+            const bool is_lossy = is_conversion_lossy<uint16_t>(original, target_units);
 
             // In order for the test to be valid, we assume the second "leg" of the round-trip
             // conversion never introduces any **new** lossiness.  (It's OK for it to be lossy, but
@@ -1139,14 +1153,17 @@ TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions
             // fundamentally, "lossiness" is all about destroying the information you need to
             // recover the original value.
             if (!is_lossy) {
-                const bool is_inverse_lossy = is_conversion_lossy(converted, source_units);
+                const bool is_inverse_lossy =
+                    is_conversion_lossy<uint16_t>(converted, source_units);
                 ASSERT_THAT(is_inverse_lossy, IsFalse());
             }
 
             std::string reason{};
             if (is_lossy) {
-                const bool truncates = will_conversion_truncate(original, target_units);
-                const bool overflows = will_conversion_overflow(original, target_units);
+                const bool truncates =
+                    will_conversion_truncate<uint16_t>(original, target_units);
+                const bool overflows =
+                    will_conversion_overflow<uint16_t>(original, target_units);
                 ASSERT_THAT(truncates || overflows, IsTrue());
                 reason = std::string{" ("} + [&] {
                     if (truncates && overflows) {

--- a/fuzz/quantity_runtime_conversion_checkers_test.cc
+++ b/fuzz/quantity_runtime_conversion_checkers_test.cc
@@ -101,7 +101,7 @@ TYPED_TEST_P(QuantityRuntimeConversionChecker, RoundTripIsIdentityIffConversionN
     for (auto _ = 1'000'000u; --_;) {
         const auto value = meters(generator.next_value());
 
-        const bool expect_loss = is_conversion_lossy(value, destination_unit);
+        const bool expect_loss = is_conversion_lossy<Rep>(value, destination_unit);
 
         const auto round_trip = value.coerce_as(destination_unit).coerce_as(meters);
         const bool actual_loss = (value != round_trip);


### PR DESCRIPTION
From now on, whenever we do not name the rep in a conversion, we'll
obtain whatever type we would naturally get if we wrote out the
conversion by hand.  The main place this makes a difference today is
promotable integers.  In the future, this will be critical for libraries
with expression templates, particularly Eigen.

To get the mechanics right, we need to make a bunch of updates to our
`:conversion_strategy` target.  Many of these involve explicitly
templating intermediate result types, instead of assuming they're the
same as the input type.  But the main new interface property is that _an
output rep of `void` is our signal for omitting the final cast
operation_.

Then, we take advantage of this by changing our implicit-rep conversion
functions in `Quantity` to use `void` as the rep type.  (`QuantityPoint`
follows naturally because it uses `Quantity` under the hood.)

We also need to tweak our overflow risk check in `in_impl`.  We need to
make the integer promotion carve-out explicit.

One common forced downstream change is that our conversion risk checkers
need to change to their explicit-rep versions in explicit-rep contexts
that we didn't formerly recognize as such.  The main place this crops up
is in `Constant`, where we had formerly been manifesting the constant as
`T{1}`, and then just using implicit rep to convert to the target unit.

Finally, as prep for the vector/matrix changes, I realized our ordering
in the main `PermitAsCarveOutForIntegerPromotion` implementation was not
as efficient as it could be.  I decided to move the `is_integral` checks
closer to the top, as they should be a lot more common than promotion
and unsigned checks, which don't really even make sense for non-integral
types.

Helps #484.  This PR is a major unblocker for Eigen being usable and
performant.