### PR TITLE
Add UDLs for `Constant` of each unit

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -27,6 +27,7 @@ cc_library(
         ":constants",
         ":math",
         ":units",
+        ":units_literals",
     ],
 )
 

--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -209,6 +209,17 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "units_literals",
+    hdrs = glob(["units/literals/*.hh"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":constant",
+        ":magnitude",
+        ":units",
+    ],
+)
+
 cc_test(
     name = "units_test",
     size = "small",
@@ -216,6 +227,7 @@ cc_test(
     deps = [
         ":testing",
         ":units",
+        ":units_literals",
         "@googletest//:gtest_main",
     ],
 )

--- a/au/CMakeLists.txt
+++ b/au/CMakeLists.txt
@@ -181,6 +181,65 @@ header_only_library(
     units/webers_fwd.hh
     units/yards.hh
     units/yards_fwd.hh
+    units/literals/amperes.hh
+    units/literals/arcminutes.hh
+    units/literals/arcseconds.hh
+    units/literals/astronomical_units.hh
+    units/literals/bars.hh
+    units/literals/becquerel.hh
+    units/literals/bits.hh
+    units/literals/bytes.hh
+    units/literals/candelas.hh
+    units/literals/celsius.hh
+    units/literals/coulombs.hh
+    units/literals/days.hh
+    units/literals/degrees.hh
+    units/literals/fahrenheit.hh
+    units/literals/farads.hh
+    units/literals/fathoms.hh
+    units/literals/feet.hh
+    units/literals/football_fields.hh
+    units/literals/furlongs.hh
+    units/literals/grams.hh
+    units/literals/grays.hh
+    units/literals/henries.hh
+    units/literals/hertz.hh
+    units/literals/hours.hh
+    units/literals/inches.hh
+    units/literals/joules.hh
+    units/literals/katals.hh
+    units/literals/kelvins.hh
+    units/literals/knots.hh
+    units/literals/liters.hh
+    units/literals/lumens.hh
+    units/literals/lux.hh
+    units/literals/meters.hh
+    units/literals/miles.hh
+    units/literals/minutes.hh
+    units/literals/moles.hh
+    units/literals/nautical_miles.hh
+    units/literals/newtons.hh
+    units/literals/ohms.hh
+    units/literals/pascals.hh
+    units/literals/percent.hh
+    units/literals/pounds_force.hh
+    units/literals/pounds_mass.hh
+    units/literals/radians.hh
+    units/literals/rankine.hh
+    units/literals/revolutions.hh
+    units/literals/seconds.hh
+    units/literals/siemens.hh
+    units/literals/slugs.hh
+    units/literals/standard_gravity.hh
+    units/literals/steradians.hh
+    units/literals/tesla.hh
+    units/literals/us_gallons.hh
+    units/literals/us_pints.hh
+    units/literals/us_quarts.hh
+    units/literals/volts.hh
+    units/literals/watts.hh
+    units/literals/webers.hh
+    units/literals/yards.hh
     utility/factoring.hh
     utility/mod.hh
     utility/probable_primes.hh

--- a/au/units/literals/amperes.hh
+++ b/au/units/literals/amperes.hh
@@ -19,13 +19,13 @@
 #include "au/units/amperes.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_A` is a `Constant` equivalent to `make_constant(1.28e-4_mag * amperes)`.
 template <char... Cs>
 constexpr auto operator""_A() {
-    return make_constant(amperes * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(amperes * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/amperes.hh
+++ b/au/units/literals/amperes.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/amperes.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_A` is a `Constant` equivalent to `make_constant(1.28e-4_mag * amperes)`.
+template <char... Cs>
+constexpr auto operator""_A() {
+    return make_constant(amperes * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/arcminutes.hh
+++ b/au/units/literals/arcminutes.hh
@@ -19,13 +19,13 @@
 #include "au/units/arcminutes.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_am` is a `Constant` equivalent to `make_constant(1.28e-4_mag * arcminutes)`.
 template <char... Cs>
 constexpr auto operator""_am() {
-    return make_constant(arcminutes * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(arcminutes * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/arcminutes.hh
+++ b/au/units/literals/arcminutes.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/arcminutes.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_am` is a `Constant` equivalent to `make_constant(1.28e-4_mag * arcminutes)`.
+template <char... Cs>
+constexpr auto operator""_am() {
+    return make_constant(arcminutes * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/arcseconds.hh
+++ b/au/units/literals/arcseconds.hh
@@ -19,13 +19,13 @@
 #include "au/units/arcseconds.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_as` is a `Constant` equivalent to `make_constant(1.28e-4_mag * arcseconds)`.
 template <char... Cs>
 constexpr auto operator""_as() {
-    return make_constant(arcseconds * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(arcseconds * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/arcseconds.hh
+++ b/au/units/literals/arcseconds.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/arcseconds.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_as` is a `Constant` equivalent to `make_constant(1.28e-4_mag * arcseconds)`.
+template <char... Cs>
+constexpr auto operator""_as() {
+    return make_constant(arcseconds * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/astronomical_units.hh
+++ b/au/units/literals/astronomical_units.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/astronomical_units.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_AU` is a `Constant` equivalent to `make_constant(1.28e-4_mag * astronomical_units)`.
+template <char... Cs>
+constexpr auto operator""_AU() {
+    return make_constant(astronomical_units * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/astronomical_units.hh
+++ b/au/units/literals/astronomical_units.hh
@@ -19,13 +19,13 @@
 #include "au/units/astronomical_units.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_AU` is a `Constant` equivalent to `make_constant(1.28e-4_mag * astronomical_units)`.
 template <char... Cs>
 constexpr auto operator""_AU() {
-    return make_constant(astronomical_units * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(astronomical_units * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/bars.hh
+++ b/au/units/literals/bars.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/bars.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_bar` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bars)`.
+template <char... Cs>
+constexpr auto operator""_bar() {
+    return make_constant(bars * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/bars.hh
+++ b/au/units/literals/bars.hh
@@ -19,13 +19,13 @@
 #include "au/units/bars.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_bar` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bars)`.
 template <char... Cs>
 constexpr auto operator""_bar() {
-    return make_constant(bars * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(bars * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/becquerel.hh
+++ b/au/units/literals/becquerel.hh
@@ -19,13 +19,13 @@
 #include "au/units/becquerel.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_Bq` is a `Constant` equivalent to `make_constant(1.28e-4_mag * becquerel)`.
 template <char... Cs>
 constexpr auto operator""_Bq() {
-    return make_constant(becquerel * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(becquerel * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/becquerel.hh
+++ b/au/units/literals/becquerel.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/becquerel.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_Bq` is a `Constant` equivalent to `make_constant(1.28e-4_mag * becquerel)`.
+template <char... Cs>
+constexpr auto operator""_Bq() {
+    return make_constant(becquerel * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/bits.hh
+++ b/au/units/literals/bits.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/bits.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_b` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bits)`.
+template <char... Cs>
+constexpr auto operator""_b() {
+    return make_constant(bits * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/bits.hh
+++ b/au/units/literals/bits.hh
@@ -19,13 +19,13 @@
 #include "au/units/bits.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_b` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bits)`.
 template <char... Cs>
 constexpr auto operator""_b() {
-    return make_constant(bits * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(bits * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/bytes.hh
+++ b/au/units/literals/bytes.hh
@@ -19,13 +19,13 @@
 #include "au/units/bytes.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_B` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bytes)`.
 template <char... Cs>
 constexpr auto operator""_B() {
-    return make_constant(bytes * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(bytes * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/bytes.hh
+++ b/au/units/literals/bytes.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/bytes.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_B` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bytes)`.
+template <char... Cs>
+constexpr auto operator""_B() {
+    return make_constant(bytes * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/candelas.hh
+++ b/au/units/literals/candelas.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/candelas.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_cd` is a `Constant` equivalent to `make_constant(1.28e-4_mag * candelas)`.
+template <char... Cs>
+constexpr auto operator""_cd() {
+    return make_constant(candelas * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/candelas.hh
+++ b/au/units/literals/candelas.hh
@@ -19,13 +19,13 @@
 #include "au/units/candelas.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_cd` is a `Constant` equivalent to `make_constant(1.28e-4_mag * candelas)`.
 template <char... Cs>
 constexpr auto operator""_cd() {
-    return make_constant(candelas * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(candelas * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/celsius.hh
+++ b/au/units/literals/celsius.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/celsius.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_degC_qty` is a `Constant` equivalent to `make_constant(1.28e-4_mag * celsius_qty)`.
+template <char... Cs>
+constexpr auto operator""_degC_qty() {
+    return make_constant(celsius_qty * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/celsius.hh
+++ b/au/units/literals/celsius.hh
@@ -19,13 +19,13 @@
 #include "au/units/celsius.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_degC_qty` is a `Constant` equivalent to `make_constant(1.28e-4_mag * celsius_qty)`.
 template <char... Cs>
 constexpr auto operator""_degC_qty() {
-    return make_constant(celsius_qty * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(celsius_qty * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/coulombs.hh
+++ b/au/units/literals/coulombs.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/coulombs.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_C` is a `Constant` equivalent to `make_constant(1.28e-4_mag * coulombs)`.
+template <char... Cs>
+constexpr auto operator""_C() {
+    return make_constant(coulombs * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/coulombs.hh
+++ b/au/units/literals/coulombs.hh
@@ -19,13 +19,13 @@
 #include "au/units/coulombs.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_C` is a `Constant` equivalent to `make_constant(1.28e-4_mag * coulombs)`.
 template <char... Cs>
 constexpr auto operator""_C() {
-    return make_constant(coulombs * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(coulombs * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/days.hh
+++ b/au/units/literals/days.hh
@@ -19,13 +19,13 @@
 #include "au/units/days.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_d` is a `Constant` equivalent to `make_constant(1.28e-4_mag * days)`.
 template <char... Cs>
 constexpr auto operator""_d() {
-    return make_constant(days * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(days * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/days.hh
+++ b/au/units/literals/days.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/days.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_d` is a `Constant` equivalent to `make_constant(1.28e-4_mag * days)`.
+template <char... Cs>
+constexpr auto operator""_d() {
+    return make_constant(days * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/degrees.hh
+++ b/au/units/literals/degrees.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/degrees.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_deg` is a `Constant` equivalent to `make_constant(1.28e-4_mag * degrees)`.
+template <char... Cs>
+constexpr auto operator""_deg() {
+    return make_constant(degrees * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/degrees.hh
+++ b/au/units/literals/degrees.hh
@@ -19,13 +19,13 @@
 #include "au/units/degrees.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_deg` is a `Constant` equivalent to `make_constant(1.28e-4_mag * degrees)`.
 template <char... Cs>
 constexpr auto operator""_deg() {
-    return make_constant(degrees * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(degrees * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/fahrenheit.hh
+++ b/au/units/literals/fahrenheit.hh
@@ -19,13 +19,13 @@
 #include "au/units/fahrenheit.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_degF_qty` is a `Constant` equivalent to `make_constant(1.28e-4_mag * fahrenheit_qty)`.
 template <char... Cs>
 constexpr auto operator""_degF_qty() {
-    return make_constant(fahrenheit_qty * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(fahrenheit_qty * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/fahrenheit.hh
+++ b/au/units/literals/fahrenheit.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/fahrenheit.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_degF_qty` is a `Constant` equivalent to `make_constant(1.28e-4_mag * fahrenheit_qty)`.
+template <char... Cs>
+constexpr auto operator""_degF_qty() {
+    return make_constant(fahrenheit_qty * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/farads.hh
+++ b/au/units/literals/farads.hh
@@ -19,13 +19,13 @@
 #include "au/units/farads.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_F` is a `Constant` equivalent to `make_constant(1.28e-4_mag * farads)`.
 template <char... Cs>
 constexpr auto operator""_F() {
-    return make_constant(farads * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(farads * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/farads.hh
+++ b/au/units/literals/farads.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/farads.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_F` is a `Constant` equivalent to `make_constant(1.28e-4_mag * farads)`.
+template <char... Cs>
+constexpr auto operator""_F() {
+    return make_constant(farads * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/fathoms.hh
+++ b/au/units/literals/fathoms.hh
@@ -19,13 +19,13 @@
 #include "au/units/fathoms.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_ftm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * fathoms)`.
 template <char... Cs>
 constexpr auto operator""_ftm() {
-    return make_constant(fathoms * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(fathoms * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/fathoms.hh
+++ b/au/units/literals/fathoms.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/fathoms.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_ftm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * fathoms)`.
+template <char... Cs>
+constexpr auto operator""_ftm() {
+    return make_constant(fathoms * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/feet.hh
+++ b/au/units/literals/feet.hh
@@ -19,13 +19,13 @@
 #include "au/units/feet.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_ft` is a `Constant` equivalent to `make_constant(1.28e-4_mag * feet)`.
 template <char... Cs>
 constexpr auto operator""_ft() {
-    return make_constant(feet * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(feet * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/feet.hh
+++ b/au/units/literals/feet.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/feet.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_ft` is a `Constant` equivalent to `make_constant(1.28e-4_mag * feet)`.
+template <char... Cs>
+constexpr auto operator""_ft() {
+    return make_constant(feet * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/football_fields.hh
+++ b/au/units/literals/football_fields.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/football_fields.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_ftbl_fld` is a `Constant` equivalent to `make_constant(1.28e-4_mag * football_fields)`.
+template <char... Cs>
+constexpr auto operator""_ftbl_fld() {
+    return make_constant(football_fields * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/football_fields.hh
+++ b/au/units/literals/football_fields.hh
@@ -19,13 +19,13 @@
 #include "au/units/football_fields.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_ftbl_fld` is a `Constant` equivalent to `make_constant(1.28e-4_mag * football_fields)`.
 template <char... Cs>
 constexpr auto operator""_ftbl_fld() {
-    return make_constant(football_fields * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(football_fields * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/furlongs.hh
+++ b/au/units/literals/furlongs.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/furlongs.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_fur` is a `Constant` equivalent to `make_constant(1.28e-4_mag * furlongs)`.
+template <char... Cs>
+constexpr auto operator""_fur() {
+    return make_constant(furlongs * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/furlongs.hh
+++ b/au/units/literals/furlongs.hh
@@ -19,13 +19,13 @@
 #include "au/units/furlongs.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_fur` is a `Constant` equivalent to `make_constant(1.28e-4_mag * furlongs)`.
 template <char... Cs>
 constexpr auto operator""_fur() {
-    return make_constant(furlongs * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(furlongs * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/grams.hh
+++ b/au/units/literals/grams.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/grams.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_g` is a `Constant` equivalent to `make_constant(1.28e-4_mag * grams)`.
+template <char... Cs>
+constexpr auto operator""_g() {
+    return make_constant(grams * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/grams.hh
+++ b/au/units/literals/grams.hh
@@ -19,13 +19,13 @@
 #include "au/units/grams.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_g` is a `Constant` equivalent to `make_constant(1.28e-4_mag * grams)`.
 template <char... Cs>
 constexpr auto operator""_g() {
-    return make_constant(grams * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(grams * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/grays.hh
+++ b/au/units/literals/grays.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/grays.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_Gy` is a `Constant` equivalent to `make_constant(1.28e-4_mag * grays)`.
+template <char... Cs>
+constexpr auto operator""_Gy() {
+    return make_constant(grays * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/grays.hh
+++ b/au/units/literals/grays.hh
@@ -19,13 +19,13 @@
 #include "au/units/grays.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_Gy` is a `Constant` equivalent to `make_constant(1.28e-4_mag * grays)`.
 template <char... Cs>
 constexpr auto operator""_Gy() {
-    return make_constant(grays * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(grays * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/henries.hh
+++ b/au/units/literals/henries.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/henries.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_H` is a `Constant` equivalent to `make_constant(1.28e-4_mag * henries)`.
+template <char... Cs>
+constexpr auto operator""_H() {
+    return make_constant(henries * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/henries.hh
+++ b/au/units/literals/henries.hh
@@ -19,13 +19,13 @@
 #include "au/units/henries.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_H` is a `Constant` equivalent to `make_constant(1.28e-4_mag * henries)`.
 template <char... Cs>
 constexpr auto operator""_H() {
-    return make_constant(henries * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(henries * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/hertz.hh
+++ b/au/units/literals/hertz.hh
@@ -19,13 +19,13 @@
 #include "au/units/hertz.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_Hz` is a `Constant` equivalent to `make_constant(1.28e-4_mag * hertz)`.
 template <char... Cs>
 constexpr auto operator""_Hz() {
-    return make_constant(hertz * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(hertz * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/hertz.hh
+++ b/au/units/literals/hertz.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/hertz.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_Hz` is a `Constant` equivalent to `make_constant(1.28e-4_mag * hertz)`.
+template <char... Cs>
+constexpr auto operator""_Hz() {
+    return make_constant(hertz * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/hours.hh
+++ b/au/units/literals/hours.hh
@@ -19,13 +19,13 @@
 #include "au/units/hours.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_h` is a `Constant` equivalent to `make_constant(1.28e-4_mag * hours)`.
 template <char... Cs>
 constexpr auto operator""_h() {
-    return make_constant(hours * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(hours * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/hours.hh
+++ b/au/units/literals/hours.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/hours.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_h` is a `Constant` equivalent to `make_constant(1.28e-4_mag * hours)`.
+template <char... Cs>
+constexpr auto operator""_h() {
+    return make_constant(hours * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/inches.hh
+++ b/au/units/literals/inches.hh
@@ -19,13 +19,13 @@
 #include "au/units/inches.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_in` is a `Constant` equivalent to `make_constant(1.28e-4_mag * inches)`.
 template <char... Cs>
 constexpr auto operator""_in() {
-    return make_constant(inches * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(inches * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/inches.hh
+++ b/au/units/literals/inches.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/inches.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_in` is a `Constant` equivalent to `make_constant(1.28e-4_mag * inches)`.
+template <char... Cs>
+constexpr auto operator""_in() {
+    return make_constant(inches * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/joules.hh
+++ b/au/units/literals/joules.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/joules.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_J` is a `Constant` equivalent to `make_constant(1.28e-4_mag * joules)`.
+template <char... Cs>
+constexpr auto operator""_J() {
+    return make_constant(joules * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/joules.hh
+++ b/au/units/literals/joules.hh
@@ -19,13 +19,13 @@
 #include "au/units/joules.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_J` is a `Constant` equivalent to `make_constant(1.28e-4_mag * joules)`.
 template <char... Cs>
 constexpr auto operator""_J() {
-    return make_constant(joules * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(joules * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/katals.hh
+++ b/au/units/literals/katals.hh
@@ -19,13 +19,13 @@
 #include "au/units/katals.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_kat` is a `Constant` equivalent to `make_constant(1.28e-4_mag * katals)`.
 template <char... Cs>
 constexpr auto operator""_kat() {
-    return make_constant(katals * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(katals * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/katals.hh
+++ b/au/units/literals/katals.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/katals.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_kat` is a `Constant` equivalent to `make_constant(1.28e-4_mag * katals)`.
+template <char... Cs>
+constexpr auto operator""_kat() {
+    return make_constant(katals * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/kelvins.hh
+++ b/au/units/literals/kelvins.hh
@@ -19,13 +19,13 @@
 #include "au/units/kelvins.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_K` is a `Constant` equivalent to `make_constant(1.28e-4_mag * kelvins)`.
 template <char... Cs>
 constexpr auto operator""_K() {
-    return make_constant(kelvins * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(kelvins * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/kelvins.hh
+++ b/au/units/literals/kelvins.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/kelvins.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_K` is a `Constant` equivalent to `make_constant(1.28e-4_mag * kelvins)`.
+template <char... Cs>
+constexpr auto operator""_K() {
+    return make_constant(kelvins * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/knots.hh
+++ b/au/units/literals/knots.hh
@@ -19,13 +19,13 @@
 #include "au/units/knots.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_kn` is a `Constant` equivalent to `make_constant(1.28e-4_mag * knots)`.
 template <char... Cs>
 constexpr auto operator""_kn() {
-    return make_constant(knots * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(knots * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/knots.hh
+++ b/au/units/literals/knots.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/knots.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_kn` is a `Constant` equivalent to `make_constant(1.28e-4_mag * knots)`.
+template <char... Cs>
+constexpr auto operator""_kn() {
+    return make_constant(knots * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/liters.hh
+++ b/au/units/literals/liters.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/liters.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_L` is a `Constant` equivalent to `make_constant(1.28e-4_mag * liters)`.
+template <char... Cs>
+constexpr auto operator""_L() {
+    return make_constant(liters * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/liters.hh
+++ b/au/units/literals/liters.hh
@@ -19,13 +19,13 @@
 #include "au/units/liters.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_L` is a `Constant` equivalent to `make_constant(1.28e-4_mag * liters)`.
 template <char... Cs>
 constexpr auto operator""_L() {
-    return make_constant(liters * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(liters * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/lumens.hh
+++ b/au/units/literals/lumens.hh
@@ -19,13 +19,13 @@
 #include "au/units/lumens.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_lm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * lumens)`.
 template <char... Cs>
 constexpr auto operator""_lm() {
-    return make_constant(lumens * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(lumens * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/lumens.hh
+++ b/au/units/literals/lumens.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/lumens.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_lm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * lumens)`.
+template <char... Cs>
+constexpr auto operator""_lm() {
+    return make_constant(lumens * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/lux.hh
+++ b/au/units/literals/lux.hh
@@ -19,13 +19,13 @@
 #include "au/units/lux.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_lx` is a `Constant` equivalent to `make_constant(1.28e-4_mag * lux)`.
 template <char... Cs>
 constexpr auto operator""_lx() {
-    return make_constant(lux * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(lux * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/lux.hh
+++ b/au/units/literals/lux.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/lux.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_lx` is a `Constant` equivalent to `make_constant(1.28e-4_mag * lux)`.
+template <char... Cs>
+constexpr auto operator""_lx() {
+    return make_constant(lux * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/meters.hh
+++ b/au/units/literals/meters.hh
@@ -19,13 +19,13 @@
 #include "au/units/meters.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_m` is a `Constant` equivalent to `make_constant(1.28e-4_mag * meters)`.
 template <char... Cs>
 constexpr auto operator""_m() {
-    return make_constant(meters * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(meters * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/meters.hh
+++ b/au/units/literals/meters.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/meters.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_m` is a `Constant` equivalent to `make_constant(1.28e-4_mag * meters)`.
+template <char... Cs>
+constexpr auto operator""_m() {
+    return make_constant(meters * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/miles.hh
+++ b/au/units/literals/miles.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/miles.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_mi` is a `Constant` equivalent to `make_constant(1.28e-4_mag * miles)`.
+template <char... Cs>
+constexpr auto operator""_mi() {
+    return make_constant(miles * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/miles.hh
+++ b/au/units/literals/miles.hh
@@ -19,13 +19,13 @@
 #include "au/units/miles.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_mi` is a `Constant` equivalent to `make_constant(1.28e-4_mag * miles)`.
 template <char... Cs>
 constexpr auto operator""_mi() {
-    return make_constant(miles * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(miles * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/minutes.hh
+++ b/au/units/literals/minutes.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/minutes.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_min` is a `Constant` equivalent to `make_constant(1.28e-4_mag * minutes)`.
+template <char... Cs>
+constexpr auto operator""_min() {
+    return make_constant(minutes * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/minutes.hh
+++ b/au/units/literals/minutes.hh
@@ -19,13 +19,13 @@
 #include "au/units/minutes.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_min` is a `Constant` equivalent to `make_constant(1.28e-4_mag * minutes)`.
 template <char... Cs>
 constexpr auto operator""_min() {
-    return make_constant(minutes * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(minutes * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/moles.hh
+++ b/au/units/literals/moles.hh
@@ -19,13 +19,13 @@
 #include "au/units/moles.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_mol` is a `Constant` equivalent to `make_constant(1.28e-4_mag * moles)`.
 template <char... Cs>
 constexpr auto operator""_mol() {
-    return make_constant(moles * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(moles * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/moles.hh
+++ b/au/units/literals/moles.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/moles.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_mol` is a `Constant` equivalent to `make_constant(1.28e-4_mag * moles)`.
+template <char... Cs>
+constexpr auto operator""_mol() {
+    return make_constant(moles * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/nautical_miles.hh
+++ b/au/units/literals/nautical_miles.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/nautical_miles.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_nmi` is a `Constant` equivalent to `make_constant(1.28e-4_mag * nautical_miles)`.
+template <char... Cs>
+constexpr auto operator""_nmi() {
+    return make_constant(nautical_miles * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/nautical_miles.hh
+++ b/au/units/literals/nautical_miles.hh
@@ -19,13 +19,13 @@
 #include "au/units/nautical_miles.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_nmi` is a `Constant` equivalent to `make_constant(1.28e-4_mag * nautical_miles)`.
 template <char... Cs>
 constexpr auto operator""_nmi() {
-    return make_constant(nautical_miles * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(nautical_miles * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/newtons.hh
+++ b/au/units/literals/newtons.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/newtons.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_N` is a `Constant` equivalent to `make_constant(1.28e-4_mag * newtons)`.
+template <char... Cs>
+constexpr auto operator""_N() {
+    return make_constant(newtons * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/newtons.hh
+++ b/au/units/literals/newtons.hh
@@ -19,13 +19,13 @@
 #include "au/units/newtons.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_N` is a `Constant` equivalent to `make_constant(1.28e-4_mag * newtons)`.
 template <char... Cs>
 constexpr auto operator""_N() {
-    return make_constant(newtons * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(newtons * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/ohms.hh
+++ b/au/units/literals/ohms.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/ohms.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_ohm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * ohms)`.
+template <char... Cs>
+constexpr auto operator""_ohm() {
+    return make_constant(ohms * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/ohms.hh
+++ b/au/units/literals/ohms.hh
@@ -19,13 +19,13 @@
 #include "au/units/ohms.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_ohm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * ohms)`.
 template <char... Cs>
 constexpr auto operator""_ohm() {
-    return make_constant(ohms * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(ohms * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/pascals.hh
+++ b/au/units/literals/pascals.hh
@@ -19,13 +19,13 @@
 #include "au/units/pascals.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_Pa` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pascals)`.
 template <char... Cs>
 constexpr auto operator""_Pa() {
-    return make_constant(pascals * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(pascals * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/pascals.hh
+++ b/au/units/literals/pascals.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/pascals.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_Pa` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pascals)`.
+template <char... Cs>
+constexpr auto operator""_Pa() {
+    return make_constant(pascals * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/percent.hh
+++ b/au/units/literals/percent.hh
@@ -19,13 +19,13 @@
 #include "au/units/percent.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_pct` is a `Constant` equivalent to `make_constant(1.28e-4_mag * percent)`.
 template <char... Cs>
 constexpr auto operator""_pct() {
-    return make_constant(percent * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(percent * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/percent.hh
+++ b/au/units/literals/percent.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/percent.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_pct` is a `Constant` equivalent to `make_constant(1.28e-4_mag * percent)`.
+template <char... Cs>
+constexpr auto operator""_pct() {
+    return make_constant(percent * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/pounds_force.hh
+++ b/au/units/literals/pounds_force.hh
@@ -19,13 +19,13 @@
 #include "au/units/pounds_force.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_lbf` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pounds_force)`.
 template <char... Cs>
 constexpr auto operator""_lbf() {
-    return make_constant(pounds_force * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(pounds_force * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/pounds_force.hh
+++ b/au/units/literals/pounds_force.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/pounds_force.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_lbf` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pounds_force)`.
+template <char... Cs>
+constexpr auto operator""_lbf() {
+    return make_constant(pounds_force * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/pounds_mass.hh
+++ b/au/units/literals/pounds_mass.hh
@@ -19,13 +19,13 @@
 #include "au/units/pounds_mass.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_lb` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pounds_mass)`.
 template <char... Cs>
 constexpr auto operator""_lb() {
-    return make_constant(pounds_mass * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(pounds_mass * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/pounds_mass.hh
+++ b/au/units/literals/pounds_mass.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/pounds_mass.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_lb` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pounds_mass)`.
+template <char... Cs>
+constexpr auto operator""_lb() {
+    return make_constant(pounds_mass * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/radians.hh
+++ b/au/units/literals/radians.hh
@@ -19,13 +19,13 @@
 #include "au/units/radians.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_rad` is a `Constant` equivalent to `make_constant(1.28e-4_mag * radians)`.
 template <char... Cs>
 constexpr auto operator""_rad() {
-    return make_constant(radians * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(radians * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/radians.hh
+++ b/au/units/literals/radians.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/radians.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_rad` is a `Constant` equivalent to `make_constant(1.28e-4_mag * radians)`.
+template <char... Cs>
+constexpr auto operator""_rad() {
+    return make_constant(radians * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/rankine.hh
+++ b/au/units/literals/rankine.hh
@@ -19,13 +19,13 @@
 #include "au/units/rankine.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_degR` is a `Constant` equivalent to `make_constant(1.28e-4_mag * rankine)`.
 template <char... Cs>
 constexpr auto operator""_degR() {
-    return make_constant(rankine * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(rankine * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/rankine.hh
+++ b/au/units/literals/rankine.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/rankine.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_degR` is a `Constant` equivalent to `make_constant(1.28e-4_mag * rankine)`.
+template <char... Cs>
+constexpr auto operator""_degR() {
+    return make_constant(rankine * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/revolutions.hh
+++ b/au/units/literals/revolutions.hh
@@ -19,13 +19,13 @@
 #include "au/units/revolutions.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_rev` is a `Constant` equivalent to `make_constant(1.28e-4_mag * revolutions)`.
 template <char... Cs>
 constexpr auto operator""_rev() {
-    return make_constant(revolutions * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(revolutions * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/revolutions.hh
+++ b/au/units/literals/revolutions.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/revolutions.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_rev` is a `Constant` equivalent to `make_constant(1.28e-4_mag * revolutions)`.
+template <char... Cs>
+constexpr auto operator""_rev() {
+    return make_constant(revolutions * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/seconds.hh
+++ b/au/units/literals/seconds.hh
@@ -19,13 +19,13 @@
 #include "au/units/seconds.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_s` is a `Constant` equivalent to `make_constant(1.28e-4_mag * seconds)`.
 template <char... Cs>
 constexpr auto operator""_s() {
-    return make_constant(seconds * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(seconds * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/seconds.hh
+++ b/au/units/literals/seconds.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/seconds.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_s` is a `Constant` equivalent to `make_constant(1.28e-4_mag * seconds)`.
+template <char... Cs>
+constexpr auto operator""_s() {
+    return make_constant(seconds * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/siemens.hh
+++ b/au/units/literals/siemens.hh
@@ -19,13 +19,13 @@
 #include "au/units/siemens.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_S` is a `Constant` equivalent to `make_constant(1.28e-4_mag * siemens)`.
 template <char... Cs>
 constexpr auto operator""_S() {
-    return make_constant(siemens * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(siemens * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/siemens.hh
+++ b/au/units/literals/siemens.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/siemens.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_S` is a `Constant` equivalent to `make_constant(1.28e-4_mag * siemens)`.
+template <char... Cs>
+constexpr auto operator""_S() {
+    return make_constant(siemens * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/slugs.hh
+++ b/au/units/literals/slugs.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/slugs.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_slug` is a `Constant` equivalent to `make_constant(1.28e-4_mag * slugs)`.
+template <char... Cs>
+constexpr auto operator""_slug() {
+    return make_constant(slugs * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/slugs.hh
+++ b/au/units/literals/slugs.hh
@@ -19,13 +19,13 @@
 #include "au/units/slugs.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_slug` is a `Constant` equivalent to `make_constant(1.28e-4_mag * slugs)`.
 template <char... Cs>
 constexpr auto operator""_slug() {
-    return make_constant(slugs * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(slugs * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/standard_gravity.hh
+++ b/au/units/literals/standard_gravity.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/standard_gravity.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_g_0` is a `Constant` equivalent to `make_constant(1.28e-4_mag * standard_gravity)`.
+template <char... Cs>
+constexpr auto operator""_g_0() {
+    return make_constant(standard_gravity * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/standard_gravity.hh
+++ b/au/units/literals/standard_gravity.hh
@@ -19,13 +19,13 @@
 #include "au/units/standard_gravity.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_g_0` is a `Constant` equivalent to `make_constant(1.28e-4_mag * standard_gravity)`.
 template <char... Cs>
 constexpr auto operator""_g_0() {
-    return make_constant(standard_gravity * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(standard_gravity * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/steradians.hh
+++ b/au/units/literals/steradians.hh
@@ -19,13 +19,13 @@
 #include "au/units/steradians.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_sr` is a `Constant` equivalent to `make_constant(1.28e-4_mag * steradians)`.
 template <char... Cs>
 constexpr auto operator""_sr() {
-    return make_constant(steradians * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(steradians * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/steradians.hh
+++ b/au/units/literals/steradians.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/steradians.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_sr` is a `Constant` equivalent to `make_constant(1.28e-4_mag * steradians)`.
+template <char... Cs>
+constexpr auto operator""_sr() {
+    return make_constant(steradians * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/tesla.hh
+++ b/au/units/literals/tesla.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/tesla.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_T` is a `Constant` equivalent to `make_constant(1.28e-4_mag * tesla)`.
+template <char... Cs>
+constexpr auto operator""_T() {
+    return make_constant(tesla * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/tesla.hh
+++ b/au/units/literals/tesla.hh
@@ -19,13 +19,13 @@
 #include "au/units/tesla.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_T` is a `Constant` equivalent to `make_constant(1.28e-4_mag * tesla)`.
 template <char... Cs>
 constexpr auto operator""_T() {
-    return make_constant(tesla * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(tesla * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/us_gallons.hh
+++ b/au/units/literals/us_gallons.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/us_gallons.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_US_gal` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_gallons)`.
+template <char... Cs>
+constexpr auto operator""_US_gal() {
+    return make_constant(us_gallons * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/us_gallons.hh
+++ b/au/units/literals/us_gallons.hh
@@ -19,13 +19,13 @@
 #include "au/units/us_gallons.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_US_gal` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_gallons)`.
 template <char... Cs>
 constexpr auto operator""_US_gal() {
-    return make_constant(us_gallons * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(us_gallons * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/us_pints.hh
+++ b/au/units/literals/us_pints.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/us_pints.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_US_pt` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_pints)`.
+template <char... Cs>
+constexpr auto operator""_US_pt() {
+    return make_constant(us_pints * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/us_pints.hh
+++ b/au/units/literals/us_pints.hh
@@ -19,13 +19,13 @@
 #include "au/units/us_pints.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_US_pt` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_pints)`.
 template <char... Cs>
 constexpr auto operator""_US_pt() {
-    return make_constant(us_pints * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(us_pints * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/us_quarts.hh
+++ b/au/units/literals/us_quarts.hh
@@ -19,13 +19,13 @@
 #include "au/units/us_quarts.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_US_qt` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_quarts)`.
 template <char... Cs>
 constexpr auto operator""_US_qt() {
-    return make_constant(us_quarts * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(us_quarts * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/us_quarts.hh
+++ b/au/units/literals/us_quarts.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/us_quarts.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_US_qt` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_quarts)`.
+template <char... Cs>
+constexpr auto operator""_US_qt() {
+    return make_constant(us_quarts * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/volts.hh
+++ b/au/units/literals/volts.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/volts.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_V` is a `Constant` equivalent to `make_constant(1.28e-4_mag * volts)`.
+template <char... Cs>
+constexpr auto operator""_V() {
+    return make_constant(volts * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/volts.hh
+++ b/au/units/literals/volts.hh
@@ -19,13 +19,13 @@
 #include "au/units/volts.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_V` is a `Constant` equivalent to `make_constant(1.28e-4_mag * volts)`.
 template <char... Cs>
 constexpr auto operator""_V() {
-    return make_constant(volts * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(volts * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/watts.hh
+++ b/au/units/literals/watts.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/watts.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_W` is a `Constant` equivalent to `make_constant(1.28e-4_mag * watts)`.
+template <char... Cs>
+constexpr auto operator""_W() {
+    return make_constant(watts * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/watts.hh
+++ b/au/units/literals/watts.hh
@@ -19,13 +19,13 @@
 #include "au/units/watts.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_W` is a `Constant` equivalent to `make_constant(1.28e-4_mag * watts)`.
 template <char... Cs>
 constexpr auto operator""_W() {
-    return make_constant(watts * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(watts * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/webers.hh
+++ b/au/units/literals/webers.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/webers.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_Wb` is a `Constant` equivalent to `make_constant(1.28e-4_mag * webers)`.
+template <char... Cs>
+constexpr auto operator""_Wb() {
+    return make_constant(webers * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/webers.hh
+++ b/au/units/literals/webers.hh
@@ -19,13 +19,13 @@
 #include "au/units/webers.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_Wb` is a `Constant` equivalent to `make_constant(1.28e-4_mag * webers)`.
 template <char... Cs>
 constexpr auto operator""_Wb() {
-    return make_constant(webers * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(webers * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/literals/yards.hh
+++ b/au/units/literals/yards.hh
@@ -1,0 +1,31 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "au/constant.hh"
+#include "au/magnitude.hh"
+#include "au/units/yards.hh"
+
+namespace au {
+namespace literals {
+
+// `1.28e-4_yd` is a `Constant` equivalent to `make_constant(1.28e-4_mag * yards)`.
+template <char... Cs>
+constexpr auto operator""_yd() {
+    return make_constant(yards * ::au::au_literals::operator""_mag < Cs... > ());
+}
+
+}  // namespace literals
+}  // namespace au

--- a/au/units/literals/yards.hh
+++ b/au/units/literals/yards.hh
@@ -19,13 +19,13 @@
 #include "au/units/yards.hh"
 
 namespace au {
-namespace literals {
+namespace au_literals {
 
 // `1.28e-4_yd` is a `Constant` equivalent to `make_constant(1.28e-4_mag * yards)`.
 template <char... Cs>
 constexpr auto operator""_yd() {
-    return make_constant(yards * ::au::au_literals::operator""_mag < Cs... > ());
+    return make_constant(yards * operator""_mag<Cs...>());
 }
 
-}  // namespace literals
+}  // namespace au_literals
 }  // namespace au

--- a/au/units/test/amperes_test.cc
+++ b/au/units/test/amperes_test.cc
@@ -43,7 +43,6 @@ TEST(Amperes, HasExpectedSymbol) {
 
 TEST(Amperes, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_A;
     EXPECT_THAT(1.28e-4_A, SameTypeAndValue(make_constant(amperes * 1.28e-4_mag)));
 }
 

--- a/au/units/test/amperes_test.cc
+++ b/au/units/test/amperes_test.cc
@@ -14,10 +14,14 @@
 
 #include "au/units/amperes.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/amperes.hh"
 #include "au/units/ohms.hh"
 #include "au/units/volts.hh"
 #include "au/units/watts.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -35,6 +39,12 @@ TEST(Amperes, ProductWithVoltsGivesPower) {
 TEST(Amperes, HasExpectedSymbol) {
     using symbols::A;
     EXPECT_THAT(5 * A, SameTypeAndValue(amperes(5)));
+}
+
+TEST(Amperes, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_A;
+    EXPECT_THAT(1.28e-4_A, SameTypeAndValue(make_constant(amperes * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/arcminutes_test.cc
+++ b/au/units/test/arcminutes_test.cc
@@ -37,7 +37,6 @@ TEST(Arcminutes, HasExpectedSymbol) {
 
 TEST(Arcminutes, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_am;
     EXPECT_THAT(1.28e-4_am, SameTypeAndValue(make_constant(arcminutes * 1.28e-4_mag)));
 }
 

--- a/au/units/test/arcminutes_test.cc
+++ b/au/units/test/arcminutes_test.cc
@@ -14,8 +14,12 @@
 
 #include "au/units/arcminutes.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/degrees.hh"
+#include "au/units/literals/arcminutes.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -29,6 +33,12 @@ TEST(Arcminutes, RelatesCorrectlyToDegrees) { EXPECT_THAT(arcminutes(120.0), Eq(
 TEST(Arcminutes, HasExpectedSymbol) {
     using symbols::am;
     EXPECT_THAT(5.f * am, SameTypeAndValue(arcminutes(5.f)));
+}
+
+TEST(Arcminutes, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_am;
+    EXPECT_THAT(1.28e-4_am, SameTypeAndValue(make_constant(arcminutes * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/arcseconds_test.cc
+++ b/au/units/test/arcseconds_test.cc
@@ -37,7 +37,6 @@ TEST(Arcseconds, HasExpectedSymbol) {
 
 TEST(Arcseconds, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_as;
     EXPECT_THAT(1.28e-4_as, SameTypeAndValue(make_constant(arcseconds * 1.28e-4_mag)));
 }
 

--- a/au/units/test/arcseconds_test.cc
+++ b/au/units/test/arcseconds_test.cc
@@ -14,8 +14,12 @@
 
 #include "au/units/arcseconds.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/degrees.hh"
+#include "au/units/literals/arcseconds.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -29,6 +33,12 @@ TEST(Arcseconds, RelatesCorrectlyToDegrees) { EXPECT_THAT(arcseconds(7200.0), Eq
 TEST(Arcseconds, HasExpectedSymbol) {
     using symbols::as;
     EXPECT_THAT(5.f * as, SameTypeAndValue(arcseconds(5.f)));
+}
+
+TEST(Arcseconds, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_as;
+    EXPECT_THAT(1.28e-4_as, SameTypeAndValue(make_constant(arcseconds * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/astronomical_units_test.cc
+++ b/au/units/test/astronomical_units_test.cc
@@ -14,7 +14,10 @@
 
 #include "au/units/astronomical_units.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/astronomical_units.hh"
 #include "au/units/meters.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -32,6 +35,12 @@ TEST(AstronomicalUnits, EquivalentTo149597870700Meters) {
 TEST(AstronomicalUnits, HasExpectedSymbol) {
     using symbols::AU;
     EXPECT_THAT(5 * AU, SameTypeAndValue(astronomical_units(5)));
+}
+
+TEST(AstronomicalUnits, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_AU;
+    EXPECT_THAT(1.28e-4_AU, SameTypeAndValue(make_constant(astronomical_units * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/astronomical_units_test.cc
+++ b/au/units/test/astronomical_units_test.cc
@@ -39,7 +39,6 @@ TEST(AstronomicalUnits, HasExpectedSymbol) {
 
 TEST(AstronomicalUnits, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_AU;
     EXPECT_THAT(1.28e-4_AU, SameTypeAndValue(make_constant(astronomical_units * 1.28e-4_mag)));
 }
 

--- a/au/units/test/bars_test.cc
+++ b/au/units/test/bars_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/bars.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
+#include "au/units/literals/bars.hh"
 #include "au/units/pascals.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -31,6 +34,12 @@ TEST(Bars, HasCorrectRelationshipWithPascals) { EXPECT_THAT(bars(1), Eq(kilo(pas
 TEST(Bars, HasExpectedSymbol) {
     using symbols::bar;
     EXPECT_THAT(5 * bar, SameTypeAndValue(bars(5)));
+}
+
+TEST(Bars, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_bar;
+    EXPECT_THAT(1.28e-4_bar, SameTypeAndValue(make_constant(bars * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/bars_test.cc
+++ b/au/units/test/bars_test.cc
@@ -38,7 +38,6 @@ TEST(Bars, HasExpectedSymbol) {
 
 TEST(Bars, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_bar;
     EXPECT_THAT(1.28e-4_bar, SameTypeAndValue(make_constant(bars * 1.28e-4_mag)));
 }
 

--- a/au/units/test/becquerel_test.cc
+++ b/au/units/test/becquerel_test.cc
@@ -37,7 +37,6 @@ TEST(Becquerel, HasExpectedSymbol) {
 
 TEST(Becquerel, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_Bq;
     EXPECT_THAT(1.28e-4_Bq, SameTypeAndValue(make_constant(becquerel * 1.28e-4_mag)));
 }
 

--- a/au/units/test/becquerel_test.cc
+++ b/au/units/test/becquerel_test.cc
@@ -14,8 +14,12 @@
 
 #include "au/units/becquerel.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/becquerel.hh"
 #include "au/units/seconds.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -29,6 +33,12 @@ TEST(Becquerel, EquivalentToInverseSeconds) {
 TEST(Becquerel, HasExpectedSymbol) {
     using symbols::Bq;
     EXPECT_THAT(5 * Bq, SameTypeAndValue(becquerel(5)));
+}
+
+TEST(Becquerel, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_Bq;
+    EXPECT_THAT(1.28e-4_Bq, SameTypeAndValue(make_constant(becquerel * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/bits_test.cc
+++ b/au/units/test/bits_test.cc
@@ -37,7 +37,6 @@ TEST(Bits, HasExpectedSymbol) {
 
 TEST(Bits, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_b;
     EXPECT_THAT(1.28e-4_b, SameTypeAndValue(make_constant(bits * 1.28e-4_mag)));
 }
 

--- a/au/units/test/bits_test.cc
+++ b/au/units/test/bits_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/bits.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/bytes.hh"
+#include "au/units/literals/bits.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -30,6 +33,12 @@ TEST(Bits, OneEighthOfAByte) { EXPECT_THAT(bits(1.0), Eq(bytes(1.0 / 8.0))); }
 TEST(Bits, HasExpectedSymbol) {
     using symbols::b;
     EXPECT_THAT(5 * b, SameTypeAndValue(bits(5)));
+}
+
+TEST(Bits, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_b;
+    EXPECT_THAT(1.28e-4_b, SameTypeAndValue(make_constant(bits * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/bytes_test.cc
+++ b/au/units/test/bytes_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/bytes.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/bits.hh"
+#include "au/units/literals/bytes.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -30,6 +33,12 @@ TEST(Bytes, EquivalentTo8Bits) { EXPECT_THAT(bytes(1), Eq(bits(8))); }
 TEST(Bytes, HasExpectedSymbol) {
     using symbols::B;
     EXPECT_THAT(5 * B, SameTypeAndValue(bytes(5)));
+}
+
+TEST(Bytes, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_B;
+    EXPECT_THAT(1.28e-4_B, SameTypeAndValue(make_constant(bytes * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/bytes_test.cc
+++ b/au/units/test/bytes_test.cc
@@ -37,7 +37,6 @@ TEST(Bytes, HasExpectedSymbol) {
 
 TEST(Bytes, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_B;
     EXPECT_THAT(1.28e-4_B, SameTypeAndValue(make_constant(bytes * 1.28e-4_mag)));
 }
 

--- a/au/units/test/candelas_test.cc
+++ b/au/units/test/candelas_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/candelas.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/candelas.hh"
 #include "au/units/lumens.hh"
 #include "au/units/steradians.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -30,6 +34,12 @@ TEST(Candelas, EquivalentToLumensPerSteradian) {
 TEST(Candelas, HasExpectedSymbol) {
     using symbols::cd;
     EXPECT_THAT(5 * cd, SameTypeAndValue(candelas(5)));
+}
+
+TEST(Candelas, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_cd;
+    EXPECT_THAT(1.28e-4_cd, SameTypeAndValue(make_constant(candelas * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/candelas_test.cc
+++ b/au/units/test/candelas_test.cc
@@ -38,7 +38,6 @@ TEST(Candelas, HasExpectedSymbol) {
 
 TEST(Candelas, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_cd;
     EXPECT_THAT(1.28e-4_cd, SameTypeAndValue(make_constant(candelas * 1.28e-4_mag)));
 }
 

--- a/au/units/test/celsius_test.cc
+++ b/au/units/test/celsius_test.cc
@@ -50,7 +50,6 @@ TEST(Celsius, HasExpectedSymbol) {
 
 TEST(Celsius, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_degC_qty;
     EXPECT_THAT(1.28e-4_degC_qty, SameTypeAndValue(make_constant(celsius_qty * 1.28e-4_mag)));
 }
 

--- a/au/units/test/celsius_test.cc
+++ b/au/units/test/celsius_test.cc
@@ -14,10 +14,13 @@
 
 #include "au/units/celsius.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/fahrenheit.hh"
 #include "au/units/kelvins.hh"
+#include "au/units/literals/celsius.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -43,6 +46,12 @@ TEST(Celsius, QuantityPointMatchesUpCorrectlyWithFahrenheit) {
 TEST(Celsius, HasExpectedSymbol) {
     using symbols::degC_qty;
     EXPECT_THAT(5 * degC_qty, SameTypeAndValue(celsius_qty(5)));
+}
+
+TEST(Celsius, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_degC_qty;
+    EXPECT_THAT(1.28e-4_degC_qty, SameTypeAndValue(make_constant(celsius_qty * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/coulombs_test.cc
+++ b/au/units/test/coulombs_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/coulombs.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/amperes.hh"
+#include "au/units/literals/coulombs.hh"
 #include "au/units/seconds.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -30,6 +34,12 @@ TEST(Coulombs, EquivalentToAmpereSeconds) {
 TEST(Coulombs, HasExpectedSymbol) {
     using symbols::C;
     EXPECT_THAT(5 * C, SameTypeAndValue(coulombs(5)));
+}
+
+TEST(Coulombs, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_C;
+    EXPECT_THAT(1.28e-4_C, SameTypeAndValue(make_constant(coulombs * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/coulombs_test.cc
+++ b/au/units/test/coulombs_test.cc
@@ -38,7 +38,6 @@ TEST(Coulombs, HasExpectedSymbol) {
 
 TEST(Coulombs, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_C;
     EXPECT_THAT(1.28e-4_C, SameTypeAndValue(make_constant(coulombs * 1.28e-4_mag)));
 }
 

--- a/au/units/test/days_test.cc
+++ b/au/units/test/days_test.cc
@@ -37,7 +37,6 @@ TEST(Days, HasExpectedSymbol) {
 
 TEST(Days, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_d;
     EXPECT_THAT(1.28e-4_d, SameTypeAndValue(make_constant(days * 1.28e-4_mag)));
 }
 

--- a/au/units/test/days_test.cc
+++ b/au/units/test/days_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/days.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/hours.hh"
+#include "au/units/literals/days.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -30,6 +33,12 @@ TEST(Days, EquivalentTo24Hours) { EXPECT_THAT(days(1), Eq(hours(24))); }
 TEST(Days, HasExpectedSymbol) {
     using symbols::d;
     EXPECT_THAT(5 * d, SameTypeAndValue(days(5)));
+}
+
+TEST(Days, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_d;
+    EXPECT_THAT(1.28e-4_d, SameTypeAndValue(make_constant(days * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/degrees_test.cc
+++ b/au/units/test/degrees_test.cc
@@ -14,7 +14,10 @@
 
 #include "au/units/degrees.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/degrees.hh"
 #include "au/units/radians.hh"
 #include "au/units/revolutions.hh"
 #include "gmock/gmock.h"
@@ -37,6 +40,12 @@ TEST(Degrees, One360thOfARevolution) { EXPECT_THAT(degrees(360), Eq(revolutions(
 TEST(Degrees, HasExpectedSymbol) {
     using symbols::deg;
     EXPECT_THAT(5 * deg, SameTypeAndValue(degrees(5)));
+}
+
+TEST(Degrees, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_deg;
+    EXPECT_THAT(1.28e-4_deg, SameTypeAndValue(make_constant(degrees * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/degrees_test.cc
+++ b/au/units/test/degrees_test.cc
@@ -44,7 +44,6 @@ TEST(Degrees, HasExpectedSymbol) {
 
 TEST(Degrees, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_deg;
     EXPECT_THAT(1.28e-4_deg, SameTypeAndValue(make_constant(degrees * 1.28e-4_mag)));
 }
 

--- a/au/units/test/fahrenheit_test.cc
+++ b/au/units/test/fahrenheit_test.cc
@@ -14,9 +14,12 @@
 
 #include "au/units/fahrenheit.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/celsius.hh"
+#include "au/units/literals/fahrenheit.hh"
 #include "au/units/rankine.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -47,6 +50,12 @@ TEST(Fahrenheit, QuantityEquivalentToRankine) {
 
 TEST(Fahrenheit, HasCorrectRelationshipWithRankine) {
     EXPECT_THAT(centi(fahrenheit_pt)(0), Eq(centi(rankine_pt)(45967)));
+}
+
+TEST(Fahrenheit, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_degF_qty;
+    EXPECT_THAT(1.28e-4_degF_qty, SameTypeAndValue(make_constant(fahrenheit_qty * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/fahrenheit_test.cc
+++ b/au/units/test/fahrenheit_test.cc
@@ -54,7 +54,6 @@ TEST(Fahrenheit, HasCorrectRelationshipWithRankine) {
 
 TEST(Fahrenheit, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_degF_qty;
     EXPECT_THAT(1.28e-4_degF_qty, SameTypeAndValue(make_constant(fahrenheit_qty * 1.28e-4_mag)));
 }
 

--- a/au/units/test/farads_test.cc
+++ b/au/units/test/farads_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/farads.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/coulombs.hh"
+#include "au/units/literals/farads.hh"
 #include "au/units/volts.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -30,6 +34,12 @@ TEST(Farads, EquivalentToCoulombsPerVolt) {
 TEST(Farads, HasExpectedSymbol) {
     using symbols::F;
     EXPECT_THAT(5 * F, SameTypeAndValue(farads(5)));
+}
+
+TEST(Farads, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_F;
+    EXPECT_THAT(1.28e-4_F, SameTypeAndValue(make_constant(farads * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/farads_test.cc
+++ b/au/units/test/farads_test.cc
@@ -38,7 +38,6 @@ TEST(Farads, HasExpectedSymbol) {
 
 TEST(Farads, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_F;
     EXPECT_THAT(1.28e-4_F, SameTypeAndValue(make_constant(farads * 1.28e-4_mag)));
 }
 

--- a/au/units/test/fathoms_test.cc
+++ b/au/units/test/fathoms_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/fathoms.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/feet.hh"
+#include "au/units/literals/fathoms.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -30,6 +33,12 @@ TEST(Fathoms, EquivalentTo6Feet) { EXPECT_THAT(fathoms(1), Eq(feet(6))); }
 TEST(Fathoms, HasExpectedSymbol) {
     using symbols::ftm;
     EXPECT_THAT(5 * ftm, SameTypeAndValue(fathoms(5)));
+}
+
+TEST(Fathoms, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_ftm;
+    EXPECT_THAT(1.28e-4_ftm, SameTypeAndValue(make_constant(fathoms * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/fathoms_test.cc
+++ b/au/units/test/fathoms_test.cc
@@ -37,7 +37,6 @@ TEST(Fathoms, HasExpectedSymbol) {
 
 TEST(Fathoms, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_ftm;
     EXPECT_THAT(1.28e-4_ftm, SameTypeAndValue(make_constant(fathoms * 1.28e-4_mag)));
 }
 

--- a/au/units/test/feet_test.cc
+++ b/au/units/test/feet_test.cc
@@ -37,7 +37,6 @@ TEST(Feet, HasExpectedSymbol) {
 
 TEST(Feet, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_ft;
     EXPECT_THAT(1.28e-4_ft, SameTypeAndValue(make_constant(feet * 1.28e-4_mag)));
 }
 

--- a/au/units/test/feet_test.cc
+++ b/au/units/test/feet_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/feet.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/inches.hh"
+#include "au/units/literals/feet.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -30,6 +33,12 @@ TEST(Feet, EquivalentTo12Inches) { EXPECT_THAT(feet(1), Eq(inches(12))); }
 TEST(Feet, HasExpectedSymbol) {
     using symbols::ft;
     EXPECT_THAT(5 * ft, SameTypeAndValue(feet(5)));
+}
+
+TEST(Feet, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_ft;
+    EXPECT_THAT(1.28e-4_ft, SameTypeAndValue(make_constant(feet * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/football_fields_test.cc
+++ b/au/units/test/football_fields_test.cc
@@ -14,7 +14,10 @@
 
 #include "au/units/football_fields.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/football_fields.hh"
 #include "au/units/meters.hh"
 #include "au/units/yards.hh"
 #include "gmock/gmock.h"
@@ -42,6 +45,12 @@ TEST(FootballFields, KnownLidarRangeIsAtLeastFourFootballFields) {
 TEST(FootballFields, HasExpectedSymbol) {
     using symbols::ftbl_fld;
     EXPECT_THAT(5 * ftbl_fld, SameTypeAndValue(football_fields(5)));
+}
+
+TEST(FootballFields, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_ftbl_fld;
+    EXPECT_THAT(1.28e-4_ftbl_fld, SameTypeAndValue(make_constant(football_fields * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/football_fields_test.cc
+++ b/au/units/test/football_fields_test.cc
@@ -49,7 +49,6 @@ TEST(FootballFields, HasExpectedSymbol) {
 
 TEST(FootballFields, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_ftbl_fld;
     EXPECT_THAT(1.28e-4_ftbl_fld, SameTypeAndValue(make_constant(football_fields * 1.28e-4_mag)));
 }
 

--- a/au/units/test/furlongs_test.cc
+++ b/au/units/test/furlongs_test.cc
@@ -37,7 +37,6 @@ TEST(Furlongs, HasExpectedSymbol) {
 
 TEST(Furlongs, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_fur;
     EXPECT_THAT(1.28e-4_fur, SameTypeAndValue(make_constant(furlongs * 1.28e-4_mag)));
 }
 

--- a/au/units/test/furlongs_test.cc
+++ b/au/units/test/furlongs_test.cc
@@ -14,7 +14,10 @@
 
 #include "au/units/furlongs.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/furlongs.hh"
 #include "au/units/miles.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -30,6 +33,12 @@ TEST(Furlongs, EquivalentToOneEighthMile) { EXPECT_THAT(furlongs(8), Eq(miles(1)
 TEST(Furlongs, HasExpectedSymbol) {
     using symbols::fur;
     EXPECT_THAT(5 * fur, SameTypeAndValue(furlongs(5)));
+}
+
+TEST(Furlongs, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_fur;
+    EXPECT_THAT(1.28e-4_fur, SameTypeAndValue(make_constant(furlongs * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/grams_test.cc
+++ b/au/units/test/grams_test.cc
@@ -40,7 +40,6 @@ TEST(Grams, HasExpectedSymbol) {
 
 TEST(Grams, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_g;
     EXPECT_THAT(1.28e-4_g, SameTypeAndValue(make_constant(grams * 1.28e-4_mag)));
 }
 

--- a/au/units/test/grams_test.cc
+++ b/au/units/test/grams_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/grams.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
+#include "au/units/literals/grams.hh"
 #include "au/units/pounds_mass.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -33,6 +36,12 @@ TEST(Grams, HasCorrectRelationshipWithPoundsMass) {
 TEST(Grams, HasExpectedSymbol) {
     using symbols::g;
     EXPECT_THAT(5 * g, SameTypeAndValue(grams(5)));
+}
+
+TEST(Grams, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_g;
+    EXPECT_THAT(1.28e-4_g, SameTypeAndValue(make_constant(grams * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/grays_test.cc
+++ b/au/units/test/grays_test.cc
@@ -14,10 +14,14 @@
 
 #include "au/units/grays.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/grams.hh"
 #include "au/units/joules.hh"
+#include "au/units/literals/grays.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -31,6 +35,12 @@ TEST(Grays, EquivalentToJoulesPerKilogram) {
 TEST(Grays, HasExpectedSymbol) {
     using symbols::Gy;
     EXPECT_THAT(5 * Gy, SameTypeAndValue(grays(5)));
+}
+
+TEST(Grays, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_Gy;
+    EXPECT_THAT(1.28e-4_Gy, SameTypeAndValue(make_constant(grays * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/grays_test.cc
+++ b/au/units/test/grays_test.cc
@@ -39,7 +39,6 @@ TEST(Grays, HasExpectedSymbol) {
 
 TEST(Grays, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_Gy;
     EXPECT_THAT(1.28e-4_Gy, SameTypeAndValue(make_constant(grays * 1.28e-4_mag)));
 }
 

--- a/au/units/test/henries_test.cc
+++ b/au/units/test/henries_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/henries.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/amperes.hh"
+#include "au/units/literals/henries.hh"
 #include "au/units/webers.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -30,6 +34,12 @@ TEST(Henries, EquivalentToWebersPerAmpere) {
 TEST(Henries, HasExpectedSymbol) {
     using symbols::H;
     EXPECT_THAT(5 * H, SameTypeAndValue(henries(5)));
+}
+
+TEST(Henries, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_H;
+    EXPECT_THAT(1.28e-4_H, SameTypeAndValue(make_constant(henries * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/henries_test.cc
+++ b/au/units/test/henries_test.cc
@@ -38,7 +38,6 @@ TEST(Henries, HasExpectedSymbol) {
 
 TEST(Henries, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_H;
     EXPECT_THAT(1.28e-4_H, SameTypeAndValue(make_constant(henries * 1.28e-4_mag)));
 }
 

--- a/au/units/test/hertz_test.cc
+++ b/au/units/test/hertz_test.cc
@@ -14,8 +14,12 @@
 
 #include "au/units/hertz.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/hertz.hh"
 #include "au/units/seconds.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -29,6 +33,12 @@ TEST(Hertz, EquivalentToInverseSeconds) {
 TEST(Hertz, HasExpectedSymbol) {
     using symbols::Hz;
     EXPECT_THAT(5 * Hz, SameTypeAndValue(hertz(5)));
+}
+
+TEST(Hertz, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_Hz;
+    EXPECT_THAT(1.28e-4_Hz, SameTypeAndValue(make_constant(hertz * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/hertz_test.cc
+++ b/au/units/test/hertz_test.cc
@@ -37,7 +37,6 @@ TEST(Hertz, HasExpectedSymbol) {
 
 TEST(Hertz, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_Hz;
     EXPECT_THAT(1.28e-4_Hz, SameTypeAndValue(make_constant(hertz * 1.28e-4_mag)));
 }
 

--- a/au/units/test/hours_test.cc
+++ b/au/units/test/hours_test.cc
@@ -37,7 +37,6 @@ TEST(Hours, HasExpectedSymbol) {
 
 TEST(Hours, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_h;
     EXPECT_THAT(1.28e-4_h, SameTypeAndValue(make_constant(hours * 1.28e-4_mag)));
 }
 

--- a/au/units/test/hours_test.cc
+++ b/au/units/test/hours_test.cc
@@ -14,7 +14,10 @@
 
 #include "au/units/hours.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/hours.hh"
 #include "au/units/minutes.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -30,6 +33,12 @@ TEST(Hours, EquivalentTo60Minutes) { EXPECT_THAT(hours(3), Eq(minutes(180))); }
 TEST(Hours, HasExpectedSymbol) {
     using symbols::h;
     EXPECT_THAT(5 * h, SameTypeAndValue(hours(5)));
+}
+
+TEST(Hours, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_h;
+    EXPECT_THAT(1.28e-4_h, SameTypeAndValue(make_constant(hours * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/inches_test.cc
+++ b/au/units/test/inches_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/inches.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
+#include "au/units/literals/inches.hh"
 #include "au/units/meters.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -31,6 +34,12 @@ TEST(Inches, EquivalentTo2Point54CentiMeters) { EXPECT_THAT(centi(meters)(254), 
 TEST(Inches, HasExpectedSymbol) {
     using symbols::in;
     EXPECT_THAT(5 * in, SameTypeAndValue(inches(5)));
+}
+
+TEST(Inches, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_in;
+    EXPECT_THAT(1.28e-4_in, SameTypeAndValue(make_constant(inches * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/inches_test.cc
+++ b/au/units/test/inches_test.cc
@@ -38,7 +38,6 @@ TEST(Inches, HasExpectedSymbol) {
 
 TEST(Inches, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_in;
     EXPECT_THAT(1.28e-4_in, SameTypeAndValue(make_constant(inches * 1.28e-4_mag)));
 }
 

--- a/au/units/test/joules_test.cc
+++ b/au/units/test/joules_test.cc
@@ -14,7 +14,10 @@
 
 #include "au/units/joules.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/joules.hh"
 #include "au/units/meters.hh"
 #include "au/units/newtons.hh"
 #include "gmock/gmock.h"
@@ -31,6 +34,12 @@ TEST(Joules, EquivalentToNewtonMeters) { EXPECT_THAT(joules(18), Eq((newton * me
 TEST(Joules, HasExpectedSymbol) {
     using symbols::J;
     EXPECT_THAT(5 * J, SameTypeAndValue(joules(5)));
+}
+
+TEST(Joules, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_J;
+    EXPECT_THAT(1.28e-4_J, SameTypeAndValue(make_constant(joules * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/joules_test.cc
+++ b/au/units/test/joules_test.cc
@@ -38,7 +38,6 @@ TEST(Joules, HasExpectedSymbol) {
 
 TEST(Joules, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_J;
     EXPECT_THAT(1.28e-4_J, SameTypeAndValue(make_constant(joules * 1.28e-4_mag)));
 }
 

--- a/au/units/test/katals_test.cc
+++ b/au/units/test/katals_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/katals.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/katals.hh"
 #include "au/units/moles.hh"
 #include "au/units/seconds.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -30,6 +34,12 @@ TEST(Katals, EquivalentToMolesPerSecond) {
 TEST(Katals, HasExpectedSymbol) {
     using symbols::kat;
     EXPECT_THAT(5 * kat, SameTypeAndValue(katals(5)));
+}
+
+TEST(Katals, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_kat;
+    EXPECT_THAT(1.28e-4_kat, SameTypeAndValue(make_constant(katals * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/katals_test.cc
+++ b/au/units/test/katals_test.cc
@@ -38,7 +38,6 @@ TEST(Katals, HasExpectedSymbol) {
 
 TEST(Katals, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_kat;
     EXPECT_THAT(1.28e-4_kat, SameTypeAndValue(make_constant(katals * 1.28e-4_mag)));
 }
 

--- a/au/units/test/kelvins_test.cc
+++ b/au/units/test/kelvins_test.cc
@@ -37,7 +37,6 @@ TEST(Kelvins, HasExpectedSymbol) {
 
 TEST(Kelvins, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_K;
     EXPECT_THAT(1.28e-4_K, SameTypeAndValue(make_constant(kelvins * 1.28e-4_mag)));
 }
 

--- a/au/units/test/kelvins_test.cc
+++ b/au/units/test/kelvins_test.cc
@@ -14,8 +14,12 @@
 
 #include "au/units/kelvins.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/celsius.hh"
+#include "au/units/literals/kelvins.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -29,6 +33,12 @@ TEST(Kelvins, QuantityEquivalentToCelsius) {
 TEST(Kelvins, HasExpectedSymbol) {
     using symbols::K;
     EXPECT_THAT(5 * K, SameTypeAndValue(kelvins(5)));
+}
+
+TEST(Kelvins, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_K;
+    EXPECT_THAT(1.28e-4_K, SameTypeAndValue(make_constant(kelvins * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/knots_test.cc
+++ b/au/units/test/knots_test.cc
@@ -41,7 +41,6 @@ TEST(Knots, HasExpectedSymbol) {
 
 TEST(Knots, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_kn;
     EXPECT_THAT(1.28e-4_kn, SameTypeAndValue(make_constant(knots * 1.28e-4_mag)));
 }
 

--- a/au/units/test/knots_test.cc
+++ b/au/units/test/knots_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/knots.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/hours.hh"
+#include "au/units/literals/knots.hh"
 #include "au/units/meters.hh"
 #include "au/units/nautical_miles.hh"
 #include "gmock/gmock.h"
@@ -34,6 +37,12 @@ TEST(Knots, EquivalentToNauticalMilesPerHour) {
 TEST(Knots, HasExpectedSymbol) {
     using symbols::kn;
     EXPECT_THAT(5 * kn, SameTypeAndValue(knots(5)));
+}
+
+TEST(Knots, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_kn;
+    EXPECT_THAT(1.28e-4_kn, SameTypeAndValue(make_constant(knots * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/liters_test.cc
+++ b/au/units/test/liters_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/liters.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
+#include "au/units/literals/liters.hh"
 #include "au/units/meters.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -36,6 +39,12 @@ TEST(Liters, HasExpectedRelationshipsWithLinearUnits) {
 TEST(Liters, HasExpectedSymbol) {
     using symbols::L;
     EXPECT_THAT(5 * L, SameTypeAndValue(liters(5)));
+}
+
+TEST(Liters, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_L;
+    EXPECT_THAT(1.28e-4_L, SameTypeAndValue(make_constant(liters * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/liters_test.cc
+++ b/au/units/test/liters_test.cc
@@ -43,7 +43,6 @@ TEST(Liters, HasExpectedSymbol) {
 
 TEST(Liters, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_L;
     EXPECT_THAT(1.28e-4_L, SameTypeAndValue(make_constant(liters * 1.28e-4_mag)));
 }
 

--- a/au/units/test/lumens_test.cc
+++ b/au/units/test/lumens_test.cc
@@ -38,7 +38,6 @@ TEST(Lumens, HasExpectedSymbol) {
 
 TEST(Lumens, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_lm;
     EXPECT_THAT(1.28e-4_lm, SameTypeAndValue(make_constant(lumens * 1.28e-4_mag)));
 }
 

--- a/au/units/test/lumens_test.cc
+++ b/au/units/test/lumens_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/lumens.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/candelas.hh"
+#include "au/units/literals/lumens.hh"
 #include "au/units/steradians.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -30,6 +34,12 @@ TEST(Lumens, EquivalentToCandelaSteradians) {
 TEST(Lumens, HasExpectedSymbol) {
     using symbols::lm;
     EXPECT_THAT(5 * lm, SameTypeAndValue(lumens(5)));
+}
+
+TEST(Lumens, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_lm;
+    EXPECT_THAT(1.28e-4_lm, SameTypeAndValue(make_constant(lumens * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/lux_test.cc
+++ b/au/units/test/lux_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/lux.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/lux.hh"
 #include "au/units/lumens.hh"
 #include "au/units/meters.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -30,6 +34,12 @@ TEST(Lux, ProductWithAreaGivesLumens) {
 TEST(Lux, HasExpectedSymbol) {
     using symbols::lx;
     EXPECT_THAT(5 * lx, SameTypeAndValue(lux(5)));
+}
+
+TEST(Lux, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_lx;
+    EXPECT_THAT(1.28e-4_lx, SameTypeAndValue(make_constant(lux * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/lux_test.cc
+++ b/au/units/test/lux_test.cc
@@ -38,7 +38,6 @@ TEST(Lux, HasExpectedSymbol) {
 
 TEST(Lux, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_lx;
     EXPECT_THAT(1.28e-4_lx, SameTypeAndValue(make_constant(lux * 1.28e-4_mag)));
 }
 

--- a/au/units/test/meters_test.cc
+++ b/au/units/test/meters_test.cc
@@ -14,9 +14,12 @@
 
 #include "au/units/meters.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/inches.hh"
+#include "au/units/literals/meters.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -33,6 +36,12 @@ TEST(Meters, HasExpectedRelationshipsWithInches) {
 TEST(Meters, HasExpectedSymbol) {
     using symbols::m;
     EXPECT_THAT(5 * m, SameTypeAndValue(meters(5)));
+}
+
+TEST(Meters, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_m;
+    EXPECT_THAT(1.28e-4_m, SameTypeAndValue(make_constant(meters * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/meters_test.cc
+++ b/au/units/test/meters_test.cc
@@ -40,7 +40,6 @@ TEST(Meters, HasExpectedSymbol) {
 
 TEST(Meters, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_m;
     EXPECT_THAT(1.28e-4_m, SameTypeAndValue(make_constant(meters * 1.28e-4_mag)));
 }
 

--- a/au/units/test/miles_test.cc
+++ b/au/units/test/miles_test.cc
@@ -37,7 +37,6 @@ TEST(Miles, HasExpectedSymbol) {
 
 TEST(Miles, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_mi;
     EXPECT_THAT(1.28e-4_mi, SameTypeAndValue(make_constant(miles * 1.28e-4_mag)));
 }
 

--- a/au/units/test/miles_test.cc
+++ b/au/units/test/miles_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/miles.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/feet.hh"
+#include "au/units/literals/miles.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -30,6 +33,12 @@ TEST(Miles, EquivalentTo5280Feet) { EXPECT_THAT(miles(1), Eq(feet(5280))); }
 TEST(Miles, HasExpectedSymbol) {
     using symbols::mi;
     EXPECT_THAT(5 * mi, SameTypeAndValue(miles(5)));
+}
+
+TEST(Miles, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_mi;
+    EXPECT_THAT(1.28e-4_mi, SameTypeAndValue(make_constant(miles * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/minutes_test.cc
+++ b/au/units/test/minutes_test.cc
@@ -37,7 +37,6 @@ TEST(Minutes, HasExpectedSymbol) {
 
 TEST(Minutes, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_min;
     EXPECT_THAT(1.28e-4_min, SameTypeAndValue(make_constant(minutes * 1.28e-4_mag)));
 }
 

--- a/au/units/test/minutes_test.cc
+++ b/au/units/test/minutes_test.cc
@@ -14,7 +14,10 @@
 
 #include "au/units/minutes.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/minutes.hh"
 #include "au/units/seconds.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -30,6 +33,12 @@ TEST(Minutes, EquivalentTo60Seconds) { EXPECT_THAT(minutes(3), Eq(seconds(180)))
 TEST(Minutes, HasExpectedSymbol) {
     using symbols::min;
     EXPECT_THAT(5 * min, SameTypeAndValue(minutes(5)));
+}
+
+TEST(Minutes, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_min;
+    EXPECT_THAT(1.28e-4_min, SameTypeAndValue(make_constant(minutes * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/moles_test.cc
+++ b/au/units/test/moles_test.cc
@@ -38,7 +38,6 @@ TEST(Moles, HasExpectedSymbol) {
 
 TEST(Moles, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_mol;
     EXPECT_THAT(1.28e-4_mol, SameTypeAndValue(make_constant(moles * 1.28e-4_mag)));
 }
 

--- a/au/units/test/moles_test.cc
+++ b/au/units/test/moles_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/moles.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/katals.hh"
+#include "au/units/literals/moles.hh"
 #include "au/units/seconds.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -30,6 +34,12 @@ TEST(Moles, EquivalentToKatalSeconds) {
 TEST(Moles, HasExpectedSymbol) {
     using symbols::mol;
     EXPECT_THAT(5 * mol, SameTypeAndValue(moles(5)));
+}
+
+TEST(Moles, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_mol;
+    EXPECT_THAT(1.28e-4_mol, SameTypeAndValue(make_constant(moles * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/nautical_miles_test.cc
+++ b/au/units/test/nautical_miles_test.cc
@@ -43,7 +43,6 @@ TEST(NauticalMiles, HasExpectedSymbol) {
 
 TEST(NauticalMiles, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_nmi;
     EXPECT_THAT(1.28e-4_nmi, SameTypeAndValue(make_constant(nautical_miles * 1.28e-4_mag)));
 }
 

--- a/au/units/test/nautical_miles_test.cc
+++ b/au/units/test/nautical_miles_test.cc
@@ -14,9 +14,12 @@
 
 #include "au/units/nautical_miles.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/hours.hh"
 #include "au/units/knots.hh"
+#include "au/units/literals/nautical_miles.hh"
 #include "au/units/meters.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -36,6 +39,12 @@ TEST(NauticalMiles, EquivalentToKnotHours) {
 TEST(NauticalMiles, HasExpectedSymbol) {
     using symbols::nmi;
     EXPECT_THAT(5 * nmi, SameTypeAndValue(nautical_miles(5)));
+}
+
+TEST(NauticalMiles, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_nmi;
+    EXPECT_THAT(1.28e-4_nmi, SameTypeAndValue(make_constant(nautical_miles * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/newtons_test.cc
+++ b/au/units/test/newtons_test.cc
@@ -40,7 +40,6 @@ TEST(Newtons, HasExpectedSymbol) {
 
 TEST(Newtons, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_N;
     EXPECT_THAT(1.28e-4_N, SameTypeAndValue(make_constant(newtons * 1.28e-4_mag)));
 }
 

--- a/au/units/test/newtons_test.cc
+++ b/au/units/test/newtons_test.cc
@@ -14,11 +14,15 @@
 
 #include "au/units/newtons.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/grams.hh"
+#include "au/units/literals/newtons.hh"
 #include "au/units/meters.hh"
 #include "au/units/seconds.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -32,6 +36,12 @@ TEST(Newtons, EquivalentToKilogramMetersPerSquaredSecond) {
 TEST(Newtons, HasExpectedSymbol) {
     using symbols::N;
     EXPECT_THAT(5 * N, SameTypeAndValue(newtons(5)));
+}
+
+TEST(Newtons, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_N;
+    EXPECT_THAT(1.28e-4_N, SameTypeAndValue(make_constant(newtons * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/ohms_test.cc
+++ b/au/units/test/ohms_test.cc
@@ -49,7 +49,6 @@ TEST(Ohms, HasExpectedSymbol) {
 
 TEST(Ohms, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_ohm;
     EXPECT_THAT(1.28e-4_ohm, SameTypeAndValue(make_constant(ohms * 1.28e-4_mag)));
 }
 

--- a/au/units/test/ohms_test.cc
+++ b/au/units/test/ohms_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/ohms.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/amperes.hh"
+#include "au/units/literals/ohms.hh"
 #include "au/units/volts.hh"
 #include "au/units/watts.hh"
 #include "gmock/gmock.h"
@@ -42,6 +45,12 @@ TEST(Ohms, SatisfiesOhmicHeatingEquation) {
 TEST(Ohms, HasExpectedSymbol) {
     using symbols::ohm;
     EXPECT_THAT(5 * ohm, SameTypeAndValue(ohms(5)));
+}
+
+TEST(Ohms, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_ohm;
+    EXPECT_THAT(1.28e-4_ohm, SameTypeAndValue(make_constant(ohms * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/pascals_test.cc
+++ b/au/units/test/pascals_test.cc
@@ -38,7 +38,6 @@ TEST(Pascals, HasExpectedSymbol) {
 
 TEST(Pascals, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_Pa;
     EXPECT_THAT(1.28e-4_Pa, SameTypeAndValue(make_constant(pascals * 1.28e-4_mag)));
 }
 

--- a/au/units/test/pascals_test.cc
+++ b/au/units/test/pascals_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/pascals.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/pascals.hh"
 #include "au/units/meters.hh"
 #include "au/units/newtons.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -30,6 +34,12 @@ TEST(Pascals, EquivalentToForcePerArea) {
 TEST(Pascals, HasExpectedSymbol) {
     using symbols::Pa;
     EXPECT_THAT(5 * Pa, SameTypeAndValue(pascals(5)));
+}
+
+TEST(Pascals, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_Pa;
+    EXPECT_THAT(1.28e-4_Pa, SameTypeAndValue(make_constant(pascals * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/percent_test.cc
+++ b/au/units/test/percent_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/percent.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
+#include "au/units/literals/percent.hh"
 #include "au/units/unos.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -31,6 +34,12 @@ TEST(Percent, OneHundredthOfUnos) { EXPECT_THAT(percent(75.0), Eq(unos(0.75))); 
 TEST(Percent, HasExpectedSymbol) {
     using symbols::pct;
     EXPECT_THAT(5 * pct, SameTypeAndValue(percent(5)));
+}
+
+TEST(Percent, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_pct;
+    EXPECT_THAT(1.28e-4_pct, SameTypeAndValue(make_constant(percent * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/percent_test.cc
+++ b/au/units/test/percent_test.cc
@@ -38,7 +38,6 @@ TEST(Percent, HasExpectedSymbol) {
 
 TEST(Percent, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_pct;
     EXPECT_THAT(1.28e-4_pct, SameTypeAndValue(make_constant(percent * 1.28e-4_mag)));
 }
 

--- a/au/units/test/pounds_force_test.cc
+++ b/au/units/test/pounds_force_test.cc
@@ -38,7 +38,6 @@ TEST(PoundsForce, HasExpectedSymbol) {
 
 TEST(PoundsForce, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_lbf;
     EXPECT_THAT(1.28e-4_lbf, SameTypeAndValue(make_constant(pounds_force * 1.28e-4_mag)));
 }
 

--- a/au/units/test/pounds_force_test.cc
+++ b/au/units/test/pounds_force_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/pounds_force.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/pounds_force.hh"
 #include "au/units/pounds_mass.hh"
 #include "au/units/standard_gravity.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -30,6 +34,12 @@ TEST(PoundsForce, EquivalentToStandardGravityActingOnPoundMass) {
 TEST(PoundsForce, HasExpectedSymbol) {
     using symbols::lbf;
     EXPECT_THAT(5 * lbf, SameTypeAndValue(pounds_force(5)));
+}
+
+TEST(PoundsForce, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_lbf;
+    EXPECT_THAT(1.28e-4_lbf, SameTypeAndValue(make_constant(pounds_force * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/pounds_mass_test.cc
+++ b/au/units/test/pounds_mass_test.cc
@@ -14,9 +14,12 @@
 
 #include "au/units/pounds_mass.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/grams.hh"
+#include "au/units/literals/pounds_mass.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -33,6 +36,12 @@ TEST(PoundsMass, EquivalentToAppropriateQuantityOfKilograms) {
 TEST(PoundsMass, HasExpectedSymbol) {
     using symbols::lb;
     EXPECT_THAT(5 * lb, SameTypeAndValue(pounds_mass(5)));
+}
+
+TEST(PoundsMass, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_lb;
+    EXPECT_THAT(1.28e-4_lb, SameTypeAndValue(make_constant(pounds_mass * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/pounds_mass_test.cc
+++ b/au/units/test/pounds_mass_test.cc
@@ -40,7 +40,6 @@ TEST(PoundsMass, HasExpectedSymbol) {
 
 TEST(PoundsMass, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_lb;
     EXPECT_THAT(1.28e-4_lb, SameTypeAndValue(make_constant(pounds_mass * 1.28e-4_mag)));
 }
 

--- a/au/units/test/radians_test.cc
+++ b/au/units/test/radians_test.cc
@@ -40,7 +40,6 @@ TEST(Radians, HasExpectedSymbol) {
 
 TEST(Radians, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_rad;
     EXPECT_THAT(1.28e-4_rad, SameTypeAndValue(make_constant(radians * 1.28e-4_mag)));
 }
 

--- a/au/units/test/radians_test.cc
+++ b/au/units/test/radians_test.cc
@@ -14,7 +14,10 @@
 
 #include "au/units/radians.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/radians.hh"
 #include "au/units/revolutions.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -33,6 +36,12 @@ TEST(Radians, TwoPiPerRevolution) {
 TEST(Radians, HasExpectedSymbol) {
     using symbols::rad;
     EXPECT_THAT(5 * rad, SameTypeAndValue(radians(5)));
+}
+
+TEST(Radians, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_rad;
+    EXPECT_THAT(1.28e-4_rad, SameTypeAndValue(make_constant(radians * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/rankine_test.cc
+++ b/au/units/test/rankine_test.cc
@@ -14,10 +14,13 @@
 
 #include "au/units/rankine.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/fahrenheit.hh"
 #include "au/units/kelvins.hh"
+#include "au/units/literals/rankine.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -40,6 +43,12 @@ TEST(Rankine, QuantityEquivalentToFahrenheit) {
 
 TEST(Rankine, HasCorrectRelationshipWithFahrenheit) {
     EXPECT_THAT(centi(rankine_pt)(45967), Eq(centi(fahrenheit_pt)(0)));
+}
+
+TEST(Rankine, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_degR;
+    EXPECT_THAT(1.28e-4_degR, SameTypeAndValue(make_constant(rankine * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/rankine_test.cc
+++ b/au/units/test/rankine_test.cc
@@ -47,7 +47,6 @@ TEST(Rankine, HasCorrectRelationshipWithFahrenheit) {
 
 TEST(Rankine, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_degR;
     EXPECT_THAT(1.28e-4_degR, SameTypeAndValue(make_constant(rankine * 1.28e-4_mag)));
 }
 

--- a/au/units/test/revolutions_test.cc
+++ b/au/units/test/revolutions_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/revolutions.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/degrees.hh"
+#include "au/units/literals/revolutions.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -30,6 +33,12 @@ TEST(Revolutions, ExactlyEquivalentTo360Degrees) { EXPECT_THAT(revolutions(1), E
 TEST(Revolutions, HasExpectedSymbol) {
     using symbols::rev;
     EXPECT_THAT(5 * rev, SameTypeAndValue(revolutions(5)));
+}
+
+TEST(Revolutions, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_rev;
+    EXPECT_THAT(1.28e-4_rev, SameTypeAndValue(make_constant(revolutions * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/revolutions_test.cc
+++ b/au/units/test/revolutions_test.cc
@@ -37,7 +37,6 @@ TEST(Revolutions, HasExpectedSymbol) {
 
 TEST(Revolutions, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_rev;
     EXPECT_THAT(1.28e-4_rev, SameTypeAndValue(make_constant(revolutions * 1.28e-4_mag)));
 }
 

--- a/au/units/test/seconds_test.cc
+++ b/au/units/test/seconds_test.cc
@@ -37,7 +37,6 @@ TEST(Seconds, HasExpectedSymbol) {
 
 TEST(Seconds, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_s;
     EXPECT_THAT(1.28e-4_s, SameTypeAndValue(make_constant(seconds * 1.28e-4_mag)));
 }
 

--- a/au/units/test/seconds_test.cc
+++ b/au/units/test/seconds_test.cc
@@ -14,7 +14,10 @@
 
 #include "au/units/seconds.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/seconds.hh"
 #include "au/units/minutes.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -30,6 +33,12 @@ TEST(Seconds, SixtyPerMinute) { EXPECT_THAT(seconds(60), Eq(minutes(1))); }
 TEST(Seconds, HasExpectedSymbol) {
     using symbols::s;
     EXPECT_THAT(5 * s, SameTypeAndValue(seconds(5)));
+}
+
+TEST(Seconds, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_s;
+    EXPECT_THAT(1.28e-4_s, SameTypeAndValue(make_constant(seconds * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/siemens_test.cc
+++ b/au/units/test/siemens_test.cc
@@ -14,8 +14,12 @@
 
 #include "au/units/siemens.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/siemens.hh"
 #include "au/units/ohms.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -29,6 +33,12 @@ TEST(Siemens, EquivalentToInverseOhms) {
 TEST(Siemens, HasExpectedSymbol) {
     using symbols::S;
     EXPECT_THAT(5 * S, SameTypeAndValue(siemens(5)));
+}
+
+TEST(Siemens, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_S;
+    EXPECT_THAT(1.28e-4_S, SameTypeAndValue(make_constant(siemens * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/siemens_test.cc
+++ b/au/units/test/siemens_test.cc
@@ -37,7 +37,6 @@ TEST(Siemens, HasExpectedSymbol) {
 
 TEST(Siemens, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_S;
     EXPECT_THAT(1.28e-4_S, SameTypeAndValue(make_constant(siemens * 1.28e-4_mag)));
 }
 

--- a/au/units/test/slugs_test.cc
+++ b/au/units/test/slugs_test.cc
@@ -14,9 +14,12 @@
 
 #include "au/units/slugs.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/grams.hh"
+#include "au/units/literals/slugs.hh"
 #include "au/units/pounds_mass.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -42,6 +45,12 @@ TEST(Slugs, ExactDefinitionIsCorrect) {
 TEST(Slugs, HasExpectedSymbol) {
     using symbols::slug;
     EXPECT_THAT(5 * slug, SameTypeAndValue(slugs(5)));
+}
+
+TEST(Slugs, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_slug;
+    EXPECT_THAT(1.28e-4_slug, SameTypeAndValue(make_constant(slugs * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/slugs_test.cc
+++ b/au/units/test/slugs_test.cc
@@ -49,7 +49,6 @@ TEST(Slugs, HasExpectedSymbol) {
 
 TEST(Slugs, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_slug;
     EXPECT_THAT(1.28e-4_slug, SameTypeAndValue(make_constant(slugs * 1.28e-4_mag)));
 }
 

--- a/au/units/test/standard_gravity_test.cc
+++ b/au/units/test/standard_gravity_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/standard_gravity.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
+#include "au/units/literals/standard_gravity.hh"
 #include "au/units/meters.hh"
 #include "au/units/seconds.hh"
 #include "gmock/gmock.h"
@@ -34,6 +37,12 @@ TEST(StandardGravity, HasExpectedValue) {
 TEST(StandardGravity, HasExpectedSymbol) {
     using symbols::g_0;
     EXPECT_THAT(5 * g_0, SameTypeAndValue(standard_gravity(5)));
+}
+
+TEST(StandardGravity, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_g_0;
+    EXPECT_THAT(1.28e-4_g_0, SameTypeAndValue(make_constant(standard_gravity * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/standard_gravity_test.cc
+++ b/au/units/test/standard_gravity_test.cc
@@ -41,7 +41,6 @@ TEST(StandardGravity, HasExpectedSymbol) {
 
 TEST(StandardGravity, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_g_0;
     EXPECT_THAT(1.28e-4_g_0, SameTypeAndValue(make_constant(standard_gravity * 1.28e-4_mag)));
 }
 

--- a/au/units/test/steradians_test.cc
+++ b/au/units/test/steradians_test.cc
@@ -37,7 +37,6 @@ TEST(Steradians, HasExpectedSymbol) {
 
 TEST(Steradians, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_sr;
     EXPECT_THAT(1.28e-4_sr, SameTypeAndValue(make_constant(steradians * 1.28e-4_mag)));
 }
 

--- a/au/units/test/steradians_test.cc
+++ b/au/units/test/steradians_test.cc
@@ -14,8 +14,12 @@
 
 #include "au/units/steradians.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/steradians.hh"
 #include "au/units/radians.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -29,6 +33,12 @@ TEST(Steradians, EquivalentToSquaredRadians) {
 TEST(Steradians, HasExpectedSymbol) {
     using symbols::sr;
     EXPECT_THAT(5 * sr, SameTypeAndValue(steradians(5)));
+}
+
+TEST(Steradians, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_sr;
+    EXPECT_THAT(1.28e-4_sr, SameTypeAndValue(make_constant(steradians * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/tesla_test.cc
+++ b/au/units/test/tesla_test.cc
@@ -38,7 +38,6 @@ TEST(Tesla, HasExpectedSymbol) {
 
 TEST(Tesla, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_T;
     EXPECT_THAT(1.28e-4_T, SameTypeAndValue(make_constant(tesla * 1.28e-4_mag)));
 }
 

--- a/au/units/test/tesla_test.cc
+++ b/au/units/test/tesla_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/tesla.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/tesla.hh"
 #include "au/units/meters.hh"
 #include "au/units/webers.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -30,6 +34,12 @@ TEST(Tesla, EquivalentToWebersPerMeterSquared) {
 TEST(Tesla, HasExpectedSymbol) {
     using symbols::T;
     EXPECT_THAT(5 * T, SameTypeAndValue(tesla(5)));
+}
+
+TEST(Tesla, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_T;
+    EXPECT_THAT(1.28e-4_T, SameTypeAndValue(make_constant(tesla * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/us_gallons_test.cc
+++ b/au/units/test/us_gallons_test.cc
@@ -14,9 +14,12 @@
 
 #include "au/units/us_gallons.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/prefix.hh"
 #include "au/testing.hh"
 #include "au/units/inches.hh"
+#include "au/units/literals/us_gallons.hh"
 #include "au/units/liters.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -36,6 +39,12 @@ TEST(USGallons, WithinExpectationComparedToLiters) {
 TEST(USGallons, HasExpectedSymbol) {
     using symbols::US_gal;
     EXPECT_THAT(5 * US_gal, SameTypeAndValue(us_gallons(5)));
+}
+
+TEST(USGallons, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_US_gal;
+    EXPECT_THAT(1.28e-4_US_gal, SameTypeAndValue(make_constant(us_gallons * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/us_gallons_test.cc
+++ b/au/units/test/us_gallons_test.cc
@@ -43,7 +43,6 @@ TEST(USGallons, HasExpectedSymbol) {
 
 TEST(USGallons, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_US_gal;
     EXPECT_THAT(1.28e-4_US_gal, SameTypeAndValue(make_constant(us_gallons * 1.28e-4_mag)));
 }
 

--- a/au/units/test/us_pints_test.cc
+++ b/au/units/test/us_pints_test.cc
@@ -14,7 +14,10 @@
 
 #include "au/units/us_pints.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/us_pints.hh"
 #include "au/units/us_gallons.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -30,6 +33,12 @@ TEST(USPints, EightInAGallon) { EXPECT_THAT(us_pints(8), Eq(us_gallons(1))); }
 TEST(USPints, HasExpectedSymbol) {
     using symbols::US_pt;
     EXPECT_THAT(5 * US_pt, SameTypeAndValue(us_pints(5)));
+}
+
+TEST(USPints, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_US_pt;
+    EXPECT_THAT(1.28e-4_US_pt, SameTypeAndValue(make_constant(us_pints * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/us_pints_test.cc
+++ b/au/units/test/us_pints_test.cc
@@ -37,7 +37,6 @@ TEST(USPints, HasExpectedSymbol) {
 
 TEST(USPints, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_US_pt;
     EXPECT_THAT(1.28e-4_US_pt, SameTypeAndValue(make_constant(us_pints * 1.28e-4_mag)));
 }
 

--- a/au/units/test/us_quarts_test.cc
+++ b/au/units/test/us_quarts_test.cc
@@ -14,7 +14,10 @@
 
 #include "au/units/us_quarts.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
+#include "au/units/literals/us_quarts.hh"
 #include "au/units/us_gallons.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -30,6 +33,12 @@ TEST(USQuarts, FourInAGallon) { EXPECT_THAT(us_quarts(4), Eq(us_gallons(1))); }
 TEST(USQuarts, HasExpectedSymbol) {
     using symbols::US_qt;
     EXPECT_THAT(5 * US_qt, SameTypeAndValue(us_quarts(5)));
+}
+
+TEST(USQuarts, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_US_qt;
+    EXPECT_THAT(1.28e-4_US_qt, SameTypeAndValue(make_constant(us_quarts * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/us_quarts_test.cc
+++ b/au/units/test/us_quarts_test.cc
@@ -37,7 +37,6 @@ TEST(USQuarts, HasExpectedSymbol) {
 
 TEST(USQuarts, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_US_qt;
     EXPECT_THAT(1.28e-4_US_qt, SameTypeAndValue(make_constant(us_quarts * 1.28e-4_mag)));
 }
 

--- a/au/units/test/volts_test.cc
+++ b/au/units/test/volts_test.cc
@@ -36,7 +36,6 @@ TEST(Volts, HasExpectedSymbol) {
 
 TEST(Volts, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_V;
     EXPECT_THAT(1.28e-4_V, SameTypeAndValue(make_constant(volts * 1.28e-4_mag)));
 }
 

--- a/au/units/test/volts_test.cc
+++ b/au/units/test/volts_test.cc
@@ -14,9 +14,13 @@
 
 #include "au/units/volts.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/amperes.hh"
+#include "au/units/literals/volts.hh"
 #include "au/units/ohms.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -28,6 +32,12 @@ TEST(Volts, SatisfiesOhmsLaw) { EXPECT_THAT(volts(8), QuantityEquivalent(amperes
 TEST(Volts, HasExpectedSymbol) {
     using symbols::V;
     EXPECT_THAT(5 * V, SameTypeAndValue(volts(5)));
+}
+
+TEST(Volts, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_V;
+    EXPECT_THAT(1.28e-4_V, SameTypeAndValue(make_constant(volts * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/watts_test.cc
+++ b/au/units/test/watts_test.cc
@@ -14,12 +14,16 @@
 
 #include "au/units/watts.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/amperes.hh"
 #include "au/units/joules.hh"
+#include "au/units/literals/watts.hh"
 #include "au/units/ohms.hh"
 #include "au/units/seconds.hh"
 #include "au/units/volts.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -43,6 +47,12 @@ TEST(Watts, EquivalentToOhmicHeating) {
 TEST(Watts, HasExpectedSymbol) {
     using symbols::W;
     EXPECT_THAT(5 * W, SameTypeAndValue(watts(5)));
+}
+
+TEST(Watts, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_W;
+    EXPECT_THAT(1.28e-4_W, SameTypeAndValue(make_constant(watts * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/watts_test.cc
+++ b/au/units/test/watts_test.cc
@@ -51,7 +51,6 @@ TEST(Watts, HasExpectedSymbol) {
 
 TEST(Watts, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_W;
     EXPECT_THAT(1.28e-4_W, SameTypeAndValue(make_constant(watts * 1.28e-4_mag)));
 }
 

--- a/au/units/test/webers_test.cc
+++ b/au/units/test/webers_test.cc
@@ -14,11 +14,15 @@
 
 #include "au/units/webers.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/amperes.hh"
 #include "au/units/henries.hh"
+#include "au/units/literals/webers.hh"
 #include "au/units/seconds.hh"
 #include "au/units/volts.hh"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace au {
@@ -36,6 +40,12 @@ TEST(Webers, EquivalentToHenryAmperes) {
 TEST(Webers, HasExpectedSymbol) {
     using symbols::Wb;
     EXPECT_THAT(5 * Wb, SameTypeAndValue(webers(5)));
+}
+
+TEST(Webers, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_Wb;
+    EXPECT_THAT(1.28e-4_Wb, SameTypeAndValue(make_constant(webers * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/au/units/test/webers_test.cc
+++ b/au/units/test/webers_test.cc
@@ -44,7 +44,6 @@ TEST(Webers, HasExpectedSymbol) {
 
 TEST(Webers, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_Wb;
     EXPECT_THAT(1.28e-4_Wb, SameTypeAndValue(make_constant(webers * 1.28e-4_mag)));
 }
 

--- a/au/units/test/yards_test.cc
+++ b/au/units/test/yards_test.cc
@@ -37,7 +37,6 @@ TEST(Yards, HasExpectedSymbol) {
 
 TEST(Yards, LiteralMakesEquivalentConstant) {
     using namespace ::au::au_literals;
-    using literals::operator""_yd;
     EXPECT_THAT(1.28e-4_yd, SameTypeAndValue(make_constant(yards * 1.28e-4_mag)));
 }
 

--- a/au/units/test/yards_test.cc
+++ b/au/units/test/yards_test.cc
@@ -14,8 +14,11 @@
 
 #include "au/units/yards.hh"
 
+#include "au/constant.hh"
+#include "au/magnitude.hh"
 #include "au/testing.hh"
 #include "au/units/feet.hh"
+#include "au/units/literals/yards.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -30,6 +33,12 @@ TEST(Yards, EquivalentTo3Feet) { EXPECT_THAT(yards(1), Eq(feet(3))); }
 TEST(Yards, HasExpectedSymbol) {
     using symbols::yd;
     EXPECT_THAT(5 * yd, SameTypeAndValue(yards(5)));
+}
+
+TEST(Yards, LiteralMakesEquivalentConstant) {
+    using namespace ::au::au_literals;
+    using literals::operator""_yd;
+    EXPECT_THAT(1.28e-4_yd, SameTypeAndValue(make_constant(yards * 1.28e-4_mag)));
 }
 
 }  // namespace au

--- a/docs/howto/new-units.md
+++ b/docs/howto/new-units.md
@@ -40,6 +40,13 @@ a complete sample definition of a new Unit, with these features annotated and ex
     constexpr auto ftm = au::SymbolFor<Fathoms>{};                  //  [6]
     }
 
+    namespace literals {                                            //  [7]
+    template <char... Cs>
+    constexpr auto operator""_ftm() {
+        return au::make_constant(fathoms * au::au_literals::operator""_mag<Cs...>());
+    }
+    }
+
     // In .cc file, in your project's namespace:
     constexpr const char Fathoms::label[];                          //  [2b]
     ```
@@ -61,6 +68,13 @@ a complete sample definition of a new Unit, with these features annotated and ex
 
     namespace symbols {
     constexpr auto ftm = au::SymbolFor<Fathoms>{};                  //  [6]
+    }
+
+    namespace literals {                                            //  [7]
+    template <char... Cs>
+    constexpr auto operator""_ftm() {
+        return au::make_constant(fathoms * au::au_literals::operator""_mag<Cs...>());
+    }
     }
     ```
 
@@ -128,6 +142,16 @@ Here are the features.
       symbols](../reference/unit.md#symbols).
     - **If omitted:** Users will either need to create their own symbols on the fly, or else spell
       out the full name of the unit.
+
+7. _Unit literal_.
+    - A [user-defined literal
+      (UDL)](https://en.cppreference.com/w/cpp/language/user_literal) whose suffix matches the unit
+      symbol, and which produces a [`Constant`](../reference/constant.md).  It forwards the numeric
+      part of the literal to the [`_mag` literal](../reference/magnitude.md#_mag-literal), so
+      `1.28e-4_ftm` is equivalent to `make_constant(fathoms * 1.28e-4_mag)`.  See [Unit
+      literals](../reference/constant.md#unit-literals).
+    - **If omitted:** Users can still write `make_constant(fathoms * 1.28e-4_mag)` explicitly; they
+      just won't have the concise literal form.
 
 !!! note
     Not shown here: adding an `origin` member.  We skipped this because it is very rare.  It only

--- a/docs/reference/constant.md
+++ b/docs/reference/constant.md
@@ -166,6 +166,42 @@ concise symbol.  The example below demonstrates the difference.
     There's no difference in the program that gets executed, but the printed label is a lot easier
     to understand.
 
+### Unit literals
+
+Every unit that ships with Au provides a _unit literal_: a [user-defined literal
+(UDL)](https://en.cppreference.com/w/cpp/language/user_literal) whose suffix is the unit's
+[symbol](./unit.md#symbols), and which produces a `Constant`.  The numeric part of the literal is
+forwarded to the [`_mag` literal](./magnitude.md#_mag-literal), and the result is the `Constant` you would
+get from `make_constant`.  For example, `1.28e-4_s` is equivalent to:
+
+```cpp
+make_constant(seconds * 1.28e-4_mag)
+```
+
+This makes very concise, readable constants:
+
+```cpp
+constexpr auto dt = 1.28e-4_s;  // A `Constant` for 128 microseconds.
+```
+
+Because a `Constant` is applied _symbolically_, a unit literal is a good choice for a magic number
+that you want to combine with quantities without any risk of rounding or overflow.
+
+Unit literals are **opt-in**, on a per-unit basis, to keep the base unit headers lightweight.  To
+use the literal for a unit, include its literals header --- for example,
+`"au/units/literals/seconds.hh"` --- and bring the literals into scope:
+
+```cpp
+#include "au/units/literals/seconds.hh"
+
+using namespace ::au::au_literals;  // Same namespace as `_mag`.
+
+constexpr auto dt = 1.28e-4_s;
+```
+
+The literals live in the `::au::au_literals` namespace, alongside `_mag`, so a single `using
+namespace ::au::au_literals;` brings in both.
+
 ## `Constant` and unit slots
 
 `Constant` can be passed to any API that takes a [unit slot](../discussion/idioms/unit-slots.md).

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -210,6 +210,14 @@ Symbols compose: the product or quotient of two `SymbolFor` instances is a new `
 | `SymbolFor<Unit> * SymbolFor<OtherUnit>` | `SymbolFor<UnitProductT<Unit, OtherUnit>>` |
 | `SymbolFor<Unit> / SymbolFor<OtherUnit>` | `SymbolFor<UnitQuotientT<Unit, OtherUnit>>` |
 
+### Unit literals {#literals}
+
+A unit symbol multiplied by a raw number produces a `Quantity`.  If you instead want a
+[`Constant`](./constant.md) --- for example, a magic number to combine with quantities without any
+risk of rounding or overflow --- use the _unit literal_, whose suffix is the same as the symbol.
+For instance, `1.28e-4_s` produces a `Constant`, while `1.28e-4 * s` would produce a `Quantity`.
+See [Unit literals](./constant.md#unit-literals) for details.
+
 ## Unit origins {#origins}
 
 The "origin" of a unit is only useful for `QuantityPoint`, our [affine space


### PR DESCRIPTION
This piggybacks on the new `_mag` literals, and should be extremely
flexible.

There are, of course, concerns about compile time impact.  But we can
mitigate those by putting each in its own _separate_ header, which users
include only when they actually use it.

Includes doc updates.