### PR TITLE
Update Alternatives guidance

### DIFF
--- a/docs/alternatives/index.md
+++ b/docs/alternatives/index.md
@@ -16,6 +16,8 @@ to the mature and widely available C++14 standard. Key features include:
 - Highly composable "quantity maker" APIs make it easy to both compose new units, and apply unit
   prefixes, on the fly.
 - Human-readable and concise compiler errors, via strong typenames for units.
+- Flexible `Constant` types with perfect conversion policies.
+- Abbreviated construction via both [unit symbols] and [user-defined literals].
 - The `Zero` type: novel, fluent handling of construction, comparison, and sign handling for
   quantities.
 - Ease of migration (both to and from Au): with minimal setup, we support bidirectional implicit
@@ -38,13 +40,22 @@ indicate which version we considered, and say a few words about why we included 
 - [**Boost Units**](https://www.boost.org/doc/libs/1_82_0/doc/html/boost_units.html) (version:
   1.2, from Boost version 1.89.0)
     - One of the longest-standing C++ unit libraries, and the most prominent pre-C++14 option.
-- [**nholthaus/units**](https://github.com/nholthaus/units) (version: 2.3.4)
+- [**nholthaus/units**](https://github.com/nholthaus/units) (versions: 2.3.5, and 3.6.1)
     - Kicked off the revolution in modern (that is, post-C++11 watershed) units libraries.
     - Its laser-sharp focus on accessibility and low friction have made it probably the most widely
       used C++ units library to date.
+    - We assess the 2.x and 3.x lines in **separate columns**, because they are effectively
+      different libraries.
+        - 3.x requires C++23 (2.x targeted C++14), renames the core vocabulary, and closes a large
+          number of long-standing gaps.
+        - 2.x has been archived as of August 2026 (branch `archive/2.3.5`), but we retain it because
+          it is very commonly used in the wild.
+    - If you are choosing today, the deciding question is usually simply whether you can meet the
+      C++23 requirement.  If you can't, the 2.x column is the one that applies to you --- and it now
+      describes an unmaintained library.
 - [**bernedom/SI**](https://github.com/bernedom/SI) (version: 2.5.4)
     - A newer, C++17-compatible offering with a large number of GitHub stars.
-- [**mp-units**](https://github.com/mpusz/mp-units) (version: 2.4.0)
+- [**mp-units**](https://github.com/mpusz/mp-units) (version: 2.5.0)
     - A library designed to take full advantage of ultra-modern (that is, post-C++20 watershed)
       features, such as concepts and non-template type parameters (NTTPs).
     - mp-units is leading the efforts towards a standard C++ units library, both by field testing
@@ -97,15 +108,27 @@ details.criterion > summary::before {
 These are the first criteria to consider.  They will tell you whether you can even use the library
 at all, and if so, how hard it will be to obtain.
 
-<table>
-    <tr>
-        <th></th>
-        <th>Boost</th>
-        <th>nholthaus</th>
-        <th>bernedom/SI</th>
-        <th>mp-units</th>
-        <th class="highlight">Au</th>
-    </tr>
+<table class="matrix">
+    <thead>
+        <tr>
+            <th></th>
+            <th></th>
+            <th colspan="2">nholthaus</th>
+            <th></th>
+            <th></th>
+            <th class="highlight"></th>
+        </tr>
+        <tr>
+            <th></th>
+            <th>Boost</th>
+            <th>2.x</th>
+            <th class="nh3">3.x</th>
+            <th>bernedom/SI</th>
+            <th>mp-units</th>
+            <th class="highlight">Au</th>
+        </tr>
+    </thead>
+    <tbody>
     <tr>
         <td>
             <details class="criterion">
@@ -115,6 +138,7 @@ at all, and if so, how hard it will be to obtain.
         </td>
         <td class="best">C++98</td>
         <td class="good">C++14</td>
+        <td class="poor nh3">C++23</td>
         <td class="fair">C++17</td>
         <td class="poor">C++20</td>
         <td class="good">C++14</td>
@@ -124,10 +148,30 @@ at all, and if so, how hard it will be to obtain.
             <details class="criterion">
                 <summary>Ease of Acquisition</summary>
                 <p>Ease of including this library in projects using a wide variety of build environments</p>
+                <p>Examples of things we look for:</p>
+                <ol>
+                    <li>Can you vendor it <i>without</i> a package manager?</li>
+                    <li>Does it support your build system natively (CMake, bazel)?</li>
+                    <li>Is it in the package managers you already use (conan, vcpkg)?</li>
+                    <li>Is there a single-header option?</li>
+                </ol>
             </details>
         </td>
         <td class="fair">Part of boost</td>
-        <td class="good">Single, self-contained header</td>
+        <td class="good">
+            <ul>
+                <li class="check">Single, self-contained header</li>
+                <li class="check">On conan and vcpkg</li>
+            </ul>
+        </td>
+        <td class="fair nh3">
+            <ul>
+                <li class="check">Header-only; full CMake support</li>
+                <li class="check">Debian, RPM, tarball, and Ubuntu PPA artifacts</li>
+                <li>Available on vcpkg</li>
+                <li class="x">No more single header option</li>
+            </ul>
+        </td>
         <td class="fair">Available on conan</td>
         <td class="fair">Available on conan and vcpkg</td>
         <td class="best">
@@ -143,6 +187,7 @@ at all, and if so, how hard it will be to obtain.
             </ul>
         </td>
     </tr>
+    </tbody>
 </table>
 
 !!! note
@@ -153,6 +198,11 @@ at all, and if so, how hard it will be to obtain.
     requirement, and its dependence on a package manager to make the installation easy.  However, if
     your project is _already_ compatible with C++20, and _already_ uses conan, then these "low"
     ratings would be completely irrelevant for you.
+
+    The same goes for nholthaus 3.x, whose C++23 requirement is the steepest here: if you're already
+    on C++23, that rating simply doesn't apply to you.  Note, though, that this one cuts both ways.
+    Because the 2.x line is now archived, a project that _can't_ move to C++23 no longer has a
+    maintained version of this library to choose.
 
 ### Generic developer experience
 
@@ -167,15 +217,31 @@ experience.
 
 These costs purchase significant benefits, but we still want them to be as small as possible.
 
-<table>
-    <tr>
-        <th></th>
-        <th>Boost</th>
-        <th>nholthaus</th>
-        <th>bernedom/SI</th>
-        <th>mp-units</th>
-        <th class="highlight">Au</th>
-    </tr>
+!!! tip
+    Note that Au is the **only** units library that provides _both_ readable compiler errors _and_
+    fast compilation times!
+
+<table class="matrix">
+    <thead>
+        <tr>
+            <th></th>
+            <th></th>
+            <th colspan="2">nholthaus</th>
+            <th></th>
+            <th></th>
+            <th class="highlight"></th>
+        </tr>
+        <tr>
+            <th></th>
+            <th>Boost</th>
+            <th>2.x</th>
+            <th class="nh3">3.x</th>
+            <th>bernedom/SI</th>
+            <th>mp-units</th>
+            <th class="highlight">Au</th>
+        </tr>
+    </thead>
+    <tbody>
     <tr>
         <td>
             <details class="criterion">
@@ -190,12 +256,30 @@ These costs purchase significant benefits, but we still want them to be as small
         </td>
         <td class="good">Comparable to Au; sometimes less, sometimes more</td>
         <td class="poor">Very slow (adds multiple seconds), but can be <i>greatly</i> improved by removing I/O support and most units</td>
+        <td class="poor nh3">
+            <ul>
+                <li class="x">
+                    Default <code>&lt;units.h&gt;</code> is the most expensive include we measured
+                    (~4x the 2.x penalty), and dropping <code>&lt;iostream&gt;</code> no longer
+                    helps
+                </li>
+                <li class="check">
+                    <a href="https://github.com/nholthaus/units/blob/main/docs/how-to/subset-headers-compile-time.md">Per-dimension
+                    headers</a> cut that ~4x, to roughly the 2.x penalty
+                </li>
+            </ul>
+        </td>
         <td class="good">Overall speed champ: roughly 2/3 the penalty of Au and Boost</td>
         <td class="poor">
             <ul>
                 <li class="x">Default config 2 to 3 times as expensive as nholthaus</li>
                 <li class="x"><a href="https://mpusz.github.io/mp-units/latest/users_guide/systems/si/#lean-umbrella-mp-unitssystemssicoreh">Lean includes</a> brings it on par with nholthaus, though lack of symbols hurts code quality</li>
                 <li>C++20 modules should mitigate all concerns</li>
+                <li>
+                    Substantial compile-time work is on main, slated for 2.6.0, including an
+                    "essential" symbols header that should blunt the tradeoff above --- worth
+                    re-measuring once it ships
+                </li>
             </ul>
         </td>
         <td class="good">
@@ -226,17 +310,17 @@ These costs purchase significant benefits, but we still want them to be as small
             </a>
         </td>
         <td class="fair">Positional dimensions</td>
-        <td class="fair">Alias for unit template</td>
-        <td class="good">
+        <td class="good nh3">
             <ul>
-                <li class="check">Pioneered strong typedefs for units</li>
-                <li class="check"><a
-                href="https://mpusz.github.io/mp-units/2.0/users_guide/framework_basics/interface_introduction/?h=expression+tem#expression-templates">Expression
-                templates</a> produce very readable errors
+                <li class="check">
+                    Named unit types in errors (<code>meters&lt;double&gt;</code>), not 2.x's
+                    positional <code>std::ratio</code> lists
                 </li>
             </ul>
         </td>
-        <td class="good">
+        <td class="fair">Alias for unit template</td>
+        <td class="good">Pioneered strong typedefs for units</td>
+        <td class="best">
             <ul>
                 <li class="check">Strong unit typenames appear in errors</li>
                 <li class="check">Short namespace minimizes clutter</li>
@@ -248,6 +332,7 @@ These costs purchase significant benefits, but we still want them to be as small
             </ul>
         </td>
     </tr>
+    </tbody>
 </table>
 
 ### Ongoing maintenance
@@ -263,15 +348,27 @@ the code, depriving you of bugfixes and improvements.  The ideal library would b
 actively maintained, but that respects its production users and makes upgrades as smooth and
 incremental as possible.
 
-<table>
-    <tr>
-        <th></th>
-        <th>Boost</th>
-        <th>nholthaus</th>
-        <th>bernedom/SI</th>
-        <th>mp-units</th>
-        <th class="highlight">Au</th>
-    </tr>
+<table class="matrix">
+    <thead>
+        <tr>
+            <th></th>
+            <th></th>
+            <th colspan="2">nholthaus</th>
+            <th></th>
+            <th></th>
+            <th class="highlight"></th>
+        </tr>
+        <tr>
+            <th></th>
+            <th>Boost</th>
+            <th>2.x</th>
+            <th class="nh3">3.x</th>
+            <th>bernedom/SI</th>
+            <th>mp-units</th>
+            <th class="highlight">Au</th>
+        </tr>
+    </thead>
+    <tbody>
     <tr>
         <td>
             <details class="criterion">
@@ -296,10 +393,23 @@ incremental as possible.
                 </li>
             </ul>
         </td>
-        <td class="fair">
+        <td class="poor">
+            <p>No longer maintained.</p>
             <ul>
-                <li class="check">Still putting out feature releases on 3.x branch as of 2025</li>
-                <li class="x">Many open issues; some unresponded for years</li>
+                <li class="x">
+                    Last release September 2025, archived as of August 2026 (branch
+                    <code>archive/2.3.5</code>); superseded by 3.x
+                </li>
+            </ul>
+        </td>
+        <td class="good nh3">
+            <ul>
+                <li class="check">The project's default branch, with frequent releases</li>
+                <li class="check">
+                    Backlog cleared: all pre-existing <a
+                    href="https://github.com/nholthaus/units/issues">issues</a> closed in August
+                    2026
+                </li>
             </ul>
         </td>
         <td class="fair">
@@ -347,10 +457,26 @@ incremental as possible.
         <td class="invalid"><p><b>Not Applicable:</b><br>No new releases to judge</p></td>
         <td class="good">
             <ul>
-                <li class="check">Updates within 2.x family usually smooth</li>
-                <li class="x">2.x to 3.x <a
-                    href="https://github.com/nholthaus/units/issues/313">expected</a> to require
-                    monolithic change, but 2.x still receives backports
+                <li class="check">Updates within the 2.x family were usually smooth</li>
+                <li class="x">
+                    Now that 2.x is archived, the only upgrade left is the monolithic <a
+                    href="https://github.com/nholthaus/units/issues/313">move to 3.x</a>
+                </li>
+            </ul>
+        </td>
+        <td class="fair nh3">
+            <ul>
+                <li class="check">
+                    Thorough <a
+                    href="https://github.com/nholthaus/units/blob/main/docs/meta/migrate-v2-to-v3.md">migration
+                    guide</a>
+                </li>
+                <li class="x">
+                    2.x to 3.x is monolithic, with no syntax that works in both versions
+                </li>
+                <li class="x">
+                    Breaking changes ship in <i>patch</i> releases (e.g., 3.4.4 changed the
+                    <code>cosh</code>/<code>sinh</code>/<code>tanh</code> signatures)
                 </li>
             </ul>
         </td>
@@ -382,6 +508,91 @@ incremental as possible.
             </ul>
         </td>
     </tr>
+    </tbody>
+</table>
+
+### Known best practices violations
+
+Users have a right to expect that a units library follows standard best practices: both for C++
+specifically, and for programming more generally.  Any violations of this expectation should be
+catalogued explicitly, so that users can be aware of them.  This final generic category gives us
+a place to do that.
+
+Note that the expected state for every library is an empty state: either grey ("N/A") for libraries
+we haven't assessed in detail, or blue ("good") for libraries we're more familiar with.  Any library
+with a non-empty cell can improve their rating by fixing the issues.
+
+!!! warning
+    A blue cell means "we don't know of any", **not** "we audited this library and found none".  We
+    are not in a position to audit libraries in depth for best practices.  Any issues we _do_ find
+    are generally discovered incidentally, while researching other rows.
+
+    Read an empty cell as absence of evidence, not evidence of absence.
+
+<table class="matrix">
+    <thead>
+        <tr>
+            <th></th>
+            <th></th>
+            <th colspan="2">nholthaus</th>
+            <th></th>
+            <th></th>
+            <th class="highlight"></th>
+        </tr>
+        <tr>
+            <th></th>
+            <th>Boost</th>
+            <th>2.x</th>
+            <th class="nh3">3.x</th>
+            <th>bernedom/SI</th>
+            <th>mp-units</th>
+            <th class="highlight">Au</th>
+        </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>
+            <details class="criterion">
+                <summary>Known best practice violations</summary>
+                <p>
+                    Departures from the rules C++ programs rely on: operators that don't
+                    mean what the language says they mean, undefined behavior, etc.
+                </p>
+            </details>
+        </td>
+        <td class="na"></td>
+        <td class="fair">
+            <ul>
+                <li class="x">
+                    Floating point <code>==</code> is not transitive (<a
+                    href="https://github.com/nholthaus/units/issues/118">#118</a>, closed as
+                    wontfix)
+                </li>
+            </ul>
+        </td>
+        <td class="poor nh3">
+            <ul>
+                <li class="x">
+                    Floating point <code>==</code> is not transitive (<a
+                    href="https://github.com/nholthaus/units/issues/118">#118</a>, closed as
+                    wontfix)
+                </li>
+                <li class="x">
+                    Per-dimension include files are prone to ODR violations and UB (<a
+                    href="https://github.com/nholthaus/units/issues/378">#378</a>, acknowledged as
+                    genuine UB, kept as-is for now)
+                </li>
+                <li class="x">
+                    Addition is not commutative (takes the left operand's unit instead of common
+                    unit; <a href="https://github.com/nholthaus/units/pull/381">#381</a>).
+                </li>
+            </ul>
+        </td>
+        <td class="na"></td>
+        <td class="good"></td>
+        <td class="good"></td>
+    </tr>
+    </tbody>
 </table>
 
 ### Library features
@@ -391,7 +602,8 @@ At this point, you've assessed:
 - whether you can use each library at all;
 - how hard it will be to add to your project;
 - what costs you'll pay in developer experience if you do;
-- and, how you can expect it to evolve over time.
+- how you can expect it to evolve over time;
+- and, whether any of them is known to break the rules.
 
 Now we're ready to compare the libraries "as units libraries" --- that is, in terms of their core
 features.
@@ -403,15 +615,27 @@ features.
 
     Of course, what matters the most for _you_ are _your_ use cases and criteria!
 
-<table>
-    <tr>
-        <th></th>
-        <th>Boost</th>
-        <th>nholthaus</th>
-        <th>bernedom/SI</th>
-        <th>mp-units</th>
-        <th class="highlight">Au</th>
-    </tr>
+<table class="matrix">
+    <thead>
+        <tr>
+            <th></th>
+            <th></th>
+            <th colspan="2">nholthaus</th>
+            <th></th>
+            <th></th>
+            <th class="highlight"></th>
+        </tr>
+        <tr>
+            <th></th>
+            <th>Boost</th>
+            <th>2.x</th>
+            <th class="nh3">3.x</th>
+            <th>bernedom/SI</th>
+            <th>mp-units</th>
+            <th class="highlight">Au</th>
+        </tr>
+    </thead>
+    <tbody>
     <tr>
         <td>
             <details class="criterion">
@@ -426,6 +650,23 @@ features.
         <td class="good"></td>
         <td class="poor">
             Integer Reps <a href="https://github.com/nholthaus/units/issues/225">unsafe</a>
+        </td>
+        <td class="good nh3">
+            <ul>
+                <li class="check">
+                    Implicit only when lossless, matching <code>std::chrono</code> (<a
+                    href="https://github.com/nholthaus/units/issues/225">#225</a>)
+                </li>
+                <li class="check">
+                    <code>consteval</code>-checked conversions for compile-time-known values
+                </li>
+                <li class="check">
+                    Overflow protection for <i>intermediate</i> results
+                </li>
+                <li class="x">
+                    Still no adaptation to overflow risk in the <i>result</i>
+                </li>
+            </ul>
         </td>
         <td class="poor">
             Integer Reps <a href="https://github.com/bernedom/SI/issues/122">unsafe</a>
@@ -455,16 +696,21 @@ features.
                 </p>
                 <ul>
                     <li>
-                        <b>Fair:</b> can achieve indirectly, by casting to known type before
+                        <b>Poor:</b> can achieve indirectly, by casting to known type before
                         retrieving value.
                     </li>
-                    <li><b>Good:</b> provide unit-safe interfaces.</li>
+                    <li><b>Fair:</b> provides unit-safe interfaces.</li>
+                    <li><b>Good:</b> <i>only</i> provides unit-safe interfaces.</li>
                 </ul>
             </details>
         </td>
-        <td class="fair"></td>
-        <td class="fair"></td>
-        <td class="fair"></td>
+        <td class="poor"></td>
+        <td class="poor"></td>
+        <td class="fair nh3">
+            <code>.value()</code> documented as unsafe; the safe route is
+            <code>q.to&lt;meters&gt;().value()</code>
+        </td>
+        <td class="poor"></td>
         <td class="good">Only contains unit-safe interfaces</td>
         <td class="good">Only contains unit-safe interfaces</td>
     </tr>
@@ -501,10 +747,22 @@ features.
                 </li>
             </ul>
         </td>
+        <td class="good nh3">
+            <ul>
+                <li class="check">
+                    2.x's namespace friction is gone (inline namespaces; <a
+                    href="https://abseil.io/tips/49">ADL</a> for math)
+                </li>
+                <li class="check">User-friendly typenames, with CTAD</li>
+                <li class="x">
+                    Literal suffixes still share one flat namespace, so they can collide
+                </li>
+            </ul>
+        </td>
         <td class="fair">
             <ul>
                 <li class="check">Single, short namespace</li>
-                <li class="check">Implicit conversions</li>
+                <li>Implicit conversions, but not safe ones</li>
                 <li>Multiple headers, but easy to guess (one per dimension)</li>
             </ul>
         </td>
@@ -523,6 +781,7 @@ features.
             <ul>
                 <li class="check">Namespaces: just one, and it's short</li>
                 <li class="check">Includes: either single-header, or easily-guessable header per unit</li>
+                <li class="check">Implicit conversions, and they adapt to the overflow risk</li>
             </ul>
         </td>
     </tr>
@@ -547,6 +806,14 @@ features.
             </ul>
         </td>
         <td class="poor"><a href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#comparison">No</a></td>
+        <td class="fair nh3">
+            <ul>
+                <li class="check">
+                    Unit constants compose: <code>3.0 * kg * m / (s*s)</code> yields newtons
+                </li>
+                <li class="x">Prefixes don't apply to unit constants on the fly</li>
+            </ul>
+        </td>
         <td class="poor">No</td>
         <td class="best">
             <ul>
@@ -595,7 +862,16 @@ features.
         <td class="fair">
             <ul>
                 <li class="check">Toggleable <code>&lt;iostream&gt;</code> support</li>
-                <li class="x">No fmtlib support</li>
+                <li class="x">No fmtlib or <code>std::format</code> support</li>
+            </ul>
+        </td>
+        <td class="good nh3">
+            <ul>
+                <li class="check">Toggleable <code>&lt;iostream&gt;</code> support</li>
+                <li class="check">Unit labels available even without <code>&lt;iostream&gt;</code></li>
+                <li class="check">
+                    Supports <code>std::format</code>, including the full numeric spec grammar
+                </li>
             </ul>
         </td>
         <td class="fair">
@@ -630,6 +906,10 @@ features.
         </td>
         <td class="good"></td>
         <td class="fair">Possible, but user-facing types use a global "preferred" Rep.</td>
+        <td class="good nh3">
+            Types name their own Rep (<code>meters&lt;int&gt;</code>); the global default applies
+            only to <code>meters&lt;&gt;</code>
+        </td>
         <td class="good"></td>
         <td class="good"></td>
         <td class="good"></td>
@@ -656,7 +936,20 @@ features.
             <ul>
                 <li class="check">Wide variety of functions</li>
                 <li class="x">
-                    <code>round</code>, <code>ceil</code>, and so on are not unit-safe
+                    <code>round</code>, <code>ceil</code>, and so on operate in whatever unit the
+                    quantity happens to hold, so they are not unit-safe
+                </li>
+            </ul>
+        </td>
+        <td class="good nh3">
+            <ul>
+                <li class="check">Wide variety of functions, found by ADL</li>
+                <li class="check">
+                    <code>round</code>, <code>ceil</code>, <code>floor</code>, and
+                    <code>trunc</code> have unit-safe versions
+                </li>
+                <li class="x">
+                    No unit-aware inverse
                 </li>
             </ul>
         </td>
@@ -708,8 +1001,32 @@ features.
             href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1935r2.html#nic-units.usage.example">Generic
             templates, constrained with traits</a>
         </td>
+        <td class="good nh3">
+            <ul>
+                <li class="check">
+                    Public <a
+                    href="https://github.com/nholthaus/units/blob/main/docs/reference/concepts.md">concept
+                    vocabulary</a> (<code>UnitType</code>, <code>same_dimension</code>, ...)
+                </li>
+                <li class="check">
+                    A concept per dimension (<code>units::Velocity auto v</code>), 50 of them, one
+                    beside each <code>is_&lt;dimension&gt;_unit</code> trait
+                </li>
+            </ul>
+        </td>
         <td class="fair">Generic templates, constrained with traits</td>
-        <td class="best">Concepts excel here</td>
+        <td class="best">
+            <ul>
+                <li class="check">
+                    Concepts name a <i>specific</i> quantity:
+                    <code>QuantityOf&lt;isq::length&gt; auto</code>
+                </li>
+                <li class="x">
+                    Which spelling you pick (a quantity spec, or its <code>kind_of</code>) changes
+                    what the function accepts
+                </li>
+            </ul>
+        </td>
         <td class="fair">
             Currently clunky.  Could be better by adding concepts in extra
             C++20-only file, without compromising C++14 support.
@@ -731,6 +1048,16 @@ features.
             <ul>
                 <li class="check">One-line macro defines new units</li>
                 <li class="x"><a href="https://github.com/nholthaus/units/issues/131">Can't add dimensions</a></li>
+            </ul>
+        </td>
+        <td class="good nh3">
+            <ul>
+                <li class="check">One-line macro defines new units, with prefixes and literals</li>
+                <li class="check">
+                    Can now add new base dimensions (<a
+                    href="https://github.com/nholthaus/units/issues/131">#131</a>), and derive
+                    compound dimensions from them
+                </li>
             </ul>
         </td>
         <td class="good">Can add new units and dimensions</td>
@@ -755,6 +1082,12 @@ features.
         </td>
         <td class="fair">No interop with other units libraries</td>
         <td class="fair">No interop with other units libraries</td>
+        <td class="fair nh3">
+            <ul>
+                <li class="check"><code>std::chrono::duration</code> interop, both directions</li>
+                <li class="x">No interop with other units libraries</li>
+            </ul>
+        </td>
         <td class="fair">No interop with other units libraries</td>
         <td class="good">
             <ul>
@@ -794,14 +1127,32 @@ features.
                 </p>
             </details>
         </td>
-        <td class="good">
-            <a href="https://www.boost.org/doc/libs/1_65_0/doc/html/boost/units/absolute.html"><code>absolute</code>
-            wrapper</a> for unit
-        </td>
         <td class="fair">
-            Optional "offset" for units, but <a
-            href="https://github.com/nholthaus/units/issues/240">can't distinguish quantity from
-            point</a>.
+            <a href="https://www.boost.org/doc/libs/1_65_0/doc/html/boost/units/absolute.html"><code>absolute</code>
+            wrapper</a> for unit, but no point-specific conversion safety
+        </td>
+        <td class="poor">
+            <ul>
+                <li class="x">
+                    Point arithmetic often produces incorrect results (see <a href="https://github.com/nholthaus/units/issues/240">#240</a>, closed as "won't fix")
+                </li>
+            </ul>
+        </td>
+        <td class="fair nh3">
+            <ul>
+                <li class="check">
+                    Opt-in <code>absolute</code>/<code>delta</code> wrappers, for any unit: point +
+                    point is ill-formed, and a difference is offset-free
+                </li>
+                <li class="x">
+                    Plain affine units keep the old hazards: <code>kelvin&lt;int&gt;(273)</code>
+                    still converts silently to <code>celsius&lt;int&gt;(0)</code>
+                </li>
+                <li class="x">
+                    No origin-aware common unit; any integer arithmetic with offset scale silently
+                    promotes to <code>double</code>
+                </li>
+            </ul>
         </td>
         <td class="poor">None; would be hard to add, since units conflated with quantity type</td>
         <td class="best">
@@ -812,6 +1163,10 @@ features.
         </td>
         <td class="good">
             <ul>
+                <li class="check">
+                    <code>QuantityPoint</code> is a first class type, with the same conversion
+                    safety surface as <code>Quantity</code>
+                </li>
                 <li class="check">Maximally efficient common units</li>
             </ul>
         </td>
@@ -834,8 +1189,9 @@ features.
         <td class="fair">
             Close: lacks only irrationals, basis, and instance arithmetic.  Ahead of its time!
         </td>
-        <td class="fair">
-            Uses ratio plus "pi powers": good angle handling, but vulnerable to overflow
+        <td class="fair" colspan="2">
+            <code>std::ratio</code> plus a pi exponent: good angle handling, but overflows when
+            compounding (<code>cubed&lt;pico&lt;meters_&gt;&gt;</code> fails to compile)
         </td>
         <td class="poor">`std::ratio` only, with no solution for pi</td>
         <td class="good">
@@ -866,6 +1222,10 @@ features.
         <td class="good">Assumed to be good, based on mixed-Rep support</td>
         <td class="fair">
             Can trim by excluding <code>&lt;iostream&gt;</code>, but integer-Rep support is poor.
+        </td>
+        <td class="good nh3">
+            Assumed to be good, based on mixed-Rep support (now safe for integer Rep) and
+            droppable <code>&lt;iostream&gt;</code>
         </td>
         <td class="fair">
             <ul>
@@ -900,6 +1260,16 @@ features.
         </td>
         <td class="na"></td>
         <td class="fair">User-defined literals (UDLs)</td>
+        <td class="fair nh3">
+            <ul>
+                <li class="check">User-defined literals (UDLs)</li>
+                <li>
+                    "Unit symbol"-like syntax (<code>5.0 * m</code>), but <code>m</code> is just
+                    a quantity with value <code>1.0</code>, and it force-routes through
+                    <code>double</code>
+                </li>
+            </ul>
+        </td>
         <td class="fair">User-defined literals (UDLs)</td>
         <td class="good">
             Unit symbols
@@ -918,21 +1288,51 @@ features.
                     Good interoperability with matrix and vector libraries, such as Eigen
                 </p>
                 <p>
-                    Most libraries can work with Eigen, but only if Eigen is patched: Quantity types
-                    break several of Eigen's deeply embedded assumptions.
+                    Historically, libraries could work with Eigen only if Eigen was patched:
+                    Quantity types break several of Eigen's deeply embedded assumptions.
                 </p>
             </details>
         </td>
-        <td class="fair"></td>
-        <td class="fair"></td>
-        <td class="fair"></td>
-        <td class="best">
-            Experimental support for <a
-            href="https://mpusz.github.io/mp-units/2.0/users_guide/framework_basics/character_of_a_quantity/">Quantity
-            Character</a>; can use matrix types as Rep
+        <td class="poor"></td>
+        <td class="poor"></td>
+        <td class="fair nh3">
+            <a href="https://github.com/nholthaus/units/issues/90">Eigen interop</a> released in
+            3.5.0: a "linalg-on-units" approach  It inverts the usual nesting: the <i>unit is the Eigen scalar</i>
+            (<code>Eigen::Matrix&lt;meters&lt;double&gt;, 3, 1&gt;</code>).
+            <ul>
+                <li class="check">Dimension-<i>preserving</i> operations stay lazy</li>
+                <li class="x">
+                    Dimension-<i>changing</i> ones (dot, cross, norm) use scalar loops that
+                    materialize, losing vectorization
+                </li>
+            </ul>
         </td>
-        <td class="fair">
-            Planned to add: <a href="https://github.com/aurora-opensource/au/issues/70">#70</a>
+        <td class="poor"></td>
+        <td class="good">
+            <ul>
+                <li class="check">"units-on-linalg" approach (most flexible)</li>
+                <li class="check">
+                    Explicit Eigen, GLM, and Blaze support (on main, slated for 2.6.0)
+                </li>
+                <li>Only library with <a
+                href="https://mpusz.github.io/mp-units/2.0/users_guide/framework_basics/character_of_a_quantity/">Quantity
+                Character</a>, and with named vector components</li>
+                <li class="x">
+                    No quantity-level dot or cross product: the result's quantity spec can't be
+                    named yet, so both stay on the raw rep
+                </li>
+            </ul>
+        </td>
+        <td class="best">
+            <ul>
+                <li class="check">"units-on-linalg" approach (most flexible)</li>
+                <li class="check">Explicit Eigen support</li>
+                <li class="check">
+                    Only library that preserves full Eigen performance in all cases: unit-aware
+                    <code>dot</code>, <code>cross</code>, <code>norm</code>, and coefficient-wise
+                    ops, each as lazy as the Eigen member it wraps
+                </li>
+            </ul>
         </td>
     </tr>
     <tr>
@@ -951,6 +1351,17 @@ features.
         <td class="poor">
             Effectively floating-point only (integer types <a
             href="https://github.com/nholthaus/units/issues/225">unsafe</a>)
+        </td>
+        <td class="fair nh3">
+            <ul>
+                <li class="check">
+                    All built-in numeric types, with integer Reps meeting <code>std::chrono</code>
+                    safety standards
+                </li>
+                <li class="x">
+                    Constrained to <code>std::is_arithmetic</code>: no custom numeric types
+                </li>
+            </ul>
         </td>
         <td class="fair">
             <ul>
@@ -990,15 +1401,23 @@ features.
             <a href="https://www.boost.org/doc/libs/1_81_0/doc/html/boost_units/FAQ.html#boost_units.FAQ.NoConstructorFromValueType">use
             default constructor</a> to construct, but no special facility for comparison
         </td>
-        <td class="fair">Supports <code>copysign()</code>, but no special construction or comparison</td>
+        <td class="fair" colspan="2">
+            Supports <code>copysign()</code>, but comparing a quantity to <code>0</code> is
+            ill-formed
+        </td>
         <td class="poor">No special construction or comparison</td>
         <td class="good">
-            <li class="check">
-                <a href="https://mpusz.github.io/mp-units/2.1/users_guide/framework_basics/quantity_arithmetics/?h=zero#comparison-against-zero">Special comparison functions</a>
-            </li>
-            <li><code>zero()</code> member</li>
+            <ul>
+                <li class="check">
+                    All six <a
+                    href="https://mpusz.github.io/mp-units/latest/users_guide/framework_basics/quantity_arithmetics/#comparison-against-zero">comparison
+                    operators</a> accept a literal <code>0</code>, enforced by a
+                    <code>consteval</code> guard (on <code>main</code>, for 2.6.0)
+                </li>
+                <li class="x">No construction from <code>0</code></li>
+            </ul>
         </td>
-        <td class="best">
+        <td class="good">
             Can use <a
             href="https://aurora-opensource.github.io/au/main/discussion/concepts/zero/"><code>ZERO</code></a>
             to construct or compare any quantity
@@ -1018,7 +1437,7 @@ features.
             <a href="https://github.com/boostorg/units/blob/45787015/include/boost/units/base_units/angle/degree.hpp#L17">pi
             value </a>
         </td>
-        <td class="good"></td>
+        <td class="good" colspan="2"></td>
         <td class="fair">
             <ul>
                 <li class="check">Supports degrees and radians</li>
@@ -1039,7 +1458,9 @@ features.
             </details>
         </td>
         <td class="fair">Includes built-in constants as quantities</td>
-        <td class="fair">Includes built-in constants as quantities</td>
+        <td class="fair" colspan="2">
+            Built-in constants as quantities (2018 CODATA values)
+        </td>
         <td class="poor"></td>
         <td class="good">
             <a
@@ -1063,7 +1484,26 @@ features.
             </details>
         </td>
         <td class="poor"></td>
-        <td class="best"></td>
+        <td class="good">
+            <ul>
+                <li class="check">Far more support than any library outside this family</li>
+                <li class="x">
+                    Not sound: <code>10 dBW + 10 dBW</code> compiles, and yields
+                    <code>20 m^4 kg^2 s^-6</code>
+                </li>
+            </ul>
+        </td>
+        <td class="best nh3">
+            <ul>
+                <li class="check">The clear leader</li>
+                <li class="check">
+                    Decibels now modelled as affine
+                </li>
+                <li class="x">
+                    Only power convention (<code>10*log10</code>); no root-power (amplitude) variant
+                </li>
+            </ul>
+        </td>
         <td class="poor"></td>
         <td class="poor"></td>
         <td class="poor">
@@ -1082,6 +1522,13 @@ features.
         </td>
         <td class="poor"></td>
         <td class="poor"></td>
+        <td class="good nh3">
+            <ul>
+                <li class="check">Supports integral and floating point Reps</li>
+                <li class="check">Supports quantity families via concepts</li>
+                <li class="x">User must provide exact unit and rep</li>
+            </ul>
+        </td>
         <td class="poor"></td>
         <td class="best">
             <ul>
@@ -1111,13 +1558,21 @@ features.
         </td>
         <td class="poor"></td>
         <td class="poor"></td>
+        <td class="poor nh3">
+            A negative conversion factor is accepted, but ordering then reflects the stored values
+            rather than the quantities
+        </td>
         <td class="poor"></td>
-        <td class="poor"></td>
+        <td class="poor">
+            Unary minus on a magnitude, added on <code>main</code> for the CODATA constants, but
+            no negative <i>units</i>
+        </td>
         <td class="best">
             <ul>
                 <li class="check">Negative constants</li>
                 <li class="check">Negative units</li>
                 <li class="check">Negative magnitudes</li>
+                <li class="check">Comparison operators correctly account for sign</li>
             </ul>
         </td>
     </tr>
@@ -1137,6 +1592,16 @@ features.
         </td>
         <td class="na"></td>
         <td class="poor"></td>
+        <td class="good nh3">
+            <ul>
+                <li class="check">
+                    Opt-in string-tagged kinds
+                </li>
+                <li class="x">
+                    Built-in kinds not included (hertz vs. becquerel, torque vs. energy)
+                </li>
+            </ul>
+        </td>
         <td class="poor"></td>
         <td class="best"></td>
         <td class="poor">No plans at present to support.</td>
@@ -1152,7 +1617,7 @@ features.
             </details>
         </td>
         <td class="good"></td>
-        <td class="poor">Single, implicit global system</td>
+        <td class="poor" colspan="2">Single, implicit global system</td>
         <td class="poor"></td>
         <td class="good"></td>
         <td class="poor">
@@ -1176,6 +1641,15 @@ features.
         </td>
         <td class="good"></td>
         <td class="fair">Types exist, but conflated with quantity names</td>
+        <td class="good nh3">
+            <ul>
+                <li class="check">
+                    Units and quantities are separate types (<code>meters_</code> vs.
+                    <code>meters&lt;double&gt;</code>)
+                </li>
+                <li class="check">Types for dimensions; arithmetic on both</li>
+            </ul>
+        </td>
         <td class="poor">No separate types for units</td>
         <td class="good">
             <ul>
@@ -1206,7 +1680,10 @@ features.
             </details>
         </td>
         <td class="poor">Common in user-facing APIs</td>
-        <td class="poor">Common in user-facing APIs</td>
+        <td class="poor" colspan="2">
+            The <code>UNIT_ADD</code> family is the only way to define a <i>named</i> unit.  (3.x
+            can at least name a <i>derived</i> type macro-free, with <code>decltype</code>.)
+        </td>
         <td class="good">Very few, and confined to implementation helpers</td>
         <td class="fair">
             <ul>
@@ -1222,4 +1699,8 @@ features.
             </ul>
         </td>
     </tr>
+    </tbody>
 </table>
+
+[unit symbols]: ../reference/unit.md#symbols
+[user-defined literals]: ../reference/constant.md#unit-literals

--- a/docs/reference/constant.md
+++ b/docs/reference/constant.md
@@ -166,7 +166,7 @@ concise symbol.  The example below demonstrates the difference.
     There's no difference in the program that gets executed, but the printed label is a lot easier
     to understand.
 
-### Unit literals
+### Unit literals {#unit-literals}
 
 Every unit that ships with Au provides a _unit literal_: a [user-defined literal
 (UDL)](https://en.cppreference.com/w/cpp/language/user_literal) whose suffix is the unit's

--- a/docs/tweaks.css
+++ b/docs/tweaks.css
@@ -122,3 +122,174 @@ li.x:before {
 .md-typeset .tabbed-set:has(p.ab-banner) > .tabbed-labels > label:nth-child(2) > a {
     color: #2c7bb6;
 }
+
+/*
+  The comparison matrices in the "Comparison of Alternatives" guide.
+
+  These tables carry seven columns, which the default content width can't hold.
+  mkdocs-material styles bare tables via `table:not([class])`, and that rule puts
+  a `min-width` on every `th`: seven of those add up to more than the content
+  column, so the whole page scrolled sideways.  Giving these tables a class opts
+  out of that rule entirely, so we can lay them out ourselves.
+*/
+
+/* Widen the content column on any page that holds a matrix. */
+.md-main:has(table.matrix) .md-grid {
+    max-width: 80rem;
+}
+
+.md-typeset table.matrix {
+    background-color: var(--md-default-bg-color);
+    border: .05rem solid var(--md-typeset-table-color);
+    border-collapse: collapse;
+    font-size: .6rem;
+    /* `fixed` plus `width: 100%` is what guarantees the table never overflows. */
+    table-layout: fixed;
+    width: 100%;
+}
+
+.md-typeset table.matrix th,
+.md-typeset table.matrix td {
+    overflow-wrap: break-word;
+    padding: .5em .6em;
+    text-align: left;
+    vertical-align: top;
+}
+
+/* Without this, two vertically adjacent cells that happen to share a rating
+   read as one tall cell. */
+.md-typeset table.matrix tbody td {
+    border-top: .05rem solid var(--md-default-bg-color);
+}
+
+.md-typeset table.matrix th {
+    font-weight: 700;
+    text-align: center;
+}
+
+/* The criterion column is wider; `fixed` layout splits the rest evenly. */
+.md-typeset table.matrix th:first-child,
+.md-typeset table.matrix td:first-child {
+    width: 17%;
+}
+
+.md-typeset table.matrix td > :first-child {
+    margin-top: 0;
+}
+
+.md-typeset table.matrix td > :last-child {
+    margin-bottom: 0;
+}
+
+.md-typeset table.matrix ul {
+    margin: 0;
+    padding-left: 0;
+}
+
+.md-typeset table.matrix code {
+    /* Long type names must not be able to push a column wider. */
+    overflow-wrap: anywhere;
+}
+
+/*
+  Sticky headers.  Material's own site header is `position: sticky` at
+  `top: 0` with `height: 2.4rem` and `z-index: 4`, so we park ours just below it
+  and give it a lower stacking order.
+
+  The two header rows are stacked rather than nested with `rowspan`, because a
+  `rowspan` cell can only have one sticky offset, which would collide with the
+  row below it.
+*/
+.md-typeset table.matrix thead th {
+    background-color: var(--md-default-bg-color);
+    position: sticky;
+    z-index: 2;
+}
+
+.md-typeset table.matrix thead tr:first-child th {
+    height: 1.3rem;
+    line-height: 1rem;
+    padding-bottom: .15rem;
+    padding-top: .15rem;
+    top: 2.4rem;
+}
+
+.md-typeset table.matrix thead tr:nth-child(2) th {
+    /* A hard bottom edge, so the pinned header reads as a lid over the rows
+       sliding underneath it. */
+    box-shadow: 0 .05rem 0 #999;
+    top: 3.7rem;
+}
+
+/*
+  Group the two nholthaus columns.  Every library cell gets a gutter on its
+  left, except the nholthaus 3.x cell, which gets a hairline instead --- so the
+  pair reads as one library with two lines.  This is done with `td + td` rather
+  than `nth-child` so that it survives the rows where the two nholthaus cells
+  are merged with `colspan`.
+
+  The gutter has to be drawn in a different color in the head than in the body.
+  A body cell sits on its rating color, so a gap the color of the page reads as
+  a separator; a header cell sits on the page color already, where that same
+  gap would be invisible.
+
+  Every color in the header is a flat, fully opaque value.  Material's own
+  `--md-*` grays are translucent, and the header is pinned: anything that isn't
+  opaque lets the rows scrolling underneath show straight through it.
+*/
+.md-typeset table.matrix tbody td + td {
+    border-left: .15rem solid var(--md-default-bg-color);
+}
+
+.md-typeset table.matrix thead tr:first-child th + th,
+.md-typeset table.matrix thead tr:nth-child(2) th + th {
+    border-left: .15rem solid #d5d5d5;
+}
+
+/*
+  Within the nholthaus group, the divider must be the *faintest* line in the
+  table --- lighter than the gutters that separate one library from the next.
+*/
+.md-typeset table.matrix tbody td.nh3 {
+    border-left: .05rem solid var(--md-default-bg-color);
+}
+
+.md-typeset table.matrix thead th.nh3 {
+    border-left: .05rem solid #e0e0e0;
+}
+
+/*
+  The nholthaus columns are deliberately left the same white as the other
+  third-party libraries: gray is reserved for Au's column, and a second gray
+  here only dilutes it.  The spanning "nholthaus" label and the fainter
+  divider between 2.x and 3.x are enough to group the pair.
+*/
+
+/* Au's column has to win over the sticky-header background. */
+.md-typeset table.matrix thead th.highlight {
+    background-color: #ccc;
+}
+
+/* Rating colors have to win over the sticky-header background above. */
+.md-typeset table.matrix td.poor {
+    background-color: #fdae61;
+}
+
+.md-typeset table.matrix td.fair {
+    background-color: #ffffbf;
+}
+
+.md-typeset table.matrix td.good {
+    background-color: #abd9e9;
+}
+
+.md-typeset table.matrix td.best,
+.md-typeset table.matrix td.best * {
+    background-color: #2c7bb6;
+    color: white;
+}
+
+.md-typeset table.matrix td.na,
+.md-typeset table.matrix td.invalid {
+    background-color: #d9d9d9;
+}


### PR DESCRIPTION
It's time to make sure this is up to date before the 0.6.0 release.  I
did a general sanity check and updated any rows I happened to notice
seemed like they were stale.

For mp-units, we now use the 2.5.0 release, with pointers to a few
expected improvements for 2.6.0.

By far the biggest change is the nholthaus library.  In the week before
Au 0.6.0, they completely cleared their 100+ issue backlog, and made the
longstanding 3.x branch the default one.  It's so different from the 2.x
branch, and the 2.x branch still _so_ widespread, that we can't just do
a replacement.  Instead, I split it into two sub-columns.  We can see
that 3.x is a huge improvement in many ways, although it also motivated
a new top-level section for best practices violations.  There are
aspects of this library that I felt we needed to point out, but that
didn't really fit anywhere else.

Overall, the page now shows that 3.x is a _substantial_ improvement over
2.x on a _wide_ variety of fronts, but still also substantially behind
Au in several ways.

The two-column split also motivated some CSS updates, which improves the
ergonomics overall.  (I can't believe we hadn't pinned the headers
before this update!)

Finally, we make one of the link targets in `constants.md` permanent and
explicit.