### PR TITLE
Respect guarded includes in single-file script

### DIFF
--- a/tools/bin/make-single-file
+++ b/tools/bin/make-single-file
@@ -210,6 +210,7 @@ class SourceFile:
         self.lines = []
 
         in_copyright_header = False
+        preproc_depth = 0
         with open(filename) as f:
             was_last_line_blank = False
             for line in f:
@@ -232,16 +233,25 @@ class SourceFile:
                         continue
                     was_last_line_blank = True
 
+                # Track `#if`/`#endif` nesting depth, so that we can tell
+                # whether an `#include` is guarded.
+                if line.startswith("#if"):
+                    preproc_depth += 1
+                elif line.startswith("#endif"):
+                    preproc_depth -= 1
+
                 # Put this line where it belongs.  If it's an `#include`, sort
                 # it with either the project-specific collection
                 # ("graph_includes"), or the global collection.  Otherwise,
-                # just add it to the list of content lines.
+                # just add it to the list of content lines.  Note that a
+                # _guarded_ global include (i.e., one inside of an `#if` block)
+                # must stay exactly where it is, because hoisting it to the top
+                # of the file would strip away its guard.
                 target = include_target(line)
-                if target:
-                    if target.startswith("au"):
-                        self.graph_includes.append(target)
-                    else:
-                        self.global_includes.append(line.rstrip())
+                if target and target.startswith("au"):
+                    self.graph_includes.append(target)
+                elif target and preproc_depth == 0:
+                    self.global_includes.append(line.rstrip())
                 else:
                     self.lines.append(line.rstrip())
 

--- a/tools/bin/make-single-file
+++ b/tools/bin/make-single-file
@@ -237,7 +237,7 @@ class SourceFile:
                 # whether an `#include` is guarded.
                 if line.startswith("#if"):
                     preproc_depth += 1
-                elif line.startswith("#endif"):
+                if line.startswith("#endif"):
                     preproc_depth -= 1
 
                 # Put this line where it belongs.  If it's an `#include`, sort


### PR DESCRIPTION
Consider something like this, from `au/operators.hh`:

```cpp
#if defined(__cpp_impl_three_way_comparison) && __cpp_impl_three_way_comparison >= 201907L
#include <compare>
#endif
```

Right now, the single-file script pulls out the include line
unconditionally, which causes a build error on compilers that don't know
about that file.

This change stops us from pulling out those includes.  They will
naturally occur in their current home (i.e., at the top of a file's
section, somewhere in the middle of the single-file include).  This
unblocks us from checking GCC 5.3 for the Au 0.6.0 release.