### PR TITLE
Expand Magnitude arithmetic operations

### DIFF
--- a/au/constant_test.cc
+++ b/au/constant_test.cc
@@ -118,6 +118,16 @@ TEST(MakeConstant, MakesConstantFromSymbol) {
     EXPECT_THAT(123 * ad_hoc_c, QuantityEquivalent(123 * c));
 }
 
+TEST(MakeConstant, MakesDimensionlessConstantFromMagnitude) {
+    constexpr auto three = make_constant(mag<3>());
+    StaticAssertTypeEq<decltype(make_constant(mag<3>())),
+                       Constant<decltype(UnitProduct<>{} * mag<3>())>>();
+
+    // A bare magnitude in numeric arithmetic acts like its corresponding constant.
+    EXPECT_THAT(2.5 * three, QuantityEquivalent((unos * three)(2.5)));
+    EXPECT_THAT(three * 2.5, QuantityEquivalent((unos * three)(2.5)));
+}
+
 TEST(Constant, CanGetQuantityBySpecifyingRep) {
     EXPECT_THAT(c.as<float>(), SameTypeAndValue(c * 1.0f));
     EXPECT_THAT(c.as<int>(), SameTypeAndValue(c * 1));

--- a/au/constant_test.cc
+++ b/au/constant_test.cc
@@ -29,6 +29,7 @@
 #include "au/units/radians.hh"
 #include "au/units/revolutions.hh"
 #include "au/units/seconds.hh"
+#include "au/units/unos.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -380,7 +380,7 @@ class Quantity {
         return make_quantity<decltype(pow<-1>(unit))>(s / a.value_);
     }
 
