### PR TITLE
Add `cast<T>` free function for Eigen

### DIFF
--- a/au/compatibility/eigen.hh
+++ b/au/compatibility/eigen.hh
@@ -35,6 +35,30 @@ auto eval(const Quantity<U, R> &q) {
     return make_quantity<U>(std::move(result));
 }
 
+// Cast the rep's _scalar_ type, preserving the unit.
+//
+// This is the free function form of Eigen's `.cast<NewScalar>()` member function.  Note that the
+// template parameter is the new _scalar_ type, not the new rep: as with Eigen, the shape and
+// options of the rep carry over automatically.  Contrast Au's usual tools for changing the rep,
+// which name a whole new rep, and which both fail for Eigen types with different scalars:
+// `.as<NewRep>(unit)` (the preferred one, since it checks conversion risk) can't form a common rep
+// for them, and `rep_cast<NewRep>` performs a `static_cast`, which Eigen deliberately rejects in
+// favor of `.cast<T>()`.
+//
+// Like every function in this header, this is a pure port of the Eigen member function: it performs
+// no unit conversion, and it does not participate in Au's conversion risk analysis.  In particular,
+// casting a floating point scalar to an integral one silently truncates, exactly as Eigen does.
+//
+// LIFETIME NOTE: Eigen's `.cast()` is lazy for dense and sparse types, so this is too; see the
+// lifetime note below.  (Eigen's geometry types --- `Quaternion`, `Transform`, ... --- cast
+// eagerly, but they can't be `Quantity` reps today anyway, because they don't support `operator+`.)
+// When `NewScalar` is already the rep's scalar type, Eigen hands back a reference to the original,
+// which `make_quantity` decays to an owning copy.
+template <typename NewScalar, typename U, typename R>
+auto cast(const Quantity<U, R> &q) {
+    return make_quantity<U>(q.data_in(U{}).template cast<NewScalar>());
+}
+
 //
 // Free-function forms of Eigen member functions, made unit-aware.
 //

--- a/au/compatibility/eigen_test.cc
+++ b/au/compatibility/eigen_test.cc
@@ -744,4 +744,69 @@ TEST(EigenFreeFunctions, DeterminantRaisesUnitToMatrixDimension) {
     EXPECT_THAT(d.data_in(UnitPowerT<Meters, 3>{}), Eq(24.0));
 }
 
+TEST(EigenFreeFunctions, CastWidensScalarAndPreservesUnit) {
+    auto q = meters(Eigen::Vector3f{1.5f, 2.5f, 3.5f});
+
+    auto result = eval(cast<double>(q));
+
+    EXPECT_THAT(result.data_in(meters), SameTypeAndValue(Eigen::Vector3d(1.5, 2.5, 3.5)));
+}
+
+TEST(EigenFreeFunctions, CastNarrowsScalar) {
+    auto q = meters(Eigen::Vector3d{1.5, 2.5, 3.5});
+
+    auto result = eval(cast<float>(q));
+
+    EXPECT_THAT(result.data_in(meters), SameTypeAndValue(Eigen::Vector3f(1.5f, 2.5f, 3.5f)));
+}
+
+TEST(EigenFreeFunctions, CastToIntegralTruncatesSilently) {
+    // `cast` is a pure port of Eigen's `.cast<T>()`: it does not consult Au's conversion risk
+    // machinery, so a lossy scalar cast is permitted (and truncates) just as it does in Eigen.
+    auto q = meters(Eigen::Vector3d{1.5, -2.5, 3.9});
+
+    auto result = eval(cast<int>(q));
+
+    EXPECT_THAT(result.data_in(meters), SameTypeAndValue(Eigen::Vector3i(1, -2, 3)));
+}
+
+TEST(EigenFreeFunctions, CastPreservesNonTrivialUnit) {
+    auto q = feet(Eigen::Vector3f{1.0f, 2.0f, 3.0f});
+
+    auto result = eval(cast<double>(q));
+
+    EXPECT_THAT(result.data_in(feet), SameTypeAndValue(Eigen::Vector3d(1.0, 2.0, 3.0)));
+}
+
+TEST(EigenFreeFunctions, CastWorksForMatrices) {
+    Eigen::Matrix2f m;
+    m << 1.0f, 2.0f, 3.0f, 4.0f;
+    auto q = meters(m);
+
+    auto result = eval(cast<double>(q));
+
+    Eigen::Matrix2d expected;
+    expected << 1.0, 2.0, 3.0, 4.0;
+    EXPECT_THAT(result.data_in(meters), SameTypeAndValue(expected));
+}
+
+TEST(EigenFreeFunctions, CastToSameScalarProducesConcreteCopy) {
+    // Eigen's `.cast<T>()` returns a reference to the original when the scalar is unchanged.
+    // `make_quantity` stores `std::decay_t<T>`, so we get an owning copy rather than a dangling
+    // reference --- no `eval()` required.
+    auto q = meters(Eigen::Vector3d{1.0, 2.0, 3.0});
+
+    auto result = cast<double>(q);
+
+    EXPECT_THAT(result.data_in(meters), SameTypeAndValue(Eigen::Vector3d(1.0, 2.0, 3.0)));
+}
+
+TEST(EigenFreeFunctions, CastAcceptsExpressionTemplateInput) {
+    auto q = meters(Eigen::Vector3f{1.0f, 2.0f, 3.0f});
+
+    auto result = eval(cast<double>(q + q));
+
+    EXPECT_THAT(result.data_in(meters), SameTypeAndValue(Eigen::Vector3d(2.0, 4.0, 6.0)));
+}
+
 }  // namespace au

