### PR TITLE
Document compiler warnings policy

### DIFF
--- a/docs/discussion/concepts/compiler_warnings.md
+++ b/docs/discussion/concepts/compiler_warnings.md
@@ -1,0 +1,152 @@
+# Compiler Warnings
+
+Every project has its own policy about compiler warnings: which ones to enable, and which of those
+to turn into errors.  That policy is expressed in _compiler flags_, and it belongs to _you_, the
+user --- not to your units library.  Au's job is to respect your choices and avoid interfering with
+them.  This page explains how we do that.
+
+## Au's core policy {#policy}
+
+The core of our approach can be summarized in a simple policy statement:
+
+> **Au neither _adds_ nor _subtracts_ compiler warnings.**
+
+More precisely: for anything which is a property of the _underlying numeric types_ --- lost
+precision, narrowing, sign conversion, and so on --- Au aims to give you _exactly_ the diagnostics
+your compiler flags would give you for the equivalent raw numbers: no more, no less.
+
+Here's what each half of our policy statement actually _means_.
+
+- **Don't add.**  "Adding" warnings would mean that your basic (raw numeric) program compiles
+  without any warnings, but you start seeing warnings when you migrate it to use Au.  This implies
+  that Au's _library-internal code_ is not clean under that warning: an incredibly frustrating
+  experience.
+
+- **Don't subtract.**  "Subtracting" is more subtle: it means that your basic (raw numeric) program
+  _would_ produce a warning in a certain situation, but when you migrate it to Au, the warning
+  disappears.  This would be a silent leak in the safety net that those warnings provide.
+
+Historically, Au has always paid careful attention to the first half ("don't add"), and strove to be
+clean under all warnings.  Noticing the other side of this coin ("don't subtract") took a lot
+longer.  It wasn't until [#528] was filed that we recognized you can be _too_ clean under warnings
+--- that an absent warning can be just as dangerous as a present one.
+
+This half matters because of what warning flags _are_.  Every project needs some way to say which
+numerical operations it considers safe: whether narrowing a `double` to a `float` is routine or
+alarming is a _policy_ choice, and different projects land in different places.  For raw numeric
+code, the canonical mechanism for expressing that choice already exists --- it _is_ the set of
+warning flags.  A library that subtracts warnings takes that mechanism away, and forces its users to
+invent a replacement.  One that doesn't lets you keep the mechanism you already have, and get the
+same answers for `Quantity` that you get for the numbers inside it.
+
+!!! note "Unit-level safety checks are a separate matter"
+    Au _does_ add errors of its own: mismatched dimensions, [forbidden integer
+    division](../../troubleshooting.md#integer-division-forbidden), and [conversion
+    risks](./conversion_risks.md) such as [truncation](./truncation.md) and
+    [overflow](./overflow.md).
+
+    These are _unit-level_ checks, and they're the entire point of the library: they catch mistakes
+    that raw numbers can't even express.  The policy on this page is about the _numeric_ layer
+    underneath, where we defer entirely to your compiler flags.
+
+### Implementation approach
+
+Au performs every unit conversion as a [sequence of operations](./conversion_risks.md), and one of
+those operations is converting from one rep to another.  Which _kind_ of conversion we use depends
+on how _you_ asked for it:
+
+- The **implicit constructor** uses an **implicit conversion**, because that's what the equivalent
+  raw-number code (`float f = d;`) would do.  Your `-Wconversion` flags therefore fire exactly as
+  they would for raw numbers.
+
+- **`.as<T>(unit)` and `.in<T>(unit)`** use a **`static_cast`**, because naming the destination type
+  explicitly _is_ an explicit request to convert.  Just as with a hand-written `static_cast`, no
+  warning is raised.
+
+!!! example
+
+    ```cpp
+    QuantityD<Meters> d = meters(1.0);
+
+    QuantityF<Meters> a = d;         // Warns under `-Wfloat-conversion`, as `float a = 1.0;` would.
+    auto b = d.as<float>(meters);    // No warning, as `static_cast<float>(1.0)` wouldn't.
+    float c = d.in<float>(meters);   // No warning, for the same reason.
+    ```
+
+## Required build configuration {#required-build-configuration}
+
+Historically, very few libraries have lived up to the "don't _add_ warnings" half of our policy.
+Surprisingly, this has created a serious obstacle for libraries trying to live up to the "don't
+_subtract_ warnings" half!
+
+The mechanism at work here began with the standard library and the operating system.  Those headers,
+as the [GCC manual][gcc-system-headers] puts it, "often cannot be written in strictly conforming C",
+so any warning they produce is a false positive that you can do nothing about.  The answer was to
+suppress essentially all warnings while processing a _system header_.  Later on, via flags such as
+`-isystem`, users could nominate _any_ directory for that same treatment.[^linters]
+
+[^linters]: Linters follow the compiler's lead here.  clang-tidy checks --- including
+`cppcoreguidelines-narrowing-conversions`, which flags exactly the kind of narrowing this page is
+about --- don't report findings in system headers either.
+
+That escape hatch proved irresistible for third party code, and understandably so: warnings from
+dependencies you don't control add noise and obscure your own mistakes --- or, under `-Werror`,
+break your build entirely.  The upshot is that many build configurations now treat _every_ external
+dependency as a system include path by default.
+
+Unfortunately, this situation hurts libraries that treat warnings more carefully.  For Au
+specifically, the effect is sweeping.  Every rep conversion physically _happens_ inside Au's
+headers, no matter which line of _your_ code requested it: that's simply where the library's code
+lives.  Compilers judge a diagnostic by the file it points to, so if Au's headers are considered
+"system" headers, then **every** numeric conversion warning in **every** unit conversion disappears
+--- silently.
+
+```cpp
+QuantityF<Meters> narrowed = meters(1.0);  // `-Wfloat-conversion` warns...
+                                           // ...unless Au is on a system include path.
+```
+
+That is precisely the "subtract" failure mode from [the policy above](#policy), and it's not
+something we can fix from inside the library.  It's a property of your build configuration.
+
+Therefore: **configure Au as a normal (non-system) dependency.**  See the
+[installation docs](../../install.md#warning-flags) for details on how to do this for each supported
+installation method, and how to check what your build is actually doing.
+
+!!! warning "Au can't do this; only users can"
+    A header can't "opt out" of warning suppression from inside itself.  This is the one part of our
+    policy that we can't deliver on your behalf: as long as your build puts Au on a system include
+    path, the "neither add nor subtract" promise simply does not apply, and warnings you rely on
+    everywhere else in your project will silently fail to fire for quantities.
+
+### Last resort: forcing warnings back on
+
+If your build genuinely cannot avoid putting Au on a system include path, these flags can restore
+the diagnostics.  Fixing the build configuration would be the better approach, but these options may
+be better than nothing.
+
+| Flag | Compilers | Effect |
+|------|-----------|--------|
+| `--no-system-header-prefix=au/` | clang | Treats headers included as `"au/..."` as non-system.  Nicely targeted, but clang-only. |
+| `-Wsystem-headers` | gcc, clang | Restores warnings in _all_ system headers, including your standard library.  Usually far too noisy. |
+| `/external:W4` (with `/external:I`) | MSVC | Sets the warning level applied to external headers. |
+| `--system-headers` (or `SystemHeaders` in `.clang-tidy`) | clang-tidy | Reports findings from all system headers, with the same noise problem as `-Wsystem-headers`. |
+
+## Violations are bugs
+
+Our policy is aspirational, not a strict guarantee, because it's hard to test every possible
+combination of compiler flags.  However, we take it very seriously, and we want to hear about it
+when we fall short.
+
+If you think you've found a violation, the first thing to check is your [build
+configuration](#required-build-configuration): a system include path for Au explains most "missing"
+warnings, and it's the one cause that only _you_ can fix.  Once you've ruled that out, a violation in
+_either_ direction is a bug in Au.  Please file an [issue] if you find one!
+
+It's possible, in principle, that someone could find a violation of this principle that is
+_architecturally impossible_ for Au to fix.  If that happens, we'll add a section to this page that
+lists all known exceptions, and explains why they can't be fixed.
+
+[#528]: https://github.com/aurora-opensource/au/issues/528
+[gcc-system-headers]: https://gcc.gnu.org/onlinedocs/cpp/System-Headers.html
+[issue]: https://github.com/aurora-opensource/au/issues/new

--- a/docs/discussion/concepts/conversion_risks.md
+++ b/docs/discussion/concepts/conversion_risks.md
@@ -7,9 +7,10 @@ Unit conversions turn one `Quantity` into another, where both the unit and the r
 2. The _target_ **rep**.
 3. The ratio between the _initial_ and _target_ **units**.
 
-Under the hood, we implement each conversion as a sequence of operations, including `static_cast`
-for changing the rep, and mathematical operations (mainly multiplying and dividing) for changing the
-value.  Each operation has an input type, and an output type (which might be the same as the input).
+Under the hood, we implement each conversion as a sequence of _operations_.  Each operation has an
+input type, and an output type (which might be the same as the input).  Elementary operations
+include type conversions (either `static_cast` or implicit conversion), multiplying or dividing by
+a constant, and so on.
 
 ## What can go wrong?
 

--- a/docs/discussion/concepts/index.md
+++ b/docs/discussion/concepts/index.md
@@ -14,6 +14,11 @@ and help you use units libraries more effectively.
   different units, the first step is to convert them to the same unit.  But which one?  This page
   teaches you what choice we make, and what advantages it has.
 
+- **[Compiler Warnings](./compiler_warnings.md)**.  A good library plays nicely with your compiler
+  flags: your code should be free from warnings when it's correct, but still produce all the same
+  warnings you rely on to catch mistakes.  Learn about Au's policy in this regard, and how to avoid
+  the common build setting that can silently defeat it.
+
 - **[Conversion Risks](./conversion_risks.md)**.  Unit conversions can be lossy.  This page explains
   how to think about conversion lossiness: both for individual input values, and for the overall
   conversion as a whole.  We'll learn about the safety checks built into Au's APIs, and how to

--- a/docs/discussion/concepts/truncation.md
+++ b/docs/discussion/concepts/truncation.md
@@ -73,6 +73,13 @@ point representation is a statement, by the user, that _exact values do not matt
 application.  It would be inappropriate for us to raise warnings about perfectly routine properties
 of the user's chosen type.  Hence: _floating point never truncates_.
 
+!!! note "This is separate from your compiler's `-Wconversion` flags"
+    "Never truncates" means Au's own [truncation risk](./conversion_risks.md) check won't
+    forbid the conversion.  It does _not_ mean we hide narrowing conversions from your compiler: an
+    implicit conversion from a `double` quantity to a `float` one still warns under
+    `-Wfloat-conversion`, exactly as it would for raw numbers.  See [compiler
+    warnings](./compiler_warnings.md).
+
 ### Other types
 
 Currently, Au has only limited support for non-arithmetic rep types (full support is tracked in

--- a/docs/install.md
+++ b/docs/install.md
@@ -74,6 +74,111 @@ Here's an overview of the tradeoffs involved.
   </tr>
 </table>
 
+## Compiler warning flags {#warning-flags}
+
+Whichever method you choose, there's one property we ask you to check: **Au's headers should _not_
+be on a "system" include path** (that is, `-isystem` on gcc and clang, or `/external:I` on MSVC).
+
+The reason is [Au's policy on compiler warnings](./discussion/concepts/compiler_warnings.md#policy):
+we aim to raise the same warnings and errors for `Quantity` that your compiler flags would raise for
+the underlying raw numbers --- no more, and no less.  Since Au is header-only, the numeric
+conversions physically happen _inside_ Au's headers.  If those headers are "system" headers, your
+compiler will silently suppress every one of those warnings, and there's nothing we can do about it
+from inside the library. See the [required build
+configuration](./discussion/concepts/compiler_warnings.md#required-build-configuration) for the full
+explanation.
+
+Here's what to check for each installation method.
+
+=== "bazel"
+    **Default behavior: correct; nothing to do.**  Bazel passes external repositories' include paths
+    as `-iquote`, which is _not_ a system include path.
+
+    The setting to watch out for is the `external_include_paths` feature, which adds `-isystem` for
+    every external repository.  If your project enables it (typically via
+    `--features=external_include_paths` in `.bazelrc`), you can turn it back off:
+
+    ```
+    # In .bazelrc:
+    build --features=-external_include_paths
+    ```
+
+    You can verify what your build actually passes:
+
+    ```sh
+    bazel aquery 'mnemonic("CppCompile", //your:target)' | grep -A1 -- -isystem
+    ```
+
+    !!! note "gcc and clang differ here"
+        With this feature enabled, Bazel passes _both_ `-iquote` and `-isystem` for the same
+        external repository directory.  In that situation, clang keeps the warnings (because the
+        quoted include `"au/au.hh"` resolves via the `-iquote` path), while gcc suppresses them.
+        Don't rely on this: disable the feature, or at least test with the compiler you care about.
+
+=== "CMake (`FetchContent`)"
+    **Default behavior: correct; nothing to do.**  Targets brought in this way are ordinary
+    (non-imported) targets, whose include directories are _not_ treated as system directories.
+
+    Just be sure not to opt in to the system treatment, which CMake 3.25 and newer offer via the
+    `SYSTEM` keyword:
+
+    ```cmake
+    FetchContent_Declare(
+      Au
+      # ...
+      SYSTEM  # <--- Don't do this for Au!
+    )
+    ```
+
+    The same applies to `add_subdirectory(... SYSTEM)`, and to setting the
+    [`SYSTEM`](https://cmake.org/cmake/help/latest/prop_tgt/SYSTEM.html) directory or target property
+    for Au.
+
+=== "CMake (`find_package`), conan, vcpkg"
+    **Default behavior: warnings suppressed; action required.**  These methods all deliver Au as an
+    _imported_ target, and CMake treats an imported target's
+    [`INTERFACE_INCLUDE_DIRECTORIES` as system directories by
+    default](https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED_NO_SYSTEM.html).
+
+    To get Au's intended warning behavior, turn this off after finding the package:
+
+    ```cmake
+    find_package(Au REQUIRED)
+
+    # CMake 3.25 and newer:
+    set_target_properties(Au::au PROPERTIES SYSTEM OFF)
+
+    # CMake 3.23 and 3.24 (deprecated in 3.25):
+    # set_target_properties(Au::au PROPERTIES IMPORTED_NO_SYSTEM TRUE)
+    ```
+
+    Alternatively, you can set
+    [`NO_SYSTEM_FROM_IMPORTED`](https://cmake.org/cmake/help/latest/prop_tgt/NO_SYSTEM_FROM_IMPORTED.html)
+    on your own target (or as a directory property).  This works on much older CMake versions, but
+    note that it applies to _all_ of that target's imported dependencies, not just Au.
+
+    We've verified this for a `find_package` installation.  For conan and vcpkg, we know the
+    underlying cause is the same CMake default, but each has its own machinery for generating package
+    config files, so it's possible that they mark the include directories as "system" in a way that
+    these properties don't override.  If you find that to be the case, please let us know!
+
+=== "Single file"
+    **You're in control.**  Add the folder holding `au.hh` with `-I` (or `/I` on MSVC), not
+    `-isystem` (or `/external:I`).  If you keep it in, say, `third_party/`, and your build treats
+    that whole folder as external, consider putting Au somewhere else.
+
+!!! note "Help us keep this advice accurate"
+    We've tested this guidance where we can.  The bazel and CMake instructions above were checked by
+    building a real client project against Au, with both gcc and clang.  Other parts rest on
+    documented behavior that we can't easily exercise: notably MSVC's `/external:I`, and the conan and
+    vcpkg packages, which are [community maintained](#package-managers-conan-vcpkg).  Build systems
+    also change their defaults over time, and this page won't always notice.
+
+    So treat this section as our best current understanding rather than a guarantee.  If you follow it
+    and Au still adds or subtracts a warning relative to the equivalent raw-number code, please [file
+    an issue](https://github.com/aurora-opensource/au/issues/new).  It's either a bug in Au, or a gap
+    in these instructions --- and we want to fix both.
+
 ## Installation instructions
 
 Here are the instructions for each installation method we support.

--- a/docs/install.md
+++ b/docs/install.md
@@ -88,6 +88,18 @@ from inside the library. See the [required build
 configuration](./discussion/concepts/compiler_warnings.md#required-build-configuration) for the full
 explanation.
 
+!!! note "Help us keep this advice accurate"
+    We've tested the guidance below where we can.  The bazel and CMake instructions were checked by
+    building a real client project against Au, with both gcc and clang.  Other parts rest on
+    documented behavior that we can't easily exercise: notably MSVC's `/external:I`, and the conan and
+    vcpkg packages, which are [community maintained](#package-managers-conan-vcpkg).  Build systems
+    also change their defaults over time, and this page won't always notice.
+
+    So treat it as our best current understanding rather than a guarantee.  If you follow it and Au
+    still adds or subtracts a warning relative to the equivalent raw-number code, please [file an
+    issue](https://github.com/aurora-opensource/au/issues/new).  It's either a bug in Au, or a gap in
+    these instructions --- and we want to fix both.
+
 Here's what to check for each installation method.
 
 === "bazel"
@@ -167,17 +179,6 @@ Here's what to check for each installation method.
     `-isystem` (or `/external:I`).  If you keep it in, say, `third_party/`, and your build treats
     that whole folder as external, consider putting Au somewhere else.
 
-!!! note "Help us keep this advice accurate"
-    We've tested this guidance where we can.  The bazel and CMake instructions above were checked by
-    building a real client project against Au, with both gcc and clang.  Other parts rest on
-    documented behavior that we can't easily exercise: notably MSVC's `/external:I`, and the conan and
-    vcpkg packages, which are [community maintained](#package-managers-conan-vcpkg).  Build systems
-    also change their defaults over time, and this page won't always notice.
-
-    So treat this section as our best current understanding rather than a guarantee.  If you follow it
-    and Au still adds or subtracts a warning relative to the equivalent raw-number code, please [file
-    an issue](https://github.com/aurora-opensource/au/issues/new).  It's either a bug in Au, or a gap
-    in these instructions --- and we want to fix both.
 
 ## Installation instructions
 

--- a/docs/tutorial/103-unit-conversions.md
+++ b/docs/tutorial/103-unit-conversions.md
@@ -392,5 +392,9 @@ Check out the [Au 103: Unit Conversions Exercise](./exercise/103-unit-conversion
     - For example, if you have an API which takes `QuantityD<Radians>`, you can pass `degrees(45)`
       directly to it.
 
+    - Implicit conversions use **implicit conversions of the underlying numbers**, so your
+      `-Wconversion` flags apply to quantities just as they would to raw numbers.  See our [compiler
+      warnings](../discussion/concepts/compiler_warnings.md) discussion doc for more details.
+
 [threshold]: https://github.com/aurora-opensource/au/blob/dbd79b2/au/conversion_policy.hh#L27-L28
 [duration]: https://en.cppreference.com/w/cpp/chrono/duration/duration


### PR DESCRIPTION
The centerpiece is a brand-new discussion doc that explains the policy
that arose out of #528: Au must neither _add_ nor _subtract_ warnings.
We explain what these mean.

The next most important piece is to update the installation instructions
to clearly tell users how to configure Au, and how to check whether they
got it right.  These instructions link to the discussion doc above.

Finally, we update a few other docs as appropriate.  In particular, our
conversion risk doc was both a little bit out of date (missing #528's
addition of implicit conversions), and also not worded as well as it
could have been (we fixed both).  We also updated the truncation doc and
the 103 tutorial.

Fixes #528.