### PR TITLE
Add `SameRep` tag to force conversion to keep rep

### DIFF
--- a/au/fwd.hh
+++ b/au/fwd.hh
@@ -20,6 +20,8 @@ namespace au {
 
 struct Zero;
 
+struct SameRep;
+
 template <typename B, std::intmax_t N>
 struct Pow;
 

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -207,7 +207,8 @@ class Quantity {
               typename RiskPolicyT = decltype(check_for(ALL_RISKS)),
               std::enable_if_t<IsConversionRiskPolicy<RiskPolicyT>::value, int> = 0>
     AU_DEVICE_FUNC constexpr auto as(RiskPolicyT policy = RiskPolicyT{}) const {
-        return make_quantity<Unit>(in_impl<detail::UseStaticCast, NewRep>(Unit{}, policy));
+        using ActualRep = detail::ResolveSameRep<Rep, NewRep>;
+        return make_quantity<Unit>(in_impl<detail::UseStaticCast, ActualRep>(Unit{}, policy));
     }
 
     // `q.as<Rep>(new_unit)`, or `q.as<Rep>(new_unit, risk_policy)`
@@ -216,8 +217,9 @@ class Quantity {
               typename RiskPolicyT = decltype(check_for(ALL_RISKS)),
               std::enable_if_t<!IsConversionRiskPolicy<NewUnitSlot>::value, int> = 0>
     AU_DEVICE_FUNC constexpr auto as(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
+        using ActualRep = detail::ResolveSameRep<Rep, NewRep>;
         return make_quantity<AssociatedUnit<NewUnitSlot>>(
-            in_impl<detail::UseStaticCast, NewRep>(u, policy));
+            in_impl<detail::UseStaticCast, ActualRep>(u, policy));
     }
 
     // `q.as(new_unit)`, or `q.as(new_unit, risk_policy)`
@@ -232,7 +234,8 @@ class Quantity {
               typename NewUnitSlot,
               typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
     AU_DEVICE_FUNC constexpr auto in(NewUnitSlot u, RiskPolicyT policy = RiskPolicyT{}) const {
-        return in_impl<detail::UseStaticCast, NewRep>(u, policy);
+        using ActualRep = detail::ResolveSameRep<Rep, NewRep>;
+        return in_impl<detail::UseStaticCast, ActualRep>(u, policy);
     }
 
     // `q.in(new_unit)`, or `q.in(new_unit, risk_policy)`

--- a/au/quantity_point.hh
+++ b/au/quantity_point.hh
@@ -155,7 +155,8 @@ class QuantityPoint {
               typename RiskPolicyT = decltype(check_for(ALL_RISKS)),
               std::enable_if_t<IsConversionRiskPolicy<RiskPolicyT>::value, int> = 0>
     AU_DEVICE_FUNC constexpr auto as(RiskPolicyT policy = RiskPolicyT{}) const {
-        return make_quantity_point<Unit>(in_impl<NewRep>(Unit{}, policy));
+        using ActualRep = detail::ResolveSameRep<Rep, NewRep>;
+        return make_quantity_point<Unit>(in_impl<ActualRep>(Unit{}, policy));
     }
 
     // `p.as<Rep>(new_unit)`, or `p.as<Rep>(new_unit, risk_policy)`
@@ -164,7 +165,8 @@ class QuantityPoint {
               typename RiskPolicyT = decltype(check_for(ALL_RISKS)),
               std::enable_if_t<!IsConversionRiskPolicy<NewUnit>::value, int> = 0>
     AU_DEVICE_FUNC constexpr auto as(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
-        return make_quantity_point<AssociatedUnitForPoints<NewUnit>>(in_impl<NewRep>(u, policy));
+        using ActualRep = detail::ResolveSameRep<Rep, NewRep>;
+        return make_quantity_point<AssociatedUnitForPoints<NewUnit>>(in_impl<ActualRep>(u, policy));
     }
 
     // `p.as(new_unit)`, or `p.as(new_unit, risk_policy)`
@@ -176,8 +178,9 @@ class QuantityPoint {
     template <typename NewRep,
               typename NewUnit,
               typename RiskPolicyT = decltype(check_for(ALL_RISKS))>
-    AU_DEVICE_FUNC constexpr NewRep in(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
-        return in_impl<NewRep>(u, policy);
+    AU_DEVICE_FUNC constexpr auto in(NewUnit u, RiskPolicyT policy = RiskPolicyT{}) const {
+        using ActualRep = detail::ResolveSameRep<Rep, NewRep>;
+        return in_impl<ActualRep>(u, policy);
     }
 
     template <typename NewUnit, typename RiskPolicyT = decltype(check_for(ALL_RISKS))>

--- a/au/quantity_point_test.cc
+++ b/au/quantity_point_test.cc
@@ -362,6 +362,20 @@ TEST(QuantityPoint, AsWithExplicitRepSetsOutputType) {
                 SameTypeAndValue(inches_pt(uint8_t{104})));
 }
 
+TEST(QuantityPoint, AsWithSameRepKeepsInputRepType) {
+    EXPECT_THAT(feet_pt(uint8_t{30}).as<SameRep>(inches_pt, ignore(OVERFLOW_RISK)),
+                SameTypeAndValue(inches_pt(uint8_t{104})));
+
+    EXPECT_THAT(inches_pt(30.0).as<SameRep>(feet_pt), SameTypeAndValue(feet_pt(2.5)));
+}
+
+TEST(QuantityPoint, InWithSameRepKeepsInputRepType) {
+    EXPECT_THAT(feet_pt(uint8_t{30}).in<SameRep>(inches_pt, ignore(OVERFLOW_RISK)),
+                SameTypeAndValue(uint8_t{104}));
+
+    EXPECT_THAT(inches_pt(30.0).in<SameRep>(feet_pt), SameTypeAndValue(2.5));
+}
+
 TEST(QuantityPoint, InWithPolicyParameterWillForceLossyConversion) {
     // Truncation.
     EXPECT_THAT(inches_pt(30).in(feet_pt, ignore(TRUNCATION_RISK)), SameTypeAndValue(2));

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -470,7 +470,7 @@ TEST(Quantity, AsWithPolicyParameterWillForceLossyConversion) {
 
     // Unsigned overflow.
     ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet(uint8_t{30}).as<uint8_t>(inches, ignore(OVERFLOW_RISK)),
+    EXPECT_THAT(feet(uint8_t{30}).as<SameRep>(inches, ignore(OVERFLOW_RISK)),
                 SameTypeAndValue(inches(uint8_t{104})));
 }
 
@@ -488,13 +488,32 @@ TEST(Quantity, AsWithExplicitRepSetsOutputType) {
                 SameTypeAndValue(inches(uint8_t{104})));
 }
 
+TEST(Quantity, AsWithSameRepKeepsInputRepType) {
+    EXPECT_THAT(meters(uint16_t{5}).as<SameRep>(milli(meters), ignore(OVERFLOW_RISK)),
+                SameTypeAndValue(milli(meters)(uint16_t{5000})));
+
+    // No conversion risk: no policy needed.
+    EXPECT_THAT(milli(meters)(uint16_t{5000}).as<SameRep>(meters, ignore(TRUNCATION_RISK)),
+                SameTypeAndValue(meters(uint16_t{5})));
+
+    // Works with floating point reps too, and needs no risk policy at all.
+    EXPECT_THAT(meters(1.5).as<SameRep>(milli(meters)), SameTypeAndValue(milli(meters)(1500.0)));
+}
+
+TEST(Quantity, InWithSameRepKeepsInputRepType) {
+    EXPECT_THAT(meters(uint16_t{5}).in<SameRep>(milli(meters), ignore(OVERFLOW_RISK)),
+                SameTypeAndValue(uint16_t{5000}));
+
+    EXPECT_THAT(meters(1.5).in<SameRep>(milli(meters)), SameTypeAndValue(1500.0));
+}
+
 TEST(Quantity, InWithPolicyParameterWillForceLossyConversion) {
     // Truncation.
     EXPECT_THAT(inches(30).in(feet, ignore(TRUNCATION_RISK)), SameTypeAndValue(2));
 
     // Unsigned overflow.
     ASSERT_THAT(static_cast<uint8_t>(30 * 12), Eq(104));
-    EXPECT_THAT(feet(uint8_t{30}).in<uint8_t>(inches, ignore(OVERFLOW_RISK)),
+    EXPECT_THAT(feet(uint8_t{30}).in<SameRep>(inches, ignore(OVERFLOW_RISK)),
                 SameTypeAndValue(uint8_t{104}));
 }
 
@@ -1074,7 +1093,7 @@ TEST(Quantity, UnitCastRequiresExplicitTypeForDangerousReps) {
     //
     // To "test" these, try deleting the `ignore(OVERFLOW_RISK)` parameter.  Make sure it fails with
     // a readable `static_assert`.
-    EXPECT_THAT(feet(uint16_t{1}).as<uint16_t>(centi(feet), ignore(OVERFLOW_RISK)),
+    EXPECT_THAT(feet(uint16_t{1}).as<SameRep>(centi(feet), ignore(OVERFLOW_RISK)),
                 SameTypeAndValue(centi(feet)(uint16_t{100})));
 }
 
@@ -1380,9 +1399,9 @@ TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions
              i <= std::numeric_limits<uint16_t>::max();
              ++i) {
             const auto original = source_units(static_cast<uint16_t>(i));
-            const auto converted = original.template as<uint16_t>(target_units, ignore(ALL_RISKS));
+            const auto converted = original.template as<SameRep>(target_units, ignore(ALL_RISKS));
             const auto round_trip =
-                converted.template as<uint16_t>(source_units, ignore(ALL_RISKS));
+                converted.template as<SameRep>(source_units, ignore(ALL_RISKS));
 
             const bool did_value_change = (original != round_trip);
 

--- a/au/quantity_test.cc
+++ b/au/quantity_test.cc
@@ -1400,8 +1400,7 @@ TEST(IsConversionLossy, CorrectlyDiscriminatesBetweenLossyAndLosslessConversions
              ++i) {
             const auto original = source_units(static_cast<uint16_t>(i));
             const auto converted = original.template as<SameRep>(target_units, ignore(ALL_RISKS));
-            const auto round_trip =
-                converted.template as<SameRep>(source_units, ignore(ALL_RISKS));
+            const auto round_trip = converted.template as<SameRep>(source_units, ignore(ALL_RISKS));
 
             const bool did_value_change = (original != round_trip);
 

--- a/au/rep.hh
+++ b/au/rep.hh
@@ -34,6 +34,26 @@ template <typename T>
 struct IsValidRep;
 
 //
+// A tag type to pass to `.as<SameRep>(...)` or `.in<SameRep>(...)`, indicating that the result
+// should keep the same Rep as the input, rather than changing it.
+//
+// As a reminder: the "implicit rep" versions (i.e., no template parameter) _usually_ produce the
+// same rep, but not always.  The most notable counter-examples are integer promotion, and Eigen
+// expression templates.
+//
+struct SameRep;
+
+namespace detail {
+// Resolve `NewRep` to `Rep` when `NewRep` is the `SameRep` tag; otherwise, leave it untouched.
+template <typename Rep, typename NewRep>
+struct ResolveSameRepImpl : stdx::type_identity<NewRep> {};
+template <typename Rep>
+struct ResolveSameRepImpl<Rep, SameRep> : stdx::type_identity<Rep> {};
+template <typename Rep, typename NewRep>
+using ResolveSameRep = typename ResolveSameRepImpl<Rep, NewRep>::type;
+}  // namespace detail
+
+//
 // A type trait to indicate whether the product of two types is a valid rep.
 //
 // Will validly return `false` if the product does not exist.

--- a/docs/discussion/concepts/overflow.md
+++ b/docs/discussion/concepts/overflow.md
@@ -166,15 +166,15 @@ template <typename U, typename R, typename TargetUnitSlot>
 constexpr auto try_converting(au::Quantity<U, R> q, TargetUnitSlot target) {
     return is_conversion_lossy(q, target)
         ? std::nullopt
-        : std::make_optional(q.as(target, ignore(ALL_RISKS)));
+        : std::make_optional(q.coerce_as(target));
 }
 ```
 
 The goal of `is_conversion_lossy` is to produce an implementation for each individual conversion
 (based on both the numeric type, and the conversion factor) that is as _accurate and efficient_ as
 an expertly hand-written implementation.  If it passes those checks, then it's safe and correct to
-ignore all risks with the policy argument: we can override the _approximate_ safety checks that
-`.as(target)` would otherwise perform, because we've already performed an _exact_ safety check.
+call `.coerce_as` instead of simply `.as`: we can override the _approximate_ safety checks of the
+latter because we've performed an _exact_ safety check.
 
 ??? note "An example of the kind of details we take care of"
     When we say "expertly hand-written", we mean it.  We even handle obscure C++ minutae such as

--- a/docs/discussion/concepts/overflow.md
+++ b/docs/discussion/concepts/overflow.md
@@ -166,15 +166,15 @@ template <typename U, typename R, typename TargetUnitSlot>
 constexpr auto try_converting(au::Quantity<U, R> q, TargetUnitSlot target) {
     return is_conversion_lossy(q, target)
         ? std::nullopt
-        : std::make_optional(q.coerce_as(target));
+        : std::make_optional(q.as(target, ignore(ALL_RISKS)));
 }
 ```
 
 The goal of `is_conversion_lossy` is to produce an implementation for each individual conversion
 (based on both the numeric type, and the conversion factor) that is as _accurate and efficient_ as
 an expertly hand-written implementation.  If it passes those checks, then it's safe and correct to
-call `.coerce_as` instead of simply `.as`: we can override the _approximate_ safety checks of the
-latter because we've performed an _exact_ safety check.
+ignore all risks with the policy argument: we can override the _approximate_ safety checks that
+`.as(target)` would otherwise perform, because we've already performed an _exact_ safety check.
 
 ??? note "An example of the kind of details we take care of"
     When we say "expertly hand-written", we mean it.  We even handle obscure C++ minutae such as

--- a/docs/reference/quantity.md
+++ b/docs/reference/quantity.md
@@ -380,6 +380,26 @@ in rare cases, such as integer promotion, or Eigen expression templates.)
 
 **With** a template argument, `.in<T>(unit)`, the output type will be `T`.
 
+### Keeping the same rep: `SameRep` {#same-rep}
+
+Sometimes you want to change the unit, but guarantee that the rep stays exactly what it was on the
+input --- even in the rare cases (integer promotion, Eigen expression templates) where the
+"implicit rep" form wouldn't preserve it.  Passing the `SameRep` tag as the explicit template
+argument does this.
+
+??? example "Example: forcing a same-rep, risky conversion"
+    ```cpp
+    auto length = feet(uint8_t{20});
+
+    // `Rep` is `uint8_t` on both the input and the output.
+    auto result = length.as<SameRep>(inches, ignore(OVERFLOW_RISK));
+    ```
+
+`q.as<SameRep>(unit)` is equivalent to `q.as<T>(unit)`, where `T` is `q`'s own `Rep`; likewise for
+`.in<SameRep>(unit)`.  The primary motivation for this is to _express author intent_ to use the same
+rep.  (Note that explicitly repeating the concrete rep `T` would _not_ accomplish this, because it's
+not clear if the author wants `T` for its own sake, or because it is the input rep.)
+
 ### Skipping risk checks: the `policy` argument {#policy-argument}
 
 Some unit conversions have too much [conversion risk](../discussion/concepts/conversion_risks.md) to
@@ -446,6 +466,9 @@ To be concrete, here are the signatures of the functions that support the policy
 
     These new versions are both more clear about their intent, and safer (because they only turn off
     the safety checks that they need to).
+
+    Note: if you were only providing `<T>` in order to keep the same rep as the input (rather than
+    to genuinely change it), use [`SameRep`](#same-rep) for `T` instead of naming the concrete type.
 
 This function performs the exact same kind of unit conversion as if the string `coerce_` were
 removed.  However, it will ignore any safety checks for overflow or truncation.

--- a/docs/reference/quantity_point.md
+++ b/docs/reference/quantity_point.md
@@ -245,6 +245,25 @@ in rare cases, such as integer promotion, or Eigen expression templates.)
 
 **With** a template argument, `.in<T>(unit)`, the output type will be `T`.
 
+### Keeping the same rep: `SameRep` {#same-rep}
+
+Sometimes you want to change the unit, but guarantee that the rep stays exactly what it was on the
+input --- even in the rare cases (integer promotion, Eigen expression templates) where the
+"implicit rep" form wouldn't preserve it.  You can achieve this by passing the `SameRep` tag as the
+explicit template argument.
+
+??? example "Example: forcing a same-rep, risky conversion"
+    ```cpp
+    auto point = feet_pt(uint8_t{30});
+
+    // `Rep` is `uint8_t` on both the input and the output.
+    auto result = point.as<SameRep>(inches_pt, ignore(OVERFLOW_RISK));
+    ```
+
+`p.as<SameRep>(unit)` is equivalent to `p.as<T>(unit)`, where `T` is `p`'s own `Rep`; likewise for
+`.in<SameRep>(unit)`.  This is most useful as a way to _express your intent_ to keep the rep the
+same.  It's also useful in generic code.
+
 ### Skipping risk checks: the `policy` argument {#policy-argument}
 
 Some unit conversions have too much [conversion risk](../discussion/concepts/conversion_risks.md) to
@@ -310,6 +329,9 @@ To be concrete, here are the signatures of the functions that support the policy
 
     These new versions are both more clear about their intent, and safer (because they only turn off
     the safety checks that they need to).
+
+    Note: if you were only providing `<T>` in order to keep the same rep as the input (rather than
+    to genuinely change it), use [`SameRep`](#same-rep) for `T` instead of naming the concrete type.
 
 This function performs the exact same kind of unit conversion as if the string `coerce_` were
 removed.  However, it will ignore any safety checks for overflow or truncation.

--- a/fuzz/quantity_runtime_conversion_checkers_test.cc
+++ b/fuzz/quantity_runtime_conversion_checkers_test.cc
@@ -103,8 +103,8 @@ TYPED_TEST_P(QuantityRuntimeConversionChecker, RoundTripIsIdentityIffConversionN
 
         const bool expect_loss = is_conversion_lossy<Rep>(value, destination_unit);
 
-        const auto round_trip = value.template as<Rep>(destination_unit, ignore(ALL_RISKS))
-                                    .as(meters, ignore(ALL_RISKS));
+        const auto round_trip = value.template as<SameRep>(destination_unit, ignore(ALL_RISKS))
+                                    .template as<SameRep>(meters, ignore(ALL_RISKS));
         const bool actual_loss = (value != round_trip);
 
         EXPECT_THAT(expect_loss, Eq(actual_loss))


### PR DESCRIPTION
`q.as<SameRep>(u)` is basically equivalent to what `q.as(u)` _used to_
be, before we changed the semantics for implicit rep to be "whatever the
computation would naturally return with raw types".  This morning, I
realized we had no way to spell this.  `q.as<T>(u)`, where `T` is the
rep of `q`, is _close_, but not quite.  Two shortcomings:

1. It is not covariant: if you _update_ the rep, then a "rep preserving"
   callsite silently becomes a "rep changing" callsite.

2. It poorly expresses intent: it's not clear whether the author
   supplied `T` because they wanted that type specifically, or because
   they wanted to preserve the input type.

In fact, (2) is what prevents us from ever being able to solve (1)
without new library machinery.  We cannot know whether we should update
the type unless we know the user's intent.

This PR adds that new machinery.  Providing `SameRep` as an explicit rep
parameter will force the output rep to be the same as the input, just as
our implicit rep functions used to do.  We also update the corresponding
docs.  And, we very recently landed some test changes with callsites
that were explicit-rep but with the "same rep" intent, so we update
those callsites to become what they were always meant to be.

Additionally, we correct a slight error that we had introduced into the
fuzz helper test, whereby we had forgotten to use explicit rep on the
_second_ leg of the round trip.  I think the reason this didn't fail is
because the lossiness generally only happens on the first leg of the
round trip, but still, we need to add `SameRep` in _both_ places to
express author intent.

Fixes #712.