### PR TITLE
Add APIs for improved Eigen support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,6 +33,7 @@ bazel_dep(
 
 # Primary deps that we use directly.
 bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)
+bazel_dep(name = "eigen", version = "5.0.0", dev_dependency = True)
 bazel_dep(name = "fmt", version = "11.0.2", dev_dependency = True)
 bazel_dep(name = "gcc_toolchain", version = "0.9.0", dev_dependency = True)
 bazel_dep(name = "platforms", version = "1.0.0", dev_dependency = True)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -40,6 +40,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/source.json": "7ebaefba0b03efe59cac88ed5bbc67bcf59a3eff33af937345ede2a38b2d368a",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/eigen/5.0.0/MODULE.bazel": "65aa1b3dfcf3b22bd45150ed4ab5bfade7cdda3ca85735fb466d45386a1722c0",
+    "https://bcr.bazel.build/modules/eigen/5.0.0/source.json": "954b73ff6d95db6b6f3fed1435cd75db95bab109d83b31fd43ffaacea7e6cd72",
     "https://bcr.bazel.build/modules/fmt/11.0.2/MODULE.bazel": "d9e0ea6f68a762a84055172ce8f55cc01da950c94b5e27f66c1acc14e6fc59ce",
     "https://bcr.bazel.build/modules/fmt/11.0.2/source.json": "36cde5a3cbbee5eefc1e7f8a5a66d8ac9f352f7742bdd0c9b2d869601169c881",
     "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",

