### PR TITLE
`static_assert` when `UnitAvoidance` specialized

### DIFF
--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -1421,13 +1421,34 @@ template <typename A, typename B>
 struct OrderByUnitOrderTiebreaker
     : stdx::bool_constant<(UnitOrderTiebreaker<A>::value < UnitOrderTiebreaker<B>::value)> {};
 
+// DEPRECATED: specialize `au::UnitOrderTiebreaker<U>` instead.
+//
+// We used to instruct users to specialize this template, but it lives in our `detail` namespace, so
+// we shouldn't have.  Specializing it is now a hard error, directing users to the new name.
 template <typename U>
 struct UnitAvoidance : std::integral_constant<int, 0> {};
+
+// The default value for `UnitOrderTiebreaker<U>` is `0`.
+//
+// We dispatch on whether `UnitAvoidance<U>` was specialized so that the error below fires only for
+// users who actually specialized it, rather than for every unit in the library.
+template <typename U, bool IsSpecialized = (UnitAvoidance<U>::value != 0)>
+struct UnitAvoidanceOrZero : std::integral_constant<int, 0> {};
+
+// NOTE: we still inherit the user's value, even though this specialization always fails to compile.
+// If we fell back to `0`, their units would no longer be ordered, and the `static_assert` below
+// would be buried under cascading "Broken strict total ordering" errors.
+template <typename U>
+struct UnitAvoidanceOrZero<U, true> : std::integral_constant<int, UnitAvoidance<U>::value> {
+    static_assert(AlwaysFalse<U>::value,
+                  "Instead of specializing `au::detail::UnitAvoidance<T>`, specialize "
+                  "`au::UnitOrderTiebreaker<T>`");
+};
 
 }  // namespace detail
 
 template <typename U>
-struct UnitOrderTiebreaker : detail::UnitAvoidance<U> {};
+struct UnitOrderTiebreaker : detail::UnitAvoidanceOrZero<U> {};
 
 template <typename A, typename B>
 struct InOrderFor<UnitProductPack, A, B>

--- a/au/unit_of_measure_test.cc
+++ b/au/unit_of_measure_test.cc
@@ -1070,20 +1070,6 @@ TEST(UnitOrderTiebreaker, CanBreakTiesForDistinctButOtherwiseUnorderableUnits) {
 
 namespace detail {
 
-struct Threet : decltype(Feet{} * mag<3>()) {};
-
-template <>
-struct UnitAvoidance<Threet> : std::integral_constant<int, 1234> {};
-
-TEST(UnitAvoidance, CanTemporarilyBreakTiesForDistinctButOtherwiseUnorderableUnits) {
-    // The point of this test is that this line would fail to compile if not for the
-    // `UnitAvoidance<Threet>` specialization just above.
-    //
-    // This method of making distinct units orderable is deprecated, because it relies on end users
-    // naming a type in our `detail::` namespace.
-    StaticAssertTypeEq<UnitProduct<Yards, Threet>, UnitProduct<Threet, Yards>>();
-}
-
 TEST(Origin, ZeroForUnitWithNoSpecifiedOrigin) {
     EXPECT_THAT(OriginOf<Kelvins>::value(), SameTypeAndValue(ZERO));
 }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1085,6 +1085,29 @@ you can _force_ a particular ordering.  Choose one of the units `U`, and give it
 creating a specialization of `::au::UnitOrderTiebreaker<U>`.  As the name suggests, this will break
 the tie, and your program will compile.
 
+!!! warning "Removed: `au::detail::UnitAvoidance`"
+    We previously documented this same technique using `::au::detail::UnitAvoidance<U>`.  That was
+    our mistake: it asked you to name a type in our `detail` namespace, which is not part of our
+    public API.  Specializing `UnitAvoidance` is now a compiler error that points you here.
+
+    To migrate, change the specialized template's name, keeping the same value:
+
+    ```cpp
+    // Before (no longer supported):
+    namespace au {
+    namespace detail {
+    template <>
+    struct UnitAvoidance<::Trinches> : std::integral_constant<int, 100> {};
+    }
+    }
+
+    // After:
+    namespace au {
+    template <>
+    struct UnitOrderTiebreaker<::Trinches> : std::integral_constant<int, 100> {};
+    }
+    ```
+
 Again, this is pretty unusual.  For most normal ways of forming units, the library should
 automatically be able to define an ordering for them.  If you do hit this error, it may be worth
 pausing to double-check that you're using the library correctly.  If you've checked, and it still


### PR DESCRIPTION
This reliably produces a readable compiler error that tells users how to
upgrade their code.  It's fine for it to be a compiler error, not just a
warning, because we already gave users the new machinery in 0.5.0, and
we gave a future-proof release that would surface any uses of the old
approach.  This means they can upgrade all of their uses in separate
commits before the 0.6.0 upgrade commit.

Fixes #429.  We will follow up in #717 to remove this machinery after
the 0.6.0 release and before 0.7.0.