### PR TITLE
Mitigate unnecessary copies in function chains

### DIFF
--- a/au/abstract_operations.hh
+++ b/au/abstract_operations.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <type_traits>
+#include <utility>
+
 #include "au/config.hh"
 #include "au/magnitude.hh"
 
@@ -84,9 +87,18 @@ template <typename T, typename U>
 struct OpOutputImpl<StaticCast<T, U>> : stdx::type_identity<U> {};
 
 // `StaticCast<T, U>` operation:
+//
+// This is an eager (materializing) operation: it produces a fresh `U`.  We take the input by
+// forwarding reference and forward it into the cast, so that when the chain hands us an rvalue
+// (e.g. the materialized result of a previous step), we *move* rather than copy a heap-backed rep.
 template <typename T, typename U>
 struct StaticCast {
-    static AU_DEVICE_FUNC constexpr U apply_to(const T &value) { return static_cast<U>(value); }
+    template <typename V>
+    static AU_DEVICE_FUNC constexpr U apply_to(V &&value) {
+        static_assert(std::is_same<std::decay_t<V>, std::decay_t<T>>::value,
+                      "Internal library error: input type does not match operation input");
+        return static_cast<U>(std::forward<V>(value));
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -99,9 +111,16 @@ template <typename T, typename U>
 struct OpOutputImpl<ImplicitConversion<T, U>> : stdx::type_identity<U> {};
 
 // `ImplicitConversion<T, U>` operation:
+//
+// Like `StaticCast`, this is eager: forward the input so an rvalue is moved into the produced `U`.
 template <typename T, typename U>
 struct ImplicitConversion {
-    static AU_DEVICE_FUNC constexpr U apply_to(const T &value) { return value; }
+    template <typename V>
+    static AU_DEVICE_FUNC constexpr U apply_to(V &&value) {
+        static_assert(std::is_same<std::decay_t<V>, std::decay_t<T>>::value,
+                      "Internal library error: input type does not match operation input");
+        return std::forward<V>(value);
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -127,9 +146,19 @@ struct MultiplyTypeBy {
 };
 
 // Specialization for identity magnitude: just return the value unchanged.
+//
+// This is eager (it produces a `T` by value), so forward the input: an rvalue coming from a prior
+// step in the chain is moved through rather than deep-copied.  (The non-identity `MultiplyTypeBy`
+// above stays a `const T &` overload on purpose: it returns a *lazy* expression that refers to its
+// input, so it must not take ownership of --- or dangle past --- that input.)
 template <typename T>
 struct MultiplyTypeBy<T, Magnitude<>> {
-    static AU_DEVICE_FUNC constexpr T apply_to(const T &value) { return value; }
+    template <typename V>
+    static AU_DEVICE_FUNC constexpr T apply_to(V &&value) {
+        static_assert(std::is_same<std::decay_t<V>, std::decay_t<T>>::value,
+                      "Internal library error: input type does not match operation input");
+        return std::forward<V>(value);
+    }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -180,17 +209,24 @@ struct OpOutputImpl<OpSequenceImpl<Op, Ops...>>
 template <typename OnlyOp>
 struct OpOutputImpl<OpSequenceImpl<OnlyOp>> : stdx::type_identity<OpOutput<OnlyOp>> {};
 
+// We thread the value through the chain by forwarding reference.  Each step's result is a prvalue
+// (for eager steps) or a lazy expression referring to a still-live operand; forwarding lets the
+// next step *move* an eager result rather than copy it.  The very first step still receives the
+// caller's lvalue (e.g. a `Quantity`'s stored member), so it copies/converts exactly once --- that
+// inherent conversion pass is unavoidable --- while every subsequent step moves.
 template <typename Op>
 struct OpSequenceImpl<Op> {
-    static AU_DEVICE_FUNC constexpr auto apply_to(const OpInput<OpSequenceImpl> &value) {
-        return Op::apply_to(value);
+    template <typename V>
+    static AU_DEVICE_FUNC constexpr auto apply_to(V &&value) {
+        return Op::apply_to(std::forward<V>(value));
     }
 };
 
 template <typename Op, typename... Ops>
 struct OpSequenceImpl<Op, Ops...> {
-    static AU_DEVICE_FUNC constexpr auto apply_to(const OpInput<OpSequenceImpl> &value) {
-        return OpSequenceImpl<Ops...>::apply_to(Op::apply_to(value));
+    template <typename V>
+    static AU_DEVICE_FUNC constexpr auto apply_to(V &&value) {
+        return OpSequenceImpl<Ops...>::apply_to(Op::apply_to(std::forward<V>(value)));
     }
 };
 

--- a/au/compatibility/BUILD.bazel
+++ b/au/compatibility/BUILD.bazel
@@ -33,3 +33,15 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "materialization_copy_count_test",
+    size = "small",
+    srcs = ["materialization_copy_count_test.cc"],
+    deps = [
+        ":eigen",
+        "//au",
+        "//au:testing",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/au/compatibility/eigen.hh
+++ b/au/compatibility/eigen.hh
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
+#include <utility>
 
 #include "au/au.hh"
 
@@ -23,9 +25,14 @@ namespace au {
 // Force evaluation of a Quantity whose rep is an Eigen expression template.
 //
 // Use this to materialize lazy expressions before the operands go out of scope.
+//
+// We bind Eigen's `.eval()` result --- a *`const`* plain object --- to a non-`const` local, then
+// move it through `make_quantity`.  Because `make_quantity` stores `std::decay_t<T>` and forwards
+// its argument, this materializes the data exactly once and then moves it into place.
 template <typename U, typename R>
 auto eval(const Quantity<U, R> &q) {
-    return make_quantity<U>(q.data_in(U{}).eval());
+    auto result = q.data_in(U{}).eval();
+    return make_quantity<U>(std::move(result));
 }
 
 //

--- a/au/compatibility/materialization_copy_count_test.cc
+++ b/au/compatibility/materialization_copy_count_test.cc
@@ -1,0 +1,236 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Deterministic copy-count gate for the materialization APIs.
+//
+// Heap-backed reps (the motivating example is `Eigen::VectorXd`) must not be silently deep-copied
+// as they flow through `make_quantity`, the `QuantityMaker`, the `Quantity` constructors, and the
+// `.as()` / `.in()` conversion chain.  Timing benchmarks can hide a stray copy behind
+// memory-bandwidth noise; exact copy counts cannot.  So here we use an *instrumented* rep that
+// counts every copy, move, and "evaluation" (materialization of a lazy expression rep), and assert
+// the theoretical minimum for each path.  Each `Tracked` copy is O(n) (it duplicates a
+// `std::vector<double>`); each move is O(1); so "copies" is the number that actually matters.
+
+#include <utility>
+#include <vector>
+
+#include "au/au.hh"
+#include "au/compatibility/eigen.hh"  // For the unit-aware `eval()` free function.
+#include "au/testing.hh"
+#include "gtest/gtest.h"
+
+namespace au {
+namespace {
+
+using ::testing::Eq;
+
+struct Meters : UnitImpl<Length> {};
+constexpr auto meters = QuantityMaker<Meters>{};
+
+struct Feet : decltype(Meters{} * mag<381>() / mag<1250>()) {};
+constexpr auto feet = QuantityMaker<Feet>{};
+
+// Global tallies.  We reset them immediately before each measured operation.
+struct Counts {
+    int copies = 0;  // copy-constructions + copy-assignments of `Tracked`
+    int moves = 0;   // move-constructions + move-assignments of `Tracked`
+    int evals = 0;   // materializations of a lazy expression rep into a concrete `Tracked`
+};
+Counts &counts() {
+    static Counts c;
+    return c;
+}
+void reset_counts() { counts() = Counts{}; }
+
+// A concrete, heap-backed rep that instruments every copy and move.
+//
+// `value_type = double` lets Au deduce `RealPart<Tracked> == double`, exactly as it does for Eigen
+// vectors, so unit-conversion scale factors get applied in `double` (this is what makes the
+// magnitude machinery work for a vector-like rep).
+class Tracked {
+ public:
+    using value_type = double;
+
+    Tracked() = default;
+    explicit Tracked(std::vector<double> data) : data_(std::move(data)) {}
+
+    Tracked(const Tracked &other) : data_(other.data_) { ++counts().copies; }
+    Tracked(Tracked &&other) noexcept : data_(std::move(other.data_)) { ++counts().moves; }
+    Tracked &operator=(const Tracked &other) {
+        data_ = other.data_;
+        ++counts().copies;
+        return *this;
+    }
+    Tracked &operator=(Tracked &&other) noexcept {
+        data_ = std::move(other.data_);
+        ++counts().moves;
+        return *this;
+    }
+    ~Tracked() = default;
+
+    // Eager scalar scaling.  This is the "one conversion pass" for a unit conversion: it produces a
+    // brand-new `Tracked` from a fresh computation, so it is NOT a copy of any existing `Tracked`.
+    Tracked operator*(double s) const {
+        std::vector<double> out = data_;
+        for (auto &x : out) {
+            x *= s;
+        }
+        return Tracked{std::move(out)};
+    }
+
+    // Element-wise add/subtract.  These exist because instantiating `Quantity<Meters, Tracked>`
+    // requires `Tracked + Tracked` and `Tracked - Tracked` to form valid types (the same
+    // requirement Au's arithmetic operators place on any rep, met by Eigen out of the box).  Each
+    // builds a fresh `Tracked`, so neither is a copy of an existing one.
+    Tracked operator+(const Tracked &other) const {
+        std::vector<double> out = data_;
+        for (std::size_t i = 0; i < out.size(); ++i) {
+            out[i] += other.data_[i];
+        }
+        return Tracked{std::move(out)};
+    }
+    Tracked operator-(const Tracked &other) const {
+        std::vector<double> out = data_;
+        for (std::size_t i = 0; i < out.size(); ++i) {
+            out[i] -= other.data_[i];
+        }
+        return Tracked{std::move(out)};
+    }
+
+    // Mirrors Eigen's `.eval()`: returns a materialized copy.  This is the single inherent copy of
+    // `eval(q)`.
+    Tracked eval() const { return *this; }
+
+    const std::vector<double> &data() const { return data_; }
+
+ private:
+    std::vector<double> data_;
+};
+
+// A stand-in for a lazy Eigen *expression* rep: it refers to a `Tracked` and materializes into a
+// concrete `Tracked` on demand.  The materialization is counted as one "eval", and --- crucially
+// --- it builds the result straight from the underlying vector, so it does NOT invoke `Tracked`'s
+// copy constructor.  This models "the expression is evaluated exactly once, with zero extra copies
+// of the concrete rep".
+class TrackedExpr {
+ public:
+    using value_type = double;
+
+    explicit TrackedExpr(const Tracked &src) : src_(&src) {}
+
+    operator Tracked() const {
+        ++counts().evals;
+        return Tracked{src_->data()};
+    }
+
+    // Present only so that `Quantity<Meters, TrackedExpr>` instantiates (its arithmetic operators
+    // require `TrackedExpr +/- TrackedExpr` to name a type, just as a real Eigen expression does).
+    // The bodies are never exercised by these tests.
+    Tracked operator+(const TrackedExpr &) const { return Tracked{src_->data()}; }
+    Tracked operator-(const TrackedExpr &) const { return Tracked{src_->data()}; }
+
+ private:
+    const Tracked *src_;
+};
+
+Tracked make_tracked(std::size_t n) {
+    std::vector<double> data(n, 1.0);
+    return Tracked{std::move(data)};
+}
+
+// (1a) `meters(v)` from an lvalue must copy exactly once (the input is not ours to steal).
+TEST(MaterializationCopyCount, MakerFromLvalueCopiesExactlyOnce) {
+    Tracked v = make_tracked(8);
+
+    reset_counts();
+    auto q = meters(v);
+    EXPECT_THAT(counts().copies, Eq(1));
+
+    // Keep `q` alive / used.
+    EXPECT_THAT(q.data_in(meters).data().size(), Eq(std::size_t{8}));
+}
+
+// (1b) `meters(rvalue)` must never copy: an rvalue may be moved from freely.
+TEST(MaterializationCopyCount, MakerFromRvalueNeverCopies) {
+    Tracked v = make_tracked(8);
+
+    reset_counts();
+    auto q = meters(std::move(v));
+    EXPECT_THAT(counts().copies, Eq(0));
+
+    EXPECT_THAT(q.data_in(meters).data().size(), Eq(std::size_t{8}));
+}
+
+// (1c) `meters(prvalue)` (a pure temporary) must never copy either.
+TEST(MaterializationCopyCount, MakerFromPrvalueNeverCopies) {
+    reset_counts();
+    auto q = meters(make_tracked(8));
+    EXPECT_THAT(counts().copies, Eq(0));
+
+    EXPECT_THAT(q.data_in(meters).data().size(), Eq(std::size_t{8}));
+}
+
+// (2) `eval(q)` on an lvalue quantity with a concrete rep: exactly one copy (the inherent one from
+// `.eval()`); everything downstream (`make_quantity` and the constructor) must move.
+TEST(MaterializationCopyCount, EvalCopiesExactlyOnce) {
+    auto q = meters(make_tracked(8));
+
+    reset_counts();
+    auto r = eval(q);
+    EXPECT_THAT(counts().copies, Eq(1));
+
+    EXPECT_THAT(r.data_in(meters).data().size(), Eq(std::size_t{8}));
+}
+
+// (3) Converting-constructor from an expression-rep quantity to the same unit with a concrete rep:
+// zero copies of the concrete rep, and the expression evaluated exactly once.
+TEST(MaterializationCopyCount, ConvertingCtorFromExpressionRepZeroCopiesOneEval) {
+    Tracked src = make_tracked(8);
+    auto q_expr = meters(TrackedExpr{src});
+
+    reset_counts();
+    Quantity<Meters, Tracked> r = q_expr;
+    EXPECT_THAT(counts().copies, Eq(0));
+    EXPECT_THAT(counts().evals, Eq(1));
+
+    EXPECT_THAT(r.data_in(meters).data().size(), Eq(std::size_t{8}));
+}
+
+// (4a) A genuine unit conversion on a concrete rep: exactly one conversion pass (the scalar
+// multiply, which builds a fresh vector), and zero copies of any existing `Tracked`.
+TEST(MaterializationCopyCount, UnitConversionZeroCopies) {
+    auto q = meters(make_tracked(8));
+
+    reset_counts();
+    auto in_feet = q.as<Tracked>(feet);
+    EXPECT_THAT(counts().copies, Eq(0));
+
+    EXPECT_THAT(in_feet.data_in(feet).data().size(), Eq(std::size_t{8}));
+}
+
+// (4b) A same-unit rep "conversion" (`.as<Rep>(same_unit)`) is an identity magnitude.  Here the one
+// conversion pass IS a copy: the result gets its own vector, duplicated from the (const) source
+// member --- there is nothing to move from --- so exactly one copy is the true minimum.
+TEST(MaterializationCopyCount, SameUnitAsCopiesExactlyOnce) {
+    auto q = meters(make_tracked(8));
+
+    reset_counts();
+    auto same = q.as<Tracked>(meters);
+    EXPECT_THAT(counts().copies, Eq(1));
+
+    EXPECT_THAT(same.data_in(meters).data().size(), Eq(std::size_t{8}));
+}
+
+}  // namespace
+}  // namespace au

--- a/au/compatibility/materialization_copy_count_test.cc
+++ b/au/compatibility/materialization_copy_count_test.cc
@@ -94,10 +94,12 @@ class Tracked {
     // requirement Au's arithmetic operators place on any rep, met by Eigen out of the box).  Each
     // builds a fresh `Tracked`, so neither is a copy of an existing one.
     Tracked operator+(const Tracked &other) const {
-        std::vector<double> out = data_;
-        for (std::size_t i = 0; i < out.size(); ++i) {
-            out[i] += other.data_[i];
-        }
+        std::vector<double> out(data_.size());
+        std::transform(data_.begin(),
+                       data_.end(),
+                       other.data_.begin(),
+                       out.begin(),
+                       std::plus<double>{});
         return Tracked{std::move(out)};
     }
     Tracked operator-(const Tracked &other) const {

--- a/au/compatibility/materialization_copy_count_test.cc
+++ b/au/compatibility/materialization_copy_count_test.cc
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include "au/au.hh"
-#include "au/compatibility/eigen.hh"  // For the unit-aware `eval()` free function.
+#include "au/compatibility/eigen.hh"
 #include "au/testing.hh"
 #include "gtest/gtest.h"
 

--- a/au/compatibility/materialization_copy_count_test.cc
+++ b/au/compatibility/materialization_copy_count_test.cc
@@ -95,11 +95,8 @@ class Tracked {
     // builds a fresh `Tracked`, so neither is a copy of an existing one.
     Tracked operator+(const Tracked &other) const {
         std::vector<double> out(data_.size());
-        std::transform(data_.begin(),
-                       data_.end(),
-                       other.data_.begin(),
-                       out.begin(),
-                       std::plus<double>{});
+        std::transform(
+            data_.begin(), data_.end(), other.data_.begin(), out.begin(), std::plus<double>{});
         return Tracked{std::move(out)};
     }
     Tracked operator-(const Tracked &other) const {

--- a/au/compatibility/materialization_copy_count_test.cc
+++ b/au/compatibility/materialization_copy_count_test.cc
@@ -41,7 +41,9 @@ constexpr auto meters = QuantityMaker<Meters>{};
 struct Feet : decltype(Meters{} * mag<381>() / mag<1250>()) {};
 constexpr auto feet = QuantityMaker<Feet>{};
 
-// Global tallies.  We reset them immediately before each measured operation.
+// Global tallies.  The `MaterializationCopyCount` fixture zeroes them in `SetUp()`, so each test
+// starts from a clean slate.  (Per-test setup --- building inputs from prvalues --- only ever
+// *moves*, contributing no copies or evals, so it does not disturb the quantities we assert on.)
 struct Counts {
     int copies = 0;  // copy-constructions + copy-assignments of `Tracked`
     int moves = 0;   // move-constructions + move-assignments of `Tracked`
@@ -148,11 +150,17 @@ Tracked make_tracked(std::size_t n) {
     return Tracked{std::move(data)};
 }
 
+// Zeroes the copy/move/eval tallies before each test, so no test has to remember to call
+// `reset_counts()` itself.
+class MaterializationCopyCount : public ::testing::Test {
+ protected:
+    void SetUp() override { reset_counts(); }
+};
+
 // (1a) `meters(v)` from an lvalue must copy exactly once (the input is not ours to steal).
-TEST(MaterializationCopyCount, MakerFromLvalueCopiesExactlyOnce) {
+TEST_F(MaterializationCopyCount, MakerFromLvalueCopiesExactlyOnce) {
     Tracked v = make_tracked(8);
 
-    reset_counts();
     auto q = meters(v);
     EXPECT_THAT(counts().copies, Eq(1));
 
@@ -161,10 +169,9 @@ TEST(MaterializationCopyCount, MakerFromLvalueCopiesExactlyOnce) {
 }
 
 // (1b) `meters(rvalue)` must never copy: an rvalue may be moved from freely.
-TEST(MaterializationCopyCount, MakerFromRvalueNeverCopies) {
+TEST_F(MaterializationCopyCount, MakerFromRvalueNeverCopies) {
     Tracked v = make_tracked(8);
 
-    reset_counts();
     auto q = meters(std::move(v));
     EXPECT_THAT(counts().copies, Eq(0));
 
@@ -172,8 +179,7 @@ TEST(MaterializationCopyCount, MakerFromRvalueNeverCopies) {
 }
 
 // (1c) `meters(prvalue)` (a pure temporary) must never copy either.
-TEST(MaterializationCopyCount, MakerFromPrvalueNeverCopies) {
-    reset_counts();
+TEST_F(MaterializationCopyCount, MakerFromPrvalueNeverCopies) {
     auto q = meters(make_tracked(8));
     EXPECT_THAT(counts().copies, Eq(0));
 
@@ -182,10 +188,9 @@ TEST(MaterializationCopyCount, MakerFromPrvalueNeverCopies) {
 
 // (2) `eval(q)` on an lvalue quantity with a concrete rep: exactly one copy (the inherent one from
 // `.eval()`); everything downstream (`make_quantity` and the constructor) must move.
-TEST(MaterializationCopyCount, EvalCopiesExactlyOnce) {
+TEST_F(MaterializationCopyCount, EvalCopiesExactlyOnce) {
     auto q = meters(make_tracked(8));
 
-    reset_counts();
     auto r = eval(q);
     EXPECT_THAT(counts().copies, Eq(1));
 
@@ -194,11 +199,10 @@ TEST(MaterializationCopyCount, EvalCopiesExactlyOnce) {
 
 // (3) Converting-constructor from an expression-rep quantity to the same unit with a concrete rep:
 // zero copies of the concrete rep, and the expression evaluated exactly once.
-TEST(MaterializationCopyCount, ConvertingCtorFromExpressionRepZeroCopiesOneEval) {
+TEST_F(MaterializationCopyCount, ConvertingCtorFromExpressionRepZeroCopiesOneEval) {
     Tracked src = make_tracked(8);
     auto q_expr = meters(TrackedExpr{src});
 
-    reset_counts();
     Quantity<Meters, Tracked> r = q_expr;
     EXPECT_THAT(counts().copies, Eq(0));
     EXPECT_THAT(counts().evals, Eq(1));
@@ -208,10 +212,9 @@ TEST(MaterializationCopyCount, ConvertingCtorFromExpressionRepZeroCopiesOneEval)
 
 // (4a) A genuine unit conversion on a concrete rep: exactly one conversion pass (the scalar
 // multiply, which builds a fresh vector), and zero copies of any existing `Tracked`.
-TEST(MaterializationCopyCount, UnitConversionZeroCopies) {
+TEST_F(MaterializationCopyCount, UnitConversionZeroCopies) {
     auto q = meters(make_tracked(8));
 
-    reset_counts();
     auto in_feet = q.as<Tracked>(feet);
     EXPECT_THAT(counts().copies, Eq(0));
 
@@ -221,10 +224,9 @@ TEST(MaterializationCopyCount, UnitConversionZeroCopies) {
 // (4b) A same-unit rep "conversion" (`.as<Rep>(same_unit)`) is an identity magnitude.  Here the one
 // conversion pass IS a copy: the result gets its own vector, duplicated from the (const) source
 // member --- there is nothing to move from --- so exactly one copy is the true minimum.
-TEST(MaterializationCopyCount, SameUnitAsCopiesExactlyOnce) {
+TEST_F(MaterializationCopyCount, SameUnitAsCopiesExactlyOnce) {
     auto q = meters(make_tracked(8));
 
-    reset_counts();
     auto same = q.as<Tracked>(meters);
     EXPECT_THAT(counts().copies, Eq(1));
 

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <type_traits>
 #include <utility>
 
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
@@ -38,15 +39,35 @@ namespace au {
 //
 // Make a Quantity of the given Unit, which has this value as measured in the Unit.
 //
+// lvalue: copy.  (Never move something the caller still owns; also the only thing that works for a
+// packed field, which can't bind to a reference.)
 template <typename UnitT, typename T>
-AU_DEVICE_FUNC constexpr auto make_quantity(T value) {
+AU_DEVICE_FUNC constexpr auto make_quantity(const T &value) {
     return QuantityMaker<UnitT>{}(value);
 }
 
+// rvalue: move.
+template <typename UnitT,
+          typename T,
+          typename = std::enable_if_t<!std::is_lvalue_reference<T>::value>>
+AU_DEVICE_FUNC constexpr auto make_quantity(T &&value) {
+    return QuantityMaker<UnitT>{}(std::move(value));
+}
+
+// lvalue: copy.  (See `make_quantity` above.)
 template <typename Unit, typename T>
-AU_DEVICE_FUNC constexpr auto make_quantity_unless_unitless(T value) {
+AU_DEVICE_FUNC constexpr auto make_quantity_unless_unitless(const T &value) {
     return std::conditional_t<IsUnitlessUnit<Unit>::value, stdx::identity, QuantityMaker<Unit>>{}(
         value);
+}
+
+// rvalue: move.
+template <typename Unit,
+          typename T,
+          typename = std::enable_if_t<!std::is_lvalue_reference<T>::value>>
+AU_DEVICE_FUNC constexpr auto make_quantity_unless_unitless(T &&value) {
+    return std::conditional_t<IsUnitlessUnit<Unit>::value, stdx::identity, QuantityMaker<Unit>>{}(
+        std::move(value));
 }
 
 // Trait to check whether two Quantity types are exactly equivalent.
@@ -161,7 +182,7 @@ class Quantity {
               typename OtherRep,
               typename Enable = EnableIfImplicitOkIs<true, OtherUnit, OtherRep>>
     AU_DEVICE_FUNC constexpr Quantity(
-        Quantity<OtherUnit, OtherRep> other)  // NOLINT(runtime/explicit)
+        const Quantity<OtherUnit, OtherRep> &other)  // NOLINT(runtime/explicit)
         : value_{other.template in_impl<detail::UseImplicitConversion, Rep>(
               UnitT{}, check_for(ALL_RISKS))} {}
 
@@ -171,14 +192,15 @@ class Quantity {
               typename Enable = EnableIfImplicitOkIs<false, OtherUnit, OtherRep>,
               typename ThisUnusedTemplateParameterDistinguishesUsFromTheAboveConstructor = void>
     // Deleted: use `.as<NewRep>(new_unit)` to force a cast.
-    explicit constexpr Quantity(Quantity<OtherUnit, OtherRep> other) = delete;
+    explicit constexpr Quantity(const Quantity<OtherUnit, OtherRep> &other) = delete;
 
     // Constructor for another Quantity with an explicit conversion risk policy.
     template <typename OtherUnit,
               typename OtherRep,
               typename RiskPolicyT,
               std::enable_if_t<IsConversionRiskPolicy<RiskPolicyT>::value, int> = 0>
-    AU_DEVICE_FUNC constexpr Quantity(Quantity<OtherUnit, OtherRep> other, RiskPolicyT policy)
+    AU_DEVICE_FUNC constexpr Quantity(const Quantity<OtherUnit, OtherRep> &other,
+                                      RiskPolicyT policy)
         : value_{other.template in<Rep>(UnitT{}, policy)} {}
 
     // Construct this Quantity with a value of exactly Zero.
@@ -618,7 +640,7 @@ class Quantity {
         return Op::apply_to(value_);
     }
 
-    AU_DEVICE_FUNC constexpr Quantity(Rep value) : value_{value} {}
+    AU_DEVICE_FUNC constexpr Quantity(Rep value) : value_{std::move(value)} {}
 
     Rep value_{};
 };
@@ -738,9 +760,16 @@ struct QuantityMaker {
     using Unit = UnitT;
     static constexpr auto unit = Unit{};
 
+    // lvalue: copy. (See `make_quantity` above.)
     template <typename T>
-    AU_DEVICE_FUNC constexpr Quantity<Unit, T> operator()(T value) const {
-        return {value};
+    AU_DEVICE_FUNC constexpr Quantity<Unit, std::decay_t<T>> operator()(const T &value) const {
+        return Quantity<Unit, std::decay_t<T>>{value};
+    }
+
+    // rvalue: move.
+    template <typename T, typename = std::enable_if_t<!std::is_lvalue_reference<T>::value>>
+    AU_DEVICE_FUNC constexpr Quantity<Unit, std::decay_t<T>> operator()(T &&value) const {
+        return Quantity<Unit, std::decay_t<T>>{std::move(value)};
     }
 
     template <typename U, typename R>

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -40,7 +40,7 @@ namespace au {
 // Make a Quantity of the given Unit, which has this value as measured in the Unit.
 //
 // lvalue: copy.  (Never move something the caller still owns; also the only thing that works for a
-// packed field, which can't bind to a reference.)
+// packed field, which can't bind to a non-const reference.)
 template <typename UnitT, typename T>
 AU_DEVICE_FUNC constexpr auto make_quantity(const T &value) {
     return QuantityMaker<UnitT>{}(value);

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <type_traits>
+#include <utility>
+
 #if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
 #include <compare>
 #endif
@@ -42,9 +45,19 @@ namespace au {
 // `std::chrono::duration`.
 
 // Make a Quantity of the given Unit, which has this value as measured in the Unit.
+// lvalue: copy.  (Never move something the caller still owns; also the only thing that works for a
+// packed field, which can't bind to a reference.)
 template <typename UnitT, typename T>
-AU_DEVICE_FUNC constexpr auto make_quantity_point(T value) {
+AU_DEVICE_FUNC constexpr auto make_quantity_point(const T &value) {
     return QuantityPointMaker<UnitT>{}(value);
+}
+
+// rvalue: move.
+template <typename UnitT,
+          typename T,
+          typename = std::enable_if_t<!std::is_lvalue_reference<T>::value>>
+AU_DEVICE_FUNC constexpr auto make_quantity_point(T &&value) {
+    return QuantityPointMaker<UnitT>{}(std::move(value));
 }
 
 // Trait to check whether two QuantityPoint types are exactly equivalent.
@@ -114,7 +127,7 @@ class QuantityPoint {
               typename OtherRep,
               typename Enable = EnableIfImplicitOkIs<true, OtherUnit, OtherRep>>
     AU_DEVICE_FUNC constexpr QuantityPoint(
-        QuantityPoint<OtherUnit, OtherRep> other)  // NOLINT(runtime/explicit)
+        const QuantityPoint<OtherUnit, OtherRep> &other)  // NOLINT(runtime/explicit)
         : QuantityPoint{other.template as<Rep>(unit)} {}
 
     template <typename OtherUnit,
@@ -122,14 +135,14 @@ class QuantityPoint {
               typename Enable = EnableIfImplicitOkIs<false, OtherUnit, OtherRep>,
               typename ThisUnusedTemplateParameterDistinguishesUsFromTheAboveConstructor = void>
     // Deleted: use `.as<NewRep>(new_unit)` to force a cast.
-    constexpr explicit QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other) = delete;
+    constexpr explicit QuantityPoint(const QuantityPoint<OtherUnit, OtherRep> &other) = delete;
 
     // Construct from another QuantityPoint with an explicit conversion risk policy.
     template <typename OtherUnit,
               typename OtherRep,
               typename RiskPolicyT,
               std::enable_if_t<IsConversionRiskPolicy<RiskPolicyT>::value, int> = 0>
-    AU_DEVICE_FUNC constexpr QuantityPoint(QuantityPoint<OtherUnit, OtherRep> other,
+    AU_DEVICE_FUNC constexpr QuantityPoint(const QuantityPoint<OtherUnit, OtherRep> &other,
                                            RiskPolicyT policy)
         : QuantityPoint{other.template as<Rep>(Unit{}, policy)} {}
 
@@ -284,7 +297,7 @@ class QuantityPoint {
         return intermediate_result.template in<OtherRep>(OtherUnit{}, policy);
     }
 
-    AU_DEVICE_FUNC constexpr explicit QuantityPoint(Diff x) : x_{x} {}
+    AU_DEVICE_FUNC constexpr explicit QuantityPoint(Diff x) : x_{std::move(x)} {}
 
     Diff x_;
 };
@@ -293,9 +306,17 @@ template <typename Unit>
 struct QuantityPointMaker {
     static constexpr auto unit = Unit{};
 
+    // lvalue: copy.  (Never move something the caller still owns; also the only thing that works
+    // for a packed field, which can't bind to a reference.)
     template <typename T>
-    AU_DEVICE_FUNC constexpr auto operator()(T value) const {
-        return QuantityPoint<Unit, T>{make_quantity<Unit>(value)};
+    AU_DEVICE_FUNC constexpr auto operator()(const T &value) const {
+        return QuantityPoint<Unit, std::decay_t<T>>{make_quantity<Unit>(value)};
+    }
+
+    // rvalue: move.
+    template <typename T, typename = std::enable_if_t<!std::is_lvalue_reference<T>::value>>
+    AU_DEVICE_FUNC constexpr auto operator()(T &&value) const {
+        return QuantityPoint<Unit, std::decay_t<T>>{make_quantity<Unit>(std::move(value))};
     }
 
     template <typename U, typename R>

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -46,7 +46,7 @@ namespace au {
 
 // Make a Quantity of the given Unit, which has this value as measured in the Unit.
 // lvalue: copy.  (Never move something the caller still owns; also the only thing that works for a
-// packed field, which can't bind to a reference.)
+// packed field, which can't bind to a non-const reference.)
 template <typename UnitT, typename T>
 AU_DEVICE_FUNC constexpr auto make_quantity_point(const T &value) {
     return QuantityPointMaker<UnitT>{}(value);
@@ -307,7 +307,7 @@ struct QuantityPointMaker {
     static constexpr auto unit = Unit{};
 
     // lvalue: copy.  (Never move something the caller still owns; also the only thing that works
-    // for a packed field, which can't bind to a reference.)
+    // for a packed field, which can't bind to a non-const reference.)
     template <typename T>
     AU_DEVICE_FUNC constexpr auto operator()(const T &value) const {
         return QuantityPoint<Unit, std::decay_t<T>>{make_quantity<Unit>(value)};

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -145,6 +145,19 @@ TEST(QuantityPoint, CanGetValueInDifferentUnits) {
     EXPECT_THAT(p.in(centi(meters_pt)), SameTypeAndValue(300));
 }
 
+// Regression test: a bitfield (packed member) cannot bind to a non-const reference, so the point
+// maker and `make_quantity_point` must accept it via their `const T&` overload.  This once failed
+// to compile.
+TEST(QuantityPointMaker, WorksOnBitfieldMembers) {
+    struct Packed {
+        int value : 20;
+    };
+    Packed p{5};
+
+    EXPECT_THAT(meters_pt(p.value), SameTypeAndValue(meters_pt(5)));
+    EXPECT_THAT(make_quantity_point<Meters>(p.value), SameTypeAndValue(meters_pt(5)));
+}
+
 TEST(QuantityPoint, IntermediateTypeIsSignedIfExplicitRepIsSigned) {
     EXPECT_THAT(milli(kelvins_pt)(0u).coerce_as<int>(celsius_pt),
                 SameTypeAndValue(celsius_pt(-273)));

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -276,6 +276,21 @@ TEST(QuantityMaker, CreatesAppropriateQuantityIfCalled) {
     EXPECT_THAT(yards(3.14).in(yards), Eq(3.14));
 }
 
+// Regression test: a bitfield (packed member) cannot bind to a non-const reference, so the maker
+// and the `make_quantity`-style free functions must accept it via their `const T&` overload.  This
+// once failed to compile.
+TEST(QuantityMaker, WorksOnBitfieldMembers) {
+    struct Packed {
+        int meters_value : 20;
+        int feet_value : 20;
+    };
+    Packed p{5, 7};
+
+    EXPECT_THAT(meters(p.meters_value), SameTypeAndValue(meters(5)));
+    EXPECT_THAT(make_quantity<Meters>(p.meters_value), SameTypeAndValue(meters(5)));
+    EXPECT_THAT(make_quantity_unless_unitless<Feet>(p.feet_value), SameTypeAndValue(feet(7)));
+}
+
 TEST(QuantityMaker, CanBeMultipliedBySingularUnitToGetMakerOfProductUnit) {
     StaticAssertTypeEq<decltype(hour * feet), QuantityMaker<UnitProduct<Feet, Hours>>>();
 }


### PR DESCRIPTION
Preliminary benchmarking revealed that sometimes `eval(...)` was causing
more copies than necessary.  We traced this to both the `eval`
implementation itself, and to various signature choices in our core
library machinery (similar to the recent changes to take inputs by
`const&` in many places).

To fix our machinery, we switch to using _forwarding references_ in the
`StaticCast`, `ImplicitConversion`, and `OpSequence` operations, as well
as the identity specialization for `MultiplyTypeBy`.  Then, in
`quantity.hh` and `quantity_point.hh`, we change the `make_quantity`-ish
functions to use forwarding references too, while switching several
constructors to use `const&`.  Finally, we take a previously missed
opportunity to `move` inside of the value constructor.

(We subsequently found that many of these "library entry" forwarding
references will break for bitfield inputs.  The principled fix was to
split based on value category: we use forwarding references for _rvalue
inputs only_, and take lvaues by `const&`.)

And now we are ready to fix `eval(...)`.  The subtlety here is that
Eigen returns a `const` object from `.eval()`.  The workaround is to
store that object in a non-`const` local variable, and then move the
variable into the `make_quantity` call.

Overall, these changes restored Au to performance parity with raw Eigen,
at least on the examples we have tested so far.