### PR TITLE
Fix compile-time factorization hitting constexpr step limit (#328)

### DIFF
--- a/au/magnitude_test.cc
+++ b/au/magnitude_test.cc
@@ -55,6 +55,14 @@ TEST(Magnitude, SupportsEqualityComparison) {
     EXPECT_THAT(mag_1, Ne(mag_2));
 }
 
+TEST(Magnitude, CanFactorNumberWithMultipleLargePrimeFactors) {
+    // Regression test for https://github.com/aurora-opensource/au/issues/328: this used to fail to
+    // compile, because factoring the number exceeded the compiler's constexpr "step limit".
+    // 9'000'000'000'000'000'500 = 2^2 * 5^3 * 89'278'723 * 201'615'787.
+    EXPECT_THAT(mag<9'000'000'000'000'000'500u>(),
+                Eq(pow<2>(mag<2>()) * pow<3>(mag<5>()) * mag<89'278'723>() * mag<201'615'787>()));
+}
+
 TEST(Magnitude, SupportsOrderingComparison) {
     // Basic ordering.
     EXPECT_THAT(mag<1>(), Lt(mag<2>()));

--- a/au/utility/factoring.hh
+++ b/au/utility/factoring.hh
@@ -41,6 +41,63 @@ constexpr std::uintmax_t absolute_diff(std::uintmax_t a, std::uintmax_t b) {
     return a > b ? a - b : b - a;
 }
 
+// A single attempt at Pollard's rho, using Brent's cycle detection method, with the polynomial
+// `x^2 + t`.  Returns a nontrivial factor of `n` on success, or `n` itself if this particular
+// parameterization fails to find one (in which case the caller should retry with a different `t`).
+//
+// To keep the number of (relatively expensive) `gcd` calls small, we accumulate the product of the
+// position differences modulo `n` across a batch of steps, and take only a single `gcd` per batch.
+// This is the standard batched form of Brent's algorithm; it trades many `gcd` calls for many
+// (much cheaper) `mul_mod` calls, which is what makes it tractable at compile time.  See
+// <https://github.com/aurora-opensource/au/issues/328>.
+//
+// Precondition: `n` is known to be composite.
+constexpr std::uintmax_t pollard_rho_attempt(std::uintmax_t n, std::uintmax_t t) {
+    constexpr std::uintmax_t batch_size = 128u;
+
+    std::uintmax_t anchor = 2u;
+    std::uintmax_t cursor = 2u;
+    std::uintmax_t batch_start = 2u;
+    std::uintmax_t diff_product = 1u;
+    std::uintmax_t factor = 1u;
+    std::uintmax_t segment_length = 1u;
+
+    do {
+        anchor = cursor;
+        for (std::uintmax_t i = 0u; i < segment_length; ++i) {
+            cursor = x_squared_plus_t_mod_n(cursor, t, n);
+        }
+
+        std::uintmax_t offset_in_segment = 0u;
+        while (offset_in_segment < segment_length && factor == 1u) {
+            batch_start = cursor;
+            const std::uintmax_t remaining = segment_length - offset_in_segment;
+            const std::uintmax_t steps = (batch_size < remaining) ? batch_size : remaining;
+            for (std::uintmax_t i = 0u; i < steps; ++i) {
+                cursor = x_squared_plus_t_mod_n(cursor, t, n);
+                diff_product = mul_mod(diff_product, absolute_diff(anchor, cursor), n);
+            }
+            factor = gcd(diff_product, n);
+            offset_in_segment += batch_size;
+        }
+
+        segment_length *= 2u;
+    } while (factor == 1u);
+
+    // If the batched product happened to accumulate _all_ of `n`'s factors at once (`factor == n`),
+    // the batch hid the real factor.  Recover it by walking the same steps one at a time, taking a
+    // `gcd` after each, until we isolate a single nontrivial factor.
+    if (factor == n) {
+        factor = 1u;
+        do {
+            batch_start = x_squared_plus_t_mod_n(batch_start, t, n);
+            factor = gcd(absolute_diff(anchor, batch_start), n);
+        } while (factor == 1u);
+    }
+
+    return factor;
+}
+
 // Pollard's rho algorithm, using Brent's cycle detection method.
 //
 // Precondition: `n` is known to be composite.
@@ -50,23 +107,8 @@ constexpr std::uintmax_t find_pollard_rho_factor(std::uintmax_t n) {
     // will succeed on the first iteration, and we don't expect that any will _ever_ come anywhere
     // _near_ to hitting this limit.
     for (std::uintmax_t t = 1u; t < n / 2u; ++t) {
-        std::size_t max_cycle_length = 1u;
-        std::size_t cycle_length = 1u;
-        std::uintmax_t tortoise = 2u;
-        std::uintmax_t hare = x_squared_plus_t_mod_n(tortoise, t, n);
-
-        std::uintmax_t factor = gcd(n, absolute_diff(tortoise, hare));
-        while (factor == 1u) {
-            if (max_cycle_length == cycle_length) {
-                tortoise = hare;
-                max_cycle_length *= 2u;
-                cycle_length = 0u;
-            }
-            hare = x_squared_plus_t_mod_n(hare, t, n);
-            ++cycle_length;
-            factor = gcd(n, absolute_diff(tortoise, hare));
-        }
-        if (factor < n) {
+        const std::uintmax_t factor = pollard_rho_attempt(n, t);
+        if (factor != n) {
             return factor;
         }
     }

--- a/au/utility/mod.hh
+++ b/au/utility/mod.hh
@@ -81,11 +81,6 @@ constexpr uint64_t mul_mod_via_chunking(uint64_t a, uint64_t b, uint64_t n) {
 // Precondition: (a < n).
 // Precondition: (b < n).
 constexpr uint64_t mul_mod(uint64_t a, uint64_t b, uint64_t n) {
-    // Start by trying the simplest case, where the product "fits" in a `uint64_t`.
-    if (b == 0u || a < std::numeric_limits<uint64_t>::max() / b) {
-        return (a * b) % n;
-    }
-
 #if defined(__SIZEOF_INT128__)
     // If the compiler provides a 128-bit integer type, we can form the full-width product and
     // reduce it in a single step.  This is dramatically cheaper at compile time than the portable

--- a/au/utility/mod.hh
+++ b/au/utility/mod.hh
@@ -44,11 +44,18 @@ constexpr uint64_t sub_mod(uint64_t a, uint64_t b, uint64_t n) {
     }
 }
 
-// (a * b) % n
+// (a * b) % n, computed without ever overflowing `uint64_t`.
+//
+// This is a portable fallback for `mul_mod` (below), used when no wider integer type is available.
+// It reduces the product in "negative space", splitting `b` into chunks small enough that every
+// intermediate product fits in a `uint64_t` and recursing on a strictly smaller problem.  The
+// recursion is bounded to `O(log b)` depth (after the first step, each level at least halves `b`),
+// which is what makes it cheap enough to use during compile-time prime factorization (see
+// https://github.com/aurora-opensource/au/issues/328).
 //
 // Precondition: (a < n).
 // Precondition: (b < n).
-constexpr uint64_t mul_mod(uint64_t a, uint64_t b, uint64_t n) {
+constexpr uint64_t mul_mod_via_chunking(uint64_t a, uint64_t b, uint64_t n) {
     // Start by trying the simplest case, where everything "fits".
     if (b == 0u || a < std::numeric_limits<uint64_t>::max() / b) {
         return (a * b) % n;
@@ -60,13 +67,35 @@ constexpr uint64_t mul_mod(uint64_t a, uint64_t b, uint64_t n) {
     uint64_t chunk_size = n / a;
     uint64_t num_chunks = b / chunk_size;
     uint64_t negative_chunk = n - (a * chunk_size);  // == n % a  (but this should be cheaper)
-    uint64_t chunk_result = n - mul_mod(negative_chunk, num_chunks, n);
+    uint64_t chunk_result = n - mul_mod_via_chunking(negative_chunk, num_chunks, n);
 
     // Compute the leftover.  (We don't need to recurse, because we know it will fit.)
     uint64_t leftover = b - num_chunks * chunk_size;
     uint64_t leftover_result = (a * leftover) % n;
 
     return add_mod(chunk_result, leftover_result, n);
+}
+
+// (a * b) % n
+//
+// Precondition: (a < n).
+// Precondition: (b < n).
+constexpr uint64_t mul_mod(uint64_t a, uint64_t b, uint64_t n) {
+    // Start by trying the simplest case, where the product "fits" in a `uint64_t`.
+    if (b == 0u || a < std::numeric_limits<uint64_t>::max() / b) {
+        return (a * b) % n;
+    }
+
+#if defined(__SIZEOF_INT128__)
+    // If the compiler provides a 128-bit integer type, we can form the full-width product and
+    // reduce it in a single step.  This is dramatically cheaper at compile time than the portable
+    // fallback, which matters because `mul_mod` dominates the cost of compile-time prime
+    // factorization (see https://github.com/aurora-opensource/au/issues/328).
+    return static_cast<uint64_t>((static_cast<__uint128_t>(a) * static_cast<__uint128_t>(b)) % n);
+#else
+    // No wider integer type is available (e.g. MSVC), so fall back to the portable algorithm.
+    return mul_mod_via_chunking(a, b, n);
+#endif
 }
 
 // (a / 2) % n

--- a/au/utility/test/factoring_test.cc
+++ b/au/utility/test/factoring_test.cc
@@ -95,6 +95,15 @@ TEST(FindFactor, CanFactorChallengingCompositeNumbers) {
         constexpr auto factor = find_prime_factor(55'245'642'489'451u);
         EXPECT_THAT(factor, AnyOf(Eq(3'716'371u), Eq(14'865'481u)));
     }
+    {
+        // Regression test for https://github.com/aurora-opensource/au/issues/328.  Factoring this
+        // number used to exceed the compiler's constexpr "step limit": first because the recursive
+        // `mul_mod` was too expensive, and then because Pollard's rho took a `gcd` on every step.
+        // Computing it as a `constexpr` forces compile-time evaluation, guarding both regressions.
+        // 18'000'000'000'000'001 = 89'278'723 * 201'615'787 (both prime).
+        constexpr auto factor = find_prime_factor(18'000'000'000'000'001u);
+        EXPECT_THAT(factor, AnyOf(Eq(89'278'723u), Eq(201'615'787u)));
+    }
 }
 
 TEST(IsPrime, FalseForLessThan2) {

--- a/au/utility/test/mod_test.cc
+++ b/au/utility/test/mod_test.cc
@@ -15,6 +15,7 @@
 #include "au/utility/mod.hh"
 
 #include <limits>
+#include <vector>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -59,6 +60,40 @@ TEST(MulMod, HandlesHugeNumbers) {
     EXPECT_THAT(mul_mod(JUST_UNDER_HALF, 10u, MAX), Eq(MAX - 5u));
 }
 
+TEST(MulMod, HandlesProductOfTwoLargeOperands) {
+    // When both operands are large, their product overflows `uint64_t`, exercising the
+    // wide-multiply path.  We use identities that hold for any modulus: since `(n - k)` is
+    // congruent to `-k`, we have e.g. `(n - 1) * (n - 1)` congruent to `1`, and `(n - 3) * (n - 5)`
+    // to `15`.
+    EXPECT_THAT(mul_mod(MAX - 1u, MAX - 1u, MAX), Eq(1u));
+    EXPECT_THAT(mul_mod(MAX - 1u, MAX - 2u, MAX), Eq(2u));
+    EXPECT_THAT(mul_mod(MAX - 3u, MAX - 5u, MAX), Eq(15u));
+}
+
+TEST(MulModViaChunking, HandlesSimpleCases) {
+    EXPECT_THAT(mul_mod_via_chunking(6u, 7u, 10u), Eq(2u));
+    EXPECT_THAT(mul_mod_via_chunking(13u, 11u, 50u), Eq(43u));
+}
+
+TEST(MulModViaChunking, MatchesMulModIncludingOverflowingProducts) {
+    // The portable fallback must agree with `mul_mod` everywhere -- including the cases that
+    // overflow `uint64_t` -- because it is the implementation used on compilers without a 128-bit
+    // integer type.  We cross-check it directly so it stays covered even where `mul_mod` itself
+    // takes the wide-multiply path instead.
+    const std::vector<uint64_t> moduli{2u, 3u, 7u, 11u, 8'723'493u, MAX / 2u, MAX - 1u, MAX};
+    for (const auto &n : moduli) {
+        const std::vector<uint64_t> values{0u, 1u, 2u, n / 3u, n / 2u, n - 2u, n - 1u};
+        for (const auto &a : values) {
+            for (const auto &b : values) {
+                if (a < n && b < n) {
+                    EXPECT_THAT(mul_mod_via_chunking(a, b, n), Eq(mul_mod(a, b, n)))
+                        << "a=" << a << ", b=" << b << ", n=" << n;
+                }
+            }
+        }
+    }
+}
+
 TEST(HalfModOdd, HalvesEvenNumbers) {
     EXPECT_THAT(half_mod_odd(0u, 11u), Eq(0u));
     EXPECT_THAT(half_mod_odd(10u, 11u), Eq(5u));
@@ -78,8 +113,8 @@ TEST(HalfModOdd, SameAsMultiplyingByCeilOfNOver2WhenNIsOdd) {
     //
     // In principle, we could replace our `half_mod_odd` implementation with this, and it would have
     // the same preconditions, but there's a chance it would be less efficient (because `mul_mod`
-    // may recurse multiple times).  Also, keeping them separate lets us use this test case as an
-    // independent check.
+    // does more work than a simple halving).  Also, keeping them separate lets us use this test
+    // case as an independent check.
     std::vector<uint64_t> n_values{9u, 11u, 8723493u, MAX};
     for (const auto &n : n_values) {
         const auto half_n = n / 2u + 1u;


### PR DESCRIPTION
## Summary

`mag<N>()` factors `N` at compile time, but some values could not be factored
because the work exceeded the compiler's constexpr step limit. For example (the
minimal repro from #328):

```cpp
using namespace au;
mag<9'000'000'000'000'000'500LL>();  // error: constexpr step limit exceeded
```

This PR implements the two improvements suggested in the issue — a "double-wide"
`mul_mod` and a batched Pollard's rho — which together bring the cost back well
under the default limit.

Fixes #328.

## Root cause

The example factors as `2² · 5³ · 89278723 · 201615787`. Factoring the composite
`18000000000000001` blew the step limit in two successive places:

1. **`mul_mod`** reduces products that overflow `uint64_t` by recursion. The
   recursion is bounded (`O(log b)`), but `mul_mod` is called so heavily during
   factorization that this reduction dominated the step budget.
2. Once that was addressed, **Pollard's rho** became the bottleneck: it took a
   `gcd` on every single step.

## Changes

- **`au/utility/mod.hh`** — `mul_mod` now forms the full-width product and
  reduces it in a single step using `__uint128_t` when the compiler provides it
  (`__SIZEOF_INT128__`). Compilers without a 128-bit integer type (e.g. MSVC)
  fall back to `mul_mod_via_chunking` — the original reduction, factored out
  under its own name and otherwise unchanged.
- **`au/utility/factoring.hh`** — Pollard's rho (`pollard_rho_attempt`) is
  reimplemented using the batched form of Brent's algorithm: it accumulates the
  product of position differences modulo `n` and takes a single `gcd` per
  128-step batch (with one-step backtracking when a batch overshoots). This
  trades many expensive `gcd` calls for cheap `mul_mod` calls. Its locals are
  named after their roles (`anchor`, `cursor`, `segment_length`, …).

## Performance (constexpr step cost)

As @chiphogg measured in the review — and I reproduced locally by binary-searching
clang's `-fconstexpr-steps` for the smallest budget each factorization compiles
under — the design choices bear out:

- The `__int128` path (which most users get) is roughly an order of magnitude
  cheaper than the pre-PR code.
- The portable chunking fallback plus the batched rho comes in under the pre-PR
  code on every input tried.
- An earlier revision of this PR used a repeated-*doubling* fallback instead of
  chunking. It measured several times more expensive (~3–5×) on the path where
  the overflow branch is actually taken — enough to push numbers the library
  factors today (e.g. the existing `55'245'642'489'451` test) past clang's
  default budget. The portable fallback therefore keeps the original chunking
  reduction.

## Notes on portability

On compilers with `__int128` (GCC, Clang) the example now compiles using a small
fraction of the previous step budget. On MSVC (no `__int128`) the fallback is the
original chunking reduction, so those targets are no worse than before; but
factoring numbers this large at compile time inherently needs more than MSVC's
default `/constexpr:steps` (100,000), so such cases still require raising that
limit. This matches the situation of the existing large-number factoring tests,
which are exercised on the GCC/Clang/CMake jobs (the MSVC CI builds only the
single-file package).

## Test plan

Added unit tests (fail before, pass after):

- `mod_test.cc` — `mul_mod` with two large operands (overflowing path), plus a
  direct cross-check of the portable `mul_mod_via_chunking` against `mul_mod`.
- `factoring_test.cc` — `constexpr` factorization of `18'000'000'000'000'001`
  (compile-time regression guard).
- `magnitude_test.cc` — end-to-end `mag<9'000'000'000'000'000'500>()` against its
  known factorization.

Additional local verification:

- `mul_mod` (both paths) cross-checked against an independent `__uint128_t`
  reference over millions of random inputs; `find_prime_factor` outputs verified
  to be prime and to divide the input across many random and hard cases.
- Builds clean under `-std=c++14/17/20` with `-Werror -Wall -Wextra
  -Wconversion -Wsign-conversion -Wpedantic`, and is `clang-format`-clean.

Note: This PR has been done with Claude Opus. Not sure if this work is compatible with your "Aurora Individual Contributor License Agreement". Please let me know.
