### PR TITLE
Add first complete compile time assessment

### DIFF
--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -188,14 +188,19 @@ These costs purchase significant benefits, but we still want them to be as small
                 </ul>
             </details>
         </td>
-        <td class="na"></td>
-        <td class="poor">Very slow, but can be <i>greatly</i> improved by removing I/O support and most units</td>
-        <td class="na"></td>
-        <td class="na"></td>
+        <td class="good">Comparable to Au; sometimes less, sometimes more</td>
+        <td class="fair">Very slow, but can be <i>greatly</i> improved by removing I/O support and most units</td>
+        <td class="good">Overall speed champ: roughly 2/3 the penalty of Au and Boost</td>
+        <td class="poor">
+            <ul>
+                <li class="x">2 to 3 times as expensive as nholthaus (which already drove adopters away)</li>
+                <li>Needs modules to be usable in large projects</li>
+            </ul>
+        </td>
         <td class="good">
             <ul>
-                <li class="check">Includes `fwd.hh` headers</li>
-                <li>Possibly "best" overall, but will need to assess all libraries on the same code</li>
+                <li class="check">Baseline performance is great (only bernedom/SI is faster)</li>
+                <li class="check">Includes `fwd.hh` headers for even more flexibility</li>
             </ul>
         </td>
     </tr>

--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -189,12 +189,13 @@ These costs purchase significant benefits, but we still want them to be as small
             </details>
         </td>
         <td class="good">Comparable to Au; sometimes less, sometimes more</td>
-        <td class="fair">Very slow, but can be <i>greatly</i> improved by removing I/O support and most units</td>
+        <td class="poor">Very slow (adds multiple seconds), but can be <i>greatly</i> improved by removing I/O support and most units</td>
         <td class="good">Overall speed champ: roughly 2/3 the penalty of Au and Boost</td>
         <td class="poor">
             <ul>
-                <li class="x">2 to 3 times as expensive as nholthaus (which already drove adopters away)</li>
-                <li>Needs modules to be usable in large projects</li>
+                <li class="x">Default config 2 to 3 times as expensive as nholthaus</li>
+                <li class="x"><a href="https://mpusz.github.io/mp-units/latest/users_guide/systems/si/#lean-umbrella-mp-unitssystemssicoreh">Lean includes</a> brings it on par with nholthaus, though lack of symbols hurts code quality</li>
+                <li>C++20 modules should mitigate all concerns</li>
             </ul>
         </td>
         <td class="good">


### PR DESCRIPTION
I made a personal project to measure the compile time performance of all
five libraries.  The project itself isn't fully ready to share, but the
results were extremely stark --- so much so that I am now very
comfortable _finally_ filling in the missing table cells.

bernedom/SI turns out to really shine here: it's consistently about 2/3
the penalty of Au.  Boost units also does really well: sometimes it's a
little faster than Au, sometimes a little slower.  Overall, these 3
libraries are all very comparable.

I didn't select a "best" for a couple of reasons.  First, both
bernedom/SI and Au/boost are firmly in "not subjectively noticeable"
territory, so the fact that bernedom/SI is clearly faster was of lesser
importance.  If it were only for this, I still would have crowned
bernedom/SI as "best", but Au has first class forward declarations,
while bernedom/SI does not.  So assessing the overall "best" is pretty
tough.  Ultimately, I opted to clearly call out the part that
bernedom/SI is best at, and by how much, in its cell.

The other big surprise was mp-units.  For context, the nholthaus library
was my previous benchmark for "very slow": it's the one where I had seen
teams choose to forego a units library altogether rather than use it.
It was slow enough to really feel, adding several seconds to every
file's compilation time.  But mp-units in the default configuratoin was
over twice as slow in every case I measured, sometimes close to 3 times
as slow.  There is a "lite" header, which eliminates more than half the
cost, but it still only gets it to parity with nholthaus, and it hurts
code quality by eliminating symbols.  Ultimately, I think the story is
that mp-units is betting on modules in order to get acceptable compile
time performance.