### PR TITLE
Tweak comparison structure to accommodate Eigen

### DIFF
--- a/au/compatibility/eigen_test.cc
+++ b/au/compatibility/eigen_test.cc
@@ -180,7 +180,7 @@ TEST(EigenCompatibility, EqualityOfDistinctExpressionRepsWorks) {
     // templates.  Like heterogeneous addition, this used to fail to compile inside
     // `std::common_type` (undefined for two distinct Eigen expressions).  Unlike order comparisons,
     // equality is well-defined for vectors --- Eigen's `operator==` compares all coefficients ---
-    // so it's something we should expect it to work.  This regression test makes sure that it does.
+    // so it's something we should expect to work.  This regression test makes sure that it does.
     const Eigen::Vector3d values{4.0, 5.0, 6.0};
     const auto base = meters(values);
 

--- a/au/compatibility/eigen_test.cc
+++ b/au/compatibility/eigen_test.cc
@@ -180,7 +180,7 @@ TEST(EigenCompatibility, EqualityOfDistinctExpressionRepsWorks) {
     // templates.  Like heterogeneous addition, this used to fail to compile inside
     // `std::common_type` (undefined for two distinct Eigen expressions).  Unlike order comparisons,
     // equality is well-defined for vectors --- Eigen's `operator==` compares all coefficients ---
-    // so it should work.
+    // so it's something we should expect it to work.  This regression test makes sure that it does.
     const Eigen::Vector3d values{4.0, 5.0, 6.0};
     const auto base = meters(values);
 

--- a/au/compatibility/eigen_test.cc
+++ b/au/compatibility/eigen_test.cc
@@ -175,6 +175,45 @@ TEST(EigenCompatibility, DifferentUnitEqualityWorks) {
     EXPECT_THAT(q_m == q_cm, IsTrue());
 }
 
+TEST(EigenCompatibility, EqualityOfDistinctExpressionRepsWorks) {
+    // `==` / `!=` between two same-unit quantities whose reps are *different* lazy Eigen expression
+    // templates.  Like heterogeneous addition, this used to fail to compile inside
+    // `std::common_type` (undefined for two distinct Eigen expressions).  Unlike order comparisons,
+    // equality is well-defined for vectors --- Eigen's `operator==` compares all coefficients ---
+    // so it should work.
+    const Eigen::Vector3d values{4.0, 5.0, 6.0};
+    const auto base = meters(values);
+
+    auto twice = base * 2.0;             // (8, 10, 12) m; rep: one scalar-product node
+    auto also_twice = 0.5 * base * 4.0;  // (8, 10, 12) m; rep: nested nodes (different type)
+    auto thrice = 0.5 * base * 6.0;      // (12, 15, 18) m; different value *and* rep type
+    ASSERT_THAT((std::is_same<decltype(twice), decltype(also_twice)>::value), IsFalse());
+
+    EXPECT_THAT(twice == also_twice, IsTrue());
+    EXPECT_THAT(twice != also_twice, IsFalse());
+    EXPECT_THAT(twice == thrice, IsFalse());
+    EXPECT_THAT(twice != thrice, IsTrue());
+}
+
+TEST(EigenCompatibility, CrossUnitEqualityOfExpressionRepsWorks) {
+    // Operands in *different* units, so one is scaled to the common unit (staying a lazy
+    // expression) before the coefficient-wise comparison.  Note that both operands here have the
+    // *same* expression rep type: this used to route through the common-rep path and try to
+    // `static_cast` one Eigen expression into another (a hard error).  Non-arithmetic reps now
+    // always take the `ref_or_scaled_copy` path instead.
+    const Eigen::Vector3d m_values{8.0, 10.0, 12.0};
+    const Eigen::Vector3d cm_values{800.0, 1000.0, 1200.0};
+    const auto in_m = meters(m_values);
+    const auto in_cm = centi(meters)(cm_values);
+
+    auto lhs = in_m * 2.0;   // (16, 20, 24) m
+    auto rhs = in_cm * 2.0;  // (1600, 2000, 2400) cm == (16, 20, 24) m; identical rep type
+    StaticAssertTypeEq<decltype(lhs)::Rep, decltype(rhs)::Rep>();
+
+    EXPECT_THAT(lhs == rhs, IsTrue());
+    EXPECT_THAT(lhs != rhs, IsFalse());
+}
+
 TEST(EigenCompatibility, ScalarMultiplicationWorks) {
     auto q = meters(Eigen::Vector3d{1.0, 2.0, 3.0});
 

--- a/au/compatibility/eigen_test.cc
+++ b/au/compatibility/eigen_test.cc
@@ -184,11 +184,10 @@ TEST(EigenCompatibility, EqualityOfDistinctExpressionRepsWorks) {
     const Eigen::Vector3d values{4.0, 5.0, 6.0};
     const auto base = meters(values);
 
-    auto twice = base * 2.0;             // (8, 10, 12) m; rep: one scalar-product node
-    auto also_twice = 0.5 * base * 4.0;  // (8, 10, 12) m; rep: nested nodes (different type)
-    auto thrice = 0.5 * base * 6.0;      // (12, 15, 18) m; different value *and* rep type
-    ASSERT_THAT((std::is_same<decltype(twice), decltype(also_twice)>::value), IsFalse());
-
+    auto twice = base * 2.0;        // (8, 10, 12) m; rep: one scalar-product node
+    auto also_twice = base + base;  // (8, 10, 12) m; rep: one sum node (different type)
+    auto thrice = base + twice;     // (12, 15, 18) m; different value *and* rep type
+    static_assert(!std::is_same<decltype(twice), decltype(also_twice)>::value, "");
     EXPECT_THAT(twice == also_twice, IsTrue());
     EXPECT_THAT(twice != also_twice, IsFalse());
     EXPECT_THAT(twice == thrice, IsFalse());

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -894,15 +894,50 @@ AU_DEVICE_FUNC constexpr bool is_conversion_lossy(Quantity<U, R> q, TargetUnitSl
 // Comparing and/or combining Quantities of different types.
 
 namespace detail {
+// Forward declaration; defined below, alongside the addition/subtraction helpers.
+template <typename OtherR, typename TargetUnit, typename U, typename R>
+AU_DEVICE_FUNC constexpr decltype(auto) ref_or_scaled_copy(TargetUnit, const Quantity<U, R> &q);
+
+// For *arithmetic* reps, we host comparisons in a rep shared by both operands
+// (`CommonTypeButPreserveIntSignedness`), which widens each operand to the common width while
+// preserving its own signedness so that mixed signed/unsigned comparisons stay correct.
+//
+// For *non-arithmetic* reps we take the same stance as `operator+`'s `ExplicitRepFor`: we have no
+// meaningful common rep, so we never relocate.  Instead we bring each operand to the common unit
+// via `ref_or_scaled_copy` (which keeps references / expression-template laziness) and let the
+// rep's own comparison operator do the work.
+template <typename Op,
+          typename U1,
+          typename U2,
+          typename R1,
+          typename R2,
+          bool BothArithmetic =
+              stdx::conjunction<std::is_arithmetic<R1>, std::is_arithmetic<R2>>::value>
+struct ConvertAndCompare {
+    AU_DEVICE_FUNC static constexpr auto compare(const Quantity<U1, R1> &q1,
+                                                 const Quantity<U2, R2> &q2) {
+        using U = CommonUnit<U1, U2>;
+        using ComRep1 = CommonTypeButPreserveIntSignedness<R1, R2>;
+        using ComRep2 = CommonTypeButPreserveIntSignedness<R2, R1>;
+        return SignAwareComparison<UnitSign<U>, Op>{}(
+            q1.template in<ComRep1>(U{}, check_for(ALL_RISKS)),
+            q2.template in<ComRep2>(U{}, check_for(ALL_RISKS)));
+    }
+};
+template <typename Op, typename U1, typename U2, typename R1, typename R2>
+struct ConvertAndCompare<Op, U1, U2, R1, R2, false> {
+    AU_DEVICE_FUNC static constexpr auto compare(const Quantity<U1, R1> &q1,
+                                                 const Quantity<U2, R2> &q2) {
+        using U = CommonUnit<U1, U2>;
+        return SignAwareComparison<UnitSign<U>, Op>{}(ref_or_scaled_copy<R2>(U{}, q1),
+                                                      ref_or_scaled_copy<R1>(U{}, q2));
+    }
+};
+
 template <typename Op, typename U1, typename U2, typename R1, typename R2>
 AU_DEVICE_FUNC constexpr auto convert_and_compare(const Quantity<U1, R1> &q1,
                                                   const Quantity<U2, R2> &q2) {
-    using U = CommonUnit<U1, U2>;
-    using ComRep1 = detail::CommonTypeButPreserveIntSignedness<R1, R2>;
-    using ComRep2 = detail::CommonTypeButPreserveIntSignedness<R2, R1>;
-    return detail::SignAwareComparison<UnitSign<U>, Op>{}(
-        q1.template in<ComRep1>(U{}, check_for(ALL_RISKS)),
-        q2.template in<ComRep2>(U{}, check_for(ALL_RISKS)));
+    return ConvertAndCompare<Op, U1, U2, R1, R2>::compare(q1, q2);
 }
 }  // namespace detail
 


### PR DESCRIPTION
Here, we really pare back the reliance on `std::common_unit` in
comparisons, reserving it for arithmetic types.  This prevents Eigen
from tripping over the `std::common_type` machinery in cases where it
doesn't exist.  We include regression test cases.  Helps #484.