--- a/docs/howto/interop/eigen.md
+++ b/docs/howto/interop/eigen.md
@@ -97,6 +97,23 @@ eval(transpose(v));  // Transposed vector, still in meters.
 
 See the [Eigen compatibility reference](../../reference/eigen.md) for the full list of functions.
 
+### Changing the scalar type {#cast}
+
+To change the _scalar_ type of an Eigen-backed `Quantity`, use
+[`cast<NewScalar>`](../../reference/eigen.md#cast), the free function form of Eigen's
+`.cast<NewScalar>()`.
+
+```cpp
+auto v_f = meters(Eigen::Vector3f{1.5f, 2.5f, 3.5f});
+
+eval(cast<double>(v_f));  // Quantity<Meters, Eigen::Vector3d>
+```
+
+Note that Au's usual tools for changing the rep do **not** work here.  Neither the preferred,
+risk-checked `.as<NewRep>(unit)` --- which can't form a common rep for two Eigen types with different
+scalars --- nor the forcing `rep_cast<NewRep>`, which performs a `static_cast` that Eigen
+deliberately rejects between types with different scalars.
+
 ## Run your tests under sanitizers
 
 Lifetime bugs with expression templates are easy to write and hard to spot in review --- again,

--- a/docs/reference/eigen.md
+++ b/docs/reference/eigen.md
@@ -51,6 +51,50 @@ auto eval(const Quantity<U, R> &q);
     auto safe = eval(q.as(centi(meters)));  // Concrete vector: owns its data.
     ```
 
+## Scalar type conversion
+
+### `cast` {#cast}
+
+Cast the rep's _scalar_ type, preserving the unit.  This is the free function form of Eigen's
+`.cast<NewScalar>()` member function.
+
+```cpp
+template <typename NewScalar, typename U, typename R>
+auto cast(const Quantity<U, R> &q);
+```
+
+Note that the template parameter is the new _scalar_ type, not the new rep: as in Eigen, the shape
+and options of the rep carry over automatically.  So casting a `Quantity<Meters, Eigen::Vector3f>`
+with `cast<double>` produces a `Quantity<Meters, Eigen::Vector3d>`.
+
+This is the only way to change the scalar type of an Eigen-backed `Quantity`.  Au's usual tools for
+changing the rep --- [`.as<NewRep>(unit)`](./quantity.md#as), which is preferred because it checks
+for [conversion risk](../discussion/concepts/conversion_risks.md), and the forcing
+[`rep_cast<NewRep>`](./quantity.md#rep_cast) --- both fail here.  `.as<NewRep>(unit)` cannot form
+a common rep for two Eigen types with different scalars, and `rep_cast<NewRep>` performs
+a `static_cast`, which Eigen _deliberately_ rejects between types with different scalars, directing
+users to `.cast<T>()` instead.
+
+!!! warning
+    Like every function on this page, `cast` is a pure port of the Eigen member function.  It does
+    **not** consult Au's [conversion risk](../discussion/concepts/conversion_risks.md) machinery, so
+    a lossy cast is permitted and will silently lose information, exactly as it does in Eigen.  For
+    instance, `cast<int>` on a `Quantity<Meters, Eigen::Vector3d>` holding `{1.5, -2.5, 3.9}` yields
+    `{1, -2, 3}`.
+
+??? example "Example: widening a float vector to double"
+    ```cpp
+    auto q = meters(Eigen::Vector3f{1.5f, 2.5f, 3.5f});
+
+    auto widened = eval(cast<double>(q));  // Quantity<Meters, Eigen::Vector3d>
+    ```
+
+--8<-- "eigen-lifetime-risk-lazy.md"
+
+When `NewScalar` is already the rep's scalar type, Eigen returns a reference to the original rather
+than an expression.  `Quantity` stores a decayed copy of that reference, so this case is always safe
+to store without `eval()`.
+
 ## Reductions
 
 These operations reduce a vector or matrix to a single scalar.  They are all evaluated eagerly, so


### PR DESCRIPTION
Eigen's pretty particular about casting.  `static_cast` is explicitly
forbidden; you have to use the `.cast<T>()` member function instead.  Au
uses `static_cast` everywhere, so right now, we can't really change the
scalar type.

The solution is obvious: just add a free function version.  We do that
here, and update the docs.

Note that this means Eigen users can't do a compound
cast-and-unit-conversion operation.  I think that's fine; it's not
really idiomatic Eigen usage anyway.  And this PR improves the state of
affairs over the current status quo, which is that rep casting can't be
done at all for Eigen backed Quantity.

Helps #70, and blocks the truncation risk doc updates.