### PR TITLE
Normalize integral rep

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -761,15 +761,17 @@ struct QuantityMaker {
     static constexpr auto unit = Unit{};
 
     // lvalue: copy. (See `make_quantity` above.)
-    template <typename T>
-    AU_DEVICE_FUNC constexpr Quantity<Unit, std::decay_t<T>> operator()(const T &value) const {
-        return Quantity<Unit, std::decay_t<T>>{value};
+    template <typename T, typename Rep = detail::NormalizeRep<std::decay_t<T>>>
+    AU_DEVICE_FUNC constexpr Quantity<Unit, Rep> operator()(const T &value) const {
+        return Quantity<Unit, Rep>{value};
     }
 
     // rvalue: move.
-    template <typename T, typename = std::enable_if_t<!std::is_lvalue_reference<T>::value>>
-    AU_DEVICE_FUNC constexpr Quantity<Unit, std::decay_t<T>> operator()(T &&value) const {
-        return Quantity<Unit, std::decay_t<T>>{std::move(value)};
+    template <typename T,
+              typename Rep = detail::NormalizeRep<std::decay_t<T>>,
+              typename = std::enable_if_t<!std::is_lvalue_reference<T>::value>>
+    AU_DEVICE_FUNC constexpr Quantity<Unit, Rep> operator()(T &&value) const {
+        return Quantity<Unit, Rep>{std::move(value)};
     }
 
     template <typename U, typename R>

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -308,15 +308,17 @@ struct QuantityPointMaker {
 
     // lvalue: copy.  (Never move something the caller still owns; also the only thing that works
     // for a packed field, which can't bind to a non-const reference.)
-    template <typename T>
+    template <typename T, typename Rep = detail::NormalizeRep<std::decay_t<T>>>
     AU_DEVICE_FUNC constexpr auto operator()(const T &value) const {
-        return QuantityPoint<Unit, std::decay_t<T>>{make_quantity<Unit>(value)};
+        return QuantityPoint<Unit, Rep>{make_quantity<Unit>(value)};
     }
 
     // rvalue: move.
-    template <typename T, typename = std::enable_if_t<!std::is_lvalue_reference<T>::value>>
+    template <typename T,
+              typename Rep = detail::NormalizeRep<std::decay_t<T>>,
+              typename = std::enable_if_t<!std::is_lvalue_reference<T>::value>>
     AU_DEVICE_FUNC constexpr auto operator()(T &&value) const {
-        return QuantityPoint<Unit, std::decay_t<T>>{make_quantity<Unit>(std::move(value))};
+        return QuantityPoint<Unit, Rep>{make_quantity<Unit>(std::move(value))};
     }
 
     template <typename U, typename R>

--- a/au/rep.hh
+++ b/au/rep.hh
@@ -97,6 +97,9 @@ struct IsStandardInteger : stdx::disjunction<std::is_same<T, bool>,
                                              std::is_same<T, char>,
                                              std::is_same<T, signed char>,
                                              std::is_same<T, unsigned char>,
+#if defined(__cpp_char8_t)
+                                             std::is_same<T, char8_t>,
+#endif
                                              std::is_same<T, char16_t>,
                                              std::is_same<T, char32_t>,
                                              std::is_same<T, wchar_t>,

--- a/au/rep.hh
+++ b/au/rep.hh
@@ -110,7 +110,8 @@ struct IsStandardInteger : stdx::disjunction<std::is_same<T, bool>,
                                              std::is_same<T, long>,
                                              std::is_same<T, unsigned long>,
                                              std::is_same<T, long long>,
-                                             std::is_same<T, unsigned long long>> {};
+                                             std::is_same<T, unsigned long long>> {
+};
 
 // The type `T` promotes to under unary `+`.  Integral promotion produces a fresh standard prvalue,
 // which launders any vendor attribute off of `T`.  (Ill-formed --- hence a SFINAE removal below ---

--- a/au/rep.hh
+++ b/au/rep.hh
@@ -14,7 +14,10 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <type_traits>
+#include <utility>
 
 #include "au/fwd.hh"
 #include "au/stdx/experimental/is_detected.hh"
@@ -58,6 +61,115 @@ struct IsAuType<::au::Quantity<U, R>> : std::true_type {};
 
 template <typename U, typename R>
 struct IsAuType<::au::QuantityPoint<U, R>> : std::true_type {};
+
+//
+// `NormalizeRep<T>`: strip vendor attributes (e.g. Green Hills' `__packed`) from an integral rep by
+// naming a clean standard type, rather than relying on `std::decay` to drop the attribute (which
+// GHS does not do).
+//
+// This is the _identity_ on every genuine standard type (integral or not), so it is a provable
+// no-op for any rep a user would normally write.  It only rewrites a type that behaves like an
+// integer, yet names *none* of the standard integer types.  This is the telltale sign of attributed
+// types, such as `__packed uint16_t`.  In these cases, we map it to the fixed-width standard
+// integer with the same `sizeof` and signedness.
+//
+// Critically, gating this on `std::is_integral<T>` won't work.  The whole reason `std::decay` fails
+// to help on GHS is that GHS keeps vendor attributes on the type --- and it *also* mis-answers
+// `std::is_integral` for such a type (it reports `false`).  So a normalization gated on
+// `is_integral` not only won't be reliable, but also fails on the motivating example.  Instead we
+// detect integer-ness through mechanisms the attribute does not defeat:
+//
+//   * Integer-ness: `is_integral<decltype(+declval<T>())>`.  Unary `+` triggers integral promotion,
+//     which yields a fresh prvalue of a *standard* type --- this reliably strips the vendor
+//     attribute.  (Note that Au already depends on exactly this behavior in `io.hh`).  We then ask
+//     `is_integral` about that clean, promoted type, which GHS answers correctly.
+//   * Width: `sizeof(T)` --- a core operator, unaffected by the attribute.
+//   * Signedness: the value test `T(-1) < T(0)` --- core arithmetic, not `std::is_signed`.
+//
+// We additionally leave every standard type untouched, and never normalize class, union, or enum
+// types, to keep this fix as targeted as possible.
+//
+
+// Is `T` *exactly* one of the standard integer types?  An attributed integral type compares unequal
+// to all of these, so it is not "standard" by this definition.
+template <typename T>
+struct IsStandardInteger : stdx::disjunction<std::is_same<T, bool>,
+                                             std::is_same<T, char>,
+                                             std::is_same<T, signed char>,
+                                             std::is_same<T, unsigned char>,
+                                             std::is_same<T, char16_t>,
+                                             std::is_same<T, char32_t>,
+                                             std::is_same<T, wchar_t>,
+                                             std::is_same<T, short>,
+                                             std::is_same<T, unsigned short>,
+                                             std::is_same<T, int>,
+                                             std::is_same<T, unsigned int>,
+                                             std::is_same<T, long>,
+                                             std::is_same<T, unsigned long>,
+                                             std::is_same<T, long long>,
+                                             std::is_same<T, unsigned long long>> {};
+
+// The type `T` promotes to under unary `+`.  Integral promotion produces a fresh standard prvalue,
+// which launders any vendor attribute off of `T`.  (Ill-formed --- hence a SFINAE removal below ---
+// for types with no unary `+`, which is exactly what we want: they are not integers to normalize.)
+template <typename T>
+using PromotedRep = decltype(+std::declval<T>());
+
+// Attribute-immune signedness: for an unsigned type `T(-1)` wraps to the maximum value (not `< 0`);
+// for a signed type it is `-1`.  Uses arithmetic, not `std::is_signed` (which the attribute may
+// defeat on GHS).
+template <typename T>
+constexpr bool rep_is_signed() {
+    return static_cast<T>(-1) < static_cast<T>(0);
+}
+
+// Should we normalize `T`?  True exactly for an integer-behaving type that is not already a
+// standard integer and is not a class/union/enum.  See the mechanism notes above for why none of
+// these predicates route through `is_integral<T>` / `is_signed<T>` on the attributed type itself.
+template <typename T, typename Enable = void>
+struct ShouldNormalizeRep : std::false_type {};  // no unary `+` (e.g. most class reps): leave alone
+template <typename T>
+struct ShouldNormalizeRep<T, stdx::void_t<PromotedRep<T>>>
+    : stdx::conjunction<std::is_integral<PromotedRep<T>>,
+                        stdx::negation<IsStandardInteger<T>>,
+                        stdx::negation<std::is_class<T>>,
+                        stdx::negation<std::is_union<T>>,
+                        stdx::negation<std::is_enum<T>>> {};
+
+// Pick the fixed-width standard integer type (`int8_t` ... `int64_t` and unsigned counterparts)
+// with the given `sizeof` and signedness; if none matches, fall back to `Fallback` (so an exotic
+// integral such as `__int128`, whose width no fixed-width type covers, is left untouched rather
+// than becoming a hard error).  We use the fixed-width candidates deliberately: there is exactly
+// one per (size, signedness), so the selection is unambiguous --- no reliance on integer-rank
+// tie-breaking.
+template <typename Fallback, std::size_t Size, bool Signed, typename... Candidates>
+struct FirstMatchingIntegerOr : stdx::type_identity<Fallback> {};
+
+template <typename Fallback, std::size_t Size, bool Signed, typename C, typename... Rest>
+struct FirstMatchingIntegerOr<Fallback, Size, Signed, C, Rest...>
+    : std::conditional_t<sizeof(C) == Size && (std::is_signed<C>::value == Signed),
+                         stdx::type_identity<C>,
+                         FirstMatchingIntegerOr<Fallback, Size, Signed, Rest...>> {};
+
+template <typename T, typename Enable = void>
+struct NormalizeRepImpl : stdx::type_identity<T> {};  // non-integer or already-standard: identity
+
+template <typename T>
+struct NormalizeRepImpl<T, std::enable_if_t<ShouldNormalizeRep<T>::value>>
+    : FirstMatchingIntegerOr<T,
+                             sizeof(T),
+                             rep_is_signed<T>(),
+                             std::int8_t,
+                             std::uint8_t,
+                             std::int16_t,
+                             std::uint16_t,
+                             std::int32_t,
+                             std::uint32_t,
+                             std::int64_t,
+                             std::uint64_t> {};
+
+template <typename T>
+using NormalizeRep = typename NormalizeRepImpl<T>::type;
 
 template <typename T>
 using CorrespondingUnit = typename CorrespondingQuantity<T>::Unit;

--- a/au/rep_test.cc
+++ b/au/rep_test.cc
@@ -15,6 +15,7 @@
 #include "au/rep.hh"
 
 #include <complex>
+#include <cstdint>
 
 #include "au/chrono_interop.hh"
 #include "au/constant.hh"
@@ -58,6 +59,17 @@ struct LeftMultiplyDoubleByThree {
 struct DivideTenByFloat {
     friend float operator/(const DivideTenByFloat &, float x) { return 10.0f / x; }
 };
+
+// A class rep with an implicit conversion to a standard integer.  Under a naive conversion-based
+// normalization it would be silently rewritten to `int`.  This helps us get coverage for the
+// `!is_class` guard.
+struct ConvertsToInt {
+    operator int() const { return 0; }  // NOLINT(google-explicit-constructor)
+};
+
+// An unscoped enum promotes to its underlying integer under unary `+`, so integer detection alone
+// would incorrectly scoop it up too.  This helps us get coverage for the `!is_enum` guard.
+enum UnscopedEnum : int { kUnscopedEnumValue = 0 };
 
 }  // namespace
 
@@ -169,6 +181,139 @@ TEST(ProductTypeOrVoid, GivesProductTypeForArithmeticInputs) {
 TEST(ProductTypeOrVoid, GivesVoidForInputsWithNoProductType) {
     StaticAssertTypeEq<void, ProductTypeOrVoid<IntWithNoOps, int>>();
     StaticAssertTypeEq<void, ProductTypeOrVoid<int, IntWithNoOps>>();
+}
+
+TEST(NormalizeRep, IsIdentityOnStandardIntegerTypes) {
+    StaticAssertTypeEq<NormalizeRep<bool>, bool>();
+    StaticAssertTypeEq<NormalizeRep<char>, char>();
+    StaticAssertTypeEq<NormalizeRep<signed char>, signed char>();
+    StaticAssertTypeEq<NormalizeRep<unsigned char>, unsigned char>();
+    StaticAssertTypeEq<NormalizeRep<short>, short>();
+    StaticAssertTypeEq<NormalizeRep<unsigned short>, unsigned short>();
+    StaticAssertTypeEq<NormalizeRep<int>, int>();
+    StaticAssertTypeEq<NormalizeRep<unsigned int>, unsigned int>();
+    StaticAssertTypeEq<NormalizeRep<long>, long>();
+    StaticAssertTypeEq<NormalizeRep<unsigned long>, unsigned long>();
+    StaticAssertTypeEq<NormalizeRep<long long>, long long>();
+    StaticAssertTypeEq<NormalizeRep<unsigned long long>, unsigned long long>();
+
+    StaticAssertTypeEq<NormalizeRep<int8_t>, int8_t>();
+    StaticAssertTypeEq<NormalizeRep<uint8_t>, uint8_t>();
+
+    StaticAssertTypeEq<NormalizeRep<int16_t>, int16_t>();
+    StaticAssertTypeEq<NormalizeRep<uint16_t>, uint16_t>();
+
+    StaticAssertTypeEq<NormalizeRep<int32_t>, int32_t>();
+    StaticAssertTypeEq<NormalizeRep<uint32_t>, uint32_t>();
+
+    StaticAssertTypeEq<NormalizeRep<int64_t>, int64_t>();
+    StaticAssertTypeEq<NormalizeRep<uint64_t>, uint64_t>();
+}
+
+TEST(NormalizeRep, IsIdentityOnNonIntegralTypes) {
+    StaticAssertTypeEq<NormalizeRep<float>, float>();
+    StaticAssertTypeEq<NormalizeRep<double>, double>();
+    StaticAssertTypeEq<NormalizeRep<long double>, long double>();
+    StaticAssertTypeEq<NormalizeRep<std::complex<double>>, std::complex<double>>();
+    StaticAssertTypeEq<NormalizeRep<IntWithNoOps>, IntWithNoOps>();
+}
+
+TEST(NormalizeRep, IsIdentityOnIntegerAdjacentClassEnumAndPointer) {
+    // Class with an implicit conversion to `int`: guarded by `!is_class`.
+    StaticAssertTypeEq<NormalizeRep<ConvertsToInt>, ConvertsToInt>();
+
+    // Unscoped enum (promotes to `int` under `+`): guarded by `!is_enum`.
+    StaticAssertTypeEq<NormalizeRep<UnscopedEnum>, UnscopedEnum>();
+
+    // Pointer (converts to `bool`; also `+ptr` is a pointer, not integral): left alone.
+    StaticAssertTypeEq<NormalizeRep<int *>, int *>();
+}
+
+// `rep_is_signed` recovers signedness by value (attribute-immune), not via `std::is_signed`.
+template <typename T>
+struct RepIsSignedAgreesWithStd
+    : stdx::bool_constant<rep_is_signed<T>() == std::is_signed<T>::value> {};
+
+TEST(NormalizeRep, RepIsSignedMatchesStdIsSignedForStandardIntegers) {
+    EXPECT_THAT(RepIsSignedAgreesWithStd<signed char>::value, IsTrue());
+    EXPECT_THAT(RepIsSignedAgreesWithStd<short>::value, IsTrue());
+    EXPECT_THAT(RepIsSignedAgreesWithStd<int>::value, IsTrue());
+    EXPECT_THAT(RepIsSignedAgreesWithStd<long long>::value, IsTrue());
+    EXPECT_THAT(RepIsSignedAgreesWithStd<unsigned char>::value, IsTrue());
+    EXPECT_THAT(RepIsSignedAgreesWithStd<unsigned short>::value, IsTrue());
+    EXPECT_THAT(RepIsSignedAgreesWithStd<unsigned int>::value, IsTrue());
+    EXPECT_THAT(RepIsSignedAgreesWithStd<unsigned long long>::value, IsTrue());
+}
+
+// `ShouldNormalizeRep` is false for everything we can spell portably (standard integers are already
+// standard; floats/classes/enums are excluded).  It goes true only for an integer-behaving type
+// that names no standard integer --- i.e. an attributed type, which we cannot spell portably.
+TEST(NormalizeRep, ShouldNormalizeRepIsFalseForAllPortablyExpressibleTypes) {
+    EXPECT_THAT(ShouldNormalizeRep<int>::value, IsFalse());
+    EXPECT_THAT(ShouldNormalizeRep<uint16_t>::value, IsFalse());
+    EXPECT_THAT(ShouldNormalizeRep<double>::value, IsFalse());
+    EXPECT_THAT(ShouldNormalizeRep<ConvertsToInt>::value, IsFalse());
+    EXPECT_THAT(ShouldNormalizeRep<UnscopedEnum>::value, IsFalse());
+    EXPECT_THAT(ShouldNormalizeRep<IntWithNoOps>::value, IsFalse());
+}
+
+// The mechanism that fires on GHS: the size+signedness remap that `NormalizeRep` uses for a
+// non-standard integral type (the portable stand-in for the non-portable attributed
+// `__packed uint16_t` that motivates the trait).  We exercise `FirstMatchingIntegerOr` directly,
+// since there is no portable way to spell an attributed integral type.
+TEST(NormalizeRep, RemapPicksStandardIntegerBySizeAndSignedness) {
+    StaticAssertTypeEq<FirstMatchingIntegerOr<void,
+                                              sizeof(int16_t),
+                                              true,
+                                              std::int8_t,
+                                              std::uint8_t,
+                                              std::int16_t,
+                                              std::uint16_t,
+                                              std::int32_t,
+                                              std::uint32_t,
+                                              std::int64_t,
+                                              std::uint64_t>::type,
+                       int16_t>();
+    StaticAssertTypeEq<FirstMatchingIntegerOr<void,
+                                              sizeof(uint16_t),
+                                              false,
+                                              std::int8_t,
+                                              std::uint8_t,
+                                              std::int16_t,
+                                              std::uint16_t,
+                                              std::int32_t,
+                                              std::uint32_t,
+                                              std::int64_t,
+                                              std::uint64_t>::type,
+                       uint16_t>();
+}
+
+// When no fixed-width standard integer matches (e.g. a hypothetical oversized integral), the remap
+// leaves the type untouched via its fallback, so exotic reps like `__int128` never become a hard
+// error.
+TEST(NormalizeRep, RemapFallsBackWhenNoStandardIntegerMatches) {
+    struct Tag {};  // stand-in for "some type"; only used as the fallback here
+    StaticAssertTypeEq<FirstMatchingIntegerOr<Tag,
+                                              sizeof(std::int64_t) * 2,
+                                              true,
+                                              std::int8_t,
+                                              std::int16_t,
+                                              std::int32_t,
+                                              std::int64_t>::type,
+                       Tag>();
+}
+
+// Identity across every fixed-width standard integer (each is already standard, so it round-trips
+// unchanged --- the full-width companion to the spot checks in `IsIdentityOnStandardIntegerTypes`).
+TEST(NormalizeRep, IsIdentityForAllFixedWidthStandardIntegers) {
+    StaticAssertTypeEq<NormalizeRep<int8_t>, int8_t>();
+    StaticAssertTypeEq<NormalizeRep<uint8_t>, uint8_t>();
+    StaticAssertTypeEq<NormalizeRep<int16_t>, int16_t>();
+    StaticAssertTypeEq<NormalizeRep<uint16_t>, uint16_t>();
+    StaticAssertTypeEq<NormalizeRep<int32_t>, int32_t>();
+    StaticAssertTypeEq<NormalizeRep<uint32_t>, uint32_t>();
+    StaticAssertTypeEq<NormalizeRep<int64_t>, int64_t>();
+    StaticAssertTypeEq<NormalizeRep<uint64_t>, uint64_t>();
 }
 
 }  // namespace detail

--- a/au/rep_test.cc
+++ b/au/rep_test.cc
@@ -197,6 +197,10 @@ TEST(NormalizeRep, IsIdentityOnStandardIntegerTypes) {
     StaticAssertTypeEq<NormalizeRep<long long>, long long>();
     StaticAssertTypeEq<NormalizeRep<unsigned long long>, unsigned long long>();
 
+#if defined(__cpp_char8_t)
+    StaticAssertTypeEq<NormalizeRep<char8_t>, char8_t>();
+#endif
+
     StaticAssertTypeEq<NormalizeRep<int8_t>, int8_t>();
     StaticAssertTypeEq<NormalizeRep<uint8_t>, uint8_t>();
 


### PR DESCRIPTION
One stubborn problem we have encountered with the Green Hills compiler
is that its `__packed`-annotated integer types are hard to unwrap.  We
therefore create `NormalizeRep<T>` as a method to reliably remove the
attribute when we name the type that we want for the Rep.

With this change, when we pass a packed (unaligned) integral value to a
quantity (or quantity point) maker, it will convert to its un-`__packed`
(i.e., properly aligned) counterpart inside the `Quantity` or
`QuantityPoint` object.

Actually _implementing_ `NormalizeRep` is a little tricky, because the
Green Hills compiler reports `false` for `std::is_integral` for these
packed types (so we can't use that to tell when `NormalizeRep` should
change the type).  The core of the solution is a one-two step: we use
unary `+` to _promote_ the type, and then check whether the _promoted_
type is integral.

Overall, this lets us keep the existing call sites unchanged.  The
alternative would have been to launder the attribute by hand at every
site that feeds a packed struct member into a maker (e.g. copying
`my_struct.value` into a clean local first) --- potentially hundreds of
them.  Normalizing centrally in the maker fixes them all at once.

Helps #484.