### PR TITLE
DO NOT LAND: Require `ScalarOf<T>` for any rep `T`

### DIFF
--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -1165,11 +1165,14 @@ struct ScalarOfTrait : detail::FirstValidTrait<T,
 
 namespace detail {
 
-// RealPart<T>: prefers ScalarOf<T> if available, falls back to T itself.
+// RealPart<T>: the scalar type underlying `T`.  This _requires_ `ScalarOf<T>` to exist: if none of
+// the automatic probes match `T`, then you must provide a `ScalarOfTrait<T>` specialization.
 template <typename T>
-struct RealPartImpl : std::conditional_t<stdx::experimental::is_detected<ScalarOf, T>::value,
-                                         ScalarOfTrait<T>,
-                                         stdx::type_identity<T>> {};
+struct RealPartImpl : ScalarOfTrait<T> {
+    static_assert(stdx::experimental::is_detected<ScalarOf, T>::value,
+                  "No `ScalarOf<T>`: provide a `ScalarOfTrait<T>` specialization for this rep "
+                  "(see https://aurora-opensource.github.io/au/main/reference/rep/#scalar-of)");
+};
 template <typename T>
 using RealPart = typename RealPartImpl<T>::type;
 

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -99,6 +99,8 @@ auto IsConstantWithUnitMatching(InnerMatcher m) {
 // We have to add a fairly large number of operators just to get this to compile as a rep.
 template <typename T>
 struct LabeledNumber {
+    using Scalar = T;
+
     constexpr LabeledNumber() : value{}, label{'\0'} {}
     constexpr LabeledNumber(T v, char l) : value{v}, label{l} {}
     constexpr LabeledNumber(T v) : value{v}, label{'\0'} {}

--- a/au/quantity.hh
+++ b/au/quantity.hh
@@ -159,7 +159,7 @@ class Quantity {
     using Unit = UnitT;
     static constexpr auto unit = Unit{};
 
-    static_assert(IsValidRep<Rep>::value, "Rep must meet our requirements for a rep");
+    static_assert(detail::AssertValidRep<Rep>::value, "Rep must meet our requirements for a rep");
 
     // IMPLICIT constructor for another Quantity of the same Dimension.
     template <typename OtherUnit,

--- a/au/rep.hh
+++ b/au/rep.hh
@@ -246,6 +246,12 @@ using ScalarOfOrVoid = stdx::experimental::detected_or_t<void, ::au::ScalarOf, T
 template <typename T>
 struct HasQuantityLikeScalar : LooksLikeAuOrOtherQuantity<ScalarOfOrVoid<T>> {};
 
+// Every rep must have a `ScalarOf`: it's what the overflow and truncation risk checks are built on.
+// Most types are covered by the automatic detection, but a type that matches no probe needs a
+// `ScalarOfTrait` specialization before it can be used as a rep.
+template <typename T>
+struct HasNoScalar : stdx::negation<stdx::experimental::is_detected<::au::ScalarOf, T>> {};
+
 // The `std::is_empty` is a good way to catch all of the various unit and other monovalue types in
 // our library, which have little else in common.  It's also just intrinsically true that it
 // wouldn't make much sense to use an empty type as a rep.
@@ -253,6 +259,7 @@ template <typename T>
 struct IsKnownInvalidRep : stdx::disjunction<std::is_empty<T>,
                                              LooksLikeAuOrOtherQuantity<T>,
                                              std::is_same<void, T>,
+                                             HasNoScalar<T>,
                                              HasQuantityLikeScalar<T>> {};
 
 // The type of the product of two types.
@@ -284,5 +291,19 @@ struct IsProductValidRep
 template <typename T, typename U>
 struct IsQuotientValidRep
     : IsValidRep<detail::ResultIfNoneAreQuantity<detail::QuotientTypeOrVoid, T, U>> {};
+
+namespace detail {
+
+// `AssertValidRep<T>::value` is `IsValidRep<T>::value`, but instantiating it also explains the
+// specific requirement that `T` fails, when we can name one.  Use this instead of `IsValidRep` in
+// `static_assert`, so that users get actionable error messages.
+template <typename T>
+struct AssertValidRep : IsValidRep<T> {
+    static_assert(!HasNoScalar<T>::value,
+                  "No `ScalarOf<Rep>`: provide a `ScalarOfTrait<Rep>` specialization for this rep "
+                  "(see https://aurora-opensource.github.io/au/main/reference/rep/#scalar-of)");
+};
+
+}  // namespace detail
 
 }  // namespace au

--- a/au/rep_test.cc
+++ b/au/rep_test.cc
@@ -101,6 +101,11 @@ struct OpaqueVector {
     T elements[3];
 };
 
+// A type with no automatically detectable scalar, and no `ScalarOfTrait` specialization.
+struct NoScalar {
+    double value;
+};
+
 }  // namespace
 
 // Set up the correspondence between `MyMeters` and `QuantityI<Meters>`.
@@ -173,6 +178,12 @@ TEST(IsValidRep, FalseForTypeWhoseScalarIsQuantityLike) {
 TEST(IsValidRep, TrueForVectorOfPlainScalars) {
     EXPECT_THAT((IsValidRep<VectorWithValueType<float>>::value), IsTrue());
     EXPECT_THAT((IsValidRep<VectorWithScalar<double>>::value), IsTrue());
+}
+
+TEST(IsValidRep, FalseForTypeWithNoScalar) {
+    // Every rep must have a `ScalarOf`, because the conversion risk checks are built on it.  A type
+    // that matches no probe needs a `ScalarOfTrait` specialization before it can be a rep.
+    EXPECT_THAT(IsValidRep<NoScalar>::value, IsFalse());
 }
 
 TEST(IsValidRep, HonorsUserSpecializationsOfScalarOfTrait) {

--- a/au/truncation_risk_test.cc
+++ b/au/truncation_risk_test.cc
@@ -32,6 +32,10 @@ constexpr auto PI = Magnitude<Pi>{};
 // A minimal non-arithmetic rep.  We can't assess overflow or truncation risk for such types in
 // general, but an _integer multiple_ is always exact, so it should carry no truncation risk.
 struct NonArithmetic {
+    // A non-arithmetic type can still be its own scalar: `NonArithmetic` is what the overflow and
+    // truncation machinery compares against.
+    using Scalar = NonArithmetic;
+
     int value;
 };
 


### PR DESCRIPTION
Helps #715.  This commit is the "preview" version for the future-proof release `0.6.0-future-715`.

This PR is for running all CI, and for Au team members to do a post hoc review when they're back from vacation.