### PR TITLE
Use the same clang-format in CI and locally

### DIFF
--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -26,9 +26,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b #v4.1.5
-    - uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 #v0.18.2
-      with:
-        source: './au'
-        extensions: 'hh,cc'
-        clangFormatVersion: 14.0.0
-        style: file
+    # Run the same `clang-format` binary that `tools/bin/clang-format` uses locally (the
+    # `@llvm_17` toolchain pinned in `MODULE.bazel`), so CI and local can never disagree on
+    # formatting the way they would with an independently-versioned clang-format.
+    - name: Check formatting
+      run: |
+        find au -type f \( -name '*.hh' -o -name '*.cc' \) -print0 \
+          | xargs -0 tools/bin/clang-format --style=file --dry-run --Werror

--- a/au/units/literals/amperes.hh
+++ b/au/units/literals/amperes.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_A` is a `Constant` equivalent to `make_constant(1.28e-4_mag * amperes)`.
 template <char... Cs>
 constexpr auto operator""_A() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(amperes * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/arcminutes.hh
+++ b/au/units/literals/arcminutes.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_am` is a `Constant` equivalent to `make_constant(1.28e-4_mag * arcminutes)`.
 template <char... Cs>
 constexpr auto operator""_am() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(arcminutes * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/arcseconds.hh
+++ b/au/units/literals/arcseconds.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_as` is a `Constant` equivalent to `make_constant(1.28e-4_mag * arcseconds)`.
 template <char... Cs>
 constexpr auto operator""_as() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(arcseconds * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/astronomical_units.hh
+++ b/au/units/literals/astronomical_units.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_AU` is a `Constant` equivalent to `make_constant(1.28e-4_mag * astronomical_units)`.
 template <char... Cs>
 constexpr auto operator""_AU() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(astronomical_units * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/bars.hh
+++ b/au/units/literals/bars.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_bar` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bars)`.
 template <char... Cs>
 constexpr auto operator""_bar() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(bars * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/becquerel.hh
+++ b/au/units/literals/becquerel.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_Bq` is a `Constant` equivalent to `make_constant(1.28e-4_mag * becquerel)`.
 template <char... Cs>
 constexpr auto operator""_Bq() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(becquerel * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/bits.hh
+++ b/au/units/literals/bits.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_b` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bits)`.
 template <char... Cs>
 constexpr auto operator""_b() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(bits * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/bytes.hh
+++ b/au/units/literals/bytes.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_B` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bytes)`.
 template <char... Cs>
 constexpr auto operator""_B() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(bytes * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/candelas.hh
+++ b/au/units/literals/candelas.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_cd` is a `Constant` equivalent to `make_constant(1.28e-4_mag * candelas)`.
 template <char... Cs>
 constexpr auto operator""_cd() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(candelas * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/celsius.hh
+++ b/au/units/literals/celsius.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_degC_qty` is a `Constant` equivalent to `make_constant(1.28e-4_mag * celsius_qty)`.
 template <char... Cs>
 constexpr auto operator""_degC_qty() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(celsius_qty * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/coulombs.hh
+++ b/au/units/literals/coulombs.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_C` is a `Constant` equivalent to `make_constant(1.28e-4_mag * coulombs)`.
 template <char... Cs>
 constexpr auto operator""_C() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(coulombs * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/days.hh
+++ b/au/units/literals/days.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_d` is a `Constant` equivalent to `make_constant(1.28e-4_mag * days)`.
 template <char... Cs>
 constexpr auto operator""_d() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(days * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/degrees.hh
+++ b/au/units/literals/degrees.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_deg` is a `Constant` equivalent to `make_constant(1.28e-4_mag * degrees)`.
 template <char... Cs>
 constexpr auto operator""_deg() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(degrees * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/fahrenheit.hh
+++ b/au/units/literals/fahrenheit.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_degF_qty` is a `Constant` equivalent to `make_constant(1.28e-4_mag * fahrenheit_qty)`.
 template <char... Cs>
 constexpr auto operator""_degF_qty() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(fahrenheit_qty * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/farads.hh
+++ b/au/units/literals/farads.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_F` is a `Constant` equivalent to `make_constant(1.28e-4_mag * farads)`.
 template <char... Cs>
 constexpr auto operator""_F() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(farads * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/fathoms.hh
+++ b/au/units/literals/fathoms.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_ftm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * fathoms)`.
 template <char... Cs>
 constexpr auto operator""_ftm() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(fathoms * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/feet.hh
+++ b/au/units/literals/feet.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_ft` is a `Constant` equivalent to `make_constant(1.28e-4_mag * feet)`.
 template <char... Cs>
 constexpr auto operator""_ft() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(feet * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/football_fields.hh
+++ b/au/units/literals/football_fields.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_ftbl_fld` is a `Constant` equivalent to `make_constant(1.28e-4_mag * football_fields)`.
 template <char... Cs>
 constexpr auto operator""_ftbl_fld() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(football_fields * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/furlongs.hh
+++ b/au/units/literals/furlongs.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_fur` is a `Constant` equivalent to `make_constant(1.28e-4_mag * furlongs)`.
 template <char... Cs>
 constexpr auto operator""_fur() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(furlongs * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/grams.hh
+++ b/au/units/literals/grams.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_g` is a `Constant` equivalent to `make_constant(1.28e-4_mag * grams)`.
 template <char... Cs>
 constexpr auto operator""_g() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(grams * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/grays.hh
+++ b/au/units/literals/grays.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_Gy` is a `Constant` equivalent to `make_constant(1.28e-4_mag * grays)`.
 template <char... Cs>
 constexpr auto operator""_Gy() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(grays * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/henries.hh
+++ b/au/units/literals/henries.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_H` is a `Constant` equivalent to `make_constant(1.28e-4_mag * henries)`.
 template <char... Cs>
 constexpr auto operator""_H() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(henries * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/hertz.hh
+++ b/au/units/literals/hertz.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_Hz` is a `Constant` equivalent to `make_constant(1.28e-4_mag * hertz)`.
 template <char... Cs>
 constexpr auto operator""_Hz() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(hertz * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/hours.hh
+++ b/au/units/literals/hours.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_h` is a `Constant` equivalent to `make_constant(1.28e-4_mag * hours)`.
 template <char... Cs>
 constexpr auto operator""_h() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(hours * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/inches.hh
+++ b/au/units/literals/inches.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_in` is a `Constant` equivalent to `make_constant(1.28e-4_mag * inches)`.
 template <char... Cs>
 constexpr auto operator""_in() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(inches * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/joules.hh
+++ b/au/units/literals/joules.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_J` is a `Constant` equivalent to `make_constant(1.28e-4_mag * joules)`.
 template <char... Cs>
 constexpr auto operator""_J() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(joules * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/katals.hh
+++ b/au/units/literals/katals.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_kat` is a `Constant` equivalent to `make_constant(1.28e-4_mag * katals)`.
 template <char... Cs>
 constexpr auto operator""_kat() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(katals * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/kelvins.hh
+++ b/au/units/literals/kelvins.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_K` is a `Constant` equivalent to `make_constant(1.28e-4_mag * kelvins)`.
 template <char... Cs>
 constexpr auto operator""_K() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(kelvins * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/knots.hh
+++ b/au/units/literals/knots.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_kn` is a `Constant` equivalent to `make_constant(1.28e-4_mag * knots)`.
 template <char... Cs>
 constexpr auto operator""_kn() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(knots * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/liters.hh
+++ b/au/units/literals/liters.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_L` is a `Constant` equivalent to `make_constant(1.28e-4_mag * liters)`.
 template <char... Cs>
 constexpr auto operator""_L() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(liters * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/lumens.hh
+++ b/au/units/literals/lumens.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_lm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * lumens)`.
 template <char... Cs>
 constexpr auto operator""_lm() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(lumens * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/lux.hh
+++ b/au/units/literals/lux.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_lx` is a `Constant` equivalent to `make_constant(1.28e-4_mag * lux)`.
 template <char... Cs>
 constexpr auto operator""_lx() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(lux * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/meters.hh
+++ b/au/units/literals/meters.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_m` is a `Constant` equivalent to `make_constant(1.28e-4_mag * meters)`.
 template <char... Cs>
 constexpr auto operator""_m() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(meters * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/miles.hh
+++ b/au/units/literals/miles.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_mi` is a `Constant` equivalent to `make_constant(1.28e-4_mag * miles)`.
 template <char... Cs>
 constexpr auto operator""_mi() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(miles * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/minutes.hh
+++ b/au/units/literals/minutes.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_min` is a `Constant` equivalent to `make_constant(1.28e-4_mag * minutes)`.
 template <char... Cs>
 constexpr auto operator""_min() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(minutes * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/moles.hh
+++ b/au/units/literals/moles.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_mol` is a `Constant` equivalent to `make_constant(1.28e-4_mag * moles)`.
 template <char... Cs>
 constexpr auto operator""_mol() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(moles * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/nautical_miles.hh
+++ b/au/units/literals/nautical_miles.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_nmi` is a `Constant` equivalent to `make_constant(1.28e-4_mag * nautical_miles)`.
 template <char... Cs>
 constexpr auto operator""_nmi() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(nautical_miles * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/newtons.hh
+++ b/au/units/literals/newtons.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_N` is a `Constant` equivalent to `make_constant(1.28e-4_mag * newtons)`.
 template <char... Cs>
 constexpr auto operator""_N() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(newtons * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/ohms.hh
+++ b/au/units/literals/ohms.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_ohm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * ohms)`.
 template <char... Cs>
 constexpr auto operator""_ohm() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(ohms * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/pascals.hh
+++ b/au/units/literals/pascals.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_Pa` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pascals)`.
 template <char... Cs>
 constexpr auto operator""_Pa() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(pascals * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/percent.hh
+++ b/au/units/literals/percent.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_pct` is a `Constant` equivalent to `make_constant(1.28e-4_mag * percent)`.
 template <char... Cs>
 constexpr auto operator""_pct() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(percent * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/pounds_force.hh
+++ b/au/units/literals/pounds_force.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_lbf` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pounds_force)`.
 template <char... Cs>
 constexpr auto operator""_lbf() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(pounds_force * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/pounds_mass.hh
+++ b/au/units/literals/pounds_mass.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_lb` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pounds_mass)`.
 template <char... Cs>
 constexpr auto operator""_lb() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(pounds_mass * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/radians.hh
+++ b/au/units/literals/radians.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_rad` is a `Constant` equivalent to `make_constant(1.28e-4_mag * radians)`.
 template <char... Cs>
 constexpr auto operator""_rad() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(radians * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/rankine.hh
+++ b/au/units/literals/rankine.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_degR` is a `Constant` equivalent to `make_constant(1.28e-4_mag * rankine)`.
 template <char... Cs>
 constexpr auto operator""_degR() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(rankine * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/revolutions.hh
+++ b/au/units/literals/revolutions.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_rev` is a `Constant` equivalent to `make_constant(1.28e-4_mag * revolutions)`.
 template <char... Cs>
 constexpr auto operator""_rev() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(revolutions * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/seconds.hh
+++ b/au/units/literals/seconds.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_s` is a `Constant` equivalent to `make_constant(1.28e-4_mag * seconds)`.
 template <char... Cs>
 constexpr auto operator""_s() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(seconds * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/siemens.hh
+++ b/au/units/literals/siemens.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_S` is a `Constant` equivalent to `make_constant(1.28e-4_mag * siemens)`.
 template <char... Cs>
 constexpr auto operator""_S() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(siemens * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/slugs.hh
+++ b/au/units/literals/slugs.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_slug` is a `Constant` equivalent to `make_constant(1.28e-4_mag * slugs)`.
 template <char... Cs>
 constexpr auto operator""_slug() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(slugs * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/standard_gravity.hh
+++ b/au/units/literals/standard_gravity.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_g_0` is a `Constant` equivalent to `make_constant(1.28e-4_mag * standard_gravity)`.
 template <char... Cs>
 constexpr auto operator""_g_0() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(standard_gravity * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/steradians.hh
+++ b/au/units/literals/steradians.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_sr` is a `Constant` equivalent to `make_constant(1.28e-4_mag * steradians)`.
 template <char... Cs>
 constexpr auto operator""_sr() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(steradians * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/tesla.hh
+++ b/au/units/literals/tesla.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_T` is a `Constant` equivalent to `make_constant(1.28e-4_mag * tesla)`.
 template <char... Cs>
 constexpr auto operator""_T() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(tesla * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/us_gallons.hh
+++ b/au/units/literals/us_gallons.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_US_gal` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_gallons)`.
 template <char... Cs>
 constexpr auto operator""_US_gal() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(us_gallons * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/us_pints.hh
+++ b/au/units/literals/us_pints.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_US_pt` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_pints)`.
 template <char... Cs>
 constexpr auto operator""_US_pt() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(us_pints * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/us_quarts.hh
+++ b/au/units/literals/us_quarts.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_US_qt` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_quarts)`.
 template <char... Cs>
 constexpr auto operator""_US_qt() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(us_quarts * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/volts.hh
+++ b/au/units/literals/volts.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_V` is a `Constant` equivalent to `make_constant(1.28e-4_mag * volts)`.
 template <char... Cs>
 constexpr auto operator""_V() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(volts * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/watts.hh
+++ b/au/units/literals/watts.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_W` is a `Constant` equivalent to `make_constant(1.28e-4_mag * watts)`.
 template <char... Cs>
 constexpr auto operator""_W() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(watts * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/webers.hh
+++ b/au/units/literals/webers.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_Wb` is a `Constant` equivalent to `make_constant(1.28e-4_mag * webers)`.
 template <char... Cs>
 constexpr auto operator""_Wb() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(webers * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals

--- a/au/units/literals/yards.hh
+++ b/au/units/literals/yards.hh
@@ -24,7 +24,10 @@ namespace au_literals {
 // `1.28e-4_yd` is a `Constant` equivalent to `make_constant(1.28e-4_mag * yards)`.
 template <char... Cs>
 constexpr auto operator""_yd() {
+    // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
+    // clang-format off
     return make_constant(yards * operator""_mag<Cs...>());
+    // clang-format on
 }
 
 }  // namespace au_literals


### PR DESCRIPTION
When we upgraded to clang-format 17, we forgot about the GitHub check,
and left it at clang-format 14.  We _could_ simply bump the version
number, but that means the same problem will just recur the next time we
upgrade our toolchain.  So instead, we drop the pre-created action, and
replace it with a direct command that uses `tools/bin/clang-format`.

Unfortunately, clang-format has its issues.  There is a bug that was
introduced between versions 14 and 17, which formats variadic UDLs badly
(see llvm/llvm-project#210135).  Therefore, we retain the old, good,
formatting for all of these, leaving an indicator as to which bug must
be fixed before we can migrate.

This unblocks #702.  Once this lands, we can merge in the latest main,
and take it out of draft.