### PR TITLE
Treat Quantity-like scalar trait as invalid rep

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -671,6 +671,7 @@ cc_library(
     hdrs = ["rep.hh"],
     deps = [
         ":fwd",
+        ":magnitude",
         ":stdx",
     ],
 )

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -15,6 +15,7 @@
 #include "au/quantity.hh"
 
 #include <complex>
+#include <utility>
 
 #include "au/prefix.hh"
 #include "au/testing.hh"
@@ -59,6 +60,46 @@ struct Vec {
         Vec r{};
         for (auto i = 0u; i < N; ++i) {
             r.data[i] = a.data[i] / s;
+        }
+        return r;
+    }
+};
+
+// A vector-of-quantities type in the style of #666: designed to hold `au::Quantity` elements, with
+// _templated_ scalar operators of its own.  `Quantity`'s scalar operators must not compete with
+// these: they would be ambiguous, and could only ever produce a rep with nested units anyway.
+template <typename T, std::size_t N>
+struct VectorOfQuantities {
+    using value_type = T;
+
+    T data[N];
+
+    template <typename Scalar>
+    friend constexpr auto operator*(const VectorOfQuantities &v, Scalar s)
+        -> VectorOfQuantities<decltype(std::declval<T>() * std::declval<Scalar>()), N> {
+        VectorOfQuantities<decltype(std::declval<T>() * std::declval<Scalar>()), N> r{};
+        for (auto i = 0u; i < N; ++i) {
+            r.data[i] = v.data[i] * s;
+        }
+        return r;
+    }
+
+    template <typename Scalar>
+    friend constexpr auto operator*(Scalar s, const VectorOfQuantities &v)
+        -> VectorOfQuantities<decltype(std::declval<Scalar>() * std::declval<T>()), N> {
+        VectorOfQuantities<decltype(std::declval<Scalar>() * std::declval<T>()), N> r{};
+        for (auto i = 0u; i < N; ++i) {
+            r.data[i] = s * v.data[i];
+        }
+        return r;
+    }
+
+    template <typename Scalar>
+    friend constexpr auto operator/(const VectorOfQuantities &v, Scalar s)
+        -> VectorOfQuantities<decltype(std::declval<T>() / std::declval<Scalar>()), N> {
+        VectorOfQuantities<decltype(std::declval<T>() / std::declval<Scalar>()), N> r{};
+        for (auto i = 0u; i < N; ++i) {
+            r.data[i] = v.data[i] / s;
         }
         return r;
     }
@@ -835,6 +876,24 @@ TEST(Quantity, ScalarDivisionWorks) {
 TEST(Quantity, ScalarDivisionIsConstexprCompatible) {
     constexpr auto quotient = feet(10.) / 2;
     EXPECT_THAT(quotient, Eq(feet(5.)));
+}
+
+TEST(Quantity, ScalarOperatorsDoNotCompeteWithVectorOfQuantityTypes) {
+    // Regression test for #666.  A vector whose elements are `Quantity`, with templated scalar
+    // operators of its own, must "own" its arithmetic with quantities: `Quantity`'s scalar
+    // overloads SFINAE themselves out, because they could only produce a rep with nested units.
+    constexpr test_types::VectorOfQuantities<decltype(meters(0.0f)), 3> distances{
+        {meters(6.0f), meters(12.0f), meters(18.0f)}};
+
+    constexpr auto velocities = distances / seconds(2.0f);
+    EXPECT_THAT(velocities.data[0], SameTypeAndValue((meters / seconds)(3.0f)));
+    EXPECT_THAT(velocities.data[2], SameTypeAndValue((meters / seconds)(9.0f)));
+
+    constexpr auto products_on_left = distances * hertz(2.0f);
+    EXPECT_THAT(products_on_left.data[0], SameTypeAndValue((meters * hertz)(12.0f)));
+
+    constexpr auto products_on_right = hertz(2.0f) * distances;
+    EXPECT_THAT(products_on_right.data[1], SameTypeAndValue((hertz * meters)(24.0f)));
 }
 
 TEST(Quantity, CanScaleByMagnitudeOnEitherSide) {

--- a/au/rep.hh
+++ b/au/rep.hh
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "au/fwd.hh"
+#include "au/magnitude.hh"
 #include "au/stdx/experimental/is_detected.hh"
 #include "au/stdx/type_traits.hh"
 
@@ -217,12 +218,22 @@ struct ResultIfNoneAreQuantityImpl
                                     Op,
                                     Ts...> {};
 
+// A type whose _scalar_ is itself quantity-like --- say, a vector whose elements are `Quantity`
+// --- can never be a valid rep, because using it as one would produce nested units.
+template <typename T>
+using ScalarOfOrVoid = stdx::experimental::detected_or_t<void, ::au::ScalarOf, T>;
+
+template <typename T>
+struct HasQuantityLikeScalar : LooksLikeAuOrOtherQuantity<ScalarOfOrVoid<T>> {};
+
 // The `std::is_empty` is a good way to catch all of the various unit and other monovalue types in
 // our library, which have little else in common.  It's also just intrinsically true that it
 // wouldn't make much sense to use an empty type as a rep.
 template <typename T>
-struct IsKnownInvalidRep
-    : stdx::disjunction<std::is_empty<T>, LooksLikeAuOrOtherQuantity<T>, std::is_same<void, T>> {};
+struct IsKnownInvalidRep : stdx::disjunction<std::is_empty<T>,
+                                             LooksLikeAuOrOtherQuantity<T>,
+                                             std::is_same<void, T>,
+                                             HasQuantityLikeScalar<T>> {};
 
 // The type of the product of two types.
 template <typename T, typename U>

--- a/au/rep_test.cc
+++ b/au/rep_test.cc
@@ -16,6 +16,7 @@
 
 #include <complex>
 #include <cstdint>
+#include <utility>
 
 #include "au/chrono_interop.hh"
 #include "au/constant.hh"
@@ -71,6 +72,35 @@ struct ConvertsToInt {
 // would incorrectly scoop it up too.  This helps us get coverage for the `!is_enum` guard.
 enum UnscopedEnum : int { kUnscopedEnumValue = 0 };
 
+// A vector whose scalar is advertised via the STL `value_type` convention, with a templated scalar
+// division operator, as in #666.
+template <typename T>
+struct VectorWithValueType {
+    using value_type = T;
+
+    T elements[3];
+
+    template <typename Scalar>
+    friend constexpr auto operator/(const VectorWithValueType &v, Scalar s)
+        -> VectorWithValueType<decltype(std::declval<T>() / std::declval<Scalar>())> {
+        return {{v.elements[0] / s, v.elements[1] / s, v.elements[2] / s}};
+    }
+};
+
+// A vector whose scalar is advertised via the Eigen `Scalar` convention.
+template <typename T>
+struct VectorWithScalar {
+    using Scalar = T;
+
+    T elements[3];
+};
+
+// A vector with no automatically detectable scalar; we specialize `ScalarOfTrait` below.
+template <typename T>
+struct OpaqueVector {
+    T elements[3];
+};
+
 }  // namespace
 
 // Set up the correspondence between `MyMeters` and `QuantityI<Meters>`.
@@ -79,6 +109,10 @@ struct CorrespondingQuantity<MyMeters> {
     using Unit = Meters;
     using Rep = int;
 };
+
+// Advertise the scalar of `OpaqueVector` via a `ScalarOfTrait` specialization.
+template <typename T>
+struct ScalarOfTrait<OpaqueVector<T>> : stdx::type_identity<T> {};
 
 TEST(IsValidRep, FalseForVoid) { EXPECT_THAT(IsValidRep<void>::value, IsFalse()); }
 
@@ -124,6 +158,30 @@ TEST(IsValidRep, FalseForTypeWithCorrespondingQuantity) {
     EXPECT_THAT(IsValidRep<std::chrono::nanoseconds>::value, IsFalse());
 }
 
+TEST(IsValidRep, FalseForTypeWhoseScalarIsQuantityLike) {
+    // A vector of quantities as a rep would produce nested units, so it can never be valid.  We
+    // catch every scalar type that `ScalarOf` can detect, whichever probe it fires on.
+    EXPECT_THAT((IsValidRep<VectorWithValueType<Quantity<Meters, float>>>::value), IsFalse());
+    EXPECT_THAT((IsValidRep<VectorWithScalar<Quantity<Meters, float>>>::value), IsFalse());
+    EXPECT_THAT((IsValidRep<std::complex<Quantity<Meters, float>>>::value), IsFalse());
+
+    // "Quantity-like" also covers `QuantityPoint`, and types with a `CorrespondingQuantity`.
+    EXPECT_THAT((IsValidRep<VectorWithValueType<QuantityPoint<Miles, double>>>::value), IsFalse());
+    EXPECT_THAT((IsValidRep<VectorWithValueType<MyMeters>>::value), IsFalse());
+}
+
+TEST(IsValidRep, TrueForVectorOfPlainScalars) {
+    EXPECT_THAT((IsValidRep<VectorWithValueType<float>>::value), IsTrue());
+    EXPECT_THAT((IsValidRep<VectorWithScalar<double>>::value), IsTrue());
+}
+
+TEST(IsValidRep, HonorsUserSpecializationsOfScalarOfTrait) {
+    // `OpaqueVector` has no automatically detectable scalar, so only its `ScalarOfTrait`
+    // specialization tells us that `OpaqueVector<Quantity<...>>` has a quantity-like scalar.
+    EXPECT_THAT((IsValidRep<OpaqueVector<Quantity<Meters, float>>>::value), IsFalse());
+    EXPECT_THAT((IsValidRep<OpaqueVector<float>>::value), IsTrue());
+}
+
 TEST(IsProductValidRep, FalseIfProductDoesNotExist) {
     EXPECT_THAT((IsProductValidRep<IntWithNoOps, int>::value), IsFalse());
     EXPECT_THAT((IsProductValidRep<int, IntWithNoOps>::value), IsFalse());
@@ -152,6 +210,18 @@ TEST(IsQuotientValidRep, TrueOnlyForSideWhereQuotientExists) {
 
     EXPECT_THAT((IsQuotientValidRep<float, DivideTenByFloat>::value), IsFalse());
     EXPECT_THAT((IsQuotientValidRep<DivideTenByFloat, float>::value), IsTrue());
+}
+
+TEST(IsQuotientValidRep, FalseWhenQuotientHasQuantityLikeScalar) {
+    // The gate that resolves #666: `VectorWithValueType<Quantity<...>> / float` exists, but its
+    // result is a vector of quantities, which is not a valid rep.  This is what disables the
+    // "divide into a scalar" overload of `Quantity::operator/`, so that it cannot be ambiguous
+    // with the vector's own scalar division operator.
+    EXPECT_THAT((IsQuotientValidRep<VectorWithValueType<Quantity<Meters, float>>, float>::value),
+                IsFalse());
+
+    // The same vector of _plain_ scalars remains a valid quotient rep.
+    EXPECT_THAT((IsQuotientValidRep<VectorWithValueType<float>, float>::value), IsTrue());
 }
 
 namespace detail {


### PR DESCRIPTION
This closes a hole in our rep reasoning.  If a type `T` is not
"quantity-like", but `::au::ScalarOf<T>` _is_ quantity-like, then `T` is
some kind of vector or container of quantities.  This means it has
units, and is not suitable as a rep.

Fixes #666.  We include regression tests at two stages (`:quantity_test`
and `:rep_test`).