-    // Scaling by a Magnitude: scales the unit, leaving the stored value untouched.
+    // Scaling by a Magnitude: scales the unit; for (m / q) we also take the reciprocal of q's stored value.
     template <typename... BPs>
     friend AU_DEVICE_FUNC constexpr auto operator*(const Quantity &a, Magnitude<BPs...> m) {
         return make_quantity<decltype(unit * m)>(a.value_);

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -380,6 +380,26 @@ class Quantity {
         return make_quantity<decltype(pow<-1>(unit))>(s / a.value_);
     }
 
+    // Scaling by a Magnitude: scales the unit, leaving the stored value untouched.
+    template <typename... BPs>
+    friend AU_DEVICE_FUNC constexpr auto operator*(const Quantity &a, Magnitude<BPs...> m) {
+        return make_quantity<decltype(unit * m)>(a.value_);
+    }
+    template <typename... BPs>
+    friend AU_DEVICE_FUNC constexpr auto operator*(Magnitude<BPs...> m, const Quantity &a) {
+        return make_quantity<decltype(m * unit)>(a.value_);
+    }
+    template <typename... BPs>
+    friend AU_DEVICE_FUNC constexpr auto operator/(const Quantity &a, Magnitude<BPs...> m) {
+        return make_quantity<decltype(unit / m)>(a.value_);
+    }
+    template <typename... BPs>
+    friend AU_DEVICE_FUNC constexpr auto operator/(Magnitude<BPs...> m, const Quantity &a) {
+        static_assert(!std::is_integral<RepT>::value,
+                      "Dividing by an integer value disallowed: would almost always produce 0");
+        return make_quantity<decltype(m / unit)>(RepT{1} / a.value_);
+    }
+
     // Multiplication for dimensioned quantities.
     //
     // We take `q` by reference and read its value via `data_in` (a reference), rather than by value
@@ -762,6 +782,71 @@ AU_DEVICE_FUNC constexpr auto rep_cast(Zero z) {
     return z;
 }
 
+namespace detail {
+
+// A SFINAE helper that is the identity, but only if we think a type is a valid rep.
+//
+// For now, we are restricting this to arithmetic types.  This doesn't mean they're the only reps we
+// support; it just means they're the only reps we can _construct via this method_.  Later on, we
+// would like to have a well-defined concept that defines what is and is not an acceptable rep for
+// our `Quantity`.  Once we have that, we can simply constrain on that concept.  For more on this
+// idea, see: https://github.com/aurora-opensource/au/issues/52
+struct NoTypeMember {};
+template <typename T>
+struct TypeIdentityIfLooksLikeValidRepImpl
+    : std::conditional_t<std::is_arithmetic<T>::value, stdx::type_identity<T>, NoTypeMember> {};
+template <typename T>
+using TypeIdentityIfLooksLikeValidRep = typename TypeIdentityIfLooksLikeValidRepImpl<T>::type;
+
+// The unit whose `Constant` corresponds to a bare `Magnitude`: a scaled version of the unitless
+// unit.
+template <typename M>
+using UnitForMagnitude = ComputeScaledUnit<UnitProduct<>, M>;
+
+}  // namespace detail
+
+//
+// Multiplication and division of raw numbers with Magnitudes.
+//
+// The Magnitude acts like its corresponding `Constant` (that is, the constant for a scaled version
+// of the unitless unit): the result is a dimensionless `Quantity` which stores the input value
+// untouched, and records the Magnitude in its unit.
+//
+
+// (N * M), for number N and magnitude M.
+template <typename T, typename... BPs>
+AU_DEVICE_FUNC constexpr auto operator*(T x, Magnitude<BPs...>)
+    -> Quantity<detail::UnitForMagnitude<Magnitude<BPs...>>,
+                detail::TypeIdentityIfLooksLikeValidRep<T>> {
+    return make_quantity<detail::UnitForMagnitude<Magnitude<BPs...>>>(x);
+}
+
+// (M * N), for number N and magnitude M.
+template <typename T, typename... BPs>
+AU_DEVICE_FUNC constexpr auto operator*(Magnitude<BPs...>, T x)
+    -> Quantity<detail::UnitForMagnitude<Magnitude<BPs...>>,
+                detail::TypeIdentityIfLooksLikeValidRep<T>> {
+    return make_quantity<detail::UnitForMagnitude<Magnitude<BPs...>>>(x);
+}
+
+// (N / M), for number N and magnitude M.
+template <typename T, typename... BPs>
+AU_DEVICE_FUNC constexpr auto operator/(T x, Magnitude<BPs...>)
+    -> Quantity<detail::UnitForMagnitude<MagInverse<Magnitude<BPs...>>>,
+                detail::TypeIdentityIfLooksLikeValidRep<T>> {
+    return make_quantity<detail::UnitForMagnitude<MagInverse<Magnitude<BPs...>>>>(x);
+}
+
+// (M / N), for number N and magnitude M.
+template <typename T, typename... BPs>
+AU_DEVICE_FUNC constexpr auto operator/(Magnitude<BPs...>, T x)
+    -> Quantity<detail::UnitForMagnitude<Magnitude<BPs...>>,
+                detail::TypeIdentityIfLooksLikeValidRep<T>> {
+    static_assert(!std::is_integral<T>::value,
+                  "Dividing by an integer value disallowed: would almost always produce 0");
+    return make_quantity<detail::UnitForMagnitude<Magnitude<BPs...>>>(T{1} / x);
+}
+
 template <typename UnitT>
 struct QuantityMaker {
     using Unit = UnitT;
@@ -801,6 +886,16 @@ struct QuantityMaker {
     template <typename... BPs>
     AU_DEVICE_FUNC constexpr auto operator/(Magnitude<BPs...> m) const {
         return QuantityMaker<decltype(unit / m)>{};
+    }
+
+    template <typename... BPs>
+    friend AU_DEVICE_FUNC constexpr auto operator*(Magnitude<BPs...> m, QuantityMaker) {
+        return QuantityMaker<decltype(m * unit)>{};
+    }
+
+    template <typename... BPs>
+    friend AU_DEVICE_FUNC constexpr auto operator/(Magnitude<BPs...> m, QuantityMaker) {
+        return QuantityMaker<decltype(m / unit)>{};
     }
 
     template <typename DivisorUnit>

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -380,7 +380,9 @@ class Quantity {
         return make_quantity<decltype(pow<-1>(unit))>(s / a.value_);
     }
 
-    // Scaling by a Magnitude: scales the unit; for (m / q) we also take the reciprocal of q's stored value.
+    // Scaling by a Magnitude scales the unit.
+    //
+    // For (m / q) we also take the reciprocal of q's stored value.
     template <typename... BPs>
     friend AU_DEVICE_FUNC constexpr auto operator*(const Quantity &a, Magnitude<BPs...> m) {
         return make_quantity<decltype(unit * m)>(a.value_);

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -343,6 +343,12 @@ struct QuantityPointMaker {
     AU_DEVICE_FUNC constexpr auto operator/(Magnitude<BPs...> m) const {
         return QuantityPointMaker<decltype(unit / m)>{};
     }
+
+    // Note: there is no `(M / maker)` counterpart, because inverting a point unit is meaningless.
+    template <typename... BPs>
+    friend AU_DEVICE_FUNC constexpr auto operator*(Magnitude<BPs...> m, QuantityPointMaker) {
+        return QuantityPointMaker<decltype(m * unit)>{};
+    }
 };
 
 template <typename U>

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -576,4 +576,8 @@ TEST(QuantityPointMaker, CanScaleByMagnitude) {
     StaticAssertTypeEq<decltype(kelvins_pt / mag<5>()),
                        QuantityPointMaker<decltype(Kelvins{} / mag<5>())>>();
 }
+
+TEST(QuantityPointMaker, CanScaleByMagnitudeOnTheLeft) {
+    StaticAssertTypeEq<decltype(mag<5>() * kelvins_pt), decltype(kelvins_pt * mag<5>())>();
+}
 }  // namespace au

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -319,6 +319,15 @@ TEST(QuantityMaker, CanDivideByMagnitudeToGetMakerOfDescaledUnit) {
     EXPECT_THAT((feet / mag<12>())(1.234), QuantityEquivalent(inches(1.234)));
 }
 
+TEST(QuantityMaker, CanBeScaledByMagnitudeOnTheLeft) {
+    StaticAssertTypeEq<decltype(mag<3>() * feet), decltype(feet * mag<3>())>();
+    EXPECT_THAT((mag<3>() * feet)(1.234), QuantityEquivalent(yards(1.234)));
+}
+
+TEST(QuantityMaker, CanDivideMagnitudeToGetMakerOfScaledInverseUnit) {
+    StaticAssertTypeEq<decltype(mag<3>() / hours), QuantityMaker<decltype(mag<3>() / Hours{})>>();
+}
+
 TEST(QuantityMaker, CanMultiplyByMultipleSingularUnits) {
     StaticAssertTypeEq<decltype(mile * minute * days),
                        QuantityMaker<UnitProduct<Miles, Minutes, Days>>>();
@@ -826,6 +835,55 @@ TEST(Quantity, ScalarDivisionWorks) {
 TEST(Quantity, ScalarDivisionIsConstexprCompatible) {
     constexpr auto quotient = feet(10.) / 2;
     EXPECT_THAT(quotient, Eq(feet(5.)));
+}
+
+TEST(Quantity, CanScaleByMagnitudeOnEitherSide) {
+    constexpr auto q = feet(6.0) * mag<3>();
+    EXPECT_THAT(q, SameTypeAndValue(mag<3>() * feet(6.0)));
+    EXPECT_THAT(q, SameTypeAndValue((feet * mag<3>())(6.0)));
+    EXPECT_THAT(q.in(feet), SameTypeAndValue(18.0));
+}
+
+TEST(Quantity, ScalingByMagnitudePreservesUnderlyingValue) {
+    // Because we scale the unit, and leave the stored value untouched, even integer quantities
+    // remain exact under any rational scaling.
+    constexpr auto q = feet(5) * (mag<1>() / mag<3>());
+    EXPECT_THAT(q.in(inches), SameTypeAndValue(20));
+}
+
+TEST(Quantity, CanDivideByMagnitude) {
+    EXPECT_THAT(feet(6.0) / mag<3>(), SameTypeAndValue((feet / mag<3>())(6.0)));
+    EXPECT_THAT((feet(6.0) / mag<3>()).in(feet), SameTypeAndValue(2.0));
+}
+
+TEST(Quantity, CanDivideMagnitudeByQuantity) {
+    constexpr auto q = mag<3>() / feet(2.0);
+    EXPECT_THAT(q, SameTypeAndValue((mag<3>() / feet)(0.5)));
+    EXPECT_THAT(q.in(inverse(feet)), SameTypeAndValue(1.5));
+}
+
+TEST(Quantity, RawNumberTimesMagnitudeMakesDimensionlessQuantity) {
+    constexpr auto x = 2.5 * mag<3>();
+    EXPECT_THAT(x, SameTypeAndValue(mag<3>() * 2.5));
+    EXPECT_THAT(x.in(unos), SameTypeAndValue(7.5));
+
+    // The multiplication is symbolic, so even integer inputs are exact.
+    EXPECT_THAT((5 * mag<3>()).in(unos), SameTypeAndValue(15));
+}
+
+TEST(Quantity, RawNumberTimesMagnitudeOfOneIsUnitlessQuantity) {
+    constexpr double x = 4.5 * mag<1>();
+    EXPECT_THAT(x, SameTypeAndValue(4.5));
+}
+
+TEST(Quantity, CanDivideRawNumberAndMagnitudeInEitherOrder) {
+    EXPECT_THAT((7.5 / mag<3>()).in(unos), SameTypeAndValue(2.5));
+    EXPECT_THAT((mag<3>() / 2.0).in(unos), SameTypeAndValue(1.5));
+}
+
+TEST(Quantity, MagnitudeCanFillUnitSlot) {
+    EXPECT_THAT((2.5 * mag<3>()).in(mag<3>()), SameTypeAndValue(2.5));
+    EXPECT_THAT(unos(7.5).in(mag<3>()), SameTypeAndValue(2.5));
 }
 
 TEST(Quantity, ShortHandAdditionAssignmentWorks) {

--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -416,6 +416,18 @@ constexpr ComputeScaledUnit<U, MagInverse<Magnitude<BPs...>>> operator/(U, Magni
     return {};
 }
 
+// Scale this Unit by multiplying by a Magnitude on the left.
+template <typename U, typename = std::enable_if_t<IsUnit<U>::value>, typename... BPs>
+constexpr ComputeScaledUnit<U, Magnitude<BPs...>> operator*(Magnitude<BPs...>, U) {
+    return {};
+}
+
+// Divide a Magnitude by this Unit.
+template <typename U, typename = std::enable_if_t<IsUnit<U>::value>, typename... BPs>
+constexpr ComputeScaledUnit<UnitInverse<U>, Magnitude<BPs...>> operator/(Magnitude<BPs...>, U) {
+    return {};
+}
+
 // Compute the product of two unit instances.
 template <typename U1,
           typename U2,
@@ -469,11 +481,36 @@ struct SingularNameFor {
     constexpr auto operator*(SingularNameFor<OtherUnit>) const {
         return SingularNameFor<UnitProduct<Unit, OtherUnit>>{};
     }
+
+    // Scale by a Magnitude on the right or the left, or divide by a Magnitude.
+    template <typename... BPs>
+    constexpr auto operator*(Magnitude<BPs...> m) const {
+        return SingularNameFor<decltype(Unit{} * m)>{};
+    }
+    template <typename... BPs>
+    constexpr auto operator/(Magnitude<BPs...> m) const {
+        return SingularNameFor<decltype(Unit{} / m)>{};
+    }
+    template <typename... BPs>
+    friend constexpr auto operator*(Magnitude<BPs...> m, SingularNameFor) {
+        return SingularNameFor<decltype(m * Unit{})>{};
+    }
+
+    // Divide a Magnitude by this `SingularNameFor`.
+    template <typename... BPs>
+    friend constexpr auto operator/(Magnitude<BPs...> m, SingularNameFor) {
+        return SingularNameFor<decltype(m / Unit{})>{};
+    }
 };
 
 // Support `SingularNameFor` in (quantity) unit slots.
 template <typename U>
 struct AssociatedUnitImpl<SingularNameFor<U>> : stdx::type_identity<U> {};
+
+// Support `Magnitude` in (quantity) unit slots: it acts as a scaled version of the unitless unit.
+template <typename... BPs>
+struct AssociatedUnitImpl<Magnitude<BPs...>>
+    : stdx::type_identity<ComputeScaledUnit<UnitProduct<>, Magnitude<BPs...>>> {};
 
 template <int Exp, typename Unit>
 constexpr auto pow(SingularNameFor<Unit>) {
@@ -1234,6 +1271,31 @@ struct UnitLabel<ScaledUnit<U, Magnitude<Negative>>> {
 template <typename U>
 constexpr typename UnitLabel<ScaledUnit<U, Magnitude<Negative>>>::LabelT
     UnitLabel<ScaledUnit<U, Magnitude<Negative>>>::value;
+
+namespace detail {
+// Labeler for a scaled version of the unitless unit: the label is just the magnitude in brackets.
+//
+// (If we used the generic `ScaledUnit` labeler, the empty label of the unitless unit would leave a
+// dangling space, as in `"[3 ]"`.)
+template <typename M>
+struct UnitlessScaledLabel {
+    using MagLab = MagnitudeLabel<M>;
+    using LabelT = StringConstant<parens_if<MagLab::has_exposed_slash>(MagLab::value).size() + 2u>;
+    static constexpr LabelT value =
+        concatenate("[", parens_if<MagLab::has_exposed_slash>(MagLab::value), "]");
+};
+template <typename M>
+constexpr typename UnitlessScaledLabel<M>::LabelT UnitlessScaledLabel<M>::value;
+}  // namespace detail
+
+// Special case for a scaled version of the unitless unit, as in `"[3]"`.
+template <typename M>
+struct UnitLabel<ScaledUnit<UnitProductPack<>, M>> : detail::UnitlessScaledLabel<M> {};
+
+// Disambiguator between the "scaled unitless unit" and "unit scaled by (-1)" special cases.
+template <>
+struct UnitLabel<ScaledUnit<UnitProductPack<>, Magnitude<Negative>>>
+    : detail::UnitlessScaledLabel<Magnitude<Negative>> {};
 
 // Implementation for CommonUnitPack: give size in terms of each constituent unit.
 template <typename... Us>

--- a/au/unit_of_measure_test.cc
+++ b/au/unit_of_measure_test.cc
@@ -127,6 +127,14 @@ TEST(ScaledUnit, IsTypeIdentityWhenScalingByOne) {
     StaticAssertTypeEq<decltype((Feet{} * mag<3>()) / mag<3>()), Feet>();
 }
 
+TEST(Unit, CanScaleByMagnitudeOnLeft) {
+    StaticAssertTypeEq<decltype(mag<3>() * Feet{}), decltype(Feet{} * mag<3>())>();
+}
+
+TEST(Unit, DividingMagnitudeByUnitScalesInverseOfUnit) {
+    StaticAssertTypeEq<decltype(mag<3>() / Feet{}), decltype(UnitInverse<Feet>{} * mag<3>())>();
+}
+
 TEST(IsUnit, TrueForUnitImpl) { EXPECT_THAT(IsUnit<UnitImpl<Length>>::value, IsTrue()); }
 
 TEST(IsUnit, TrueForOpaqueTypedef) { EXPECT_THAT(IsUnit<Feet>::value, IsTrue()); }
@@ -159,6 +167,8 @@ TEST(FitsInUnitSlot, TrueForUnitAndQuantityMakerAndSingularNameFor) {
 
     EXPECT_THAT(fits_in_unit_slot(1.2), IsFalse());
 }
+
+TEST(FitsInUnitSlot, TrueForMagnitude) { EXPECT_THAT(fits_in_unit_slot(mag<3>()), IsTrue()); }
 
 TEST(Product, IsUnitWithProductOfMagnitudesAndDimensions) {
     constexpr auto foot_yards = Feet{} * Yards{};
@@ -451,6 +461,25 @@ TEST(AssociatedUnit, HandlesWrappersWhichHaveSpecializedAssociatedUnit) {
 
 TEST(AssociatedUnit, SupportsSingularNameFor) {
     StaticAssertTypeEq<AssociatedUnit<SingularNameFor<Feet>>, Feet>();
+}
+
+TEST(AssociatedUnit, MagnitudeActsLikeScaledVersionOfUnitlessUnit) {
+    StaticAssertTypeEq<AssociatedUnit<decltype(mag<3>())>,
+                       decltype(UnitProductPack<>{} * mag<3>())>();
+}
+
+TEST(SingularNameFor, CanScaleByMagnitudeOnEitherSide) {
+    StaticAssertTypeEq<decltype(meter * mag<3>()),
+                       SingularNameFor<decltype(Meters{} * mag<3>())>>();
+    StaticAssertTypeEq<decltype(mag<3>() * meter),
+                       SingularNameFor<decltype(Meters{} * mag<3>())>>();
+    StaticAssertTypeEq<decltype(meter / mag<3>()),
+                       SingularNameFor<decltype(Meters{} / mag<3>())>>();
+}
+
+TEST(SingularNameFor, DividingMagnitudeScalesInverseOfUnit) {
+    StaticAssertTypeEq<decltype(mag<3>() / meter),
+                       SingularNameFor<decltype(mag<3>() / Meters{})>>();
 }
 
 TEST(AppropriateAssociatedUnit, GivesAssociatedUnitForQuantity) {
@@ -886,6 +915,13 @@ TEST(UnitLabel, ApplyingMultipleScaleFactorsComposesToOneSingleScaleFactor) {
 
 TEST(UnitLabel, NegatedUnitOmitsNumerals) {
     EXPECT_THAT(unit_label<decltype(Feet{} * (-mag<1>()))>(), StrEq("[-ft]"));
+}
+
+TEST(UnitLabel, ScaledUnitlessUnitContainsOnlyMagnitude) {
+    EXPECT_THAT(unit_label(UnitProductPack<>{} * mag<3>()), StrEq("[3]"));
+    EXPECT_THAT(unit_label(UnitProductPack<>{} * (-mag<3>())), StrEq("[-3]"));
+    EXPECT_THAT(unit_label(UnitProductPack<>{} * mag<3>() / mag<4>()), StrEq("[(3 / 4)]"));
+    EXPECT_THAT(unit_label(UnitProductPack<>{} * (-mag<1>())), StrEq("[-1]"));
 }
 
 TEST(UnitLabel, OmitsTrivialScaleFactor) {

--- a/au/wrapper_operations.hh
+++ b/au/wrapper_operations.hh
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "au/quantity.hh"
-#include "au/stdx/type_traits.hh"
 
 // "Mixin" classes to add operations for a "unit wrapper" --- that is, a template with a _single
 // template parameter_ that is a unit.
@@ -36,19 +35,7 @@
 namespace au {
 namespace detail {
 
-// A SFINAE helper that is the identity, but only if we think a type is a valid rep.
-//
-// For now, we are restricting this to arithmetic types.  This doesn't mean they're the only reps we
-// support; it just means they're the only reps we can _construct via this method_.  Later on, we
-// would like to have a well-defined concept that defines what is and is not an acceptable rep for
-// our `Quantity`.  Once we have that, we can simply constrain on that concept.  For more on this
-// idea, see: https://github.com/aurora-opensource/au/issues/52
-struct NoTypeMember {};
-template <typename T>
-struct TypeIdentityIfLooksLikeValidRepImpl
-    : std::conditional_t<std::is_arithmetic<T>::value, stdx::type_identity<T>, NoTypeMember> {};
-template <typename T>
-using TypeIdentityIfLooksLikeValidRep = typename TypeIdentityIfLooksLikeValidRepImpl<T>::type;
+// (Note: `TypeIdentityIfLooksLikeValidRep`, which these mixins use, lives in "au/quantity.hh".)
 
 //
 // A mixin that enables turning a raw number into a Quantity by multiplying or dividing.

--- a/docs/discussion/idioms/unit-slots.md
+++ b/docs/discussion/idioms/unit-slots.md
@@ -60,8 +60,10 @@ they have two advantages that make them easier to read:
 ### Other expressions
 
 There are other monovalue types that would feel right at home in a unit slot.  We typically support
-those too!  Key examples include [unit symbols](../../reference/unit.md#symbols) and
-[constants](../../reference/constant.md).  Expand the block below to see a worked example.
+those too!  Key examples include [unit symbols](../../reference/unit.md#symbols),
+[constants](../../reference/constant.md), and even
+[magnitudes](../../reference/magnitude.md#unit-slots) (which act as scaled versions of the unitless
+unit).  Expand the block below to see a worked example.
 
 ??? example "Example: using unit symbols and constants in unit slots"
     Suppose we have the following preamble, simply to set everything up.
@@ -90,6 +92,19 @@ those too!  Key examples include [unit symbols](../../reference/unit.md#symbols)
     //                ^
     // Passing a constant to the unit slot.  Output:
     // "9.69257e-08 c"
+    ```
+
+??? example "Example: using a magnitude in a unit slot"
+    A `Magnitude` in a unit slot acts as a scaled version of the unitless unit, which can be handy
+    for re-expressing dimensionless quantities.
+
+    ```cpp
+    constexpr auto ratio = unos(0.35);
+
+    std::cout << ratio.as(mag<1>() / mag<100>()) << std::endl;
+    //                    ^^^^^^^^^^^^^^^^^^^^^
+    // Passing a magnitude to the unit slot: express as "hundredths".
+    // Output: "35 [(1 / 100)]"
     ```
 
 #### Notes for `QuantityPoint`

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -707,9 +707,11 @@ We expect that the relation `m == sign(m) * abs(m)` will hold for every `Magnitu
 
 ### Combining with other types
 
-A `Magnitude` instance `m` can be multiplied or divided with the library's other value types.  In
-every case, the effect is _symbolic_: we scale the _unit_, never the underlying value.  This makes
-these operations exact, even for integral types.
+A `Magnitude` instance `m` can be multiplied or divided with the library's other value types. In
+many cases the effect is _symbolic_: we scale the _unit_ while leaving the stored value unchanged,
+which makes these operations exact even for integral reps. When `m` is divided by a numeric value or
+quantity (`m / x` or `m / q`), the stored value becomes the reciprocal of the divisor, so these
+overloads are only enabled for non-integral divisors.
 
 #### Raw numbers
 
@@ -717,8 +719,9 @@ these operations exact, even for integral types.
 scaled version of the unitless unit.  The `Magnitude` acts like its "corresponding constant":
 `m` behaves the same as `make_constant(UnitProduct<>{} * m)`.
 
-The stored value is the input number, untouched.  To retrieve the fully evaluated result, convert to
-a specific unit, as with any other dimensionless quantity.
+The stored value is the input number for `x * m`, `m * x`, and `x / m`. For `m / x`, the stored
+value is `1 / x` (so this overload is only enabled for non-integral `x`). To retrieve the fully
+evaluated result, convert to a specific unit, as with any other dimensionless quantity.
 
 **Syntax**, for a raw number `x`:
 
@@ -735,9 +738,10 @@ a specific unit, as with any other dimensionless quantity.
 
 #### `Quantity`
 
-**Result:** A `Quantity` of the same rep, whose unit is scaled by the `Magnitude` (or its inverse,
-for division).  The stored value is untouched, so the operation is always exact --- even for
-integral reps.
+**Result:** A `Quantity` of the same rep, whose unit is scaled by the `Magnitude` (or its inverse
+for division). For `q * m`, `m * q`, and `q / m`, the stored value is untouched (exact even for
+integral reps). For `m / q`, the stored value becomes the reciprocal of `q`'s stored value, so this
+overload is only enabled for non-integral reps.
 
 **Syntax**, for a `Quantity` instance `q`:
 

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -704,3 +704,66 @@ We expect that the relation `m == sign(m) * abs(m)` will hold for every `Magnitu
     - `Sign<M>`
 - For an _instance_ `m`:
     - `sign(m)`
+
+### Combining with other types
+
+A `Magnitude` instance `m` can be multiplied or divided with the library's other value types.  In
+every case, the effect is _symbolic_: we scale the _unit_, never the underlying value.  This makes
+these operations exact, even for integral types.
+
+#### Raw numbers
+
+**Result:** A dimensionless `Quantity`, whose rep is the raw number's type, and whose unit is a
+scaled version of the unitless unit.  The `Magnitude` acts like its "corresponding constant":
+`m` behaves the same as `make_constant(UnitProduct<>{} * m)`.
+
+The stored value is the input number, untouched.  To retrieve the fully evaluated result, convert to
+a specific unit, as with any other dimensionless quantity.
+
+**Syntax**, for a raw number `x`:
+
+- `x * m`
+- `m * x`
+- `x / m`
+- `m / x`
+    - Only when `x` is not an integral type; dividing a `Magnitude` by an integer would almost
+      always produce 0, so it is a compile-time error.
+
+**Example:**
+
+- `(2.5 * mag<3>()).in(unos)` equals `7.5`
+
+#### `Quantity`
+
+**Result:** A `Quantity` of the same rep, whose unit is scaled by the `Magnitude` (or its inverse,
+for division).  The stored value is untouched, so the operation is always exact --- even for
+integral reps.
+
+**Syntax**, for a `Quantity` instance `q`:
+
+- `q * m`
+- `m * q`
+- `q / m`
+- `m / q`
+    - Only when the rep of `q` is not an integral type.
+
+**Example:**
+
+- `(feet(6.0) * mag<3>()).in(feet)` equals `18.0`
+
+#### Units, quantity makers, and other unit-adjacent types
+
+Instances of units, `QuantityMaker`, `QuantityPointMaker`, `SingularNameFor`, `Constant`, and
+`SymbolFor` can all be multiplied or divided by a `Magnitude`, on either side, producing the same
+kind of object with a scaled unit.  (The one exception is that you cannot divide a `Magnitude` _by_
+a `QuantityPointMaker`, because the inverse of a point unit is meaningless.)
+
+For example, `mag<3>() * feet` is a `QuantityMaker` for the unit "3 feet" --- the same as
+`feet * mag<3>()`.
+
+#### Unit slots
+
+A `Magnitude` instance can fill a [unit slot](../discussion/idioms/unit-slots.md), where it acts as
+a scaled version of the unitless unit.  For example, `make_constant(mag<3>())` is a dimensionless
+`Constant` representing the number 3, and `some_dimensionless_quantity.in(mag<3>())` retrieves the
+value of that quantity, as measured in units of "3".

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -568,8 +568,9 @@ feet(6).in(Inches{});
 ```
 
 The underlined arguments are all unit slots.  The kinds of things that can be passed here include
-a `QuantityMaker` for a unit, a [constant](./constant.md), a [unit symbol](#symbols), or simply
-a unit type itself.
+a `QuantityMaker` for a unit, a [constant](./constant.md), a [unit symbol](#symbols),
+a [magnitude](./magnitude.md#unit-slots) (which acts as a scaled version of the unitless unit), or
+simply a unit type itself.
 
 The use case for this trait is to _implement_ the unit slot argument for a function.
 


### PR DESCRIPTION
The basic idea is that everywhere we can multiply or divide by `Constant`, we should be able to multiply or divide by a `Magnitude`, and it should do the same thing as the `Constant` for the dimensionless unit with that magnitude.

We also enable Magnitude to work in unit slots.

This table summarizes the big picture of what is changing.

* = new on this branch, Y = pre-existing.

| Partner            | M*x | x*M |  M/x  | x/M |
|--------------------|-----|-----|-------|-----|
| Magnitude          |  Y  |  Y  |   Y   |  Y  |
| Zero               |  Y  |  Y  |  (1)  |  Y  |
| Constant           |  Y  |  Y  |   Y   |  Y  |
| SymbolFor          |  Y  |  Y  |   Y   |  Y  |
| Unit instance      |  *  |  Y  |   *   |  Y  |
| QuantityMaker      |  *  |  Y  |   *   |  Y  |
| QuantityPointMaker |  *  |  Y  |  (2)  |  Y  |
| SingularNameFor    |  *  |  *  |   *   |  *  |
| Quantity           |  *  |  *  | * (3) |  *  |
| Raw numeric        |  *  |  *  | * (3) |  *  |

(1) Absent by design: this would be division by zero.
(2) Deliberately omitted: the inverse of a point unit is meaningless.
(3) static_asserts when the divisor is integral (integer rep or
    integer number), matching existing `Constant` behavior.