### PR TITLE
Assume multiplying by integer never truncates

### DIFF
--- a/au/truncation_risk.hh
+++ b/au/truncation_risk.hh
@@ -126,10 +126,17 @@ struct TruncationRiskForMultiplyByRational
                          stdx::type_identity<CannotAssessTruncationRiskFor<T>>> {};
 
 template <typename T, typename M>
-struct TruncationRiskForMultiplyByAssumingScalar
+struct TruncationRiskForMultiplyByRationalOrIrrational
     : std::conditional_t<IsRational<M>::value,
                          TruncationRiskForMultiplyByRational<T, M>,
                          TruncationRiskForMultiplyByIrrational<T, M>> {};
+
+// We assume that multiplying by an integer magnitude can never truncate, for any rep.
+template <typename T, typename M>
+struct TruncationRiskForMultiplyByAssumingScalar
+    : std::conditional_t<IsInteger<M>::value,
+                         stdx::type_identity<NoTruncationRisk<T>>,
+                         TruncationRiskForMultiplyByRationalOrIrrational<T, M>> {};
 
 template <typename T, typename M>
 struct TruncationRiskForImpl<MultiplyTypeBy<T, M>>

--- a/au/truncation_risk_test.cc
+++ b/au/truncation_risk_test.cc
@@ -29,6 +29,12 @@ namespace {
 
 constexpr auto PI = Magnitude<Pi>{};
 
+// A minimal non-arithmetic rep.  We can't assess overflow or truncation risk for such types in
+// general, but an _integer multiple_ is always exact, so it should carry no truncation risk.
+struct NonArithmetic {
+    int value;
+};
+
 template <typename T, typename M>
 using ValueTimesIntIsNotInteger = ValueTimesRatioIsNotInteger<T, M>;
 
@@ -121,6 +127,25 @@ TEST(TruncationRiskFor, MultiplyAnythingByIntNeverTruncates) {
 
     StaticAssertTypeEq<TruncationRiskFor<MultiplyTypeBy<float, decltype(mag<3000>())>>,
                        NoTruncationRisk<float>>();
+}
+
+TEST(TruncationRiskFor, MultiplyNonArithmeticByIntNeverTruncates) {
+    // The identity factor (multiply by 1) is the case that arises for same-unit, same-rep
+    // conversions of non-arithmetic reps (e.g. inside `au::max`/`au::min`).
+    StaticAssertTypeEq<TruncationRiskFor<MultiplyTypeBy<NonArithmetic, decltype(mag<1>())>>,
+                       NoTruncationRisk<NonArithmetic>>();
+
+    StaticAssertTypeEq<TruncationRiskFor<MultiplyTypeBy<NonArithmetic, decltype(mag<1000>())>>,
+                       NoTruncationRisk<NonArithmetic>>();
+}
+
+TEST(TruncationRiskFor, MultiplyNonArithmeticByNonIntegerCannotBeAssessed) {
+    StaticAssertTypeEq<
+        TruncationRiskFor<MultiplyTypeBy<NonArithmetic, decltype(mag<1>() / mag<2>())>>,
+        CannotAssessTruncationRiskFor<NonArithmetic>>();
+
+    StaticAssertTypeEq<TruncationRiskFor<MultiplyTypeBy<NonArithmetic, decltype(sqrt(mag<2>()))>>,
+                       CannotAssessTruncationRiskFor<NonArithmetic>>();
 }
 
 TEST(TruncationRiskFor, MultiplyFloatByInverseIntNeverTruncates) {


### PR DESCRIPTION
This should be true regardless of the rep.  After all, integer
multiplication is just equivalent to repeated addition.  We may
overflow, but we could never truncate.

To implement this, we do an integer multiplication check at the highest
level, even before we split on arithmetic vs. non-arithmetic rep.  This
will enable a small but meaningful chunk of non-arithmetic rep use cases
in a low-risk way.  (It's a complete no-op for arithmetic reps.)

Helps #122 by unblocking our fix PR.