### PR TITLE
Refer to `UnitT` to improve compiler errors

### DIFF
--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -862,7 +862,7 @@ struct QuantityMaker {
 
     // lvalue: copy. (See `make_quantity` above.)
     template <typename T, typename Rep = detail::NormalizeRep<std::decay_t<T>>>
-    AU_DEVICE_FUNC constexpr Quantity<Unit, Rep> operator()(const T &value) const {
+    AU_DEVICE_FUNC constexpr Quantity<UnitT, Rep> operator()(const T &value) const {
         return Quantity<Unit, Rep>{value};
     }
 
@@ -870,7 +870,7 @@ struct QuantityMaker {
     template <typename T,
               typename Rep = detail::NormalizeRep<std::decay_t<T>>,
               typename = std::enable_if_t<!std::is_lvalue_reference<T>::value>>
-    AU_DEVICE_FUNC constexpr Quantity<Unit, Rep> operator()(T &&value) const {
+    AU_DEVICE_FUNC constexpr Quantity<UnitT, Rep> operator()(T &&value) const {
         return Quantity<Unit, Rep>{std::move(value)};
     }
 


### PR DESCRIPTION
This is exactly equivalent to `Unit`, but it has a big impact on
compiler errors.  Consider a function like this, which takes a duration
quantity:

```cpp
take_seconds(au::meters(5.0));
```

Before this, the compiler error begins:

```
no known conversion from 'Quantity<Unit, [...]>'
```

After, it begins:

```
no known conversion from 'Quantity<au::Meters, [...]>'
```

Pretty good bang for the buck on this change.