### PR TITLE
Enable using ref for unscaled quantity inputs

### DIFF
--- a/au/math.hh
+++ b/au/math.hh
@@ -748,8 +748,15 @@ AU_DEVICE_FUNC constexpr auto int_round_as_explicit_rep_impl(RoundingUnits, QTyp
 
     constexpr auto target = AppropriateAssociatedUnit<QType, RoundingUnits>{};
     auto trunced = val.template as<OutputRep>(target, ignore(TRUNCATION_RISK));
+
+    // Compute the fractional remainder `val - trunced` in an intermediate rep that is both precise
+    // enough to preserve `val`'s fractional part (so it must be at least as precise as `R`) and
+    // wide enough to hold the (already truncated) integer value (so it must cover `OutputRep`).
+    using CalcRep = typename detail::IntermediateRep<R, OutputRep>::type;
+
     trunced.data_in(target) +=
-        (val - trunced).template in<OutputRep>(target / mag<2>(), ignore(TRUNCATION_RISK));
+        (rep_cast<CalcRep>(val) - rep_cast<CalcRep>(trunced))
+            .template in<OutputRep>(target / mag<2>(), ignore(TRUNCATION_RISK));
     return trunced;
 }
 // (a) Version for Quantity.

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -953,13 +953,15 @@ using ExplicitRepFor = typename ExplicitRepForImpl<R, M, OtherR>::type;
 // Scaled conversion, given the already-decided host rep (`void` => convert implicitly).
 template <typename Host, typename TargetUnit, typename U, typename R>
 struct ScaledCopy {  // Host is a concrete rep: materialize into it.
-    constexpr auto operator()(const Quantity<U, R> &q) const {
-        return q.template in<Host>(TargetUnit{});
+    AU_DEVICE_FUNC constexpr auto operator()(const Quantity<U, R> &q) const {
+        return q.template in<Host>(TargetUnit{}, check_for(ALL_RISKS));
     }
 };
 template <typename TargetUnit, typename U, typename R>
 struct ScaledCopy<void, TargetUnit, U, R> {  // No host rep: convert implicitly (lazy).
-    constexpr auto operator()(const Quantity<U, R> &q) const { return q.in(TargetUnit{}); }
+    AU_DEVICE_FUNC constexpr auto operator()(const Quantity<U, R> &q) const {
+        return q.in(TargetUnit{});
+    }
 };
 
 // Top level: return a reference when no conversion is needed; otherwise, delegate to ScaledCopy.
@@ -971,7 +973,7 @@ template <typename OtherR,
 struct RefOrScaledCopy {
     static_assert(IsUnitEquivalent,
                   "Primary template should only be instantiated when units are equivalent");
-    constexpr decltype(auto) operator()(const Quantity<U, R> &q) const {
+    AU_DEVICE_FUNC constexpr decltype(auto) operator()(const Quantity<U, R> &q) const {
         return q.data_in(TargetUnit{});
     }
 };
@@ -980,7 +982,7 @@ struct RefOrScaledCopy<OtherR, TargetUnit, U, R, false>
     : ScaledCopy<ExplicitRepFor<R, UnitRatio<U, TargetUnit>, OtherR>, TargetUnit, U, R> {};
 
 template <typename OtherR, typename TargetUnit, typename U, typename R>
-constexpr decltype(auto) ref_or_scaled_copy(TargetUnit, const Quantity<U, R> &q) {
+AU_DEVICE_FUNC constexpr decltype(auto) ref_or_scaled_copy(TargetUnit, const Quantity<U, R> &q) {
     return RefOrScaledCopy<OtherR, TargetUnit, U, R>{}(q);
 }
 

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -863,36 +863,6 @@ AU_DEVICE_FUNC constexpr bool is_conversion_lossy(Quantity<U, R> q, TargetUnitSl
 // Comparing and/or combining Quantities of different types.
 
 namespace detail {
-// Helper to cast this Quantity to its common type with some other Quantity (explicitly supplied).
-//
-// Note that `TargetUnit` is supposed to be the common type of the input Quantity and some other
-// Quantity.  This function should never be called directly; it should only be called by
-// `using_common_type()`.  The program behaviour is undefined if anyone calls this function
-// directly.  (In particular, we explicitly assume that the conversion to the Rep of TargetUnit is
-// not narrowing for the input Quantity.)
-//
-// We would have liked this to just be a simple lambda, but some old compilers sometimes struggle
-// with understanding that the lambda implementation of this can be constexpr.
-template <typename TargetUnit, typename U, typename R>
-AU_DEVICE_FUNC constexpr auto cast_to_common_type(Quantity<U, R> q) {
-    // When we perform a unit conversion to U, we need to make sure the library permits this
-    // conversion *implicitly* for a rep R.  The form `rep_cast<R>(q).as(U{})` achieves
-    // this.  First, we cast the Rep to R (which will typically be the wider of the input Reps).
-    // Then, we use the *unit-only* form of the conversion operator: `as(U{})`, not
-    // `as<R>(U{})`, because only the former actually checks the conversion policy.
-    return rep_cast<typename TargetUnit::Rep>(q).as(TargetUnit::unit);
-}
-
-template <typename T, typename U, typename Func>
-AU_DEVICE_FUNC constexpr auto using_common_type(T t, U u, Func f) {
-    using C = std::common_type_t<T, U>;
-    static_assert(
-        std::is_same<typename C::Rep, std::common_type_t<typename T::Rep, typename U::Rep>>::value,
-        "Rep of common type is not common type of Reps (this should never occur)");
-
-    return f(cast_to_common_type<C>(t), cast_to_common_type<C>(u));
-}
-
 template <typename Op, typename U1, typename U2, typename R1, typename R2>
 AU_DEVICE_FUNC constexpr auto convert_and_compare(const Quantity<U1, R1> &q1,
                                                   const Quantity<U2, R2> &q2) {
@@ -931,14 +901,103 @@ AU_DEVICE_FUNC constexpr bool operator>=(const Quantity<U1, R1> &q1, const Quant
     return detail::convert_and_compare<detail::GreaterEqual>(q1, q2);
 }
 
+namespace detail {
+
+//
+// The explicit rep in which to *host* an operand's unit conversion, or `void` for implicit rep.
+//
+// When two Quantities with different units are combined, one or both operands must be scaled by
+// some conversion magnitude `M`.  That scaling has to be carried out in some rep.  By default we
+// use the operand's own rep `R` (signaled by `void` here), which preserves expression-template
+// laziness for reps such as Eigen.  We relocate to a different "host" rep only when that host is a
+// *safer* place to apply `M` -- e.g. wide enough to avoid integer overflow, or able to represent a
+// non-integer `M` that `R` cannot.
+//
+// The decision is fundamentally per-operand and asymmetric: it depends on the operand's own rep
+// `R`, the conversion magnitude `M` it undergoes, and the other operand's rep `OtherR`.  Today, we
+// simply use `std::common_type`.  `M` is not consulted yet; it is part of the signature because a
+// future, rep-agnostic overflow/truncation risk model will need it to compare "risk of applying `M`
+// in `R`" against "risk of applying `M` in the host".
+//
+// Today we can only reliably reason about this for arithmetic reps: we relocate to
+// `std::common_type_t<R, OtherR>` when it differs from `R` (the usual arithmetic conversions yield
+// a type with more headroom, and make a non-integer `M` representable).  For non-arithmetic reps we
+// lack both a risk model and a meaningful common rep, so we never relocate yet.
+//
+template <typename R,
+          typename M,
+          typename OtherR,
+          bool BothArithmetic =
+              stdx::conjunction<std::is_arithmetic<R>, std::is_arithmetic<OtherR>>::value>
+struct ExplicitRepForImpl : stdx::type_identity<void> {};
+template <typename R, typename M, typename OtherR>
+struct ExplicitRepForImpl<R, M, OtherR, true>
+    : std::conditional<std::is_same<std::common_type_t<R, OtherR>, R>::value,
+                       void,
+                       std::common_type_t<R, OtherR>> {};
+template <typename R, typename M, typename OtherR>
+using ExplicitRepFor = typename ExplicitRepForImpl<R, M, OtherR>::type;
+
+//
+// `ref_or_scaled_copy<OtherR>(target, q)` converts `q` to `target`, choosing how to host the
+// conversion:
+//   - `q.data_in(target)` (a reference) when units are quantity-equivalent (no conversion);
+//   - `q.in<Host>(target)` some explicit "host" rep, `Host`, for cases where we determine that
+//     implicit-rep is not good enough (e.g., it needlessly increases overflow or truncation risk).
+//   - `q.in(target)` (implicit) otherwise.  Note that this pathway preserves expression templates
+//     (laziness) in the case of libraries, such as Eigen, which use this approach.
+//
+// `OtherR` is the rep of the *other* operand in the enclosing operation; see `ExplicitRepFor`.
+//
+
+// Scaled conversion, given the already-decided host rep (`void` => convert implicitly).
+template <typename Host, typename TargetUnit, typename U, typename R>
+struct ScaledCopy {  // Host is a concrete rep: materialize into it.
+    constexpr auto operator()(const Quantity<U, R> &q) const {
+        return q.template in<Host>(TargetUnit{});
+    }
+};
+template <typename TargetUnit, typename U, typename R>
+struct ScaledCopy<void, TargetUnit, U, R> {  // No host rep: convert implicitly (lazy).
+    constexpr auto operator()(const Quantity<U, R> &q) const { return q.in(TargetUnit{}); }
+};
+
+// Top level: return a reference when no conversion is needed; otherwise, delegate to ScaledCopy.
+template <typename OtherR,
+          typename TargetUnit,
+          typename U,
+          typename R,
+          bool IsUnitEquivalent = are_units_quantity_equivalent(TargetUnit{}, U{})>
+struct RefOrScaledCopy {
+    static_assert(IsUnitEquivalent,
+                  "Primary template should only be instantiated when units are equivalent");
+    constexpr decltype(auto) operator()(const Quantity<U, R> &q) const {
+        return q.data_in(TargetUnit{});
+    }
+};
+template <typename OtherR, typename TargetUnit, typename U, typename R>
+struct RefOrScaledCopy<OtherR, TargetUnit, U, R, false>
+    : ScaledCopy<ExplicitRepFor<R, UnitRatio<U, TargetUnit>, OtherR>, TargetUnit, U, R> {};
+
+template <typename OtherR, typename TargetUnit, typename U, typename R>
+constexpr decltype(auto) ref_or_scaled_copy(TargetUnit, const Quantity<U, R> &q) {
+    return RefOrScaledCopy<OtherR, TargetUnit, U, R>{}(q);
+}
+
+}  // namespace detail
+
 // Addition and subtraction functions for compatible Quantity types.
 template <typename U1, typename U2, typename R1, typename R2>
 AU_DEVICE_FUNC constexpr auto operator+(const Quantity<U1, R1> &q1, const Quantity<U2, R2> &q2) {
-    return detail::using_common_type(q1, q2, detail::plus);
+    using U = CommonUnit<U1, U2>;
+    return make_quantity<U>(detail::ref_or_scaled_copy<R2>(U{}, q1) +
+                            detail::ref_or_scaled_copy<R1>(U{}, q2));
 }
 template <typename U1, typename U2, typename R1, typename R2>
 AU_DEVICE_FUNC constexpr auto operator-(const Quantity<U1, R1> &q1, const Quantity<U2, R2> &q2) {
-    return detail::using_common_type(q1, q2, detail::minus);
+    using U = CommonUnit<U1, U2>;
+    return make_quantity<U>(detail::ref_or_scaled_copy<R2>(U{}, q1) -
+                            detail::ref_or_scaled_copy<R1>(U{}, q2));
 }
 
 // Mixed-type operations with a left-Quantity, and right-Quantity-equivalent.

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -64,12 +64,70 @@ struct Vec {
     }
 };
 
+// Minimal expression template mock.  Arithmetic on HeapDouble returns a lightweight HeapExpr that
+// stores a pointer to the source data on the heap, deferring evaluation.  Because HeapDouble
+// heap-allocates, ASAN reliably detects use-after-free if a conversion path lets the source die
+// before the expression is evaluated --- exactly the bug that RefOrScaledCopyIn prevents.
+struct HeapExpr {
+    const double *source;
+    double scale;
+    double eval() const { return *source * scale; }
+
+    friend double operator+(HeapExpr a, HeapExpr b) { return a.eval() + b.eval(); }
+    friend double operator-(HeapExpr a, HeapExpr b) { return a.eval() - b.eval(); }
+};
+
+struct HeapDouble {
+    double *ptr;
+
+    HeapDouble() : ptr(new double(0.0)) {}
+    explicit HeapDouble(double v) : ptr(new double(v)) {}
+    HeapDouble(const HeapDouble &other) : ptr(new double(*other.ptr)) {}
+    HeapDouble(HeapDouble &&other) noexcept : ptr(other.ptr) { other.ptr = nullptr; }
+    HeapDouble &operator=(const HeapDouble &other) {
+        *ptr = *other.ptr;
+        return *this;
+    }
+    HeapDouble &operator=(HeapDouble &&other) noexcept {
+        delete ptr;
+        ptr = other.ptr;
+        other.ptr = nullptr;
+        return *this;
+    }
+    ~HeapDouble() { delete ptr; }
+
+    operator HeapExpr() const { return {ptr, 1.0}; }
+
+    friend HeapExpr operator*(const HeapDouble &v, double s) { return {v.ptr, s}; }
+    friend HeapExpr operator*(double s, const HeapDouble &v) { return {v.ptr, s}; }
+    friend HeapExpr operator/(const HeapDouble &v, double s) { return {v.ptr, 1.0 / s}; }
+
+    friend HeapDouble operator+(const HeapDouble &a, const HeapDouble &b) {
+        return HeapDouble{*a.ptr + *b.ptr};
+    }
+    friend HeapDouble operator-(const HeapDouble &a, const HeapDouble &b) {
+        return HeapDouble{*a.ptr - *b.ptr};
+    }
+};
+
 }  // namespace test_types
+
+template <>
+struct std::numeric_limits<test_types::HeapExpr> : std::numeric_limits<double> {};
+
+template <>
+struct std::numeric_limits<test_types::HeapDouble> : std::numeric_limits<double> {};
 
 namespace au {
 
 template <typename T, std::size_t N>
 struct ScalarOfTrait<test_types::Vec<T, N>> : stdx::type_identity<T> {};
+
+template <>
+struct ScalarOfTrait<test_types::HeapDouble> : stdx::type_identity<double> {};
+
+template <>
+struct ScalarOfTrait<test_types::HeapExpr> : stdx::type_identity<double> {};
 
 using ::testing::DoubleEq;
 using ::testing::DoubleNear;
@@ -141,6 +199,12 @@ constexpr auto days = QuantityMaker<Days>{};
 
 struct PerDay : decltype(UnitInverse<Days>{}) {};
 constexpr auto per_day = QuantityMaker<PerDay>{};
+
+struct Degrees : UnitImpl<Angle> {};
+constexpr auto degrees = QuantityMaker<Degrees>{};
+
+struct Radians : decltype(Degrees{} * mag<180>() / Magnitude<Pi>{}) {};
+constexpr auto radians = QuantityMaker<Radians>{};
 
 template <typename... Us>
 constexpr auto num_units_in_product(UnitProductPack<Us...>) {
@@ -651,6 +715,10 @@ TEST(Quantity, InCanExplicitlyOptOutOfTruncationRiskCheckForExplicitRep) {
 TEST(Quantity, IgnoringOverflowRiskCanProduceOverflow) {
     EXPECT_THAT(seconds(uint8_t{1}).as<uint8_t>(milli(seconds), ignore(OVERFLOW_RISK)),
                 SameTypeAndValue(milli(seconds)(uint8_t{1'000 % 256})));
+}
+
+TEST(Quantity, MixedRepMixedUnitSubtractionWorks) {
+    EXPECT_THAT(radians(1.0) - degrees(57), IsNear(degrees(0), degrees(1)));
 }
 
 TEST(Quantity, IgnoringTruncationRiskCanProduceTruncation) {
@@ -1405,6 +1473,29 @@ TEST(QuantityPassthrough, AssignmentToElementDoesNotCompile) {
     auto q = meters(make_vec(1.0, 2.0, 3.0));
     static_assert(!std::is_assignable<decltype(q[0]), decltype(meters(10.0))>::value, "");
     static_assert(!std::is_assignable<decltype(q(0)), decltype(meters(10.0))>::value, "");
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Mixed-unit arithmetic with expression-template-like rep.
+//
+// These tests exercise RefOrScaledCopyIn by using a rep type (HeapDouble) whose arithmetic returns
+// a lazy proxy (HeapExpr) holding a pointer to the source data.  Under ASAN, the old
+// cast_to_common_type / using_common_type path would trigger heap-use-after-free because it copies
+// the Quantity by value, converts to an expression referencing the copy's data, then destroys
+// the copy before the expression is evaluated.
+
+TEST(MixedUnitExprTemplate, AdditionEvaluatesCorrectly) {
+    // 2 feet + 6 inches = 24 inches + 6 inches = 30 inches.
+    auto q1 = feet(test_types::HeapDouble{2.0});
+    auto q2 = inches(test_types::HeapDouble{6.0});
+    EXPECT_THAT((q1 + q2).in(inches), DoubleEq(30.0));
+}
+
+TEST(MixedUnitExprTemplate, SubtractionEvaluatesCorrectly) {
+    // 3 feet - 12 inches = 36 inches - 12 inches = 24 inches.
+    auto q1 = feet(test_types::HeapDouble{3.0});
+    auto q2 = inches(test_types::HeapDouble{12.0});
+    EXPECT_THAT((q1 - q2).in(inches), DoubleEq(24.0));
 }
 
 }  // namespace au

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -67,7 +67,7 @@ struct Vec {
 // Minimal expression template mock.  Arithmetic on HeapDouble returns a lightweight HeapExpr that
 // stores a pointer to the source data on the heap, deferring evaluation.  Because HeapDouble
 // heap-allocates, ASAN reliably detects use-after-free if a conversion path lets the source die
-// before the expression is evaluated --- exactly the bug that RefOrScaledCopyIn prevents.
+// before the expression is evaluated --- exactly the bug that ref_or_scaled_copy prevents.
 struct HeapExpr {
     const double *source;
     double scale;
@@ -112,11 +112,13 @@ struct HeapDouble {
 
 }  // namespace test_types
 
+namespace std {
 template <>
-struct std::numeric_limits<test_types::HeapExpr> : std::numeric_limits<double> {};
+struct numeric_limits<test_types::HeapExpr> : numeric_limits<double> {};
 
 template <>
-struct std::numeric_limits<test_types::HeapDouble> : std::numeric_limits<double> {};
+struct numeric_limits<test_types::HeapDouble> : numeric_limits<double> {};
+}  // namespace std
 
 namespace au {
 
@@ -1478,7 +1480,7 @@ TEST(QuantityPassthrough, AssignmentToElementDoesNotCompile) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Mixed-unit arithmetic with expression-template-like rep.
 //
-// These tests exercise RefOrScaledCopyIn by using a rep type (HeapDouble) whose arithmetic returns
+// These tests exercise ref_or_scaled_copy by using a rep type (HeapDouble) whose arithmetic returns
 // a lazy proxy (HeapExpr) holding a pointer to the source data.  Under ASAN, the old
 // cast_to_common_type / using_common_type path would trigger heap-use-after-free because it copies
 // the Quantity by value, converts to an expression referencing the copy's data, then destroys


### PR DESCRIPTION
This might be the trickiest and most subtle part of the whole
matrix/vector/Eigen support chain.  I went back and forth on the names
and shapes of the APIs many times, even though I got all of the _tests_
to pass a long time ago.

Consider adding two Eigen vectors with different units, where one of the
inputs is already equivalent to their common unit.  That input won't be
scaled.  But the current mixed-unit addition implementation (built on
`detail::using_common_type`) _unconditionally copies_ its inputs.  That
(internal!) copy is a _temporary_, and the expression template we return
holds a _pointer_ to that temporary.  Bottom line: a library-internal
lifetime bug that wasn't present in raw Eigen, and that end users can't
do anything to fix.  Ouch!

So, we need to perform the arithmetic _directly_.  And we need a _new_
helper, which passes along the reference for unscaled inputs, but does
the usual scaling (which produces expression templates) for inputs that
need scaling.  The helper follows these rules:

1. If we're not scaling (target unit is quantity-equivalent to input),
   just return a reference unconditionally (using `.data_in`).

2. If we _are_ scaling, we need to choose between implicit and explicit
   rep.

Branch (2) is where we hit the tricky and subtle parts.  How do we know
when implicit rep is OK?  And if it's not, than _which_ rep do we use
for "explicit rep"?

We can't really hope to get a fully generic answer right now, so we're
starting with a reasonable first-draft policy, and focusing on making
sure it has the right _API shape_.

- On the shape: the inputs to this sub-utility are our own rep, the
  scale factor, and the rep of the other operand.  (This is _asymmetric_
  in the two inputs, in general.)

- On the policy: we use the common rep when both inputs are arithmetic
  types, and implicit rep otherwise.

Overall, this seems pretty safe.  We're confident in reasoning about the
built-in arithmetic types, and this covers edge cases like integral to
floating point, and integer promotion.  And "implicit rep" for third
party types is a minimal and direct translation of "do what the raw code
would do".

We also fix one implementation that was failing under `-Wconversion`.
We checked all similar functions, but found that this was the only one
that was affected.

Helps #484: this prevents what would have been a terrible bug in our
(still in-progress) Eigen support.