--- a/au/compatibility/BUILD.bazel
+++ b/au/compatibility/BUILD.bazel
@@ -1,0 +1,35 @@
+# Copyright 2025 Aurora Operations, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "eigen",
+    hdrs = ["eigen.hh"],
+    visibility = ["//visibility:public"],
+    deps = ["//au"],
+)
+
+cc_test(
+    name = "eigen_test",
+    size = "small",
+    srcs = ["eigen_test.cc"],
+    deps = [
+        ":eigen",
+        "//au",
+        "//au:testing",
+        "@eigen",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/au/compatibility/eigen.hh
+++ b/au/compatibility/eigen.hh
@@ -24,7 +24,7 @@ namespace au {
 //
 // Use this to materialize lazy expressions before the operands go out of scope.
 template <typename U, typename R>
-auto eval(Quantity<U, R> q) {
+auto eval(const Quantity<U, R> &q) {
     return make_quantity<U>(q.data_in(U{}).eval());
 }
 

--- a/au/compatibility/eigen.hh
+++ b/au/compatibility/eigen.hh
@@ -1,0 +1,356 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+
+#include "au/au.hh"
+
+namespace au {
+
+// Force evaluation of a Quantity whose rep is an Eigen expression template.
+//
+// Use this to materialize lazy expressions before the operands go out of scope.
+template <typename U, typename R>
+auto eval(Quantity<U, R> q) {
+    return make_quantity<U>(q.data_in(U{}).eval());
+}
+
+//
+// Free-function forms of Eigen member functions, made unit-aware.
+//
+// Eigen's `.transpose()`, `.norm()`, etc. are member functions, and `Quantity` does not forward
+// arbitrary member calls, so `q.norm()` does not compile.  These free functions fill that gap while
+// tracking how each operation transforms the unit.
+//
+// LIFETIME NOTE: operations whose Eigen counterpart returns a scalar (e.g. `norm`, `sum`, `dot`,
+// `trace`) are evaluated eagerly and are always safe.  Operations whose Eigen counterpart returns
+// an _expression template_ -- the coefficient-wise ops (`cwiseProduct`, ...) and the view/accessor
+// ops (`transpose`, `cross`, `diagonal`, `block`, `head`, ...) -- return a lazy `Quantity` that
+// references its operands, exactly like `Quantity`'s arithmetic operators.  Such a result is valid
+// only while its operands are alive; use `eval()` to materialize it otherwise.
+//
+
+// The Euclidean (L2) norm.  Unit-preserving.
+template <typename U, typename R>
+auto norm(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).norm());
+}
+
+// The squared Euclidean norm (sum of squared coefficients).  Squares the unit; avoids a `sqrt`.
+template <typename U, typename R>
+auto squaredNorm(const Quantity<U, R> &q) {
+    return make_quantity<UnitPowerT<U, 2>>(q.data_in(U{}).squaredNorm());
+}
+
+// The sum of all coefficients.  Unit-preserving.
+template <typename U, typename R>
+auto sum(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).sum());
+}
+
+// The mean of all coefficients.  Unit-preserving.
+template <typename U, typename R>
+auto mean(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).mean());
+}
+
+// The smallest coefficient.  Unit-preserving.
+template <typename U, typename R>
+auto minCoeff(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).minCoeff());
+}
+
+// The largest coefficient.  Unit-preserving.
+template <typename U, typename R>
+auto maxCoeff(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).maxCoeff());
+}
+
+// The transpose.  Unit-preserving.  LAZY: see the lifetime note above.
+template <typename U, typename R>
+auto transpose(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).transpose());
+}
+
+// The dot (inner) product.  The result unit is the product of the operand units.
+template <typename U1, typename R1, typename U2, typename R2>
+auto dot(const Quantity<U1, R1> &a, const Quantity<U2, R2> &b) {
+    return make_quantity<UnitProductT<U1, U2>>(a.data_in(U1{}).dot(b.data_in(U2{})));
+}
+
+// `dot` overloads where one operand is a raw (dimensionless) Eigen object.  The result carries the
+// unit of the `Quantity` operand.
+template <typename U, typename R, typename V>
+auto dot(const Quantity<U, R> &a, const V &b) {
+    return make_quantity<U>(a.data_in(U{}).dot(b));
+}
+template <typename V, typename U, typename R>
+auto dot(const V &a, const Quantity<U, R> &b) {
+    return make_quantity<U>(a.dot(b.data_in(U{})));
+}
+
+// The cross product.  The result unit is the product of the operand units.  LAZY: see the lifetime
+// note above.
+template <typename U1, typename R1, typename U2, typename R2>
+auto cross(const Quantity<U1, R1> &a, const Quantity<U2, R2> &b) {
+    return make_quantity<UnitProductT<U1, U2>>(a.data_in(U1{}).cross(b.data_in(U2{})));
+}
+
+// `cross` overloads where one operand is a raw (dimensionless) Eigen object.  The result carries
+// the unit of the `Quantity` operand.  LAZY: see the lifetime note above.
+template <typename U, typename R, typename V>
+auto cross(const Quantity<U, R> &a, const V &b) {
+    return make_quantity<U>(a.data_in(U{}).cross(b));
+}
+template <typename V, typename U, typename R>
+auto cross(const V &a, const Quantity<U, R> &b) {
+    return make_quantity<U>(a.cross(b.data_in(U{})));
+}
+
+// The normalized (unit-length) vector.
+//
+// The norm always carries the operand's unit, so it cancels exactly: the result is unitless *by
+// definition of the operation, for all inputs*.  Unlike operations whose unit is a function of the
+// operand units (`norm`, `squaredNorm`, `dot`, ...), there is no operand-dependent unit for a
+// `Quantity` wrapper to track, so we return the raw Eigen vector directly.  Evaluated eagerly
+// (Eigen's `.normalized()` returns a concrete vector).
+template <typename U, typename R>
+auto normalized(const Quantity<U, R> &q) {
+    return q.data_in(U{}).normalized();
+}
+
+//
+// Additional scalar-returning reductions.  All unit-preserving and evaluated eagerly.
+//
+
+// Numerically stable Euclidean norm.
+template <typename U, typename R>
+auto stableNorm(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).stableNorm());
+}
+
+// Euclidean norm computed with Kahan's "Blue's" algorithm (overflow/underflow safe).
+template <typename U, typename R>
+auto blueNorm(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).blueNorm());
+}
+
+// Euclidean norm computed via a recursive `hypot`-based scheme (overflow/underflow safe).
+template <typename U, typename R>
+auto hypotNorm(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).hypotNorm());
+}
+
+// The L^p norm.  `p` is a compile-time `int`; pass `Eigen::Infinity` for the max-absolute norm.
+template <int p, typename U, typename R>
+auto lpNorm(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).template lpNorm<p>());
+}
+
+// The trace (sum of diagonal coefficients).  Unit-preserving.
+template <typename U, typename R>
+auto trace(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).trace());
+}
+
+//
+// Coefficient-wise binary/unary ops.  LAZY: see the lifetime note above.
+//
+
+// Coefficient-wise (Hadamard) product.  The result unit is the product of the operand units.
+template <typename U1, typename R1, typename U2, typename R2>
+auto cwiseProduct(const Quantity<U1, R1> &a, const Quantity<U2, R2> &b) {
+    return make_quantity<UnitProductT<U1, U2>>(a.data_in(U1{}).cwiseProduct(b.data_in(U2{})));
+}
+template <typename U, typename R, typename V>
+auto cwiseProduct(const Quantity<U, R> &a, const V &b) {
+    return make_quantity<U>(a.data_in(U{}).cwiseProduct(b));
+}
+template <typename V, typename U, typename R>
+auto cwiseProduct(const V &a, const Quantity<U, R> &b) {
+    return make_quantity<U>(a.cwiseProduct(b.data_in(U{})));
+}
+
+// Coefficient-wise quotient.  The result unit is the quotient of the operand units.
+template <typename U1, typename R1, typename U2, typename R2>
+auto cwiseQuotient(const Quantity<U1, R1> &a, const Quantity<U2, R2> &b) {
+    return make_quantity<UnitQuotientT<U1, U2>>(a.data_in(U1{}).cwiseQuotient(b.data_in(U2{})));
+}
+template <typename U, typename R, typename V>
+auto cwiseQuotient(const Quantity<U, R> &a, const V &b) {
+    return make_quantity<U>(a.data_in(U{}).cwiseQuotient(b));
+}
+template <typename V, typename U, typename R>
+auto cwiseQuotient(const V &a, const Quantity<U, R> &b) {
+    return make_quantity<UnitInverseT<U>>(a.cwiseQuotient(b.data_in(U{})));
+}
+
+// Coefficient-wise absolute value.  Unit-preserving.
+template <typename U, typename R>
+auto cwiseAbs(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).cwiseAbs());
+}
+
+//
+// View / accessor ops.  All unit-preserving.  LAZY: see the lifetime note above.
+//
+
+// The main diagonal.
+template <typename U, typename R>
+auto diagonal(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).diagonal());
+}
+// The `index`-th diagonal (positive for super-diagonals, negative for sub-diagonals).
+template <typename U, typename R>
+auto diagonal(const Quantity<U, R> &q, std::ptrdiff_t index) {
+    return make_quantity<U>(q.data_in(U{}).diagonal(index));
+}
+
+// The `i`-th row.
+template <typename U, typename R>
+auto row(const Quantity<U, R> &q, std::ptrdiff_t i) {
+    return make_quantity<U>(q.data_in(U{}).row(i));
+}
+
+// The `j`-th column.
+template <typename U, typename R>
+auto col(const Quantity<U, R> &q, std::ptrdiff_t j) {
+    return make_quantity<U>(q.data_in(U{}).col(j));
+}
+
+// The reverse (coefficients in reverse order).
+template <typename U, typename R>
+auto reverse(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).reverse());
+}
+
+// The complex conjugate (a no-op for real reps).
+template <typename U, typename R>
+auto conjugate(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).conjugate());
+}
+
+// The first `N` (fixed-size) coefficients of a vector.
+template <int N, typename U, typename R>
+auto head(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).template head<N>());
+}
+// The first `n` (dynamic-size) coefficients of a vector.
+template <typename U, typename R>
+auto head(const Quantity<U, R> &q, std::ptrdiff_t n) {
+    return make_quantity<U>(q.data_in(U{}).head(n));
+}
+
+// The last `N` (fixed-size) coefficients of a vector.
+template <int N, typename U, typename R>
+auto tail(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).template tail<N>());
+}
+// The last `n` (dynamic-size) coefficients of a vector.
+template <typename U, typename R>
+auto tail(const Quantity<U, R> &q, std::ptrdiff_t n) {
+    return make_quantity<U>(q.data_in(U{}).tail(n));
+}
+
+// A fixed-size length-`N` segment of a vector starting at `start`.
+template <int N, typename U, typename R>
+auto segment(const Quantity<U, R> &q, std::ptrdiff_t start) {
+    return make_quantity<U>(q.data_in(U{}).template segment<N>(start));
+}
+// A dynamic-size length-`n` segment of a vector starting at `start`.
+template <typename U, typename R>
+auto segment(const Quantity<U, R> &q, std::ptrdiff_t start, std::ptrdiff_t n) {
+    return make_quantity<U>(q.data_in(U{}).segment(start, n));
+}
+
+// A fixed-size `Rows`x`Cols` block whose top-left corner is at (`i`, `j`).
+template <int Rows, int Cols, typename U, typename R>
+auto block(const Quantity<U, R> &q, std::ptrdiff_t i, std::ptrdiff_t j) {
+    return make_quantity<U>(q.data_in(U{}).template block<Rows, Cols>(i, j));
+}
+// A dynamic-size `rows`x`cols` block whose top-left corner is at (`i`, `j`).
+template <typename U, typename R>
+auto block(const Quantity<U, R> &q,
+           std::ptrdiff_t i,
+           std::ptrdiff_t j,
+           std::ptrdiff_t rows,
+           std::ptrdiff_t cols) {
+    return make_quantity<U>(q.data_in(U{}).block(i, j, rows, cols));
+}
+
+// Tile into a fixed-size `RowFactor`x`ColFactor` grid of copies.
+template <int RowFactor, int ColFactor, typename U, typename R>
+auto replicate(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).template replicate<RowFactor, ColFactor>());
+}
+// Tile into a dynamic-size `row_factor`x`col_factor` grid of copies.
+template <typename U, typename R>
+auto replicate(const Quantity<U, R> &q, std::ptrdiff_t row_factor, std::ptrdiff_t col_factor) {
+    return make_quantity<U>(q.data_in(U{}).replicate(row_factor, col_factor));
+}
+
+//
+// Ops whose result unit is a non-trivial power of the operand unit.
+//
+
+// Coefficient-wise square root.  Takes the square root of the unit.  LAZY: see the lifetime note
+// above.
+template <typename U, typename R>
+auto cwiseSqrt(const Quantity<U, R> &q) {
+    return make_quantity<UnitPowerT<U, 1, 2>>(q.data_in(U{}).cwiseSqrt());
+}
+
+// The matrix inverse.  Inverts the unit (since `A * A.inverse()` is dimensionless).  LAZY: see the
+// lifetime note above.
+//
+// This is exact for a matrix with a single shared unit, which is all `Quantity<U, Matrix>` can
+// represent today: every cell carries `U`, so every cell of the inverse carries `1 / U`.  A
+// heterogeneous matrix (distinct per-row/per-col units) also has a well-defined inverse --- the
+// cell units are the reciprocal of the transposed original --- but representing such matrices is
+// planned future work.  Until then, this is a known (temporary) gap.
+template <typename U, typename R>
+auto inverse(const Quantity<U, R> &q) {
+    return make_quantity<UnitInverseT<U>>(q.data_in(U{}).inverse());
+}
+
+// The product of all coefficients.  Raises the unit to the power of the coefficient count.
+//
+// Restricted to fixed-size operands: the result unit is `U^N` where `N` is the number of
+// coefficients, which cannot be expressed in the type system when the size is only known at
+// runtime.
+template <typename U, typename R>
+auto prod(const Quantity<U, R> &q) {
+    constexpr int N = R::SizeAtCompileTime;
+    static_assert(N != -1,  // i.e. not Eigen::Dynamic
+                  "prod() requires a fixed-size operand: its result unit is U^(coefficient count), "
+                  "which cannot be expressed when the size is only known at runtime");
+    return make_quantity<UnitPowerT<U, N>>(q.data_in(U{}).prod());
+}
+
+// The determinant.  Raises the unit to the power of the matrix dimension.
+//
+// Restricted to fixed-size operands: the result unit is `U^N` for an `N`x`N` matrix, which cannot
+// be expressed in the type system when the size is only known at runtime.
+template <typename U, typename R>
+auto determinant(const Quantity<U, R> &q) {
+    constexpr int N = R::RowsAtCompileTime;
+    static_assert(N != -1,  // i.e. not Eigen::Dynamic
+                  "determinant() requires a fixed-size operand: its result unit is U^N for an NxN "
+                  "matrix, which cannot be expressed when the size is only known at runtime");
+    return make_quantity<UnitPowerT<U, N>>(q.data_in(U{}).determinant());
+}
+
+}  // namespace au

