### PR TITLE
Always return `Quantity`, not raw number

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -54,22 +54,6 @@ AU_DEVICE_FUNC constexpr auto make_quantity(T &&value) {
     return QuantityMaker<UnitT>{}(std::move(value));
 }
 
-// lvalue: copy.  (See `make_quantity` above.)
-template <typename Unit, typename T>
-AU_DEVICE_FUNC constexpr auto make_quantity_unless_unitless(const T &value) {
-    return std::conditional_t<IsUnitlessUnit<Unit>::value, stdx::identity, QuantityMaker<Unit>>{}(
-        value);
-}
-
-// rvalue: move.
-template <typename Unit,
-          typename T,
-          typename = std::enable_if_t<!std::is_lvalue_reference<T>::value>>
-AU_DEVICE_FUNC constexpr auto make_quantity_unless_unitless(T &&value) {
-    return std::conditional_t<IsUnitlessUnit<Unit>::value, stdx::identity, QuantityMaker<Unit>>{}(
-        std::move(value));
-}
-
 // Trait to check whether two Quantity types are exactly equivalent.
 //
 // For purposes of our library, "equivalent" means that they have the same Dimension and Magnitude.
@@ -410,8 +394,7 @@ class Quantity {
     // leaving the result's rep dangling.  `data_in` instead references the caller's live object.
     template <typename OtherUnit, typename OtherRep>
     AU_DEVICE_FUNC constexpr auto operator*(const Quantity<OtherUnit, OtherRep> &q) const {
-        return make_quantity_unless_unitless<UnitProduct<Unit, OtherUnit>>(value_ *
-                                                                           q.data_in(OtherUnit{}));
+        return make_quantity<UnitProduct<Unit, OtherUnit>>(value_ * q.data_in(OtherUnit{}));
     }
 
     // Division for dimensioned quantities.
@@ -420,8 +403,7 @@ class Quantity {
     template <typename OtherUnit, typename OtherRep>
     AU_DEVICE_FUNC constexpr auto operator/(const Quantity<OtherUnit, OtherRep> &q) const {
         warn_if_integer_division<OtherUnit, OtherRep>();
-        return make_quantity_unless_unitless<UnitQuotient<Unit, OtherUnit>>(value_ /
-                                                                            q.data_in(OtherUnit{}));
+        return make_quantity<UnitQuotient<Unit, OtherUnit>>(value_ / q.data_in(OtherUnit{}));
     }
 
     // Copy and move assignment: lvalue-only.

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -318,7 +318,7 @@ TEST(QuantityMaker, CreatesAppropriateQuantityIfCalled) {
 }
 
 // Regression test: a bitfield (packed member) cannot bind to a non-const reference, so the maker
-// and the `make_quantity`-style free functions must accept it via their `const T&` overload.  This
+// and the `make_quantity`-style free function must accept it via their `const T&` overload.  This
 // once failed to compile.
 TEST(QuantityMaker, WorksOnBitfieldMembers) {
     struct Packed {
@@ -328,8 +328,7 @@ TEST(QuantityMaker, WorksOnBitfieldMembers) {
     Packed p{5, 7};
 
     EXPECT_THAT(meters(p.meters_value), SameTypeAndValue(meters(5)));
-    EXPECT_THAT(make_quantity<Meters>(p.meters_value), SameTypeAndValue(meters(5)));
-    EXPECT_THAT(make_quantity_unless_unitless<Feet>(p.feet_value), SameTypeAndValue(feet(7)));
+    EXPECT_THAT(make_quantity<Feet>(p.feet_value), SameTypeAndValue(feet(7)));
 }
 
 TEST(QuantityMaker, CanBeMultipliedBySingularUnitToGetMakerOfProductUnit) {
@@ -1481,8 +1480,8 @@ TEST(UnblockIntDiv, IsNoOpForDivisionThatWouldBeAllowedAnyway) {
 }
 
 TEST(DivideInCommonUnits, ConvertsInputsToSameUnit) {
-    EXPECT_THAT(divide_using_common_unit(inches(80), feet(2)), SameTypeAndValue(3));
-    EXPECT_THAT(divide_using_common_unit(hours(8), minutes(60)), SameTypeAndValue(8));
+    EXPECT_THAT(divide_using_common_unit(inches(80), feet(2)), QuantityEquivalent(unos(3)));
+    EXPECT_THAT(divide_using_common_unit(hours(8), minutes(60)), QuantityEquivalent(unos(8)));
 }
 
 TEST(Quantity, CanIntegerDivideQuantitiesOfQuantityEquivalentUnits) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -840,20 +840,20 @@ TEST(Quantity, CanDivideArbitraryQuantities) {
     EXPECT_THAT(v, Eq(d / t));
 }
 
-TEST(Quantity, RatioOfSameTypeIsScalar) {
+TEST(Quantity, RatioOfSameTypeIsQuantity) {
     constexpr auto x = yards(8.2);
 
-    EXPECT_THAT(x / x, SameTypeAndValue(1.0));
+    EXPECT_THAT(x / x, QuantityEquivalent(unos(1.0)));
 }
 
-TEST(Quantity, RatioOfEquivalentTypesIsScalar) {
+TEST(Quantity, RatioOfEquivalentTypesIsQuantity) {
     constexpr auto x = feet(10.0);
     constexpr auto y = (feet * mag<1>())(5.0);
 
-    EXPECT_THAT(x / y, SameTypeAndValue(2.0));
+    EXPECT_THAT(x / y, QuantityEquivalent(unos(2.0)));
 }
 
-TEST(Quantity, ProductOfInvertingUnitsIsScalar) {
+TEST(Quantity, ProductOfInvertingUnitsIsQuantity) {
     // We pass `UnitProduct` to this function template, which ensures that we get a
     // `UnitProductPack` (note: NOT `UnitProduct`!) with the expected number of arguments.  Recall
     // that `UnitProduct` is the user-facing "unit computation" interface, and `UnitProductPack` is
@@ -864,7 +864,7 @@ TEST(Quantity, ProductOfInvertingUnitsIsScalar) {
     // unit---although, naturally, it must be **quantity-equivalent** to `UnitProductPack<>`.
     ASSERT_THAT(num_units_in_product(UnitProduct<Days, PerDay>{}), Eq(2));
 
-    EXPECT_THAT(days(3) * per_day(8), SameTypeAndValue(24));
+    EXPECT_THAT(days(3) * per_day(8), QuantityEquivalent(unos(24)));
 }
 
 TEST(Quantity, ScalarDivisionWorks) {
@@ -1487,7 +1487,7 @@ TEST(DivideInCommonUnits, ConvertsInputsToSameUnit) {
 
 TEST(Quantity, CanIntegerDivideQuantitiesOfQuantityEquivalentUnits) {
     constexpr auto ratio = meters(60) / meters(25);
-    EXPECT_THAT(ratio, Eq(2));
+    EXPECT_THAT(ratio, QuantityEquivalent(unos(2)));
 }
 
 TEST(Mod, ComputesRemainderForSameUnits) {

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -564,10 +564,9 @@ Here are the usage patterns, and their corresponding signatures.
 ### Dimensionless and unitless results: `as_raw_number` {#as-raw-number}
 
 Users may expect that the product of quantities such as `seconds` and `hertz` would completely
-cancel out, and produce a raw, simple C++ numeric type.  Currently, this is indeed the case, but we
-have also found that it makes the library harder to reason about.  Instead, we hope in the future to
-return a `Quantity` type _consistently_ from arithmetical operations on `Quantity` inputs (see
-[#185]).
+cancel out, and produce a raw, simple C++ numeric type.  While this was formerly the case, we found
+that it made the library harder to reason about consistently.  Instead, we return a `Quantity` type
+_consistently_ from arithmetical operations on `Quantity` inputs.
 
 In order to obtain that raw number robustly, both now and in the future, you can use the
 `as_raw_number` function, a callsite-readable way to "exit" the library.  This will also opt into
@@ -579,8 +578,7 @@ all mechanisms and safety features of the library.  In particular:
   represented exactly as a raw `int`), we will also fail to compile, unless users provide a second
   policy argument to override the safety check.
 
-Users should get in the habit of using `as_raw_number` whenever they really want a raw number.  This
-communicates intent, and also works both before and after [#185] is implemented.
+Users should use `as_raw_number` whenever they really want a raw number.  This communicates intent.
 
 Here are the available APIs:
 
@@ -1039,7 +1037,6 @@ the following conditions hold.
     - `AreQuantityTypesEquivalent<U1, U2>::value`
 
 [#122]: https://github.com/aurora-opensource/au/issues/122
-[#185]: https://github.com/aurora-opensource/au/issues/185
 [#481]: https://github.com/aurora-opensource/au/issues/481
 [0.6.0]: https://github.com/aurora-opensource/au/milestone/9
 [integer division section]: ../troubleshooting.md#integer-division-forbidden


### PR DESCRIPTION
This is a long-desired breaking change.  Fixes #185.