### PR TITLE
Remove old explicit-rep uses in coerce functions

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -245,7 +245,7 @@ class Quantity {
     template <typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {
         // Usage example: `q.coerce_as(new_units)`.
-        return as<Rep>(NewUnit{}, ignore(ALL_RISKS));
+        return as(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewRep, typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {
@@ -255,7 +255,7 @@ class Quantity {
     template <typename NewUnit>
     constexpr auto coerce_in(NewUnit) const {
         // Usage example: `q.coerce_in(new_units)`.
-        return in<Rep>(NewUnit{}, ignore(ALL_RISKS));
+        return in(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewRep, typename NewUnit>
     constexpr auto coerce_in(NewUnit) const {

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -189,7 +189,7 @@ class QuantityPoint {
     template <typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {
         // Usage example: `p.coerce_as(new_units)`.
-        return as<Rep>(NewUnit{}, ignore(ALL_RISKS));
+        return as(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewRep, typename NewUnit>
     constexpr auto coerce_as(NewUnit) const {
@@ -199,7 +199,7 @@ class QuantityPoint {
     template <typename NewUnit>
     constexpr auto coerce_in(NewUnit) const {
         // Usage example: `p.coerce_in(new_units)`.
-        return in<Rep>(NewUnit{}, ignore(ALL_RISKS));
+        return in(NewUnit{}, ignore(ALL_RISKS));
     }
     template <typename NewRep, typename NewUnit>
     constexpr auto coerce_in(NewUnit) const {

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -470,7 +470,8 @@ TEST(Quantity, CoerceAsWillForceLossyConversion) {
 
     // Unsigned overflow.
     ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet(uint8_t{30}).coerce_as(inches), SameTypeAndValue(inches(uint8_t{104})));
+    EXPECT_THAT(feet(uint8_t{30}).coerce_as<uint8_t>(inches),
+                SameTypeAndValue(inches(uint8_t{104})));
 }
 
 TEST(Quantity, CoerceAsExplicitRepSetsOutputType) {
@@ -491,7 +492,7 @@ TEST(Quantity, CoerceInWillForceLossyConversion) {
 
     // Unsigned overflow.
     ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet(uint8_t{30}).coerce_in(inches), SameTypeAndValue(uint8_t{104}));
+    EXPECT_THAT(feet(uint8_t{30}).coerce_in<uint8_t>(inches), SameTypeAndValue(uint8_t{104}));
 }
 
 TEST(Quantity, CoerceInExplicitRepSetsOutputType) {
@@ -1068,7 +1069,7 @@ TEST(Quantity, UnitCastRequiresExplicitTypeForDangerousReps) {
     //
     // To "test" these, try replacing `.coerce_as(...)` with `.as(...)`.  Make sure it fails with a
     // readable `static_assert`.
-    EXPECT_THAT(feet(uint16_t{1}).coerce_as(centi(feet)),
+    EXPECT_THAT(feet(uint16_t{1}).coerce_as<uint16_t>(centi(feet)),
                 SameTypeAndValue(centi(feet)(uint16_t{100})));
 }
 
@@ -1374,8 +1375,8 @@ TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions
              i <= std::numeric_limits<uint16_t>::max();
              ++i) {
             const auto original = source_units(static_cast<uint16_t>(i));
-            const auto converted = original.coerce_as(target_units);
-            const auto round_trip = converted.coerce_as(source_units);
+            const auto converted = original.template coerce_as<uint16_t>(target_units);
+            const auto round_trip = converted.template coerce_as<uint16_t>(source_units);
 
             const bool did_value_change = (original != round_trip);
 

--- a/fuzz/quantity_runtime_conversion_checkers_test.cc
+++ b/fuzz/quantity_runtime_conversion_checkers_test.cc
@@ -103,7 +103,8 @@ TYPED_TEST_P(QuantityRuntimeConversionChecker, RoundTripIsIdentityIffConversionN
 
         const bool expect_loss = is_conversion_lossy<Rep>(value, destination_unit);
 
-        const auto round_trip = value.coerce_as(destination_unit).coerce_as(meters);
+        const auto round_trip =
+            value.template coerce_as<Rep>(destination_unit).template coerce_as<Rep>(meters);
         const bool actual_loss = (value != round_trip);
 
         EXPECT_THAT(expect_loss, Eq(actual_loss))


### PR DESCRIPTION
Explicit rep used to be the way to override safety checks, so it's what
we used in our `coerce` functions.  More recently, explicit-rep
_doesn't_ do this, so we needed to add a risk policy parameter.

This would have been fine, except that we _also_ changed "implicit rep"
to not automatically mean "same rep".  This makes `coerce_as(u)`
different from `as(u, ignore(ALL_RISKS))` in some rare cases.

This PR fixes that discrepancy, and updates any callsites that are
affected.  Paves the way for #481.