### PR TITLE
Fix dangling when multiplying scalar-times-vector

### DIFF
--- a/au/compatibility/eigen_test.cc
+++ b/au/compatibility/eigen_test.cc
@@ -315,6 +315,37 @@ TEST(EigenCompatibility, ConstantAccelerationKinematicsExpressionWorks) {
     EXPECT_THAT(eval(trajectory).data_in(meters), Eq(Eigen::Vector3d(11.0, 14.0, 17.0)));
 }
 
+TEST(EigenCompatibility, ScalarQuantityTimesVectorQuantityDoesNotDangle) {
+    // Regression test: `scalar_quantity * vector_quantity` (scalar on the LEFT) used to build a
+    // lazy Eigen expression that referenced a *temporary* vector, produced by-value by `q.in()`
+    // inside `operator*`.  That temporary died when `operator*` returned, well before the full
+    // expression ended, so evaluating the product was undefined behavior (a size-0 vector at -O0, a
+    // `std::bad_alloc`, or a segfault in a loop).  The commutative form (scalar on the RIGHT) was
+    // always safe, because Eigen stores a `matrix * scalar` operand's scalar by value.
+    const auto x = (meters / sec)(Eigen::Vector3d{2.0, 4.0, 6.0});
+    const auto alpha = secs(5.0);
+
+    // Both orderings must give the same, correct Meters vector.
+    const Eigen::Vector3d expected{10.0, 20.0, 30.0};
+    EXPECT_THAT(eval(alpha * x).data_in(meters), Eq(expected));  // scalar on the left
+    EXPECT_THAT(eval(x * alpha).data_in(meters), Eq(expected));  // scalar on the right
+}
+
+TEST(EigenCompatibility, ScalarQuantityDividedByVectorQuantityDoesNotDangle) {
+    // `operator/` shares `operator*`'s flaw: the denominator's rep also came back by value from
+    // `q.in()`, so a `scalar / vector` quotient referenced a dead temporary.  Eigen only defines
+    // `scalar / vector` (coefficient-wise) for Array reps, so we use an Array here to exercise it.
+    const auto x = (meters / sec)(Eigen::Array3d{2.0, 4.0, 5.0});
+    const auto alpha = secs(10.0);
+
+    // 10 s / (2, 4, 5) m/s == (5, 2.5, 2) s^2/m.
+    auto quotient = eval(alpha / x);
+    using U = decltype(quotient)::Unit;
+    const Eigen::Array3d expected{5.0, 2.5, 2.0};
+    EXPECT_THAT(Eigen::Vector3d{quotient.data_in(U{}).matrix()},
+                Eq(Eigen::Vector3d{expected.matrix()}));
+}
+
 TEST(EigenCompatibility, MixedInputAdditionWithConvertedQuantityWorks) {
     auto q_m = meters(Eigen::Vector3d{1.0, 2.0, 3.0});
     auto q_cm = centi(meters)(Eigen::Vector3d{100.0, 200.0, 300.0});

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -381,18 +381,25 @@ class Quantity {
     }
 
     // Multiplication for dimensioned quantities.
+    //
+    // We take `q` by reference and read its value via `data_in` (a reference), rather than by value
+    // via `in` (a copy).  For lazy-expression reps (e.g. Eigen), the product node binds its operand
+    // by reference; a by-value operand would be a temporary that dies when this function returns,
+    // leaving the result's rep dangling.  `data_in` instead references the caller's live object.
     template <typename OtherUnit, typename OtherRep>
-    AU_DEVICE_FUNC constexpr auto operator*(Quantity<OtherUnit, OtherRep> q) const {
+    AU_DEVICE_FUNC constexpr auto operator*(const Quantity<OtherUnit, OtherRep> &q) const {
         return make_quantity_unless_unitless<UnitProduct<Unit, OtherUnit>>(value_ *
-                                                                           q.in(OtherUnit{}));
+                                                                           q.data_in(OtherUnit{}));
     }
 
     // Division for dimensioned quantities.
+    //
+    // See `operator*` above for why `q` is taken by reference and read via `data_in`.
     template <typename OtherUnit, typename OtherRep>
-    AU_DEVICE_FUNC constexpr auto operator/(Quantity<OtherUnit, OtherRep> q) const {
+    AU_DEVICE_FUNC constexpr auto operator/(const Quantity<OtherUnit, OtherRep> &q) const {
         warn_if_integer_division<OtherUnit, OtherRep>();
         return make_quantity_unless_unitless<UnitQuotient<Unit, OtherUnit>>(value_ /
-                                                                            q.in(OtherUnit{}));
+                                                                            q.data_in(OtherUnit{}));
     }
 
     // Copy and move assignment: lvalue-only.


### PR DESCRIPTION
This turned out to be due to taking our arguments by value instead of
`const&`.  We add regression tests to cover both multiplying and
dividing.

Helps #484.