### PR TITLE
Add ADC code example

### DIFF
--- a/docs/examples/adc-millivolts.md
+++ b/docs/examples/adc-millivolts.md
@@ -64,7 +64,7 @@ integer multiply-and-divide the raw version performs by hand.  Everything else f
   conversion factor to _any_ target unit, and apply it with a [tailor made
   strategy](../discussion/implementation/applying_magnitudes.md) for your specific situation.
 
-- **A reading is now a quantity, from the moment it arrives.**  `adc_counts(2000)` is a voltage,
+- **A reading is now a quantity, from the moment it arrives.**  `adc_volts(2000)` is a voltage,
   and can be passed anywhere a voltage belongs, compared against other voltages, or converted to
   any other voltage unit.  In the raw version it is an `int` until someone remembers to call the
   conversion function.

--- a/docs/examples/adc-millivolts.md
+++ b/docs/examples/adc-millivolts.md
@@ -1,0 +1,104 @@
+# Analog-to-digital converter counts to millivolts
+
+A 12-bit analog-to-digital converter (ADC) reports voltages from 0 to 3300 millivolts (mV) as
+integer counts from 0 to 4095.  For example, a reading of 2048 "ADC counts" corresponds to a voltage
+of roughly 1650 mV: about half of the 3300 mV maximum.
+
+Let's see how we would safely handle taking a reading from this device, and expressing it in more
+familiar units.
+
+=== "⚠️ Before: raw C++"
+
+    ⚠️ **Before** --- the scale factor is a pair of magic numbers, and truncation is silent.
+    { .ab-banner .ab-before }
+
+    ??? note "Includes and usings"
+
+        ```cpp
+        --8<-- "examples/adc_millivolts/raw.cc:frontmatter"
+        ```
+
+    ```cpp
+    --8<-- "examples/adc_millivolts/raw.cc:example"
+    ```
+
+=== "✅ After: with Au"
+
+    ✅ **After** --- the hardware's count *is* a unit, and truncation must be opted into.
+    { .ab-banner .ab-after }
+
+    ??? note "Includes and usings"
+
+        ```cpp
+        --8<-- "examples/adc_millivolts/au.cc:frontmatter"
+        ```
+
+    ```cpp
+    --8<-- "examples/adc_millivolts/au.cc:example"
+    ```
+
+Both programs print `1650 mV`.
+
+## What's happening
+
+Handling quantities on embedded devices, such as ADCs, has historically been a pain.  Each device
+maps its integer output to its own bespoke range of values.  You would need to either convert to SI
+units immediately (even if that might be less efficient for your use case), or risk passing a number
+around your program with obscure or confusing units.
+
+This is an ideal use case for Au!  The trick is to turn this range into a full-fledged _custom
+unit_.  You get the safety and ergonomics of Au, from the moment the value leaves the board. You can
+even _safely keep the value in its natural ADC units_ as long as you want, confident that any
+conversions you _do_ need will be tracked and checked by the library.
+
+One reason people are often reluctant to use units libraries with embedded applications is the need
+for exact integer arithmetic.  Most units libraries use floating point as a strong default; even if
+they technically support integer types, it's rare for them to be battle-tested enough to trust.  Not
+so with Au: Aurora's embedded teams have been first-class customers since the library's inception,
+so integer arithmetic is our bread and butter.  With Au, the conversion here compiles to the same
+integer multiply-and-divide the raw version performs by hand.  Everything else follows from that:
+
+- **The "magic numbers" move into the unit definition.**  Read them right off the spec sheet, and
+  put them in one single place in your codebase.  Au will automatically generate the most efficient
+  conversion factor to _any_ target unit, and apply it with a [tailor made
+  strategy](../discussion/implementation/applying_magnitudes.md) for your specific situation.
+
+- **A reading is now a quantity, from the moment it arrives.**  `adc_counts(2048)` is a voltage,
+  and can be passed anywhere a voltage belongs, compared against other voltages, or converted to
+  any other voltage unit.  In the raw version it is an `int` until someone remembers to call the
+  conversion function.
+
+- **You're in control of conversion risks.**  Au catches the truncating integer division here.  By
+  default, it won't compile, but the `ignore(TRUNCATION_RISK)` [risk
+  policy](../reference/conversion_risk_policies.md) argument overrides that.  Notice the
+  readability: any risky conversions you accept _stand out visually_, and clearly communicate your
+  intent to the reader.
+
+- **The label comes along.**  Because `AdcCounts` declares one, a count prints as `counts`, and the
+  converted value prints as `1650 mV` without anyone typing `"mV"` into a format string.
+
+- **None of this costs anything at runtime.**  The rational factor is a compile-time constant, and
+  the rep stays `int`: Au does not silently promote you to `double` to make a conversion work.  In
+  fact, Au reduces 3300/4095 to 220/273 for you, so the same instruction sequence runs with a
+  15-times-smaller intermediate product than the hand-written version: a significant reduction in
+  overflow risk!
+
+### A note on `<iostream>`
+
+These examples print with `std::cout`, because it lets the value carry its own unit label and keeps
+the whole example inside the library.  Plenty of embedded projects avoid `<iostream>` for code
+size, and Au is entirely indifferent: nothing in the library depends on it.  Drop
+[`au/io.hh`](https://github.com/aurora-opensource/au/blob/main/au/io.hh), reach for `.in()` instead
+of `.as()`, and print however you like:
+
+```cpp
+std::printf("%d mV\n", v.in(milli(volts), ignore(TRUNCATION_RISK)));
+```
+
+## Related reading
+
+- [Quantity: `.in()` and `.as()`](../reference/quantity.md), and which conversions are allowed.
+- [Prefixes](../reference/prefix.md), for `milli(volts)`.
+- [Rounding](../reference/math.md), when you *do* want the truncating conversion.
+- [Namespaces and includes](../discussion/idioms/namespaces-and-includes.md), including why a `.cc`
+  imports names individually and a `.hh` does not.

--- a/docs/examples/adc-millivolts.md
+++ b/docs/examples/adc-millivolts.md
@@ -1,8 +1,9 @@
 # Analog-to-digital converter counts to millivolts
 
-A 12-bit analog-to-digital converter (ADC) reports voltages from 0 to 3300 millivolts (mV) as
-integer counts from 0 to 4095.  For example, a reading of 2048 "ADC counts" corresponds to a voltage
-of roughly 1650 mV: about half of the 3300 mV maximum.
+A 12-bit analog-to-digital converter (ADC) measures voltages against a 3300 millivolt (mV)
+reference, and reports them as integer counts from 0 to 4095.  One count --- one least significant
+bit --- is therefore 3300 mV / 2<sup>12</sup>, or exactly 825/1024 mV.  So, for example, a reading
+of 2000 "ADC voltage counts" corresponds to a voltage of roughly 1611 mV.
 
 Let's see how we would safely handle taking a reading from this device, and expressing it in more
 familiar units.
@@ -37,7 +38,7 @@ familiar units.
     --8<-- "examples/adc_millivolts/au.cc:example"
     ```
 
-Both programs print `1650 mV`.
+Both programs print `1611 mV`.
 
 ## What's happening
 
@@ -63,7 +64,7 @@ integer multiply-and-divide the raw version performs by hand.  Everything else f
   conversion factor to _any_ target unit, and apply it with a [tailor made
   strategy](../discussion/implementation/applying_magnitudes.md) for your specific situation.
 
-- **A reading is now a quantity, from the moment it arrives.**  `adc_counts(2048)` is a voltage,
+- **A reading is now a quantity, from the moment it arrives.**  `adc_counts(2000)` is a voltage,
   and can be passed anywhere a voltage belongs, compared against other voltages, or converted to
   any other voltage unit.  In the raw version it is an `int` until someone remembers to call the
   conversion function.
@@ -74,14 +75,19 @@ integer multiply-and-divide the raw version performs by hand.  Everything else f
   readability: any risky conversions you accept _stand out visually_, and clearly communicate your
   intent to the reader.
 
-- **The label comes along.**  Because `AdcCounts` declares one, a count prints as `counts`, and the
-  converted value prints as `1650 mV` without anyone typing `"mV"` into a format string.
+- **The label writes itself.**  We never named this unit for the reader, and we didn't have to: Au
+  composes a label out of the definition, so printing the raw reading gives `2000 [(825 / 1024)
+  mV]`.  This `"[(825 / 1024) mV]"` label is generally more useful than a custom label such as `"adc
+  volts"`: it presents the value in familiar units, but it still preserves the separation between
+  the underlying value and the size of the unit.  In general, these anonymous scaled units are
+  a great choice, unless there's already a named unit that your end users would find meaningful
+  without having to look it up.
 
 - **None of this costs anything at runtime.**  The rational factor is a compile-time constant, and
   the rep stays `int`: Au does not silently promote you to `double` to make a conversion work.  In
-  fact, Au reduces 3300/4095 to 220/273 for you, so the same instruction sequence runs with a
-  15-times-smaller intermediate product than the hand-written version: a significant reduction in
-  overflow risk!
+  fact, Au reduces 3300/4096 to 825/1024 for you, so the intermediate product is four times smaller
+  than the hand-written version's --- a real reduction in overflow risk --- and the division is a
+  power of two that the compiler turns into a shift.
 
 ### A note on `<iostream>`
 

--- a/docs/examples/angular-velocity.md
+++ b/docs/examples/angular-velocity.md
@@ -1,4 +1,4 @@
-# Linear speed to revolutions per minute
+# Angular velocity in RPM
 
 A wheel rolls along the ground at some speed.  How fast is it turning, in revolutions per minute?
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -8,13 +8,18 @@ lines in place --- the two versions are kept line-aligned on purpose.
 
 ## The examples
 
+- **[Analog-to-digital converter counts to millivolts](./adc-millivolts.md).**  Au's secret strength
+  for embedded applications is not just the built-in units; it's the ability to define _custom_
+  units _specifically tailored to your hardware_.  This gets you unit safety from the moment the
+  value leaves the board.
+
+- **[Atomic units](./atomic-units.md).**  Building an entire system of units on top of Au --- exact
+  within itself, and as accurate as physics allows at the boundary.  Unlike most others, this one has
+  no plain-C++ counterpart: this example shows how to extend Au for a specific domain.
+
 - **[Linear speed to revolutions per minute](./angular-velocity.md).**  Converting a wheel's road
   speed into revolutions per minute (RPM), without fussing with manual conversion factors like `2π`
   or `60`.
-
-- **[Atomic units](./atomic-units.md).**  Building an entire system of units on top of Au --- exact
-  within itself, and as accurate as physics allows at the boundary.  Unlike the others, this one has
-  no plain-C++ counterpart: this example shows how to extend Au for a specific domain.
 
 ## How these examples are written {#front-matter}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,9 +31,9 @@ compare.
     ```
 
 The `2π` and the `60` vanish: in their place, Au _automatically_ generates the [_single_
-number](./discussion/implementation/applying_magnitudes/#summary-and-conclusion) that represents the
-overall conversion --- _at compile time_, so there's no runtime penalty.  And the code now directly
-states the physical truth: converting between linear and angular speed is just applying
+number](./discussion/implementation/applying_magnitudes.md#summary-and-conclusion) that represents
+the overall conversion --- _at compile time_, so there's no runtime penalty.  And the code now
+directly states the physical truth: converting between linear and angular speed is just applying
 a length/angle ratio, and `rad / r` --- "one radian per radius" --- is nothing more than the
 _definition_ of a radian, applied as a formula.
 <!-- The last sentence above, in particular, sounds very "Claude-y" to me.  But I actually wrote

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -20,11 +20,21 @@ load(":defs.bzl", "ab_example", "single_example")
 filegroup(
     name = "doc_sources",
     srcs = [
+        ":adc_millivolts_doc_sources",
         ":angular_velocity_doc_sources",
         ":atomic_units_doc_sources",
     ],
     # Only the docs build consumes these.  Nothing here is part of the library's API.
     visibility = ["//:__pkg__"],
+)
+
+ab_example(
+    name = "adc_millivolts",
+    au_deps = [
+        "//au",
+        "//au:io",
+    ],
+    expected_output = "1650 mV\n",
 )
 
 ab_example(

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -34,7 +34,7 @@ ab_example(
         "//au",
         "//au:io",
     ],
-    expected_output = "1650 mV\n",
+    expected_output = "1611 mV\n",
 )
 
 ab_example(

--- a/examples/adc_millivolts/au.cc
+++ b/examples/adc_millivolts/au.cc
@@ -41,13 +41,13 @@ using au::volts;
 // millivolt (mV) reference.  One count is one LSB: 3300 mV / 2^12.
 //
 // With Au, we can capture this as a custom unit.  Au even generates a readable label!
-using AdcCounts = decltype(Milli<Volts>{} * mag<3300>() / pow<12>(mag<2>()));
-constexpr auto adc_counts = QuantityMaker<AdcCounts>{};
+using AdcVolts = decltype(Milli<Volts>{} * mag<3300>() / pow<12>(mag<2>()));
+constexpr auto adc_volts = QuantityMaker<AdcVolts>{};
 
 
 
 int main() {
-    const auto v = adc_counts(2000);
+    const auto v = adc_volts(2000);
     // Exact rational conversion, applied once.  Without `ignore(...)`, this would not compile.
     std::cout << v.as(milli(volts), ignore(TRUNCATION_RISK)) << '\n';
 }

--- a/examples/adc_millivolts/au.cc
+++ b/examples/adc_millivolts/au.cc
@@ -1,0 +1,53 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE TO EDITORS: this file is line-aligned with `raw.cc`.  See the note in that file.
+
+// --8<-- [start:frontmatter]
+#include "au/au.hh"
+
+#include <iostream>
+
+#include "au/io.hh"
+#include "au/prefix.hh"
+#include "au/units/volts.hh"
+
+// This is a `.cc` file, so we import the names we use, one at a time.  See the "Namespaces and
+// includes" discussion page for why we do this rather than `using namespace au;`.
+using au::mag;
+using au::Milli;
+using au::milli;
+using au::QuantityMaker;
+using au::TRUNCATION_RISK;
+using au::Volts;
+using au::volts;
+// --8<-- [end:frontmatter]
+
+// clang-format off
+// --8<-- [start:example]
+// A 12-bit analog-to-digital converter (ADC) reports `counts` out of 4095,
+// spanning a 3300 millivolt (mV) reference.  That ratio is exact, so name it a unit.
+struct AdcCounts : decltype(Milli<Volts>{} * mag<3300>() / mag<4095>()) {
+    static constexpr const char label[] = "counts";
+};
+constexpr const char AdcCounts::label[];  // C++14 needs this; C++17 does not.
+constexpr auto adc_counts = QuantityMaker<AdcCounts>{};
+
+int main() {
+    const auto v = adc_counts(2048);
+    // Exact rational conversion, applied once.  Without `ignore(...)`, this would not compile.
+    std::cout << v.as(milli(volts), ignore(TRUNCATION_RISK)) << std::endl;
+}
+// --8<-- [end:example]
+// clang-format on

--- a/examples/adc_millivolts/au.cc
+++ b/examples/adc_millivolts/au.cc
@@ -28,6 +28,7 @@
 using au::mag;
 using au::Milli;
 using au::milli;
+using au::pow;
 using au::QuantityMaker;
 using au::TRUNCATION_RISK;
 using au::Volts;
@@ -36,16 +37,17 @@ using au::volts;
 
 // clang-format off
 // --8<-- [start:example]
-// A 12-bit analog-to-digital converter (ADC) reports `counts` out of 4095,
-// spanning a 3300 millivolt (mV) reference.  That ratio is exact, so name it a unit.
-struct AdcCounts : decltype(Milli<Volts>{} * mag<3300>() / mag<4095>()) {
-    static constexpr const char label[] = "counts";
-};
-constexpr const char AdcCounts::label[];  // C++14 needs this; C++17 does not.
+// A 12-bit analog-to-digital converter (ADC) reports `counts` from 0 to 4095, spanning a 3300
+// millivolt (mV) reference.  One count is one LSB: 3300 mV / 2^12.
+//
+// With Au, we can capture this as a custom unit.  Au even generates a readable label!
+using AdcCounts = decltype(Milli<Volts>{} * mag<3300>() / pow<12>(mag<2>()));
 constexpr auto adc_counts = QuantityMaker<AdcCounts>{};
 
+
+
 int main() {
-    const auto v = adc_counts(2048);
+    const auto v = adc_counts(2000);
     // Exact rational conversion, applied once.  Without `ignore(...)`, this would not compile.
     std::cout << v.as(milli(volts), ignore(TRUNCATION_RISK)) << '\n';
 }

--- a/examples/adc_millivolts/au.cc
+++ b/examples/adc_millivolts/au.cc
@@ -47,7 +47,7 @@ constexpr auto adc_counts = QuantityMaker<AdcCounts>{};
 int main() {
     const auto v = adc_counts(2048);
     // Exact rational conversion, applied once.  Without `ignore(...)`, this would not compile.
-    std::cout << v.as(milli(volts), ignore(TRUNCATION_RISK)) << std::endl;
+    std::cout << v.as(milli(volts), ignore(TRUNCATION_RISK)) << '\n';
 }
 // --8<-- [end:example]
 // clang-format on

--- a/examples/adc_millivolts/raw.cc
+++ b/examples/adc_millivolts/raw.cc
@@ -33,7 +33,7 @@ int adc_to_millivolts(int counts) {
 int main() {
     const int mv = adc_to_millivolts(2048);
     // Careful: `mv / 1000` would quietly report 1650 mV as "1 V".
-    std::cout << mv << " mV" << std::endl;
+    std::cout << mv << " mV" << '\n';
 }
 // --8<-- [end:example]
 // clang-format on

--- a/examples/adc_millivolts/raw.cc
+++ b/examples/adc_millivolts/raw.cc
@@ -22,17 +22,18 @@
 
 // clang-format off
 // --8<-- [start:example]
-// A 12-bit analog-to-digital converter (ADC) reports `counts` out of 4095,
-// spanning a 3300 millivolt (mV) reference.
+// A 12-bit analog-to-digital converter (ADC) reports `counts` from 0 to 4095, spanning a 3300
+// millivolt (mV) reference.  One count is one LSB: 3300 mV / 2^12.
+//
+// The scale factor and the unit label both live in this reader's head, and in a comment at best.
 int adc_to_millivolts(int counts) {
-    return counts * 3300 / 4095;  // Multiply first: 3300 / 4095 would truncate to 0.
+    return counts * 3300 / 4096;  // Multiply first: 3300 / 4096 would truncate to 0.
 }
 
 
-
 int main() {
-    const int mv = adc_to_millivolts(2048);
-    // Careful: `mv / 1000` would quietly report 1650 mV as "1 V".
+    const int mv = adc_to_millivolts(2000);
+    // Careful: `mv / 1000` would quietly report 1611 mV as "1 V".
     std::cout << mv << " mV" << '\n';
 }
 // --8<-- [end:example]

--- a/examples/adc_millivolts/raw.cc
+++ b/examples/adc_millivolts/raw.cc
@@ -1,0 +1,39 @@
+// Copyright 2026 Aurora Operations, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE TO EDITORS: this file is line-aligned with `au.cc`, and the doc-visible region is fenced off
+// from clang-format so the alignment survives.  See `examples/angular_velocity/raw.cc` for the
+// full explanation.
+
+// --8<-- [start:frontmatter]
+#include <iostream>
+// --8<-- [end:frontmatter]
+
+// clang-format off
+// --8<-- [start:example]
+// A 12-bit analog-to-digital converter (ADC) reports `counts` out of 4095,
+// spanning a 3300 millivolt (mV) reference.
+int adc_to_millivolts(int counts) {
+    return counts * 3300 / 4095;  // Multiply first: 3300 / 4095 would truncate to 0.
+}
+
+
+
+int main() {
+    const int mv = adc_to_millivolts(2048);
+    // Careful: `mv / 1000` would quietly report 1650 mV as "1 V".
+    std::cout << mv << " mV" << std::endl;
+}
+// --8<-- [end:example]
+// clang-format on


### PR DESCRIPTION
This gives us our first explicitly embedded use case, and shows off our
integer arithmetic handling.

Along the way, I alphabetized the links in the example index page.  The
angular velocity page had a "Linear velocity..." title, so they looked
off in the sidebar, so I changed its title to be consistent.  I also
fixed a broken link that the doc build identified, in the main docs
page.