### PR TITLE
Support decimals, scientific notation in mag UDLs

### DIFF
--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -744,7 +744,7 @@ constexpr std::uintmax_t parse_magnitude_integer() {
 }
 
 // Count the number of mantissa digits after the decimal point in a `_mag` literal.  For example,
-// `12.34_mag` has two decimal places, while `1234_mag` and `1.234e3_mag`... the latter has three.
+// `12.34_mag` has two decimal places, while `1234_mag` has 0, and `1.234e3_mag` has three.
 template <char... Cs>
 constexpr int count_decimal_places() {
     constexpr char chars[] = {Cs...};

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -767,10 +767,10 @@ constexpr int count_decimal_places() {
 // example, `6.022e23_mag` produces `23`, and `1e-3_mag` produces `-3`.  A literal with no exponent
 // produces `0`.
 template <char... Cs>
-constexpr int parse_scientific_exponent() {
+constexpr std::int64_t parse_scientific_exponent() {
     constexpr char chars[] = {Cs...};
-    std::uintmax_t exponent = 0u;
-    int sign = 1;
+    std::uint64_t exponent = 0u;
+    std::int64_t sign = 1;
     bool in_exponent = false;
     for (std::size_t i = 0u; i < sizeof...(Cs); ++i) {
         const char c = chars[i];
@@ -779,14 +779,12 @@ constexpr int parse_scientific_exponent() {
         } else if (in_exponent) {
             if (c == '-') {
                 sign = -1;
-            } else if (c == '+') {
-                // Explicitly ignore.
             } else if (c >= '0' && c <= '9') {
-                exponent = exponent * 10u + static_cast<std::uintmax_t>(c - '0');
+                exponent = exponent * 10u + static_cast<std::uint64_t>(c - '0');
             }
         }
     }
-    return sign * static_cast<int>(exponent);
+    return sign * static_cast<std::int64_t>(exponent);
 }
 }  // namespace detail
 

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -769,7 +769,7 @@ constexpr int count_decimal_places() {
 template <char... Cs>
 constexpr int parse_scientific_exponent() {
     constexpr char chars[] = {Cs...};
-    int exponent = 0;
+    std::uintmax_t exponent = 0u;
     int sign = 1;
     bool in_exponent = false;
     for (std::size_t i = 0u; i < sizeof...(Cs); ++i) {
@@ -779,12 +779,14 @@ constexpr int parse_scientific_exponent() {
         } else if (in_exponent) {
             if (c == '-') {
                 sign = -1;
+            } else if (c == '+') {
+                // Explicitly ignore.
             } else if (c >= '0' && c <= '9') {
-                exponent = exponent * 10 + (c - '0');
+                exponent = exponent * 10u + static_cast<std::uintmax_t>(c - '0');
             }
         }
     }
-    return sign * exponent;
+    return sign * static_cast<int>(exponent);
 }
 }  // namespace detail
 

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -699,36 +699,101 @@ AU_DEVICE_FUNC constexpr auto mag() {
 namespace detail {
 constexpr bool is_valid_magnitude_digit(char c) { return (c >= '0' && c <= '9') || c == '\''; }
 
+constexpr bool is_exponent_marker(char c) { return c == 'e' || c == 'E'; }
+
 template <char... Cs>
-constexpr bool all_valid_magnitude_digits() {
-    constexpr char digits[] = {Cs...};
+constexpr bool all_valid_magnitude_chars() {
+    constexpr char chars[] = {Cs...};
+    std::size_t num_decimal_points = 0u;
+    std::size_t num_exponent_markers = 0u;
     for (std::size_t i = 0u; i < sizeof...(Cs); ++i) {
-        if (!is_valid_magnitude_digit(digits[i])) {
+        const char c = chars[i];
+        if (c == '.') {
+            ++num_decimal_points;
+        } else if (is_exponent_marker(c)) {
+            ++num_exponent_markers;
+        } else if (c == '+' || c == '-') {
+            // A sign is only meaningful as part of an exponent; the compiler guarantees it appears
+            // there, so we accept it here without further checking.
+        } else if (!is_valid_magnitude_digit(c)) {
             return false;
         }
     }
-    return true;
+    return num_decimal_points <= 1u && num_exponent_markers <= 1u;
 }
 
+// Parse the significant digits (the mantissa) of a `_mag` literal, ignoring any decimal point and
+// stopping at the exponent.  For example, `1234_mag`, `12.34_mag`, and `1.234e3_mag` all produce
+// `1234`.
 template <char... Cs>
 constexpr std::uintmax_t parse_magnitude_integer() {
-    static_assert(all_valid_magnitude_digits<Cs...>(),
-                  "_mag literals must contain only decimal digits (and optional ' separators)");
+    static_assert(all_valid_magnitude_chars<Cs...>(),
+                  "_mag literals must contain only decimal digits, an optional decimal point, an "
+                  "optional exponent, and optional ' separators");
     constexpr char digits[] = {Cs...};
     std::uintmax_t result = 0u;
     for (std::size_t i = 0u; i < sizeof...(Cs); ++i) {
+        if (is_exponent_marker(digits[i])) {
+            break;
+        }
         if (digits[i] >= '0' && digits[i] <= '9') {
             result = result * 10u + static_cast<std::uintmax_t>(digits[i] - '0');
         }
     }
     return result;
 }
+
+// Count the number of mantissa digits after the decimal point in a `_mag` literal.  For example,
+// `12.34_mag` has two decimal places, while `1234_mag` and `1.234e3_mag`... the latter has three.
+template <char... Cs>
+constexpr int count_decimal_places() {
+    constexpr char chars[] = {Cs...};
+    int num_decimal_places = 0;
+    bool after_decimal_point = false;
+    for (std::size_t i = 0u; i < sizeof...(Cs); ++i) {
+        if (is_exponent_marker(chars[i])) {
+            break;
+        }
+        if (chars[i] == '.') {
+            after_decimal_point = true;
+        } else if (after_decimal_point && chars[i] >= '0' && chars[i] <= '9') {
+            ++num_decimal_places;
+        }
+    }
+    return num_decimal_places;
+}
+
+// Parse the (signed) exponent of a `_mag` literal: the integer following the `e`/`E` marker.  For
+// example, `6.022e23_mag` produces `23`, and `1e-3_mag` produces `-3`.  A literal with no exponent
+// produces `0`.
+template <char... Cs>
+constexpr int parse_scientific_exponent() {
+    constexpr char chars[] = {Cs...};
+    int exponent = 0;
+    int sign = 1;
+    bool in_exponent = false;
+    for (std::size_t i = 0u; i < sizeof...(Cs); ++i) {
+        const char c = chars[i];
+        if (is_exponent_marker(c)) {
+            in_exponent = true;
+        } else if (in_exponent) {
+            if (c == '-') {
+                sign = -1;
+            } else if (c >= '0' && c <= '9') {
+                exponent = exponent * 10 + (c - '0');
+            }
+        }
+    }
+    return sign * exponent;
+}
 }  // namespace detail
 
 namespace au_literals {
 template <char... Cs>
 constexpr auto operator""_mag() {
-    return mag<detail::parse_magnitude_integer<Cs...>()>();
+    return mag<detail::parse_magnitude_integer<Cs...>()>() *
+           pow<detail::parse_scientific_exponent<Cs...>() - detail::count_decimal_places<Cs...>()>(
+               mag<10>());
 }
 }  // namespace au_literals
 

--- a/au/magnitude_test.cc
+++ b/au/magnitude_test.cc
@@ -1043,8 +1043,7 @@ TEST(MagnitudeUDL, SupportsScientificNotationWithoutDecimalPoint) {
 
 TEST(MagnitudeUDL, SupportsScientificNotationWithDecimalPoint) {
     EXPECT_THAT(6.022e23_mag, SameTypeAndValue(mag<6022>() * pow<23 - 3>(mag<10>())));
-    EXPECT_THAT(6.62607015e-34_mag,
-                SameTypeAndValue(mag<662607015>() * pow<-34 - 8>(mag<10>())));
+    EXPECT_THAT(6.62607015e-34_mag, SameTypeAndValue(mag<662607015>() * pow<-34 - 8>(mag<10>())));
 }
 
 TEST(MagnitudeUDL, ScientificNotationProducesExactRationalMagnitude) {

--- a/au/magnitude_test.cc
+++ b/au/magnitude_test.cc
@@ -1021,6 +1021,40 @@ TEST(MagnitudeUDL, WorksInConstexprContext) {
     EXPECT_THAT(m, SameTypeAndValue(mag<42>()));
 }
 
+TEST(MagnitudeUDL, SupportsDecimalPoint) {
+    EXPECT_THAT(12.34_mag, SameTypeAndValue(mag<1234>() / pow<2>(mag<10>())));
+    EXPECT_THAT(0.5_mag, SameTypeAndValue(mag<5>() / mag<10>()));
+    EXPECT_THAT(3.14159_mag, SameTypeAndValue(mag<314159>() / pow<5>(mag<10>())));
+}
+
+TEST(MagnitudeUDL, TrailingDecimalPointIsEquivalentToInteger) {
+    EXPECT_THAT(12._mag, SameTypeAndValue(mag<12>()));
+}
+
+TEST(MagnitudeUDL, DecimalPointComposesWithSeparators) {
+    EXPECT_THAT(1'234.567'8_mag, SameTypeAndValue(mag<12345678>() / pow<4>(mag<10>())));
+}
+
+TEST(MagnitudeUDL, SupportsScientificNotationWithoutDecimalPoint) {
+    EXPECT_THAT(34e6_mag, SameTypeAndValue(mag<34>() * pow<6>(mag<10>())));
+    EXPECT_THAT(5e-3_mag, SameTypeAndValue(mag<5>() * pow<-3>(mag<10>())));
+    EXPECT_THAT(2E3_mag, SameTypeAndValue(mag<2>() * pow<3>(mag<10>())));
+}
+
+TEST(MagnitudeUDL, SupportsScientificNotationWithDecimalPoint) {
+    EXPECT_THAT(6.022e23_mag, SameTypeAndValue(mag<6022>() * pow<23 - 3>(mag<10>())));
+    EXPECT_THAT(6.62607015e-34_mag,
+                SameTypeAndValue(mag<662607015>() * pow<-34 - 8>(mag<10>())));
+}
+
+TEST(MagnitudeUDL, ScientificNotationProducesExactRationalMagnitude) {
+    // 34e6 is exactly 34'000'000.
+    EXPECT_THAT(34e6_mag, SameTypeAndValue(mag<34'000'000>()));
+
+    // 0.5e1 is exactly 5.
+    EXPECT_THAT(0.5e1_mag, SameTypeAndValue(mag<5>()));
+}
+
 }  // namespace au_literals
 
 namespace detail {

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -60,6 +60,28 @@ integer `N`.
 example, `123_mag` produces the exact same type and value as `mag<123>()`.  It also supports digit
 separators: `1'000'000_mag` is equivalent to `mag<1000000>()`.
 
+Beyond plain integers, `_mag` also accepts decimal and scientific-notation literals, and always
+produces the _exact_ rational `Magnitude` they represent (never a floating point approximation).
+The literal's digits form an integer mantissa, which is then scaled by the appropriate power of ten:
+
+- **Decimal point:** each digit after the `.` divides the mantissa by another factor of ten.  For
+  example, `12.34_mag` is equivalent to `mag<1234>() / pow<2>(mag<10>())` (i.e., exactly
+  $\frac{1234}{100}$).
+- **Exponent:** an `e` (or `E`) exponent multiplies by the corresponding power of ten.  For example,
+  `34e6_mag` is equivalent to `mag<34>() * pow<6>(mag<10>())` (exactly $34{,}000{,}000$), and
+  `5e-3_mag` is exactly $\frac{5}{1000}$.
+- **Both together:** the decimal places and exponent combine.  For example, `6.62607015e-34_mag`
+  produces `mag<662607015>() * pow<-42>(mag<10>())` --- the exact value of the Planck constant's
+  mantissa in SI units.
+
+| Literal | Equivalent to | Exact value |
+|---------|---------------|-------------|
+| `123_mag` | `mag<123>()` | $123$ |
+| `1'000'000_mag` | `mag<1000000>()` | $1{,}000{,}000$ |
+| `12.34_mag` | `mag<1234>() / pow<2>(mag<10>())` | $\frac{1234}{100}$ |
+| `34e6_mag` | `mag<34>() * pow<6>(mag<10>())` | $34{,}000{,}000$ |
+| `6.022e23_mag` | `mag<6022>() * pow<20>(mag<10>())` | $6.022 \times 10^{23}$ |
+
 To use it, add the following to your file:
 
 ```cpp


### PR DESCRIPTION
Having seen more `Constant` use cases in the wild, I find they can be
pretty awkward.  We end up having to write `3_mag / 2_mag`, say, when
what we'd really like to write is `1.5_mag`.

This PR expands `_mag` UDLs to support a decimal point, as well as
optional scientific notation, using `e` or `E`.  Every such literal
always represents a _fully exact rational_ magnitude.  We also update
the docs.