--- a/au/compatibility/eigen_test.cc
+++ b/au/compatibility/eigen_test.cc
@@ -1,0 +1,635 @@
+// Copyright 2025 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "au/compatibility/eigen.hh"
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <Eigen/LU>
+
+#include "au/au.hh"
+#include "au/testing.hh"
+#include "gtest/gtest.h"
+
+namespace au {
+
+struct Meters : UnitImpl<Length> {};
+constexpr auto meters = QuantityMaker<Meters>{};
+
+struct Feet : decltype(Meters{} * mag<381>() / mag<1250>()) {};
+constexpr auto feet = QuantityMaker<Feet>{};
+
+using ::testing::Eq;
+using ::testing::IsFalse;
+using ::testing::IsTrue;
+using ::testing::StaticAssertTypeEq;
+
+TEST(EigenCompatibility, CanCreateQuantityOfVector3d) {
+    Eigen::Vector3d v(1.0, 2.0, 3.0);
+
+    auto q = meters(v);
+
+    StaticAssertTypeEq<decltype(q), Quantity<Meters, Eigen::Vector3d>>();
+}
+
+TEST(EigenCompatibility, OperatorParenReturnsQuantityOfScalar) {
+    Eigen::Vector3d v(1.0, 2.0, 3.0);
+    auto q = meters(v);
+
+    EXPECT_THAT(q(0), SameTypeAndValue(meters(1.0)));
+    EXPECT_THAT(q(1), SameTypeAndValue(meters(2.0)));
+    EXPECT_THAT(q(2), SameTypeAndValue(meters(3.0)));
+}
+
+TEST(EigenCompatibility, OperatorBracketReturnsQuantityOfScalar) {
+    Eigen::Vector3d v(1.0, 2.0, 3.0);
+    auto q = meters(v);
+
+    auto elem = q[0];
+
+    StaticAssertTypeEq<decltype(elem), Quantity<Meters, double>>();
+    EXPECT_THAT(elem, SameTypeAndValue(meters(1.0)));
+}
+
+TEST(EigenCompatibility, MutableViewAllowsElementAssignment) {
+    Eigen::Vector3d v(1.0, 2.0, 3.0);
+    auto q = meters(v);
+
+    q.mutable_view()(0) = meters(10.0);
+    EXPECT_THAT(q(0), SameTypeAndValue(meters(10.0)));
+
+    q.mutable_view()[1] = meters(20.0);
+    EXPECT_THAT(q(1), SameTypeAndValue(meters(20.0)));
+}
+
+TEST(EigenCompatibility, SameUnitAdditionWorks) {
+    Eigen::Vector3d v(1.0, 2.0, 3.0);
+    auto q = meters(v);
+
+    auto sum = q + q;
+
+    Eigen::Vector3d expected(2.0, 4.0, 6.0);
+    EXPECT_THAT(sum.data_in(meters), Eq(expected));
+}
+
+TEST(EigenCompatibility, UnitConversionWorks) {
+    Eigen::Vector3d v(1.0, 2.0, 3.0);
+    auto q = meters(v);
+
+    auto result = q.in<Eigen::Vector3d>(centi(meters));
+
+    Eigen::Vector3d expected(100.0, 200.0, 300.0);
+    EXPECT_THAT(result, Eq(expected));
+}
+
+TEST(EigenCompatibility, ExplicitRepConversionForcesEvaluation) {
+    Eigen::Vector3d v_m(1.0, 2.0, 3.0);
+    auto q_m = meters(v_m);
+
+    // With explicit rep, the conversion forces evaluation to Vector3d
+    auto converted = q_m.in<Eigen::Vector3d>(centi(meters));
+
+    Eigen::Vector3d expected(100.0, 200.0, 300.0);
+    EXPECT_THAT(converted, Eq(expected));
+}
+
+TEST(EigenCompatibility, EvalForcesExpressionEvaluation) {
+    Eigen::Vector3d v(1.0, 2.0, 3.0);
+    auto q = meters(v);
+
+    // .as() returns a Quantity with expression template rep
+    auto q_cm = q.as(centi(meters));
+
+    // eval() forces materialization to concrete type
+    auto q_cm_materialized = eval(q_cm);
+
+    StaticAssertTypeEq<decltype(q_cm_materialized), Quantity<Centi<Meters>, Eigen::Vector3d>>();
+    EXPECT_THAT(q_cm_materialized.data_in(centi(meters)), Eq(Eigen::Vector3d(100.0, 200.0, 300.0)));
+}
+
+TEST(EigenCompatibility, MixedUnitAdditionWithExplicitConversion) {
+    Eigen::Vector3d v_m(1.0, 2.0, 3.0);
+    Eigen::Vector3d v_cm(100.0, 200.0, 300.0);
+
+    auto q_m = meters(v_m);
+    auto q_cm = centi(meters)(v_cm);
+
+    auto sum = q_m.as(centi(meters)) + q_cm;
+
+    Eigen::Vector3d result = sum.data_in(centi(meters));
+    Eigen::Vector3d expected(200.0, 400.0, 600.0);
+    EXPECT_THAT(result, Eq(expected));
+}
+
+TEST(EigenCompatibility, MixedUnitAdditionWithImplicitConversion) {
+    auto q_m = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+    auto q_cm = centi(meters)(Eigen::Vector3d(100.0, 200.0, 300.0));
+
+    // `auto` is a danger sign.  This is safe _only_ because `q_m` and `q_cm` are still alive when
+    // we evaluate `sum` below.
+    auto sum = q_m + q_cm;
+
+    Eigen::Vector3d expected(200.0, 400.0, 600.0);
+    EXPECT_THAT(sum.in(centi(meters)), Eq(expected));
+}
+
+TEST(EigenCompatibility, SameUnitSubtractionWorks) {
+    auto q1 = meters(Eigen::Vector3d{4.0, 5.0, 6.0});
+    auto q2 = meters(Eigen::Vector3d{1.0, 2.0, 3.0});
+
+    // `auto` is a danger sign.  This is safe _only_ because `q1` and `q2` are still alive when we
+    // evaluate `diff` below.
+    auto diff = q1 - q2;
+
+    Eigen::Vector3d expected(3.0, 3.0, 3.0);
+    EXPECT_THAT(diff.data_in(meters), Eq(expected));
+}
+
+TEST(EigenCompatibility, SameUnitEqualityWorks) {
+    Eigen::Vector3d v(1.0, 2.0, 3.0);
+    auto q1 = meters(v);
+    auto q2 = meters(v);
+
+    EXPECT_THAT(q1 == q2, IsTrue());
+}
+
+TEST(EigenCompatibility, DifferentUnitEqualityWorks) {
+    auto q_m = meters(Eigen::Vector3d{1.0, 2.0, 3.0});
+    auto q_cm = eval(q_m.as(centi(meters)));
+
+    EXPECT_THAT(q_m == q_cm, IsTrue());
+}
+
+TEST(EigenCompatibility, ScalarMultiplicationWorks) {
+    auto q = meters(Eigen::Vector3d{1.0, 2.0, 3.0});
+
+    // `auto` is a danger sign.  This is safe _only_ because `q` is still alive when we evaluate
+    // `scaled` below.
+    auto scaled = q * 2.0;
+
+    Eigen::Vector3d expected(2.0, 4.0, 6.0);
+    EXPECT_THAT(scaled.data_in(meters), Eq(expected));
+}
+
+TEST(EigenCompatibility, ScalarDivisionWorks) {
+    auto q = meters(Eigen::Vector3d{2.0, 4.0, 6.0});
+
+    // `auto` is a danger sign.  This is safe _only_ because `q` is still alive when we evaluate
+    // `scaled` below.
+    auto scaled = q / 2.0;
+
+    Eigen::Vector3d expected(1.0, 2.0, 3.0);
+    EXPECT_THAT(scaled.data_in(meters), Eq(expected));
+}
+
+TEST(EigenCompatibility, UnaryMinusWorks) {
+    auto q = meters(Eigen::Vector3d{1.0, 2.0, 3.0});
+
+    // `auto` is a danger sign.  This is safe _only_ because `q` is still alive when we evaluate
+    // `negated` below.
+    auto negated = -q;
+
+    Eigen::Vector3d expected(-1.0, -2.0, -3.0);
+    EXPECT_THAT(negated.data_in(meters), Eq(expected));
+}
+
+TEST(EigenCompatibility, CompoundAdditionWorks) {
+    Eigen::Vector3d v(1.0, 2.0, 3.0);
+    auto q = meters(v);
+    auto delta = meters(Eigen::Vector3d(10.0, 20.0, 30.0));
+
+    q += delta;
+
+    Eigen::Vector3d expected(11.0, 22.0, 33.0);
+    EXPECT_THAT(q.data_in(meters), Eq(expected));
+}
+
+TEST(EigenCompatibility, CompoundScalarMultiplicationWorks) {
+    auto q = meters(Eigen::Vector3d{1.0, 2.0, 3.0});
+
+    q *= 2.0;
+
+    Eigen::Vector3d expected(2.0, 4.0, 6.0);
+    EXPECT_THAT(q.data_in(meters), Eq(expected));
+}
+
+TEST(EigenCompatibility, DifferentUnitAdditionWorks) {
+    auto q1 = meters(Eigen::Vector3d{1.0, 2.0, 3.0});
+    auto q2 = centi(meters)(Eigen::Vector3d{100.0, 200.0, 300.0});
+
+    auto sum = q1 + q2;
+
+    Eigen::Vector3d expected(200.0, 400.0, 600.0);
+    EXPECT_THAT(sum.data_in(centi(meters)), Eq(expected));
+}
+
+TEST(EigenCompatibility, MixedInputAdditionWithConvertedQuantityWorks) {
+    auto q_m = meters(Eigen::Vector3d{1.0, 2.0, 3.0});
+    auto q_cm = centi(meters)(Eigen::Vector3d{100.0, 200.0, 300.0});
+
+    // Pass a converted Quantity (with expression template rep) to mixed-input operator.
+    //
+    // `auto` is a danger sign.  This is safe _only_ because `q_m` and `q_cm` are still alive when
+    // we evaluate `sum` below.
+    auto sum = q_m.as(centi(meters)) + q_cm;
+
+    Eigen::Vector3d expected(200.0, 400.0, 600.0);
+    EXPECT_THAT(sum.data_in(centi(meters)), Eq(expected));
+}
+
+TEST(EigenCompatibility, IntegralMultiStepConversionWorks) {
+    // Meters to feet requires multiply then divide (irrational ratio).
+    // This tests whether intermediate expression templates in OpSequence cause dangling.
+    auto q_m = meters(Eigen::Vector3i{1000, 2000, 3000});
+
+    auto result = q_m.in(feet, ignore(TRUNCATION_RISK)).eval();
+
+    // 1000 m * 1250 / 381 = 3280 ft (truncated)
+    // 2000 m * 1250 / 381 = 6561 ft (truncated)
+    // 3000 m * 1250 / 381 = 9842 ft (truncated)
+    Eigen::Vector3i expected(3280, 6561, 9842);
+    EXPECT_THAT(result, Eq(expected));
+}
+
+TEST(EigenCompatibility, IntegralMultiStepConversionWithImplicitRepWorks) {
+    // Same as above but using implicit rep .in() to see if expression templates dangle
+    auto q_m = meters(Eigen::Vector3i{1000, 2000, 3000});
+
+    // Use implicit rep with risk acknowledgement - returns expression template if not materialized
+    auto result = q_m.in(feet, ignore(TRUNCATION_RISK));
+
+    Eigen::Vector3i expected(3280, 6561, 9842);
+    EXPECT_THAT(result, Eq(expected));
+}
+
+__attribute__((noinline)) auto do_conversion_return_expr(
+    const Quantity<Meters, Eigen::Vector3i> &q) {
+    // Return expression template from function - intermediate temps should die
+    return q.in(feet, ignore(TRUNCATION_RISK));
+}
+
+TEST(EigenCompatibility, IntegralMultiStepConversionAcrossFunctionBoundary) {
+    Eigen::Vector3i v_m(1000, 2000, 3000);
+    auto q_m = meters(v_m);
+
+    // Get the expression template, then evaluate it after function returns
+    auto expr = do_conversion_return_expr(q_m);
+    // At this point, any intermediates created inside in_impl are dead
+
+    Eigen::Vector3i result = expr;
+
+    Eigen::Vector3i expected(3280, 6561, 9842);
+    EXPECT_THAT(result, Eq(expected));
+}
+
+//
+// Free-function forms of Eigen member functions.
+//
+
+TEST(EigenFreeFunctions, NormIsUnitPreserving) {
+    auto q = meters(Eigen::Vector3d(3.0, 4.0, 0.0));
+
+    EXPECT_THAT(norm(q), SameTypeAndValue(meters(5.0)));
+}
+
+TEST(EigenFreeFunctions, SquaredNormSquaresTheUnit) {
+    auto q = meters(Eigen::Vector3d(3.0, 4.0, 0.0));
+
+    auto sq = squaredNorm(q);
+
+    StaticAssertTypeEq<decltype(sq), Quantity<UnitPowerT<Meters, 2>, double>>();
+    EXPECT_THAT(sq.in(meters * meters), Eq(25.0));
+}
+
+TEST(EigenFreeFunctions, SumIsUnitPreserving) {
+    auto q = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+
+    EXPECT_THAT(sum(q), SameTypeAndValue(meters(6.0)));
+}
+
+TEST(EigenFreeFunctions, MeanIsUnitPreserving) {
+    auto q = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+
+    EXPECT_THAT(mean(q), SameTypeAndValue(meters(2.0)));
+}
+
+TEST(EigenFreeFunctions, MinCoeffIsUnitPreserving) {
+    auto q = meters(Eigen::Vector3d(3.0, 1.0, 2.0));
+
+    EXPECT_THAT(minCoeff(q), SameTypeAndValue(meters(1.0)));
+}
+
+TEST(EigenFreeFunctions, MaxCoeffIsUnitPreserving) {
+    auto q = meters(Eigen::Vector3d(3.0, 1.0, 2.0));
+
+    EXPECT_THAT(maxCoeff(q), SameTypeAndValue(meters(3.0)));
+}
+
+TEST(EigenFreeFunctions, TransposeIsUnitPreserving) {
+    Eigen::Matrix<double, 2, 3> m;
+    m << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
+    auto q = meters(m);
+
+    // `transpose` is lazy; `q` stays alive through the evaluation below.
+    auto qt = transpose(q);
+
+    Eigen::Matrix<double, 3, 2> expected = m.transpose();
+    EXPECT_THAT(eval(qt).data_in(meters), Eq(expected));
+}
+
+TEST(EigenFreeFunctions, DotProductMultipliesUnits) {
+    auto a = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+    auto b = feet(Eigen::Vector3d(1.0, 1.0, 1.0));
+
+    auto d = dot(a, b);
+
+    StaticAssertTypeEq<decltype(d), Quantity<UnitProductT<Meters, Feet>, double>>();
+    EXPECT_THAT(d.in(meters * feet), Eq(6.0));
+}
+
+TEST(EigenFreeFunctions, DotProductWithRawEigenVectorKeepsQuantityUnit) {
+    auto a = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+    Eigen::Vector3d raw(4.0, 5.0, 6.0);
+
+    auto d = dot(a, raw);
+
+    StaticAssertTypeEq<decltype(d), Quantity<Meters, double>>();
+    EXPECT_THAT(d, SameTypeAndValue(meters(32.0)));
+}
+
+TEST(EigenFreeFunctions, DotProductWithRawEigenVectorFirstKeepsQuantityUnit) {
+    Eigen::Vector3d raw(4.0, 5.0, 6.0);
+    auto b = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+
+    auto d = dot(raw, b);
+
+    StaticAssertTypeEq<decltype(d), Quantity<Meters, double>>();
+    EXPECT_THAT(d, SameTypeAndValue(meters(32.0)));
+}
+
+TEST(EigenFreeFunctions, CrossProductMultipliesUnits) {
+    auto a = meters(Eigen::Vector3d(1.0, 0.0, 0.0));
+    auto b = feet(Eigen::Vector3d(0.0, 1.0, 0.0));
+
+    // `cross` is lazy; `a` and `b` stay alive through the evaluation below.
+    auto c = cross(a, b);
+
+    Eigen::Vector3d expected(0.0, 0.0, 1.0);
+    EXPECT_THAT(eval(c).data_in(meters * feet), Eq(expected));
+}
+
+TEST(EigenFreeFunctions, CrossProductWithRawEigenVectorKeepsQuantityUnit) {
+    auto a = meters(Eigen::Vector3d(1.0, 0.0, 0.0));
+    Eigen::Vector3d raw(0.0, 1.0, 0.0);
+
+    // `cross` is lazy; `a` and `raw` stay alive through the evaluation below.
+    auto c = cross(a, raw);
+
+    StaticAssertTypeEq<decltype(eval(c)), Quantity<Meters, Eigen::Vector3d>>();
+    Eigen::Vector3d expected(0.0, 0.0, 1.0);
+    EXPECT_THAT(eval(c).data_in(meters), Eq(expected));
+}
+
+TEST(EigenFreeFunctions, CrossProductWithRawEigenVectorFirstKeepsQuantityUnit) {
+    Eigen::Vector3d raw(1.0, 0.0, 0.0);
+    auto b = meters(Eigen::Vector3d(0.0, 1.0, 0.0));
+
+    // `cross` is lazy; `raw` and `b` stay alive through the evaluation below.
+    auto c = cross(raw, b);
+
+    StaticAssertTypeEq<decltype(eval(c)), Quantity<Meters, Eigen::Vector3d>>();
+    Eigen::Vector3d expected(0.0, 0.0, 1.0);
+    EXPECT_THAT(eval(c).data_in(meters), Eq(expected));
+}
+
+TEST(EigenFreeFunctions, NormalizedReturnsRawVector) {
+    auto q = meters(Eigen::Vector3d(3.0, 4.0, 0.0));
+
+    auto n = normalized(q);
+
+    // The result is unitless by definition, so we return the raw Eigen vector, not a Quantity.
+    StaticAssertTypeEq<decltype(n), Eigen::Vector3d>();
+
+    Eigen::Vector3d expected(0.6, 0.8, 0.0);
+    EXPECT_THAT(n, Eq(expected));
+}
+
+//
+// Additional scalar reductions.
+//
+
+TEST(EigenFreeFunctions, StableNormIsUnitPreserving) {
+    auto q = meters(Eigen::Vector3d(3.0, 4.0, 0.0));
+
+    EXPECT_THAT(stableNorm(q), SameTypeAndValue(meters(5.0)));
+}
+
+TEST(EigenFreeFunctions, BlueNormIsUnitPreserving) {
+    auto q = meters(Eigen::Vector3d(3.0, 4.0, 0.0));
+
+    EXPECT_THAT(blueNorm(q), SameTypeAndValue(meters(5.0)));
+}
+
+TEST(EigenFreeFunctions, HypotNormIsUnitPreserving) {
+    auto q = meters(Eigen::Vector3d(3.0, 4.0, 0.0));
+
+    EXPECT_THAT(hypotNorm(q), SameTypeAndValue(meters(5.0)));
+}
+
+TEST(EigenFreeFunctions, LpNormSupportsVariousOrders) {
+    auto q = meters(Eigen::Vector3d(3.0, -4.0, 0.0));
+
+    EXPECT_THAT(lpNorm<1>(q), SameTypeAndValue(meters(7.0)));
+    EXPECT_THAT(lpNorm<2>(q), SameTypeAndValue(meters(5.0)));
+    EXPECT_THAT(lpNorm<Eigen::Infinity>(q), SameTypeAndValue(meters(4.0)));
+}
+
+TEST(EigenFreeFunctions, TraceIsUnitPreserving) {
+    Eigen::Matrix3d m = Eigen::Vector3d(1.0, 2.0, 3.0).asDiagonal();
+    auto q = meters(m);
+
+    EXPECT_THAT(trace(q), SameTypeAndValue(meters(6.0)));
+}
+
+//
+// Coefficient-wise ops.
+//
+
+TEST(EigenFreeFunctions, CwiseProductMultipliesUnits) {
+    auto a = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+    auto b = feet(Eigen::Vector3d(2.0, 2.0, 2.0));
+
+    auto c = cwiseProduct(a, b);
+
+    StaticAssertTypeEq<decltype(eval(c)), Quantity<UnitProductT<Meters, Feet>, Eigen::Vector3d>>();
+    EXPECT_THAT(eval(c).data_in(UnitProductT<Meters, Feet>{}), Eq(Eigen::Vector3d(2.0, 4.0, 6.0)));
+}
+
+TEST(EigenFreeFunctions, CwiseProductWithRawEigenObjectKeepsQuantityUnit) {
+    auto a = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+    Eigen::Vector3d raw(2.0, 2.0, 2.0);
+
+    EXPECT_THAT(eval(cwiseProduct(a, raw)).data_in(meters), Eq(Eigen::Vector3d(2.0, 4.0, 6.0)));
+    EXPECT_THAT(eval(cwiseProduct(raw, a)).data_in(meters), Eq(Eigen::Vector3d(2.0, 4.0, 6.0)));
+}
+
+TEST(EigenFreeFunctions, CwiseQuotientDividesUnits) {
+    auto a = meters(Eigen::Vector3d(2.0, 4.0, 6.0));
+    auto b = feet(Eigen::Vector3d(1.0, 2.0, 3.0));
+
+    auto c = cwiseQuotient(a, b);
+
+    StaticAssertTypeEq<decltype(eval(c)), Quantity<UnitQuotientT<Meters, Feet>, Eigen::Vector3d>>();
+    EXPECT_THAT(eval(c).data_in(UnitQuotientT<Meters, Feet>{}), Eq(Eigen::Vector3d(2.0, 2.0, 2.0)));
+}
+
+TEST(EigenFreeFunctions, CwiseQuotientWithRawEigenObject) {
+    auto a = meters(Eigen::Vector3d(2.0, 4.0, 6.0));
+    Eigen::Vector3d raw(1.0, 2.0, 3.0);
+
+    // Quantity / raw -> keeps the unit.
+    auto num = cwiseQuotient(a, raw);
+    StaticAssertTypeEq<decltype(eval(num)), Quantity<Meters, Eigen::Vector3d>>();
+    EXPECT_THAT(eval(num).data_in(meters), Eq(Eigen::Vector3d(2.0, 2.0, 2.0)));
+
+    // raw / Quantity -> inverts the unit.
+    auto den = cwiseQuotient(raw, a);
+    StaticAssertTypeEq<decltype(eval(den)), Quantity<UnitInverseT<Meters>, Eigen::Vector3d>>();
+    EXPECT_THAT(eval(den).data_in(UnitInverseT<Meters>{}), Eq(Eigen::Vector3d(0.5, 0.5, 0.5)));
+}
+
+TEST(EigenFreeFunctions, CwiseAbsIsUnitPreserving) {
+    auto q = meters(Eigen::Vector3d(-1.0, 2.0, -3.0));
+
+    EXPECT_THAT(eval(cwiseAbs(q)).data_in(meters), Eq(Eigen::Vector3d(1.0, 2.0, 3.0)));
+}
+
+//
+// View / accessor ops.
+//
+
+TEST(EigenFreeFunctions, DiagonalIsUnitPreserving) {
+    Eigen::Matrix3d m = Eigen::Vector3d(1.0, 2.0, 3.0).asDiagonal();
+    auto q = meters(m);
+
+    EXPECT_THAT(eval(diagonal(q)).data_in(meters), Eq(Eigen::Vector3d(1.0, 2.0, 3.0)));
+}
+
+TEST(EigenFreeFunctions, RowAndColAreUnitPreserving) {
+    Eigen::Matrix3d m = Eigen::Vector3d(1.0, 2.0, 3.0).asDiagonal();
+    auto q = meters(m);
+
+    EXPECT_THAT(eval(row(q, 0)).data_in(meters), Eq(Eigen::RowVector3d(1.0, 0.0, 0.0)));
+    EXPECT_THAT(eval(col(q, 1)).data_in(meters), Eq(Eigen::Vector3d(0.0, 2.0, 0.0)));
+}
+
+TEST(EigenFreeFunctions, ReverseIsUnitPreserving) {
+    auto q = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+
+    EXPECT_THAT(eval(reverse(q)).data_in(meters), Eq(Eigen::Vector3d(3.0, 2.0, 1.0)));
+}
+
+TEST(EigenFreeFunctions, ConjugateIsUnitPreservingForRealReps) {
+    auto q = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+
+    EXPECT_THAT(eval(conjugate(q)).data_in(meters), Eq(Eigen::Vector3d(1.0, 2.0, 3.0)));
+}
+
+TEST(EigenFreeFunctions, HeadFixedAndDynamic) {
+    auto q = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+
+    EXPECT_THAT(eval(head<2>(q)).data_in(meters), Eq(Eigen::Vector2d(1.0, 2.0)));
+    EXPECT_THAT(eval(head(q, 2)).data_in(meters), Eq(Eigen::Vector2d(1.0, 2.0)));
+}
+
+TEST(EigenFreeFunctions, TailFixedAndDynamic) {
+    auto q = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+
+    EXPECT_THAT(eval(tail<2>(q)).data_in(meters), Eq(Eigen::Vector2d(2.0, 3.0)));
+    EXPECT_THAT(eval(tail(q, 2)).data_in(meters), Eq(Eigen::Vector2d(2.0, 3.0)));
+}
+
+TEST(EigenFreeFunctions, SegmentFixedAndDynamic) {
+    auto q = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+
+    EXPECT_THAT(eval(segment<2>(q, 1)).data_in(meters), Eq(Eigen::Vector2d(2.0, 3.0)));
+    EXPECT_THAT(eval(segment(q, 1, 2)).data_in(meters), Eq(Eigen::Vector2d(2.0, 3.0)));
+}
+
+TEST(EigenFreeFunctions, BlockFixedAndDynamic) {
+    Eigen::Matrix3d m = Eigen::Vector3d(1.0, 2.0, 3.0).asDiagonal();
+    auto q = meters(m);
+
+    Eigen::Matrix2d expected;
+    expected << 1.0, 0.0, 0.0, 2.0;
+
+    EXPECT_THAT((eval(block<2, 2>(q, 0, 0)).data_in(meters)), Eq(expected));
+    EXPECT_THAT(eval(block(q, 0, 0, 2, 2)).data_in(meters), Eq(expected));
+}
+
+TEST(EigenFreeFunctions, ReplicateFixedAndDynamic) {
+    auto q = meters(Eigen::Vector3d(1.0, 2.0, 3.0));
+
+    Eigen::Matrix<double, 6, 1> expected;
+    expected << 1.0, 2.0, 3.0, 1.0, 2.0, 3.0;
+
+    EXPECT_THAT((eval(replicate<2, 1>(q)).data_in(meters)), Eq(expected));
+    EXPECT_THAT(eval(replicate(q, 2, 1)).data_in(meters), Eq(expected));
+}
+
+//
+// Ops whose result unit is a non-trivial power of the operand unit.
+//
+
+TEST(EigenFreeFunctions, CwiseSqrtTakesSquareRootOfUnit) {
+    auto q = meters(Eigen::Vector3d(4.0, 9.0, 16.0));
+
+    auto r = cwiseSqrt(q);
+
+    StaticAssertTypeEq<decltype(eval(r)), Quantity<UnitPowerT<Meters, 1, 2>, Eigen::Vector3d>>();
+    EXPECT_THAT(eval(r).data_in(UnitPowerT<Meters, 1, 2>{}), Eq(Eigen::Vector3d(2.0, 3.0, 4.0)));
+}
+
+TEST(EigenFreeFunctions, InverseInvertsTheUnit) {
+    Eigen::Matrix2d m = Eigen::Vector2d(2.0, 4.0).asDiagonal();
+    auto q = meters(m);
+
+    auto r = inverse(q);
+
+    StaticAssertTypeEq<decltype(eval(r)), Quantity<UnitInverseT<Meters>, Eigen::Matrix2d>>();
+
+    Eigen::Matrix2d expected = Eigen::Vector2d(0.5, 0.25).asDiagonal();
+    EXPECT_THAT(eval(r).data_in(UnitInverseT<Meters>{}), Eq(expected));
+}
+
+TEST(EigenFreeFunctions, ProdRaisesUnitToCoefficientCount) {
+    auto q = meters(Eigen::Vector3d(2.0, 3.0, 4.0));
+
+    auto p = prod(q);
+
+    StaticAssertTypeEq<decltype(p), Quantity<UnitPowerT<Meters, 3>, double>>();
+    EXPECT_THAT(p.data_in(UnitPowerT<Meters, 3>{}), Eq(24.0));
+}
+
+TEST(EigenFreeFunctions, DeterminantRaisesUnitToMatrixDimension) {
+    Eigen::Matrix3d m = Eigen::Vector3d(2.0, 3.0, 4.0).asDiagonal();
+    auto q = meters(m);
+
+    auto d = determinant(q);
+
+    StaticAssertTypeEq<decltype(d), Quantity<UnitPowerT<Meters, 3>, double>>();
+    EXPECT_THAT(d.data_in(UnitPowerT<Meters, 3>{}), Eq(24.0));
+}
+
+}  // namespace au


### PR DESCRIPTION
Eigen has many member functions.  We can't add these as member functions
on `Quantity` without causing massive bloat to `quantity.hh`.  We _can_
add them as free functions that simply call the corresponding member
function in a unit-aware way.

This approach does not have any physical dependencies on the Eigen
library, whose APIs have been stable for decades.  Users simply include
"au/compatibility/eigen.hh" in any file where they want to use these.

Helps #484: this completes the code implementation.  We will follow up
with a doc PR and a comment on #484 explaining our design.