### PR TITLE
Check risks by default in explicit-rep overloads

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -167,8 +167,9 @@ class Quantity {
               typename Enable = EnableIfImplicitOkIs<true, OtherUnit, OtherRep>>
     AU_DEVICE_FUNC constexpr Quantity(
         const Quantity<OtherUnit, OtherRep> &other)  // NOLINT(runtime/explicit)
-        : value_{other.template in_impl<detail::UseImplicitConversion, Rep>(
-              UnitT{}, check_for(ALL_RISKS))} {}
+        // `ignore(ALL_RISKS)` because we already determined that this implicit conversion is OK.
+        : value_{other.template in_impl<detail::UseImplicitConversion, Rep>(UnitT{},
+                                                                            ignore(ALL_RISKS))} {}
 
     // EXPLICIT constructor for another Quantity of the same Dimension.
     template <typename OtherUnit,
@@ -212,7 +213,7 @@ class Quantity {
     // `q.as<Rep>(new_unit)`, or `q.as<Rep>(new_unit, risk_policy)`
     template <typename NewRep,
               typename NewUnitSlot,
-              typename RiskPolicyT = decltype(ignore(ALL_RISKS)),
+              typename RiskPolicyT = decltype(check_for(ALL_RISKS)),
               std::enable_if_t<!IsConversionRiskPolicy<NewUnitSlot>::value, int> = 0>
     AU_DEVICE_FUNC constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity<AssociatedUnit<NewUnitSlot>>(
@@ -229,7 +230,7 @@ class Quantity {
     // `q.in<Rep>(new_unit)`, or `q.in<Rep>(new_unit, risk_policy)`
     template <typename NewRep,
               typename NewUnitSlot,
-              typename RiskPolicyT = decltype(ignore(ALL_RISKS))>
+              typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
     AU_DEVICE_FUNC constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<detail::UseStaticCast, NewRep>(u, policy);
     }
@@ -244,22 +245,22 @@ class Quantity {
     template <typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {
         // Usage example: `q.coerce_as(new_units)`.
-        return as<Rep>(NewUnit{});
+        return as<Rep>(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewRep, typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {
         // Usage example: `q.coerce_as<T>(new_units)`.
-        return as<NewRep>(NewUnit{});
+        return as<NewRep>(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewUnit>
     constexpr auto coerce_in(NewUnit) const {
         // Usage example: `q.coerce_in(new_units)`.
-        return in<Rep>(NewUnit{});
+        return in<Rep>(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewRep, typename NewUnit>
     constexpr auto coerce_in(NewUnit) const {
         // Usage example: `q.coerce_in<T>(new_units)`.
-        return in<NewRep>(NewUnit{});
+        return in<NewRep>(NewUnit{}, ignore(ALL_RISKS));
     }
 
     // Direct access to the underlying value member, with any Quantity-equivalent Unit.
@@ -755,7 +756,7 @@ struct AreQuantityTypesEquivalent<Quantity<U1, R1>, Quantity<U2, R2>>
 // Cast Quantity to a different underlying type.
 template <typename NewRep, typename Unit, typename Rep>
 AU_DEVICE_FUNC constexpr auto rep_cast(Quantity<Unit, Rep> q) {
-    return q.template as<NewRep>(Unit{});
+    return q.template as<NewRep>(Unit{}, ignore(ALL_RISKS));
 }
 
 // Help Zero act more faithfully like a Quantity.

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -161,7 +161,7 @@ class QuantityPoint {
     // `p.as<Rep>(new_unit)`, or `p.as<Rep>(new_unit, risk_policy)`
     template <typename NewRep,
               typename NewUnit,
-              typename RiskPolicyT = decltype(ignore(ALL_RISKS)),
+              typename RiskPolicyT = decltype(check_for(ALL_RISKS)),
               std::enable_if_t<!IsConversionRiskPolicy<NewUnit>::value, int> = 0>
     AU_DEVICE_FUNC constexpr auto as(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return make_quantity_point<AssociatedUnitForPoints<NewUnit>>(in_impl<NewRep>(u, policy));
@@ -173,7 +173,9 @@ class QuantityPoint {
         return make_quantity_point<AssociatedUnitForPoints<NewUnit>>(in_impl<Rep>(u, policy));
     }
 
-    template <typename NewRep, typename NewUnit, typename RiskPolicyT = decltype(ignore(ALL_RISKS))>
+    template <typename NewRep,
+              typename NewUnit,
+              typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
     AU_DEVICE_FUNC constexpr NewRep in(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
         return in_impl<NewRep>(u, policy);
     }
@@ -187,22 +189,22 @@ class QuantityPoint {
     template <typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {
         // Usage example: `p.coerce_as(new_units)`.
-        return as<Rep>(NewUnit{});
+        return as<Rep>(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewRep, typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {
         // Usage example: `p.coerce_as<T>(new_units)`.
-        return as<NewRep>(NewUnit{});
+        return as<NewRep>(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewUnit>
     constexpr auto coerce_in(NewUnit) const {
         // Usage example: `p.coerce_in(new_units)`.
-        return in<Rep>(NewUnit{});
+        return in<Rep>(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewRep, typename NewUnit>
     constexpr auto coerce_in(NewUnit) const {
         // Usage example: `p.coerce_in<T>(new_units)`.
-        return in<NewRep>(NewUnit{});
+        return in<NewRep>(NewUnit{}, ignore(ALL_RISKS));
     }
 
     // Direct access to the underlying value member, with any Point-equivalent Unit.
@@ -385,7 +387,7 @@ struct AreQuantityPointTypesEquivalent<QuantityPoint<U1, R1>, QuantityPoint<U2, 
 // Cast QuantityPoint to a different underlying type.
 template <typename NewRep, typename Unit, typename Rep>
 AU_DEVICE_FUNC constexpr auto rep_cast(QuantityPoint<Unit, Rep> q) {
-    return q.template as<NewRep>(Unit{});
+    return q.template as<NewRep>(Unit{}, ignore(ALL_RISKS));
 }
 
 namespace detail {

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -262,7 +262,7 @@ TEST(QuantityPoint, InHandlesIntegerRepInUnitsWithNonzeroOffset) {
 }
 
 TEST(QuantityPoint, CanRequestOutputRepWhenCallingIn) {
-    EXPECT_THAT(celsius_pt(5.2).in<int>(Celsius{}), Eq(5));
+    EXPECT_THAT(celsius_pt(5.2).in<int>(Celsius{}, ignore(TRUNCATION_RISK)), Eq(5));
 }
 
 TEST(QuantityPoint, CanCastToUnitWithDifferentMagnitude) {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -733,49 +733,41 @@ TEST(Quantity, ConvertingByNegativeOneCanBeDoneImplicitly) {
 }
 
 TEST(Quantity, AsCanExplicitlyOptOutOfOverflowRiskCheck) {
-    // This line would fail to compile without the `ignore(OVERFLOW_RISK)` argument.
     constexpr auto q = seconds(int32_t{2}).as(nano(seconds), ignore(OVERFLOW_RISK));
     EXPECT_THAT(q, SameTypeAndValue(nano(seconds)(int32_t{2'000'000'000})));
 }
 
 TEST(Quantity, AsCanExplicitlyOptOutOfOverflowRiskCheckForExplicitRep) {
-    // This line would fail to compile without the `ignore(OVERFLOW_RISK)` argument.
     constexpr auto q = seconds(2u).as<int32_t>(nano(seconds), ignore(OVERFLOW_RISK));
     EXPECT_THAT(q, SameTypeAndValue(nano(seconds)(int32_t{2'000'000'000})));
 }
 
 TEST(Quantity, AsCanExplicitlyOptOutOfTruncationRiskCheck) {
-    // This line would fail to compile without the `ignore(TRUNCATION_RISK)` argument.
     constexpr auto q = inches(36).as(feet, ignore(TRUNCATION_RISK));
     EXPECT_THAT(q, SameTypeAndValue(feet(3)));
 }
 
 TEST(Quantity, AsCanExplicitlyOptOutOfTruncationRiskCheckForExplicitRep) {
-    // This line would fail to compile without the `ignore(TRUNCATION_RISK)` argument.
     constexpr auto q = inches(36u).as<int>(feet, ignore(TRUNCATION_RISK));
     EXPECT_THAT(q, SameTypeAndValue(feet(int{3})));
 }
 
 TEST(Quantity, InCanExplicitlyOptOutOfOverflowRiskCheck) {
-    // This line would fail to compile without the `ignore(OVERFLOW_RISK)` argument.
     constexpr auto q = seconds(int32_t{2}).in(nano(seconds), ignore(OVERFLOW_RISK));
     EXPECT_THAT(q, SameTypeAndValue(int32_t{2'000'000'000}));
 }
 
 TEST(Quantity, InCanExplicitlyOptOutOfOverflowRiskCheckForExplicitRep) {
-    // This line would fail to compile without the `ignore(OVERFLOW_RISK)` argument.
     constexpr auto q = seconds(2u).in<int32_t>(nano(seconds), ignore(OVERFLOW_RISK));
     EXPECT_THAT(q, SameTypeAndValue(int32_t{2'000'000'000}));
 }
 
 TEST(Quantity, InCanExplicitlyOptOutOfTruncationRiskCheck) {
-    // This line would fail to compile without the `ignore(TRUNCATION_RISK)` argument.
     constexpr auto q = inches(36).in(feet, ignore(TRUNCATION_RISK));
     EXPECT_THAT(q, SameTypeAndValue(3));
 }
 
 TEST(Quantity, InCanExplicitlyOptOutOfTruncationRiskCheckForExplicitRep) {
-    // This line would fail to compile without the `ignore(TRUNCATION_RISK)` argument.
     constexpr auto q = inches(36u).in<int>(feet, ignore(TRUNCATION_RISK));
     EXPECT_THAT(q, SameTypeAndValue(3));
 }

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -298,7 +298,9 @@ TEST(Quantity, PolicyConstructorDoesNotCreateAmbiguities) {
     overload_that_takes_a_quantity_or_a_combo({meters(5.0), seconds(10.0)});
 }
 
-TEST(Quantity, CanRequestOutputRepWhenCallingIn) { EXPECT_THAT(feet(3.14).in<int>(feet), Eq(3)); }
+TEST(Quantity, CanRequestOutputRepWhenCallingIn) {
+    EXPECT_THAT(feet(3.14).in<int>(feet, ignore(TRUNCATION_RISK)), Eq(3));
+}
 
 TEST(MakeQuantity, MakesQuantityInGivenUnit) {
     EXPECT_THAT(make_quantity<Feet>(1.234), Eq(feet(1.234)));
@@ -737,7 +739,7 @@ TEST(Quantity, AsCanExplicitlyOptOutOfOverflowRiskCheck) {
 }
 
 TEST(Quantity, AsCanExplicitlyOptOutOfOverflowRiskCheckForExplicitRep) {
-    // In future versions (see #122), this would fail to compile without `ignore(OVERFLOW_RISK)`.
+    // This line would fail to compile without the `ignore(OVERFLOW_RISK)` argument.
     constexpr auto q = seconds(2u).as<int32_t>(nano(seconds), ignore(OVERFLOW_RISK));
     EXPECT_THAT(q, SameTypeAndValue(nano(seconds)(int32_t{2'000'000'000})));
 }
@@ -749,7 +751,7 @@ TEST(Quantity, AsCanExplicitlyOptOutOfTruncationRiskCheck) {
 }
 
 TEST(Quantity, AsCanExplicitlyOptOutOfTruncationRiskCheckForExplicitRep) {
-    // In future versions (see #122), this would fail to compile without `ignore(TRUNCATION_RISK)`.
+    // This line would fail to compile without the `ignore(TRUNCATION_RISK)` argument.
     constexpr auto q = inches(36u).as<int>(feet, ignore(TRUNCATION_RISK));
     EXPECT_THAT(q, SameTypeAndValue(feet(int{3})));
 }
@@ -761,7 +763,7 @@ TEST(Quantity, InCanExplicitlyOptOutOfOverflowRiskCheck) {
 }
 
 TEST(Quantity, InCanExplicitlyOptOutOfOverflowRiskCheckForExplicitRep) {
-    // In future versions (see #122), this would fail to compile without `ignore(OVERFLOW_RISK)`.
+    // This line would fail to compile without the `ignore(OVERFLOW_RISK)` argument.
     constexpr auto q = seconds(2u).in<int32_t>(nano(seconds), ignore(OVERFLOW_RISK));
     EXPECT_THAT(q, SameTypeAndValue(int32_t{2'000'000'000}));
 }
@@ -773,7 +775,7 @@ TEST(Quantity, InCanExplicitlyOptOutOfTruncationRiskCheck) {
 }
 
 TEST(Quantity, InCanExplicitlyOptOutOfTruncationRiskCheckForExplicitRep) {
-    // In future versions (see #122), this would fail to compile without `ignore(TRUNCATION_RISK)`.
+    // This line would fail to compile without the `ignore(TRUNCATION_RISK)` argument.
     constexpr auto q = inches(36u).in<int>(feet, ignore(TRUNCATION_RISK));
     EXPECT_THAT(q, SameTypeAndValue(3));
 }
@@ -804,7 +806,7 @@ TEST(Quantity, AddingNegativeAndPositiveUnitsGivesPositiveUnit) {
 
 TEST(Quantity, SupportsExplicitRepConversionToComplexRep) {
     constexpr auto a = feet(15'000.0);
-    const auto b = a.as<std::complex<int>>(miles);
+    const auto b = a.as<std::complex<int>>(miles, ignore(TRUNCATION_RISK));
     EXPECT_THAT(b, SameTypeAndValue(miles(std::complex<int>{2, 0})));
 }
 

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -289,28 +289,11 @@ the [unit slots](../discussion/idioms/unit-slots.md) discussion for valid choice
     type `Inches`, writing `length.as(Inches{})`.  The former is generally preferable; the latter is
     mainly useful in generic code where the unit type may be all you have.
 
-**Without** a template argument, `.as(unit)` obeys the same safety checks as for the [implicit
-constructors](#implicit-from-quantity): conversions at high risk for integer overflow or truncation
-are forbidden.  Additionally, the `Rep` of the output is identical to the `Rep` of the input.
+**Without** a template argument, `.as(unit)`, the output `Rep` is whatever type would naturally be
+produced by the conversion operation.  (This is usually the same as the input `Rep`, but can differ
+in rare cases, such as integer promotion, or Eigen expression templates.)
 
-**With** a template argument, `.as<T>(unit)` has two differences.
-
-1. The output `Rep` will be `T`.
-2. The conversion is considered "forcing", and will be permitted in spite of any overflow or
-   truncation risk.  The semantics are similar to `static_cast<T>`.
-
-However, note that we may change this second property in the future.  The version with the template
-arguments may be changed later so that it _does_ prevent lossy conversions.  If you want this
-"forcing" semantic, prefer to use a policy argument, and add the explicit template parameter only if
-you want to change the rep.  See [#122] to track progress on this change, and see the [policy
-argument section](#policy-argument) for an example of the _preferred_ way to force a conversion.
-
-!!! tip
-    Prefer to **omit** the template argument if possible, because you will get more safety checks.
-    The risks which the no-template-argument version warns about are real.
-
-    As of [0.6.0] and [#122], however, this advice will no longer apply.  At that point, the
-    explicit-rep versions will have the same safety checks as the implicit-rep versions.
+**With** a template argument, `.as<T>(unit)`, the output `Rep` will be `T`.
 
 ### `.in(unit)`, `.in<T>(unit)`
 
@@ -332,28 +315,11 @@ slots](../discussion/idioms/unit-slots.md) discussion for valid choices for `uni
     type `Inches`, writing `length.in(Inches{})`.  The former is generally preferable; the latter is
     mainly useful in generic code where the unit type may be all you have.
 
-**Without** a template argument, `.in(unit)` obeys the same safety checks as for the [implicit
-constructors](#implicit-from-quantity): conversions at high risk for integer overflow or truncation
-are forbidden.  Additionally, the `Rep` of the output is identical to the `Rep` of the input.
+**Without** a template argument, `.in(unit)`, the output `Rep` is whatever type would naturally be
+produced by the conversion operation.  (This is usually the same as the input `Rep`, but can differ
+in rare cases, such as integer promotion, or Eigen expression templates.)
 
-**With** a template argument, `.in<T>(unit)` has two differences.
-
-1. The output type will be `T`.
-2. The conversion is considered "forcing", and will be permitted in spite of any overflow or
-   truncation risk.  The semantics are similar to `static_cast<T>`.
-
-However, note that we may change this second property in the future.  The version with the template
-arguments may be changed later so that it _does_ prevent lossy conversions.  If you want this
-"forcing" semantic, prefer to use a policy argument, and add the explicit template parameter only if
-you want to change the rep.  See [#122] to track progress on this change, and see the [policy
-argument section](#policy-argument) for an example of the _preferred_ way to force a conversion.
-
-!!! tip
-    Prefer to **omit** the template argument if possible, because you will get more safety checks.
-    The risks which the no-template-argument version warns about are real.
-
-    As of [0.6.0] and [#122], however, this advice will no longer apply.  At that point, the
-    explicit-rep versions will have the same safety checks as the implicit-rep versions.
+**With** a template argument, `.in<T>(unit)`, the output type will be `T`.
 
 ### Skipping risk checks: the `policy` argument {#policy-argument}
 
@@ -814,7 +780,7 @@ the denominator.
 The `divide_using_common_unit()` utility takes two `Quantity` inputs, `a`, and `b`, whose dimension is
 the same.  It first converts each input to their [common
 unit](../discussion/concepts/common_unit.md), and then performs regular division.  The result
-will be a dimensionless and unitless number (or, after [#185], a `Quantity`).
+will be a dimensionless and unitless `Quantity`.
 
 There is no need to wrap the denominator in a call to `unblock_int_div`, because same-unit division
 is always allowed by Au.
@@ -1036,7 +1002,6 @@ the following conditions hold.
 - For _types_ `U1` and `U2`:
     - `AreQuantityTypesEquivalent<U1, U2>::value`
 
-[#122]: https://github.com/aurora-opensource/au/issues/122
 [#481]: https://github.com/aurora-opensource/au/issues/481
 [0.6.0]: https://github.com/aurora-opensource/au/milestone/9
 [integer division section]: ../troubleshooting.md#integer-division-forbidden

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -906,9 +906,10 @@ had raw numeric types, `rep_cast` is a good replacement for `Quantity` types.
 Given any `Quantity<U, R> q` whose rep is `R`, then `rep_cast<T>(q)` gives a `Quantity<U, T>`, whose
 underlying value is `static_cast<T>(q.in(U{}))`.
 
-Unlike `.as<T>()`, `rep_cast` won't guard against [conversion
-risks](../discussion/concepts/conversion_risks.md); it will force the conversion through regardless.
-This cannot be customized.
+!!! note
+    Unlike `.as<T>()`, `rep_cast` won't guard against [conversion
+    risks](../discussion/concepts/conversion_risks.md); it will force the conversion through
+    regardless.  This cannot be customized.
 
 ## Templates and Traits
 

--- a/docs/reference/quantity_point.md
+++ b/docs/reference/quantity_point.md
@@ -213,28 +213,11 @@ See the [unit slots](../discussion/idioms/unit-slots.md) discussion for valid ch
     of the unit type `Centi<Meters>`, writing `point.as(Centi<Meters>{})`.  The former is generally
     preferable; the latter is mainly useful in generic code where the unit type may be all you have.
 
-**Without** a template argument, `.as(unit)` obeys the same safety checks as for the [implicit
-constructors](#implicit-from-quantity): conversions at high risk for integer overflow or truncation
-are forbidden.  Additionally, the `Rep` of the output is identical to the `Rep` of the input.
+**Without** a template argument, `.as(unit)`, the output `Rep` is whatever type would naturally be
+produced by the conversion operation.  (This is usually the same as the input `Rep`, but can differ
+in rare cases, such as integer promotion, or Eigen expression templates.)
 
-**With** a template argument, `.as<T>(unit)` has two differences.
-
-1. The output `Rep` will be `T`.
-2. The conversion is considered "forcing", and will be permitted in spite of any overflow or
-   truncation risk.  The semantics are similar to `static_cast<T>`.
-
-However, note that we may change this second property in the future.  The version with the template
-arguments may be changed later so that it _does_ prevent lossy conversions.  If you want this
-"forcing" semantic, prefer to use a policy argument, and add the explicit template parameter only if
-you want to change the rep.  See [#122] to track progress on this change, and see the [policy
-argument section](#policy-argument) for an example of the _preferred_ way to force a conversion.
-
-!!! tip
-    Prefer to **omit** the template argument if possible, because you will get more safety checks.
-    The risks which the no-template-argument version warns about are real.
-
-    As of [0.6.0] and [#122], however, this advice will no longer apply.  At that point, the
-    explicit-rep versions will have the same safety checks as the implicit-rep versions.
+**With** a template argument, `.as<T>(unit)`, the output `Rep` will be `T`.
 
 ### `.in(unit)`, `.in<T>(unit)`
 
@@ -256,28 +239,11 @@ be either a `QuantityPointMaker` for the quantity's unit, or an instance of the 
     of the unit type `Centi<Meters>`, writing `point.in(Centi<Meters>{})`.  The former is generally
     preferable; the latter is mainly useful in generic code where the unit type may be all you have.
 
-**Without** a template argument, `.in(unit)` obeys the same safety checks as for the [implicit
-constructors](#implicit-from-quantity): conversions at high risk for integer overflow or truncation
-are forbidden.  Additionally, the `Rep` of the output is identical to the `Rep` of the input.
+**Without** a template argument, `.in(unit)`, the output `Rep` is whatever type would naturally be
+produced by the conversion operation.  (This is usually the same as the input `Rep`, but can differ
+in rare cases, such as integer promotion, or Eigen expression templates.)
 
-**With** a template argument, `.in<T>(unit)` has two differences.
-
-1. The output type will be `T`.
-2. The conversion is considered "forcing", and will be permitted in spite of any overflow or
-   truncation risk.  The semantics are similar to `static_cast<T>`.
-
-However, note that we may change this second property in the future.  The version with the template
-arguments may be changed later so that it _does_ prevent lossy conversions.  If you want this
-"forcing" semantic, prefer to use a policy argument, and add the explicit template parameter only if
-you want to change the rep.  See [#122] to track progress on this change, and see the [policy
-argument section](#policy-argument) for an example of the _preferred_ way to force a conversion.
-
-!!! tip
-    Prefer to **omit** the template argument if possible, because you will get more safety checks.
-    The risks which the no-template-argument version warns about are real.
-
-    As of [0.6.0] and [#122], however, this advice will no longer apply.  At that point, the
-    explicit-rep versions will have the same safety checks as the implicit-rep versions.
+**With** a template argument, `.in<T>(unit)`, the output type will be `T`.
 
 ### Skipping risk checks: the `policy` argument {#policy-argument}
 
@@ -588,7 +554,6 @@ More precisely, `QuantityPoint<U1, R1>` and `QuantityPoint<U2, R2>` are equivale
 - For _types_ `U1` and `U2`:
     - `AreQuantityPointTypesEquivalent<U1, U2>::value`
 
-[#122]: https://github.com/aurora-opensource/au/issues/122
 [#352]: https://github.com/aurora-opensource/au/issues/352
 [#481]: https://github.com/aurora-opensource/au/issues/481
 [0.6.0]: https://github.com/aurora-opensource/au/milestone/9

--- a/docs/reference/quantity_point.md
+++ b/docs/reference/quantity_point.md
@@ -403,9 +403,10 @@ if you had raw numeric types, `rep_cast` is a good replacement for `QuantityPoin
 Given any `QuantityPoint<U, R> p` whose rep is `R`, then `rep_cast<T>(p)` gives a `QuantityPoint<U,
 T>`, whose underlying value is `static_cast<T>(p.in(U{}))`.
 
-Unlike `.as<T>()`, `rep_cast` won't guard against [conversion
-risks](../discussion/concepts/conversion_risks.md); it will force the conversion through regardless.
-This cannot be customized.
+!!! note
+    Unlike `.as<T>()`, `rep_cast` won't guard against [conversion
+    risks](../discussion/concepts/conversion_risks.md); it will force the conversion through
+    regardless.  This cannot be customized.
 
 ## Operations
 


### PR DESCRIPTION
Instead of `ignore(ALL_RISKS)`, these functions now get
`check_for(ALL_RISKS)`.  Some other implementations that didn't have a
policy at all now get an explicit `ignore(ALL_RISKS)`: particularly, the
`coerce` functions that we are about to deprecate.

The constructor change isn't strictly necessary, but it's a slight
improvement.  The `EnableIfImplicitOkIs` template parameter really is
the source of truth for whether this constructor should be allowed.
Using `ignore(ALL_RISKS)` instead of `check_for(ALL_RISKS)` removes the
possibility for the gates to disagree if we change it in the future, and
also avoids re-doing redundant compile time checks that we already
performed.

And, of course, we update various unit tests that are affected by this
interface change, and also update the docs.  Fixes #122.