### PR TITLE
Improve Constant/UDL composability

### DIFF
--- a/au/BUILD.bazel
+++ b/au/BUILD.bazel
@@ -349,6 +349,7 @@ cc_library(
         ":fwd",
         ":quantity",
         ":unit_of_measure",
+        ":unit_symbol",
         ":wrapper_operations",
     ],
 )
@@ -362,6 +363,7 @@ cc_test(
         ":constant",
         ":testing",
         ":units",
+        ":units_literals",
         "@googletest//:gtest_main",
     ],
 )
@@ -576,6 +578,7 @@ cc_library(
     name = "prefix",
     hdrs = ["prefix.hh"],
     deps = [
+        ":constant",
         ":fwd",
         ":quantity",
         ":quantity_point",
@@ -589,6 +592,7 @@ cc_test(
     size = "small",
     srcs = ["prefix_test.cc"],
     deps = [
+        ":constant",
         ":prefix",
         ":testing",
         "@googletest//:gtest_main",

--- a/au/constant.hh
+++ b/au/constant.hh
@@ -23,6 +23,7 @@
 #include "au/quantity.hh"
 #include "au/stdx/type_traits.hh"
 #include "au/unit_of_measure.hh"
+#include "au/unit_symbol.hh"
 #include "au/wrapper_operations.hh"
 
 namespace au {
@@ -45,6 +46,7 @@ struct Constant : detail::MakesQuantityFromNumber<Constant, Unit>,
                   detail::ComposesWith<Constant, Unit, Constant, Constant>,
                   detail::ComposesWith<Constant, Unit, QuantityMaker, QuantityMaker>,
                   detail::ComposesWith<Constant, Unit, SingularNameFor, SingularNameFor>,
+                  detail::ComposesWith<Constant, Unit, SymbolFor, Constant>,
                   detail::SupportsRationalPowers<Constant, Unit>,
                   detail::CanScaleByMagnitude<Constant, Unit> {
     // Convert this constant to a Quantity of the given rep.

--- a/au/constant_test.cc
+++ b/au/constant_test.cc
@@ -22,9 +22,12 @@
 #include "au/units/bytes.hh"
 #include "au/units/degrees.hh"
 #include "au/units/feet.hh"
+#include "au/units/hours.hh"
 #include "au/units/inches.hh"
 #include "au/units/joules.hh"
+#include "au/units/literals/miles.hh"
 #include "au/units/meters.hh"
+#include "au/units/miles.hh"
 #include "au/units/newtons.hh"
 #include "au/units/radians.hh"
 #include "au/units/revolutions.hh"
@@ -287,6 +290,39 @@ TEST(Constant, ChangesUnitsForSingularNameWhenPreMultiplying) {
 
 TEST(Constant, ChangesUnitsForSingularNameWhenDividedIntoIt) {
     StaticAssertTypeEq<decltype(c / meter), SingularNameFor<decltype(SpeedOfLight{} / Meters{})>>();
+}
+
+TEST(Constant, ChangesUnitsForSymbolWhenPostMultiplying) {
+    constexpr auto N = symbol_for(newtons);
+    StaticAssertTypeEq<decltype(N * c), Constant<decltype(Newtons{} * SpeedOfLight{})>>();
+}
+
+TEST(Constant, ChangesUnitsForSymbolWhenDividingIt) {
+    constexpr auto J = symbol_for(joules);
+    StaticAssertTypeEq<decltype(J / c), Constant<decltype(Joules{} / SpeedOfLight{})>>();
+}
+
+TEST(Constant, ChangesUnitsForSymbolWhenPreMultiplying) {
+    constexpr auto s = symbol_for(seconds);
+    StaticAssertTypeEq<decltype(c * s), Constant<decltype(SpeedOfLight{} * Seconds{})>>();
+}
+
+TEST(Constant, ChangesUnitsForSymbolWhenDividedIntoIt) {
+    constexpr auto m = symbol_for(meters);
+    StaticAssertTypeEq<decltype(c / m), Constant<decltype(SpeedOfLight{} / Meters{})>>();
+}
+
+TEST(Constant, ComposingUnitLiteralWithSymbolActsAsCompoundUnitLiteral) {
+    // Au provides unit literals for named units only, so there is no `_mph`.  Dividing a unit
+    // literal by a unit symbol gets the same effect.
+    using namespace ::au::au_literals;
+    using symbols::h;
+
+    constexpr auto speed_limit = 55_mi / h;
+
+    StaticAssertTypeEq<decltype(speed_limit),
+                       const Constant<decltype(Miles{} * mag<55>() / Hours{})>>();
+    EXPECT_THAT(speed_limit.as<double>(miles / hour), SameTypeAndValue((miles / hour)(55.0)));
 }
 
 TEST(Constant, ComposesViaMultiplication) {

--- a/au/prefix.hh
+++ b/au/prefix.hh
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "au/config.hh"
+#include "au/constant.hh"
 #include "au/fwd.hh"
 #include "au/quantity.hh"
 #include "au/quantity_point.hh"
@@ -74,10 +75,18 @@ constexpr auto make_prefixed_unit_label(const StringConstant<N> &prefix, U) {
 
 template <template <class U> class Prefix>
 struct PrefixApplier {
-    // Applying a Prefix to a Unit instance, creates an instance of the Prefixed Unit.
-    template <typename U>
+    // Applying a Prefix to a Unit instance, creates an instance of the Prefixed Unit.  (We
+    // constrain this, so that unhandled types fail here rather than at their first use.)
+    template <typename U, typename = std::enable_if_t<IsUnit<U>::value>>
     AU_DEVICE_FUNC constexpr auto operator()(U) const {
         return Prefix<U>{};
+    }
+
+    // Applying a Prefix to a Constant instance, prefixes the unit under its scale factor.
+    template <typename U>
+    AU_DEVICE_FUNC constexpr auto operator()(Constant<U>) const {
+        return Constant<
+            ComputeScaledUnit<Prefix<detail::UnscaledUnit<U>>, detail::UnitCoefficient<U>>>{};
     }
 
     // Applying a Prefix to a QuantityMaker instance, creates a maker for the Prefixed Unit.

--- a/au/prefix_test.cc
+++ b/au/prefix_test.cc
@@ -14,6 +14,7 @@
 
 #include "au/prefix.hh"
 
+#include "au/constant.hh"
 #include "au/testing.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -21,6 +22,8 @@
 namespace au {
 
 using ::testing::Eq;
+using ::testing::IsFalse;
+using ::testing::IsTrue;
 using ::testing::StaticAssertTypeEq;
 
 struct Bytes : UnitImpl<Information> {};
@@ -67,6 +70,39 @@ TEST(PrefixApplier, ConvertsSingularNameForToCorrespondingPrefixedType) {
 TEST(PrefixApplier, ConvertsSymbolForToCorrespondingPrefixedType) {
     constexpr auto X = symbol_for(XeroxedBytes{});
     StaticAssertTypeEq<decltype(kibi(X)), SymbolFor<Kibi<XeroxedBytes>>>();
+}
+
+// Detector for "can we apply a prefix to this at all?", so we can check that the unit overload
+// declines types that are not units, instead of silently producing an ill-formed prefixed type.
+template <typename T>
+using PrefixApplicationResult = decltype(kilo(std::declval<T>()));
+
+TEST(PrefixApplier, AppliesPrefixToUnscaledUnitUnderlyingConstant) {
+    constexpr auto two_bytes = make_constant(Bytes{} * mag<2>());
+    StaticAssertTypeEq<decltype(kilo(two_bytes)), Constant<decltype(Kilo<Bytes>{} * mag<2>())>>();
+    EXPECT_THAT(unit_ratio(associated_unit(kilo(two_bytes)), Bytes{}), Eq(mag<2'000>()));
+}
+
+TEST(PrefixApplier, AppliesPrefixDirectlyToUnitOfConstantWithNoScaleFactor) {
+    StaticAssertTypeEq<decltype(kilo(make_constant(Bytes{}))), Constant<Kilo<Bytes>>>();
+}
+
+TEST(PrefixApplier, PrefixedConstantLabelsPrefixTheUnitRatherThanTheScaleFactor) {
+    expect_label<decltype(associated_unit(kilo(make_constant(Inches{} * mag<2>()))))>("[2 kin]");
+}
+
+TEST(PrefixApplier, PrefixedConstantEquivalentToConstantWithPrefixFoldedIntoScaleFactor) {
+    // These are deliberately _different types_: the former prefixes the unit, while the latter
+    // scales it.  They must still be equal.
+    EXPECT_THAT(kilo(make_constant(Inches{} * mag<2>())),
+                Eq(make_constant(Inches{} * mag<2'000>())));
+}
+
+TEST(PrefixApplier, DeclinesTypesThatAreNotUnits) {
+    EXPECT_THAT((stdx::experimental::is_detected<PrefixApplicationResult, Inches>{}), IsTrue());
+    EXPECT_THAT((stdx::experimental::is_detected<PrefixApplicationResult, Magnitude<>>{}),
+                IsFalse());
+    EXPECT_THAT((stdx::experimental::is_detected<PrefixApplicationResult, int>{}), IsFalse());
 }
 
 TEST(SiPrefixes, HaveCorrectAbsoluteValues) {

--- a/docs/reference/constant.md
+++ b/docs/reference/constant.md
@@ -202,6 +202,51 @@ constexpr auto dt = 1.28e-4_s;
 The literals live in the `::au::au_literals` namespace, alongside `_mag`, so a single `using
 namespace ::au::au_literals;` brings in both.
 
+#### Prefixed unit literals {#prefixed-unit-literals}
+
+Unit literals exist for _named_ units only, so there is no `_kg`.  To get a prefixed unit literal,
+apply the [prefix applier](./prefix.md#constant) to the literal:
+
+```cpp
+constexpr auto m_e = kilo(9.1093837015e-31_g);  // The electron mass, in kg.
+```
+
+`kilo(1.234_g)` is a `Constant` for $1234\,\text{g}$, and its label is `[(617 / 500) kg]`: the
+prefix goes on the unit, and the digits you wrote stay put.  Every prefix applier works this way, so
+`micro(2.5_m)`, `mebi(3_B)`, and so on are all available.
+
+??? info "Why this unusual syntax?"
+    Grammatically, `kilo(1.234_g)` reads strangely, compared to `1.234_kg`.  We'd certainly much
+    rather write the latter!  However, C++ provides no convenient way to programmatically derive one
+    literal, such as `_kg`, from another, such as `_g`.  This means that supporting `_kg` (along
+    with every other prefixed unit) would create a tremendous implementation burden.  Thus, we stick
+    to defining literals for named units only.
+
+    And yet, literals have one key advantage that we can't get any other way: they support a highly
+    flexible, _human readable_ numeric syntax, which produces _exact_ results.  It's a huge
+    readability benefit to be able to define our physical constants using exactly the same digits,
+    same power of 10, and same units as the official definitions.  Therefore, we _must_ have _some_
+    way to (effectively) "apply a prefix to a literal".  The closest we could come up with was to
+    apply the prefix _to the result_ of the literal.  The syntax may be odd, but it is flexible, and
+    it is unambiguous.
+
+    Note, by contrast, that [unit symbols](./unit.md#prefixed-symbols) do not have this
+    restriction.  They _do_ compose naturally, so it's easy to create a `kg` _symbol_ on the fly.
+
+#### Compound unit literals {#compound-unit-literals}
+
+Unit literals also exist for _single_ units only, so there is no `_mph`.  To get a compound unit
+literal, divide or multiply by a [unit symbol](./unit.md#symbols):
+
+```cpp
+using symbols::h;
+
+constexpr auto speed_limit = 55_mi / h;  // A `Constant` for 55 miles per hour.
+```
+
+Composing a unit literal with a symbol produces another `Constant`, so the result behaves exactly
+like any other unit literal: it is applied symbolically, with no risk of rounding or overflow.
+
 ## `Constant` and unit slots
 
 `Constant` can be passed to any API that takes a [unit slot](../discussion/idioms/unit-slots.md).

--- a/docs/reference/prefix.md
+++ b/docs/reference/prefix.md
@@ -43,9 +43,26 @@ applier can be used.
 | `QuantityPointMaker` | `meters_pt` | `centi(meters_pt)` | `centi(meters_pt)(1.5)` |
 | `SingularNameFor` | `meter` | `centi(meter)` | `curvature.in(radians / centi(meter))` |
 | `SymbolFor` | `m` | `centi(m)` | `constexpr auto cm = centi(m); 170 * cm` |
+| [`Constant`](./constant.md) | `1.7_m` | `centi(1.7_m)` | `height.as<double>(centi(1.7_m))` |
 
 Note again that every output here is the same kind of thing as the input.  So, `centi(meters_pt)` is
 a `QuantityPointMaker`, and `centi(meters_pt)(1.5)` creates a `QuantityPoint` of $1.5\,\text{cm}$.
+
+Anything that is _not_ one of these kinds is rejected at the call site.  (Otherwise, the unit
+instance overload would swallow it and produce a prefixed type that is only ill-formed when you
+first use it, in an error message that mentions neither the prefix nor your code.)
+
+### Applying to a `Constant` {#constant}
+
+A [`Constant`](./constant.md) carries a value as well as a unit, so applying a prefix to one scales
+that value.  `kilo(1.234_g)` is a `Constant` for $1234\,\text{g}$.  This is the main way to apply
+a prefix to a [unit literal](./constant.md#unit-literals): see [prefixed unit
+literals](./constant.md#prefixed-unit-literals).
+
+The prefix goes on the _unit_, not on the value.  A unit literal such as `1.234_g` is grams
+_scaled_ by $1.234$, and we prefix the underlying grams: `kilo(1.234_g)` is labeled
+`[(617 / 500) kg]`, not `k[(617 / 500) g]`.  (The scale factor prints as a fraction because
+[magnitudes](./magnitude.md) are exact; that is independent of the prefix.)
 
 ## List of supported prefixes
 


### PR DESCRIPTION
`Constant`-producing UDLs have some striking advantages: in particular,
you can write the number in a wide variety of formats (including
scientific notation), and it will _always_ parse as an _exact_ value!
Their main disadvantage is that they don't compose the way unit symbols
do.

I used to think we could just live with this, until I started working on
the atomic units example.  It involves several physical constants
spelled out exactly, which can be very large or small in regular SI
units.  The old school Au way to tackle this would be to shift the
denominator and compensate with the power of 10: so `1.234e-5 kg` would
become `Kilo<Grams>{} * mag<1234>() / pow<8>(mag<10>())`.  Well, it sure
would be a lot nicer if we could just write `1.234e-5_kg`!

While we technically _could_ provide `_kg`, the key problem is that it
wouldn't scale at all.  So we do the next best thing: support applying a
prefix to the _result_ of the UDL.  We end up with `kilo(1.234e-5_g)`,
which may look a little weird, but it _is_ totally unambiguous, and it
preserves the core features that we most want!  We also made it so that
the prefix attaches to the "unscaled" unit symbol, which makes the
result exactly the same as if we had enabled `1.234e-5_kg`.

While we're at it, I also turned on interop between `Constant` and
`SymbolFor`.  The only reason they didn't already interop was that I
didn't know which one should "win": should the result be a `Constant`,
or a `SymbolFor`?  I took my guidance from the `55_mi / h` example: this
is our workaround for not being able to compose a `55_mi_per_h` UDL, so
we want this to be a `Constant`.

Along the way, we tightened up the prefix applier so the "catch all"
overload, intended for units, applies to actual units only.  Without
this, people _could_ write `kilo(1.234e-5_g)` before, but it would fail
in a nasty way!

Includes doc updates.  Helps #529 and #660 because it unblocks the
atomic units example.