### PR TITLE
SFINAE out impossible hidden friend conversions

### DIFF
--- a/au/compatibility/eigen_test.cc
+++ b/au/compatibility/eigen_test.cc
@@ -246,7 +246,7 @@ TEST(EigenCompatibility, SameUnitAdditionOfDistinctExpressionRepsWorks) {
     // `std::common_type`, which is undefined for two distinct Eigen expressions.
     const Eigen::Vector3d v{4.0, 5.0, 6.0};
 
-    // `base` must outlive `term_a`/`term_b`: their lazy reps bind its `value_` by reference.  (Using
+    // `base` must outlive `term_a`/`term_b`: their lazy reps bind its `value_` by reference. (Using
     // the `meters(v)` temporaries inline would leave the reps dangling after each statement's `;`.)
     const auto base = meters(v);
 

--- a/au/compatibility/eigen_test.cc
+++ b/au/compatibility/eigen_test.cc
@@ -30,6 +30,10 @@ constexpr auto meters = QuantityMaker<Meters>{};
 struct Feet : decltype(Meters{} * mag<381>() / mag<1250>()) {};
 constexpr auto feet = QuantityMaker<Feet>{};
 
+struct Secs : UnitImpl<Time> {};
+constexpr auto secs = QuantityMaker<Secs>{};
+constexpr auto sec = SingularNameFor<Secs>{};
+
 using ::testing::Eq;
 using ::testing::IsFalse;
 using ::testing::IsTrue;
@@ -232,6 +236,45 @@ TEST(EigenCompatibility, DifferentUnitAdditionWorks) {
 
     Eigen::Vector3d expected(200.0, 400.0, 600.0);
     EXPECT_THAT(sum.data_in(centi(meters)), Eq(expected));
+}
+
+TEST(EigenCompatibility, SameUnitAdditionOfDistinctExpressionRepsWorks) {
+    // Regression test: adding two same-unit quantities whose reps are *different* lazy Eigen
+    // expression templates used to fail to compile.  The hidden-friend `operator+(const Quantity&,
+    // const Quantity&)` is a candidate, and probing it asks whether one operand converts to the
+    // other's type via the implicit constructor -- whose SFINAE guard hard-errored inside
+    // `std::common_type`, which is undefined for two distinct Eigen expressions.
+    const Eigen::Vector3d v{4.0, 5.0, 6.0};
+
+    // `base` must outlive `term_a`/`term_b`: their lazy reps bind its `value_` by reference.  (Using
+    // the `meters(v)` temporaries inline would leave the reps dangling after each statement's `;`.)
+    const auto base = meters(v);
+
+    // Two `Quantity<Meters, ...>` values with distinct expression-template rep types.
+    auto term_a = base * 2.0;        // rep: one scalar-product node
+    auto term_b = 0.5 * base * 2.0;  // rep: nested scalar-product nodes (different type)
+    ASSERT_THAT((std::is_same<decltype(term_a), decltype(term_b)>::value), IsFalse());
+
+    auto sum = term_a + term_b;
+
+    // The result must still be a lazy expression (not a materialized Matrix), preserving fusion.
+    ASSERT_THAT((std::is_same<std::decay_t<decltype(sum.data_in(meters))>, Eigen::Vector3d>::value),
+                IsFalse());
+    EXPECT_THAT(eval(sum).data_in(meters), Eq(Eigen::Vector3d(12.0, 15.0, 18.0)));
+}
+
+TEST(EigenCompatibility, ConstantAccelerationKinematicsExpressionWorks) {
+    // The canonical `p0 + v*t + 0.5*a*t*t` expression, with an Eigen-vector rep.  Each product term
+    // is a distinct lazy Eigen expression that simplifies to the same unit (Meters), so summing
+    // them exercises the same-unit / distinct-expression-rep addition path.
+    const auto p0 = meters(Eigen::Vector3d{1.0, 2.0, 3.0});
+    const auto v = (meters / sec)(Eigen::Vector3d{4.0, 5.0, 6.0});
+    const auto a = (meters / squared(sec))(Eigen::Vector3d{1.0, 1.0, 1.0});
+    const auto t = secs(2.0);
+
+    auto trajectory = p0 + v * t + 0.5 * a * t * t;
+
+    EXPECT_THAT(eval(trajectory).data_in(meters), Eq(Eigen::Vector3d(11.0, 14.0, 17.0)));
 }
 
 TEST(EigenCompatibility, MixedInputAdditionWithConvertedQuantityWorks) {

--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -198,6 +198,7 @@ struct PassesConversionRiskCheck
           PermitAsCarveOutForIntegerPromotion<Rep, ScaleFactor, SourceRep>,
           ConversionRiskAcceptablyLow<
               ConversionForRepsAndFactor<CastStrategy, SourceRep, Rep, ScaleFactor>>> {};
+
 // If the reps have no common type, the conversion arithmetic can't even be formed, so the
 // conversion is simply not permitted.  (This keeps the check SFINAE-friendly for reps like distinct
 // Eigen expression templates, rather than hard-erroring deep inside `std::common_type`.)

--- a/au/conversion_policy.hh
+++ b/au/conversion_policy.hh
@@ -188,12 +188,22 @@ struct PermitAsCarveOutForIntegerPromotion
 template <typename ScaleFactor, typename SourceRep>
 struct PermitAsCarveOutForIntegerPromotion<void, ScaleFactor, SourceRep> : std::false_type {};
 
-template <typename CastStrategy, typename Rep, typename ScaleFactor, typename SourceRep>
+template <typename CastStrategy,
+          typename Rep,
+          typename ScaleFactor,
+          typename SourceRep,
+          bool = HasConversionRep<SourceRep, Rep>::value>
 struct PassesConversionRiskCheck
     : stdx::disjunction<
           PermitAsCarveOutForIntegerPromotion<Rep, ScaleFactor, SourceRep>,
           ConversionRiskAcceptablyLow<
               ConversionForRepsAndFactor<CastStrategy, SourceRep, Rep, ScaleFactor>>> {};
+// If the reps have no common type, the conversion arithmetic can't even be formed, so the
+// conversion is simply not permitted.  (This keeps the check SFINAE-friendly for reps like distinct
+// Eigen expression templates, rather than hard-erroring deep inside `std::common_type`.)
+template <typename CastStrategy, typename Rep, typename ScaleFactor, typename SourceRep>
+struct PassesConversionRiskCheck<CastStrategy, Rep, ScaleFactor, SourceRep, false>
+    : std::false_type {};
 
 template <typename CastStrategy, typename Rep, typename ScaleFactor, typename SourceRep>
 using ImplicitConversionPolicy =

--- a/au/conversion_strategy.hh
+++ b/au/conversion_strategy.hh
@@ -127,10 +127,9 @@ template <typename A, typename B>
 struct HasCommonType : stdx::experimental::is_detected<CommonTypeMemberT, A, B> {};
 
 template <typename OldRep, typename NewRep>
-struct HasConversionRep
-    : std::conditional_t<IsRealToComplex<OldRep, NewRep>::value,
-                         HasCommonType<RealPart<OldRep>, RealPart<NewRep>>,
-                         HasCommonType<OldRep, NewRep>> {};
+struct HasConversionRep : std::conditional_t<IsRealToComplex<OldRep, NewRep>::value,
+                                             HasCommonType<RealPart<OldRep>, RealPart<NewRep>>,
+                                             HasCommonType<OldRep, NewRep>> {};
 
 //
 // `CastStep<CastType, T, U>` is a single step of casting from type `T` to type `U`, using the

--- a/au/conversion_strategy.hh
+++ b/au/conversion_strategy.hh
@@ -111,6 +111,28 @@ struct ConversionRepImpl
                        PromotedType<std::common_type_t<OldRep, NewRep>>> {};
 
 //
+// `HasConversionRep<OldRep, NewRep>` tells us (SFINAE-friendly) whether `ConversionRep<OldRep,
+// NewRep>` is well-formed.
+//
+// The conversion arithmetic is hosted in `std::common_type` of the two reps, but some reps have no
+// common type at all --- most notably, two *distinct* Eigen expression templates.  Asking
+// `std::common_type` for such a pair is a hard error rather than a soft one, which would otherwise
+// blow up any conversion *policy* check (e.g. the implicit-constructor's SFINAE guard) that merely
+// needs to answer "is this conversion permitted?" with `false`.  This trait lets those callers
+// short-circuit to `false` instead.
+//
+template <typename A, typename B>
+using CommonTypeMemberT = typename std::common_type<A, B>::type;
+template <typename A, typename B>
+struct HasCommonType : stdx::experimental::is_detected<CommonTypeMemberT, A, B> {};
+
+template <typename OldRep, typename NewRep>
+struct HasConversionRep
+    : std::conditional_t<IsRealToComplex<OldRep, NewRep>::value,
+                         HasCommonType<RealPart<OldRep>, RealPart<NewRep>>,
+                         HasCommonType<OldRep, NewRep>> {};
+
+//
 // `CastStep<CastType, T, U>` is a single step of casting from type `T` to type `U`, using the
 // appropriate operation based on `CastType`.
 //


### PR DESCRIPTION
Surprisingly, `(v * t) + (0.5 * a * t * t)` _doesn't compile_ when `v`
and `a` are Eigen vector-backed quantities!  The problem is that both of
these are _different_ expression templates.  Right now, we directly use
`std::common_type` for these conversions, and `std::common_type` does
not have a specialization for combinations of different Eigen expression
templates.

The solution is to make the implicit constructors that these hidden
friend functions rely on SFINAE-friendly, via the conversion risk
policy. This means neither direction of hidden friend conversion will
work (which also precludes us from running into ambiguous overload
issues). Therefore, we fall back to the non-member `operator+`, which is
able to handle this kind of heterogeneous operation.

Helps #484: we will now be able to support this very basic operation.