### PR TITLE
DO NOT LAND: Remove deprecated `T`-suffixed template names

### DIFF
--- a/au/compatibility/eigen.hh
+++ b/au/compatibility/eigen.hh
@@ -83,7 +83,7 @@ auto norm(const Quantity<U, R> &q) {
 // The squared Euclidean norm (sum of squared coefficients).  Squares the unit; avoids a `sqrt`.
 template <typename U, typename R>
 auto squaredNorm(const Quantity<U, R> &q) {
-    return make_quantity<UnitPowerT<U, 2>>(q.data_in(U{}).squaredNorm());
+    return make_quantity<UnitPower<U, 2>>(q.data_in(U{}).squaredNorm());
 }
 
 // The sum of all coefficients.  Unit-preserving.
@@ -119,7 +119,7 @@ auto transpose(const Quantity<U, R> &q) {
 // The dot (inner) product.  The result unit is the product of the operand units.
 template <typename U1, typename R1, typename U2, typename R2>
 auto dot(const Quantity<U1, R1> &a, const Quantity<U2, R2> &b) {
-    return make_quantity<UnitProductT<U1, U2>>(a.data_in(U1{}).dot(b.data_in(U2{})));
+    return make_quantity<UnitProduct<U1, U2>>(a.data_in(U1{}).dot(b.data_in(U2{})));
 }
 
 // `dot` overloads where one operand is a raw (dimensionless) Eigen object.  The result carries the
@@ -137,7 +137,7 @@ auto dot(const V &a, const Quantity<U, R> &b) {
 // note above.
 template <typename U1, typename R1, typename U2, typename R2>
 auto cross(const Quantity<U1, R1> &a, const Quantity<U2, R2> &b) {
-    return make_quantity<UnitProductT<U1, U2>>(a.data_in(U1{}).cross(b.data_in(U2{})));
+    return make_quantity<UnitProduct<U1, U2>>(a.data_in(U1{}).cross(b.data_in(U2{})));
 }
 
 // `cross` overloads where one operand is a raw (dimensionless) Eigen object.  The result carries
@@ -204,7 +204,7 @@ auto trace(const Quantity<U, R> &q) {
 // Coefficient-wise (Hadamard) product.  The result unit is the product of the operand units.
 template <typename U1, typename R1, typename U2, typename R2>
 auto cwiseProduct(const Quantity<U1, R1> &a, const Quantity<U2, R2> &b) {
-    return make_quantity<UnitProductT<U1, U2>>(a.data_in(U1{}).cwiseProduct(b.data_in(U2{})));
+    return make_quantity<UnitProduct<U1, U2>>(a.data_in(U1{}).cwiseProduct(b.data_in(U2{})));
 }
 template <typename U, typename R, typename V>
 auto cwiseProduct(const Quantity<U, R> &a, const V &b) {
@@ -218,7 +218,7 @@ auto cwiseProduct(const V &a, const Quantity<U, R> &b) {
 // Coefficient-wise quotient.  The result unit is the quotient of the operand units.
 template <typename U1, typename R1, typename U2, typename R2>
 auto cwiseQuotient(const Quantity<U1, R1> &a, const Quantity<U2, R2> &b) {
-    return make_quantity<UnitQuotientT<U1, U2>>(a.data_in(U1{}).cwiseQuotient(b.data_in(U2{})));
+    return make_quantity<UnitQuotient<U1, U2>>(a.data_in(U1{}).cwiseQuotient(b.data_in(U2{})));
 }
 template <typename U, typename R, typename V>
 auto cwiseQuotient(const Quantity<U, R> &a, const V &b) {
@@ -226,7 +226,7 @@ auto cwiseQuotient(const Quantity<U, R> &a, const V &b) {
 }
 template <typename V, typename U, typename R>
 auto cwiseQuotient(const V &a, const Quantity<U, R> &b) {
-    return make_quantity<UnitInverseT<U>>(a.cwiseQuotient(b.data_in(U{})));
+    return make_quantity<UnitInverse<U>>(a.cwiseQuotient(b.data_in(U{})));
 }
 
 // Coefficient-wise absolute value.  Unit-preserving.
@@ -341,7 +341,7 @@ auto replicate(const Quantity<U, R> &q, std::ptrdiff_t row_factor, std::ptrdiff_
 // above.
 template <typename U, typename R>
 auto cwiseSqrt(const Quantity<U, R> &q) {
-    return make_quantity<UnitPowerT<U, 1, 2>>(q.data_in(U{}).cwiseSqrt());
+    return make_quantity<UnitPower<U, 1, 2>>(q.data_in(U{}).cwiseSqrt());
 }
 
 // The matrix inverse.  Inverts the unit (since `A * A.inverse()` is dimensionless).  LAZY: see the
@@ -354,7 +354,7 @@ auto cwiseSqrt(const Quantity<U, R> &q) {
 // planned future work.  Until then, this is a known (temporary) gap.
 template <typename U, typename R>
 auto inverse(const Quantity<U, R> &q) {
-    return make_quantity<UnitInverseT<U>>(q.data_in(U{}).inverse());
+    return make_quantity<UnitInverse<U>>(q.data_in(U{}).inverse());
 }
 
 // The product of all coefficients.  Raises the unit to the power of the coefficient count.
@@ -368,7 +368,7 @@ auto prod(const Quantity<U, R> &q) {
     static_assert(N != -1,  // i.e. not Eigen::Dynamic
                   "prod() requires a fixed-size operand: its result unit is U^(coefficient count), "
                   "which cannot be expressed when the size is only known at runtime");
-    return make_quantity<UnitPowerT<U, N>>(q.data_in(U{}).prod());
+    return make_quantity<UnitPower<U, N>>(q.data_in(U{}).prod());
 }
 
 // The determinant.  Raises the unit to the power of the matrix dimension.
@@ -381,7 +381,7 @@ auto determinant(const Quantity<U, R> &q) {
     static_assert(N != -1,  // i.e. not Eigen::Dynamic
                   "determinant() requires a fixed-size operand: its result unit is U^N for an NxN "
                   "matrix, which cannot be expressed when the size is only known at runtime");
-    return make_quantity<UnitPowerT<U, N>>(q.data_in(U{}).determinant());
+    return make_quantity<UnitPower<U, N>>(q.data_in(U{}).determinant());
 }
 
 }  // namespace au

--- a/au/compatibility/eigen_test.cc
+++ b/au/compatibility/eigen_test.cc
@@ -427,7 +427,7 @@ TEST(EigenFreeFunctions, SquaredNormSquaresTheUnit) {
 
     auto sq = squaredNorm(q);
 
-    StaticAssertTypeEq<decltype(sq), Quantity<UnitPowerT<Meters, 2>, double>>();
+    StaticAssertTypeEq<decltype(sq), Quantity<UnitPower<Meters, 2>, double>>();
     EXPECT_THAT(sq.in(meters * meters), Eq(25.0));
 }
 
@@ -473,7 +473,7 @@ TEST(EigenFreeFunctions, DotProductMultipliesUnits) {
 
     auto d = dot(a, b);
 
-    StaticAssertTypeEq<decltype(d), Quantity<UnitProductT<Meters, Feet>, double>>();
+    StaticAssertTypeEq<decltype(d), Quantity<UnitProduct<Meters, Feet>, double>>();
     EXPECT_THAT(d.in(meters * feet), Eq(6.0));
 }
 
@@ -591,8 +591,8 @@ TEST(EigenFreeFunctions, CwiseProductMultipliesUnits) {
 
     auto c = cwiseProduct(a, b);
 
-    StaticAssertTypeEq<decltype(eval(c)), Quantity<UnitProductT<Meters, Feet>, Eigen::Vector3d>>();
-    EXPECT_THAT(eval(c).data_in(UnitProductT<Meters, Feet>{}), Eq(Eigen::Vector3d(2.0, 4.0, 6.0)));
+    StaticAssertTypeEq<decltype(eval(c)), Quantity<UnitProduct<Meters, Feet>, Eigen::Vector3d>>();
+    EXPECT_THAT(eval(c).data_in(UnitProduct<Meters, Feet>{}), Eq(Eigen::Vector3d(2.0, 4.0, 6.0)));
 }
 
 TEST(EigenFreeFunctions, CwiseProductWithRawEigenObjectKeepsQuantityUnit) {
@@ -609,8 +609,8 @@ TEST(EigenFreeFunctions, CwiseQuotientDividesUnits) {
 
     auto c = cwiseQuotient(a, b);
 
-    StaticAssertTypeEq<decltype(eval(c)), Quantity<UnitQuotientT<Meters, Feet>, Eigen::Vector3d>>();
-    EXPECT_THAT(eval(c).data_in(UnitQuotientT<Meters, Feet>{}), Eq(Eigen::Vector3d(2.0, 2.0, 2.0)));
+    StaticAssertTypeEq<decltype(eval(c)), Quantity<UnitQuotient<Meters, Feet>, Eigen::Vector3d>>();
+    EXPECT_THAT(eval(c).data_in(UnitQuotient<Meters, Feet>{}), Eq(Eigen::Vector3d(2.0, 2.0, 2.0)));
 }
 
 TEST(EigenFreeFunctions, CwiseQuotientWithRawEigenObject) {
@@ -624,8 +624,8 @@ TEST(EigenFreeFunctions, CwiseQuotientWithRawEigenObject) {
 
     // raw / Quantity -> inverts the unit.
     auto den = cwiseQuotient(raw, a);
-    StaticAssertTypeEq<decltype(eval(den)), Quantity<UnitInverseT<Meters>, Eigen::Vector3d>>();
-    EXPECT_THAT(eval(den).data_in(UnitInverseT<Meters>{}), Eq(Eigen::Vector3d(0.5, 0.5, 0.5)));
+    StaticAssertTypeEq<decltype(eval(den)), Quantity<UnitInverse<Meters>, Eigen::Vector3d>>();
+    EXPECT_THAT(eval(den).data_in(UnitInverse<Meters>{}), Eq(Eigen::Vector3d(0.5, 0.5, 0.5)));
 }
 
 TEST(EigenFreeFunctions, CwiseAbsIsUnitPreserving) {
@@ -716,8 +716,8 @@ TEST(EigenFreeFunctions, CwiseSqrtTakesSquareRootOfUnit) {
 
     auto r = cwiseSqrt(q);
 
-    StaticAssertTypeEq<decltype(eval(r)), Quantity<UnitPowerT<Meters, 1, 2>, Eigen::Vector3d>>();
-    EXPECT_THAT(eval(r).data_in(UnitPowerT<Meters, 1, 2>{}), Eq(Eigen::Vector3d(2.0, 3.0, 4.0)));
+    StaticAssertTypeEq<decltype(eval(r)), Quantity<UnitPower<Meters, 1, 2>, Eigen::Vector3d>>();
+    EXPECT_THAT(eval(r).data_in(UnitPower<Meters, 1, 2>{}), Eq(Eigen::Vector3d(2.0, 3.0, 4.0)));
 }
 
 TEST(EigenFreeFunctions, InverseInvertsTheUnit) {
@@ -726,10 +726,10 @@ TEST(EigenFreeFunctions, InverseInvertsTheUnit) {
 
     auto r = inverse(q);
 
-    StaticAssertTypeEq<decltype(eval(r)), Quantity<UnitInverseT<Meters>, Eigen::Matrix2d>>();
+    StaticAssertTypeEq<decltype(eval(r)), Quantity<UnitInverse<Meters>, Eigen::Matrix2d>>();
 
     Eigen::Matrix2d expected = Eigen::Vector2d(0.5, 0.25).asDiagonal();
-    EXPECT_THAT(eval(r).data_in(UnitInverseT<Meters>{}), Eq(expected));
+    EXPECT_THAT(eval(r).data_in(UnitInverse<Meters>{}), Eq(expected));
 }
 
 TEST(EigenFreeFunctions, ProdRaisesUnitToCoefficientCount) {
@@ -737,8 +737,8 @@ TEST(EigenFreeFunctions, ProdRaisesUnitToCoefficientCount) {
 
     auto p = prod(q);
 
-    StaticAssertTypeEq<decltype(p), Quantity<UnitPowerT<Meters, 3>, double>>();
-    EXPECT_THAT(p.data_in(UnitPowerT<Meters, 3>{}), Eq(24.0));
+    StaticAssertTypeEq<decltype(p), Quantity<UnitPower<Meters, 3>, double>>();
+    EXPECT_THAT(p.data_in(UnitPower<Meters, 3>{}), Eq(24.0));
 }
 
 TEST(EigenFreeFunctions, DeterminantRaisesUnitToMatrixDimension) {
@@ -747,8 +747,8 @@ TEST(EigenFreeFunctions, DeterminantRaisesUnitToMatrixDimension) {
 
     auto d = determinant(q);
 
-    StaticAssertTypeEq<decltype(d), Quantity<UnitPowerT<Meters, 3>, double>>();
-    EXPECT_THAT(d.data_in(UnitPowerT<Meters, 3>{}), Eq(24.0));
+    StaticAssertTypeEq<decltype(d), Quantity<UnitPower<Meters, 3>, double>>();
+    EXPECT_THAT(d.data_in(UnitPower<Meters, 3>{}), Eq(24.0));
 }
 
 TEST(EigenFreeFunctions, CastWidensScalarAndPreservesUnit) {
@@ -862,7 +862,7 @@ TEST(EigenUnitSymbols, DividingVectorBySymbolMakesInverseUnit) {
 
     const auto q = Eigen::Vector3d{1.0, 2.0, 3.0} / s;
 
-    StaticAssertTypeEq<decltype(q), const Quantity<UnitInverseT<Secs>, Eigen::Vector3d>>();
+    StaticAssertTypeEq<decltype(q), const Quantity<UnitInverse<Secs>, Eigen::Vector3d>>();
     EXPECT_THAT(q.data_in(inverse(secs)), Eq(Eigen::Vector3d(1.0, 2.0, 3.0)));
 }
 
@@ -872,7 +872,7 @@ TEST(EigenUnitSymbols, ComposedSymbolsMakeCompoundUnit) {
 
     const auto v = Eigen::Vector3d{4.0, 5.0, 6.0} * m / s;
 
-    StaticAssertTypeEq<decltype(v), const Quantity<UnitQuotientT<Meters, Secs>, Eigen::Vector3d>>();
+    StaticAssertTypeEq<decltype(v), const Quantity<UnitQuotient<Meters, Secs>, Eigen::Vector3d>>();
     EXPECT_THAT(v.data_in(meters / sec), Eq(Eigen::Vector3d(4.0, 5.0, 6.0)));
 }
 

--- a/au/dimension.hh
+++ b/au/dimension.hh
@@ -38,22 +38,14 @@ struct Dimension {
 // Define readable operations for product, quotient, power, inverse on Dimensions.
 template <typename... BPs>
 using DimProduct = PackProduct<Dimension, BPs...>;
-template <typename... BPs>
-using DimProductT = DimProduct<BPs...>;
 template <typename T, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
 using DimPower = PackPower<Dimension, T, ExpNum, ExpDen>;
-template <typename T, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
-using DimPowerT = DimPower<T, ExpNum, ExpDen>;
 
 template <typename T, typename U>
 using DimQuotient = PackQuotient<Dimension, T, U>;
-template <typename T, typename U>
-using DimQuotientT = DimQuotient<T, U>;
 
 template <typename T>
 using DimInverse = PackInverse<Dimension, T>;
-template <typename T>
-using DimInverseT = DimInverse<T>;
 
 template <typename... BP1s, typename... BP2s>
 constexpr auto operator*(Dimension<BP1s...>, Dimension<BP2s...>) {
@@ -79,8 +71,6 @@ template <typename... Dims>
 struct CommonDimensionImpl;
 template <typename... Dims>
 using CommonDimension = typename CommonDimensionImpl<Dims...>::type;
-template <typename... Dims>
-using CommonDimensionT = CommonDimension<Dims...>;
 
 template <typename... BaseDims>
 struct CommonDimensionImpl<Dimension<BaseDims...>> : stdx::type_identity<Dimension<BaseDims...>> {};

--- a/au/magnitude.hh
+++ b/au/magnitude.hh
@@ -60,23 +60,15 @@ struct Magnitude {
 // Define readable operations for product, quotient, power, inverse on Magnitudes.
 template <typename... BPs>
 using MagProduct = PackProduct<Magnitude, BPs...>;
-template <typename... BPs>
-using MagProductT = MagProduct<BPs...>;
 
 template <typename T, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
 using MagPower = PackPower<Magnitude, T, ExpNum, ExpDen>;
-template <typename T, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
-using MagPowerT = MagPower<T, ExpNum, ExpDen>;
 
 template <typename T, typename U>
 using MagQuotient = PackQuotient<Magnitude, T, U>;
-template <typename T, typename U>
-using MagQuotientT = MagQuotient<T, U>;
 
 template <typename T>
 using MagInverse = PackInverse<Magnitude, T>;
-template <typename T>
-using MagInverseT = MagInverse<T>;
 
 // Enable negative magnitudes with a type representing (-1) that appears/disappears under powers.
 struct Negative {};
@@ -191,8 +183,6 @@ template <typename MagT>
 struct IntegerPartImpl;
 template <typename MagT>
 using IntegerPart = typename IntegerPartImpl<MagT>::type;
-template <typename MagT>
-using IntegerPartT = IntegerPart<MagT>;
 
 template <typename MagT>
 struct AbsImpl;
@@ -208,13 +198,9 @@ template <typename MagT>
 struct NumeratorImpl;
 template <typename MagT>
 using Numerator = typename NumeratorImpl<MagT>::type;
-template <typename MagT>
-using NumeratorT = Numerator<MagT>;
 
 template <typename MagT>
 using Denominator = Numerator<MagInverse<Abs<MagT>>>;
-template <typename MagT>
-using DenominatorT = Denominator<MagT>;
 
 template <typename MagT>
 struct IsPositive : std::true_type {};
@@ -283,8 +269,6 @@ template <typename... Ms>
 struct CommonMagnitudeImpl;
 template <typename... Ms>
 using CommonMagnitude = typename CommonMagnitudeImpl<Ms...>::type;
-template <typename... Ms>
-using CommonMagnitudeT = CommonMagnitude<Ms...>;
 
 // The sum of arbitrarily many `Magnitude` and/or `Zero` types.
 //

--- a/au/math_test.cc
+++ b/au/math_test.cc
@@ -86,7 +86,7 @@ auto IsConstantWithUnitMatching(InnerMatcher m) {
             ::testing::IsTrue()),
         ::testing::ResultOf(
             "unit",
-            [](const auto &c) { return AssociatedUnitT<stdx::remove_cvref_t<decltype(c)>>{}; },
+            [](const auto &c) { return AssociatedUnit<stdx::remove_cvref_t<decltype(c)>>{}; },
             m));
 }
 

--- a/au/packs.hh
+++ b/au/packs.hh
@@ -48,16 +48,12 @@ template <typename T>
 struct BaseImpl : stdx::type_identity<T> {};
 template <typename T>
 using Base = typename BaseImpl<T>::type;
-template <typename T>
-using BaseT = Base<T>;
 
 // Type trait for the rational exponent of a type, interpreted as a base power.
 template <typename T>
 struct ExpImpl : stdx::type_identity<std::ratio<1>> {};
 template <typename T>
 using Exp = typename ExpImpl<T>::type;
-template <typename T>
-using ExpT = Exp<T>;
 
 // Type trait for treating an arbitrary type as a given type of pack.
 //
@@ -67,8 +63,6 @@ template <template <class... Ts> class Pack, typename T>
 struct AsPackImpl : stdx::type_identity<Pack<T>> {};
 template <template <class... Ts> class Pack, typename T>
 using AsPack = typename AsPackImpl<Pack, T>::type;
-template <template <class... Ts> class Pack, typename T>
-using AsPackT = AsPack<Pack, T>;
 
 // Type trait to remove a Pack enclosing a single item.
 //
@@ -78,8 +72,6 @@ template <template <class... Ts> class Pack, typename T>
 struct UnpackIfSoloImpl;
 template <template <class... Ts> class Pack, typename T>
 using UnpackIfSolo = typename UnpackIfSoloImpl<Pack, T>::type;
-template <template <class... Ts> class Pack, typename T>
-using UnpackIfSoloT = UnpackIfSolo<Pack, T>;
 
 // Trait to define whether two types are in order, based on the total ordering for some pack.
 //
@@ -121,16 +113,14 @@ using SortAs = typename SortAsImpl<PackForOrdering, ListT>::type;
 // ordering for List, with duplicates removed.  It will be "flattened" in that any elements which
 // are already `List<Ts...>` will be effectively replaced by `Ts...`.
 //
-// A precondition for `FlatDedupedTypeListT` is that any inputs which are already of type
+// A precondition for `FlatDedupedTypeList` is that any inputs which are already of type
 // `List<...>`, respect the _ordering_ for `List`, with no duplicates.  Otherwise, behaviour is
 // undefined.  (This precondition will automatically be satisfied if *every* instance of `List<...>`
-// arises as the result of a call to `FlatDedupedTypeListT<...>`.)
+// arises as the result of a call to `FlatDedupedTypeList<...>`.)
 template <template <class...> class List, typename... Ts>
 struct FlatDedupedTypeListImpl;
 template <template <class...> class List, typename... Ts>
 using FlatDedupedTypeList = typename FlatDedupedTypeListImpl<List, AsPack<List, Ts>...>::type;
-template <template <class...> class List, typename... Ts>
-using FlatDedupedTypeListT = FlatDedupedTypeList<List, Ts...>;
 
 namespace detail {
 // Express a base power in its simplest form (base alone if power is 1, or Pow if exp is integral).
@@ -424,7 +414,7 @@ struct SortAsImpl<PackForOrdering, Pack<T, Ts...>>
           InsertUsingOrderingFor<PackForOrdering, T, SortAs<PackForOrdering, Pack<Ts...>>>> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-// `FlatDedupedTypeListT` implementation.
+// `FlatDedupedTypeList` implementation.
 
 // 0-ary trivial case:
 template <template <class...> class List>
@@ -461,8 +451,7 @@ struct FlatDedupedTypeListImpl<List, List<T>, List<H, Ts...>> :
                            // If we're here, we know the candidate comes after the head.  So, try
                            // inserting it (recursively) in the tail, and then prepend the old Head
                            // (because we know it comes first).
-                           detail::Prepend<FlatDedupedTypeListT<List, List<T>, List<Ts...>>, H>>> {
-};
+                           detail::Prepend<FlatDedupedTypeList<List, List<T>, List<Ts...>>, H>>> {};
 
 // 2-ary recursive case, multi-element head: insert head of second element, and recurse.
 template <template <class...> class List,
@@ -474,7 +463,7 @@ template <template <class...> class List,
 struct FlatDedupedTypeListImpl<List, List<H1, N1, T1...>, List<H2, T2...>>
     : FlatDedupedTypeListImpl<List,
                               // Put H2 first so we can use single-element-head case from above.
-                              FlatDedupedTypeListT<List, List<H2>, List<H1, N1, T1...>>,
+                              FlatDedupedTypeList<List, List<H2>, List<H1, N1, T1...>>,
                               List<T2...>> {};
 
 // N-ary case, multi-element head: peel off tail-of-head, and recurse.
@@ -482,7 +471,7 @@ struct FlatDedupedTypeListImpl<List, List<H1, N1, T1...>, List<H2, T2...>>
 // Note that this also handles the 2-ary case where the head list has more than one element.
 template <template <class...> class List, typename L1, typename L2, typename L3, typename... Ls>
 struct FlatDedupedTypeListImpl<List, L1, L2, L3, Ls...>
-    : FlatDedupedTypeListImpl<List, FlatDedupedTypeListT<List, L1, L2>, L3, Ls...> {};
+    : FlatDedupedTypeListImpl<List, FlatDedupedTypeList<List, L1, L2>, L3, Ls...> {};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // `PackProduct` implementation.

--- a/au/packs_test.cc
+++ b/au/packs_test.cc
@@ -164,35 +164,35 @@ TEST(PackPower, MultipliesExponentsAndSimplifies) {
 }
 
 TEST(FlatDedupedTypeList, EmptyInputsYieldsEmptyPack) {
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack>, Pack<>>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack>, Pack<>>();
 }
 
-TEST(FlatDedupedTypeListT, OrdersAsExpected) {
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, Pack<B<2>>>, Pack<B<2>>>();
+TEST(FlatDedupedTypeList, OrdersAsExpected) {
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, Pack<B<2>>>, Pack<B<2>>>();
 
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<2>, B<3>>, Pack<B<2>, B<3>>>();
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<3>, B<2>>, Pack<B<2>, B<3>>>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<2>, B<3>>, Pack<B<2>, B<3>>>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<3>, B<2>>, Pack<B<2>, B<3>>>();
 
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<2>, B<3>, B<5>>, Pack<B<2>, B<3>, B<5>>>();
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<2>, B<5>, B<3>>, Pack<B<2>, B<3>, B<5>>>();
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<3>, B<2>, B<5>>, Pack<B<2>, B<3>, B<5>>>();
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<3>, B<5>, B<2>>, Pack<B<2>, B<3>, B<5>>>();
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<5>, B<2>, B<3>>, Pack<B<2>, B<3>, B<5>>>();
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<5>, B<3>, B<2>>, Pack<B<2>, B<3>, B<5>>>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<2>, B<3>, B<5>>, Pack<B<2>, B<3>, B<5>>>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<2>, B<5>, B<3>>, Pack<B<2>, B<3>, B<5>>>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<3>, B<2>, B<5>>, Pack<B<2>, B<3>, B<5>>>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<3>, B<5>, B<2>>, Pack<B<2>, B<3>, B<5>>>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<5>, B<2>, B<3>>, Pack<B<2>, B<3>, B<5>>>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<5>, B<3>, B<2>>, Pack<B<2>, B<3>, B<5>>>();
 }
 
-TEST(FlatDedupedTypeListT, DedupesAtAnyPosition) {
+TEST(FlatDedupedTypeList, DedupesAtAnyPosition) {
     using T = Pack<B<2>, B<3>, B<5>, B<7>, B<11>>;
 
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<2>, T>, T>();
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<3>, T>, T>();
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<5>, T>, T>();
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<7>, T>, T>();
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, B<11>, T>, T>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<2>, T>, T>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<3>, T>, T>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<5>, T>, T>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<7>, T>, T>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, B<11>, T>, T>();
 
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, T, T>, T>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, T, T>, T>();
 
-    StaticAssertTypeEq<FlatDedupedTypeListT<Pack, T, Pack<B<2>>, T, B<11>, T>, T>();
+    StaticAssertTypeEq<FlatDedupedTypeList<Pack, T, Pack<B<2>>, T, B<11>, T>, T>();
 }
 
 TEST(PackPower, SupportsRationalPowers) {

--- a/au/unit_of_measure.hh
+++ b/au/unit_of_measure.hh
@@ -134,8 +134,6 @@ struct UnitRatioImpl : stdx::type_identity<MagQuotient<detail::MagT<U1>, detail:
 };
 template <typename U1, typename U2>
 using UnitRatio = typename UnitRatioImpl<U1, U2>::type;
-template <typename U1, typename U2>
-using UnitRatioT = UnitRatio<U1, U2>;
 
 // The sign of a unit: almost always `mag<1>()`, but `-mag<1>()` for "negative" units.
 template <typename U>
@@ -145,15 +143,11 @@ template <typename U>
 struct AssociatedUnitImpl : stdx::type_identity<U> {};
 template <typename U>
 using AssociatedUnit = typename AssociatedUnitImpl<U>::type;
-template <typename U>
-using AssociatedUnitT = AssociatedUnit<U>;
 
 template <typename U>
 struct AssociatedUnitForPointsImpl : stdx::type_identity<U> {};
 template <typename U>
 using AssociatedUnitForPoints = typename AssociatedUnitForPointsImpl<U>::type;
-template <typename U>
-using AssociatedUnitForPointsT = AssociatedUnitForPoints<U>;
 
 template <template <class, class> class QType, typename U>
 struct AppropriateAssociatedUnitImpl;
@@ -176,8 +170,6 @@ template <typename... Us>
 struct ComputeCommonUnit;
 template <typename... Us>
 using CommonUnit = typename ComputeCommonUnit<Us...>::type;
-template <typename... Us>
-using CommonUnitT = CommonUnit<Us...>;
 
 // `CommonPointUnit`: the largest-magnitude, highest-origin unit which is "common" to the units of
 // a collection of `QuantityPoint` instances.
@@ -202,8 +194,6 @@ template <typename... Us>
 struct ComputeCommonPointUnit;
 template <typename... Us>
 using CommonPointUnit = typename ComputeCommonPointUnit<Us...>::type;
-template <typename... Us>
-using CommonPointUnitT = CommonPointUnit<Us...>;
 
 template <template <class, class> class QType, typename... Us>
 struct AppropriateCommonUnitImpl;
@@ -366,28 +356,20 @@ template <typename... UnitPows>
 using UnitProduct =
     UnpackIfSolo<UnitProductPack,
                  PackProduct<UnitProductPack, AsPack<UnitProductPack, UnitPows>...>>;
-template <typename... UnitPows>
-using UnitProductT = UnitProduct<UnitPows...>;
 
 // Raise a Unit to a (possibly rational) Power.
 template <typename U, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
 using UnitPower =
     UnpackIfSolo<UnitProductPack,
                  PackPower<UnitProductPack, AsPack<UnitProductPack, U>, ExpNum, ExpDen>>;
-template <typename U, std::intmax_t ExpNum, std::intmax_t ExpDen = 1>
-using UnitPowerT = UnitPower<U, ExpNum, ExpDen>;
 
 // Compute the inverse of a unit.
 template <typename U>
 using UnitInverse = UnitPower<U, -1>;
-template <typename U>
-using UnitInverseT = UnitInverse<U>;
 
 // Compute the quotient of two units.
 template <typename U1, typename U2>
 using UnitQuotient = UnitProduct<U1, UnitInverse<U2>>;
-template <typename U1, typename U2>
-using UnitQuotientT = UnitQuotient<U1, U2>;
 
 template <typename... Us>
 constexpr bool is_forward_declared_unit_valid(ForwardDeclareUnitProduct<Us...>) {
@@ -797,7 +779,7 @@ template <typename U>
 using DistinctUnscaledUnits = typename DistinctUnscaledUnitsImpl<U>::type;
 template <typename... Us>
 struct DistinctUnscaledUnitsImpl<CommonUnitPack<Us...>>
-    : stdx::type_identity<FlatDedupedTypeListT<UnitList, UnscaledUnit<Us>...>> {};
+    : stdx::type_identity<FlatDedupedTypeList<UnitList, UnscaledUnit<Us>...>> {};
 
 template <typename U, typename DistinctUnits>
 struct SimplifyIfOnlyOneUnscaledUnitImpl;
@@ -906,13 +888,13 @@ template <typename... Us>
 using UnitSum = typename detail::UnitSumImpl<Us...>::type;
 
 template <typename... Us>
-using CommonUnitLabel = FlatDedupedTypeListT<detail::CommonUnitLabelImpl, Us...>;
+using CommonUnitLabel = FlatDedupedTypeList<detail::CommonUnitLabelImpl, Us...>;
 
 template <typename... Us>
 struct ComputeCommonUnitImpl
     : stdx::type_identity<detail::EliminateRedundantUnits<
-          FlatDedupedTypeListT<CommonUnitPack,
-                               detail::ReplaceCommonPointUnitWithCommonUnit<Us>...>>> {};
+          FlatDedupedTypeList<CommonUnitPack,
+                              detail::ReplaceCommonPointUnitWithCommonUnit<Us>...>>> {};
 template <>
 struct ComputeCommonUnitImpl<> : stdx::type_identity<Zero> {};
 
@@ -1055,7 +1037,7 @@ template <typename A, typename B>
 struct InOrderFor<CommonPointUnitPack, A, B> : InOrderFor<UnitProductPack, A, B> {};
 
 template <typename... Us>
-using ComputeCommonPointUnitImpl = FlatDedupedTypeListT<CommonPointUnitPack, Us...>;
+using ComputeCommonPointUnitImpl = FlatDedupedTypeList<CommonPointUnitPack, Us...>;
 
 template <typename... Us>
 struct ComputeCommonPointUnit

--- a/docs/discussion/concepts/zero.md
+++ b/docs/discussion/concepts/zero.md
@@ -98,7 +98,7 @@ left and right arrow keys to flip back and forth.)
 === "Without `ZERO`"
     ```cpp
     // Initialization
-    QuantityD<UnitQuotientT<Radians, Meters>> curvature = (radians / meter)(0);
+    QuantityD<UnitQuotient<Radians, Meters>> curvature = (radians / meter)(0);
 
     // Checking for negative numbers
     if (v_squared < squared(meters / second)(0)) { /* ... */ }
@@ -107,7 +107,7 @@ left and right arrow keys to flip back and forth.)
 === "With `ZERO`"
     ```cpp
     // Initialization
-    QuantityD<UnitQuotientT<Radians, Meters>> curvature = ZERO;
+    QuantityD<UnitQuotient<Radians, Meters>> curvature = ZERO;
 
     // Checking for negative numbers
     if (v_squared < ZERO) { /* ... */ }

--- a/docs/discussion/idioms/unit-slots.md
+++ b/docs/discussion/idioms/unit-slots.md
@@ -38,8 +38,8 @@ something as simple as `Meters{}`, an instance of the unit type `Meters`.
 
 It could also be the result of _combining several_ such instances, via arithmetic.  For example,
 `Meters{} / squared(Seconds{})` is also a unit expression.  It's an instance of the type
-`UnitQuotientT<Meters, UnitPowerT<Seconds, 2>>`.  However, the unit expression is much easier to
-write and to read than the `UnitQuotientT<...>` version!  That's why we recommend using them to
+`UnitQuotient<Meters, UnitPower<Seconds, 2>>`.  However, the unit expression is much easier to
+write and to read than the `UnitQuotient<...>` version!  That's why we recommend using them to
 [create new units](../../howto/new-units.md).
 
 ### Quantity maker expression
@@ -162,7 +162,7 @@ constexpr auto rpm = round_as(Revolutions{} / Minutes{}, angular_velocity);
 
 // Alternative, clunkier unit-expression approach (doing arithmetic on *types*):
 constexpr auto rpm = round_as(
-   UnitQuotientT<Revolutions, Minutes>{}, angular_velocity);
+   UnitQuotient<Revolutions, Minutes>{}, angular_velocity);
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //            unit expression
 ```
@@ -187,7 +187,7 @@ approach in the wild!  Here is an example:
 // !!   Do not do this!   !!
 //
 constexpr auto rpm = round_as(
-    QuantityMaker<UnitQuotientT<Revolutions, Minutes>>{}, angular_velocity);
+    QuantityMaker<UnitQuotient<Revolutions, Minutes>>{}, angular_velocity);
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 //           manual QuantityMaker instance
 ```
@@ -196,8 +196,8 @@ Presumably, this mistake comes from reading the signatures in the source code
 without understanding their core design goal: namely, to provide a place to specify the units,
 concisely and explicitly, at a callsite.
 
-This provides no benefit at all.  We could replace the `QuantityMaker<UnitQuotientT<Revolutions,
-Minutes>>` with its contents (`UnitQuotientT<Revolutions, Minutes>`) and it would be strictly
+This provides no benefit at all.  We could replace the `QuantityMaker<UnitQuotient<Revolutions,
+Minutes>>` with its contents (`UnitQuotient<Revolutions, Minutes>`) and it would be strictly
 better.
 
 The reason we endorse the `QuantityMaker` overloads is because of the convention to provide "canned"

--- a/docs/discussion/implementation/vector_space.md
+++ b/docs/discussion/implementation/vector_space.md
@@ -69,7 +69,7 @@ struct Dimension;
 
 using Length = Dimension<std::ratio<1>, std::ratio<0>>;
 using Time   = Dimension<std::ratio<0>, std::ratio<1>>;
-using Speed  = DimQuotientT<Length, Time>;
+using Speed  = DimQuotient<Length, Time>;
 ```
 
 This approach is easy to implement, but its simplicity comes at a cost.
@@ -92,7 +92,7 @@ struct Dimension;
 
 using Length = Dimension<base_dim::Length>;
 using Time   = Dimension<base_dim::Time>;
-using Speed  = DimQuotientT<Length, Time>;  // As before.
+using Speed  = DimQuotient<Length, Time>;  // As before.
 ```
 
 Compiler errors are now easy (or at least possible) to read: when we see something like

--- a/docs/howto/forward-declarations.md
+++ b/docs/howto/forward-declarations.md
@@ -61,7 +61,7 @@ that takes, say, `const QuantityD<Kilo<Meters>>&` as an argument.
 
 This is _not_ enough to forward declare a _compound unit_, such as meters per second.  Our [best
 practices](./new-units.md#alias-vs-strong) for new units suggests using a simple _alias_ in this
-case, rather than a strong type (for example, `UnitQuotientT<Meters, Seconds>`).  However, this
+case, rather than a strong type (for example, `UnitQuotient<Meters, Seconds>`).  However, this
 cannot be computed without the full machinery of the library, which can cost tens of milliseconds.
 This may not sound like much, but it's far too slow for a forward declaration file.
 
@@ -137,8 +137,8 @@ Suppose, too, that we want our library to be as lightweight as possible: maybe s
 are interacting with all of their `Quantity` types by const-ref, so they don't actually need to see
 Au's definitions.
 
-Normally, we'd refer to our speed type as `QuantityD<UnitQuotientT<Kilo<Meters>, Hours>>`.  However,
-`UnitQuotientT` needs the full machinery of the library.  Instead, let's create an alias,
+Normally, we'd refer to our speed type as `QuantityD<UnitQuotient<Kilo<Meters>, Hours>>`.  However,
+`UnitQuotient` needs the full machinery of the library.  Instead, let's create an alias,
 `KilometersPerHour`, so we can write `QuantityD<KilometersPerHour>`.
 
 The first step is to find out which types go inside `UnitProductPack<...>`, and in which order.

--- a/docs/howto/interop/index.md
+++ b/docs/howto/interop/index.md
@@ -219,15 +219,15 @@ here's an example using the nholthaus library:
         using NU = NholthausUnit;
 
         using type = decltype(
-            UnitPowerT<Meters, MeterExpT<NU>::num, MeterExpT<NU>::den>{} *
-            UnitPowerT<Kilo<Grams>, KilogramExpT<NU>::num, KilogramExpT<NU>::den>{} *
-            UnitPowerT<Seconds, SecondExpT<NU>::num, SecondExpT<NU>::den>{} *
-            UnitPowerT<Radians, RadianExpT<NU>::num, RadianExpT<NU>::den>{} *
-            UnitPowerT<Amperes, AmpExpT<NU>::num, AmpExpT<NU>::den>{} *
-            UnitPowerT<Kelvins, KelvinExpT<NU>::num, KelvinExpT<NU>::den>{} *
-            UnitPowerT<Bytes, ByteExpT<NU>::num, ByteExpT<NU>::den>{} *
-            UnitPowerT<Candelas, CandelaExpT<NU>::num, CandelaExpT<NU>::den>{} *
-            UnitPowerT<Moles, MoleExpT<NU>::num, MoleExpT<NU>::den>{} *
+            UnitPower<Meters, MeterExpT<NU>::num, MeterExpT<NU>::den>{} *
+            UnitPower<Kilo<Grams>, KilogramExpT<NU>::num, KilogramExpT<NU>::den>{} *
+            UnitPower<Seconds, SecondExpT<NU>::num, SecondExpT<NU>::den>{} *
+            UnitPower<Radians, RadianExpT<NU>::num, RadianExpT<NU>::den>{} *
+            UnitPower<Amperes, AmpExpT<NU>::num, AmpExpT<NU>::den>{} *
+            UnitPower<Kelvins, KelvinExpT<NU>::num, KelvinExpT<NU>::den>{} *
+            UnitPower<Bytes, ByteExpT<NU>::num, ByteExpT<NU>::den>{} *
+            UnitPower<Candelas, CandelaExpT<NU>::num, CandelaExpT<NU>::den>{} *
+            UnitPower<Moles, MoleExpT<NU>::num, MoleExpT<NU>::den>{} *
             NholthausUnitMagT<NU>{});
     };
     ```

--- a/docs/howto/new-units.md
+++ b/docs/howto/new-units.md
@@ -174,7 +174,7 @@ the type directly.  The reason we do is that in C++ code generally, instances ar
 than types.  This is especially true for units, which support a variety of operations: multiplying
 and dividing by other units, scaling by magnitudes, and even raising to rational powers.
 
-If we used types directly, users would need to learn obscure new traits, like `UnitProductT` for
+If we used types directly, users would need to learn obscure new traits, like `UnitProduct` for
 unit-unit products, and `ScaledUnit` for unit-magnitude products.  With instances, we can simply
 write `*` as we would for any other kind of instances --- and this `*` covers both use cases!
 Wrapping the result in `decltype(...)` is a small price to pay for this familiarity and flexibility.

--- a/docs/reference/constant.md
+++ b/docs/reference/constant.md
@@ -411,7 +411,7 @@ This provides great flexibility and confidence in passing `Constant` values to A
     [overflow safety surface](../discussion/concepts/overflow.md), which is a more conservative
     heuristic.
 
-    For example, suppose you have an API accepting `Quantity<UnitQuotientT<Meters, Seconds>, int>`,
+    For example, suppose you have an API accepting `Quantity<UnitQuotient<Meters, Seconds>, int>`,
     and a constant `c` representing the speed of light.
 
     You will be able to pass `c` to this API, because the constant-to-quantity conversion operation
@@ -552,7 +552,7 @@ In the following table, we will use `x` to represent the value that was stored i
 | `Constant<Unit> * T` | `Quantity<Unit, T>` | `x` | |
 | `Constant<Unit> / T` | `Quantity<Unit, T>` | `T{1} / x` | Disallowed for integral `T` |
 | `T * Constant<Unit>` | `Quantity<Unit, T>` | `x` | |
-| `T / Constant<Unit>` | `Quantity<UnitInverseT<Unit>, T>` | `x` | |
+| `T / Constant<Unit>` | `Quantity<UnitInverse<Unit>, T>` | `x` | |
 
 #### `Quantity<U, R>`
 
@@ -564,10 +564,10 @@ that is, if the input quantity was `q`, then `x` is `q.in(U{})`.
 
 | Operation | Resulting Type | Underlying Value | Notes |
 | --------- | -------------- | ---------------- | ----- |
-| `Constant<Unit> * Quantity<U, R>` | `Quantity<UnitProductT<Unit, U>, R>` | `x` | |
-| `Constant<Unit> / Quantity<U, R>` | `Quantity<UnitQuotientT<Unit, U>, R>` | `R{1} / x` | Disallowed for integral `R` |
-| `Quantity<U, R> * Constant<Unit>` | `Quantity<UnitProductT<U, Unit>, R>` | `x` | |
-| `Quantity<U, R> / Constant<Unit>` | `Quantity<UnitQuotientT<U, Unit>, R>` | `x` | |
+| `Constant<Unit> * Quantity<U, R>` | `Quantity<UnitProduct<Unit, U>, R>` | `x` | |
+| `Constant<Unit> / Quantity<U, R>` | `Quantity<UnitQuotient<Unit, U>, R>` | `R{1} / x` | Disallowed for integral `R` |
+| `Quantity<U, R> * Constant<Unit>` | `Quantity<UnitProduct<U, Unit>, R>` | `x` | |
+| `Quantity<U, R> / Constant<Unit>` | `Quantity<UnitQuotient<U, Unit>, R>` | `x` | |
 
 #### `Constant<U>`
 
@@ -575,8 +575,8 @@ Constants compose: the product or quotient of two `Constant` instances is a new 
 
 | Operation | Resulting Type |
 | --------- | -------------- |
-| `Constant<Unit> * Constant<U>` | `Constant<UnitProductT<Unit, U>>` |
-| `Constant<Unit> / Constant<U>` | `Constant<UnitQuotientT<Unit, U>>` |
+| `Constant<Unit> * Constant<U>` | `Constant<UnitProduct<Unit, U>>` |
+| `Constant<Unit> / Constant<U>` | `Constant<UnitQuotient<Unit, U>>` |
 
 #### `QuantityMaker<U>`
 
@@ -585,10 +585,10 @@ whose unit is derived from `Unit` and `U`.
 
 | Operation | Resulting Type |
 | --------- | -------------- |
-| `Constant<Unit> * QuantityMaker<U>` | `QuantityMaker<UnitProductT<Unit, U>>` |
-| `Constant<Unit> / QuantityMaker<U>` | `QuantityMaker<UnitQuotientT<Unit, U>>` |
-| `QuantityMaker<U> * Constant<Unit>` | `QuantityMaker<UnitProductT<U, Unit>>` |
-| `QuantityMaker<U> / Constant<Unit>` | `QuantityMaker<UnitQuotientT<U, Unit>>` |
+| `Constant<Unit> * QuantityMaker<U>` | `QuantityMaker<UnitProduct<Unit, U>>` |
+| `Constant<Unit> / QuantityMaker<U>` | `QuantityMaker<UnitQuotient<Unit, U>>` |
+| `QuantityMaker<U> * Constant<Unit>` | `QuantityMaker<UnitProduct<U, Unit>>` |
+| `QuantityMaker<U> / Constant<Unit>` | `QuantityMaker<UnitQuotient<U, Unit>>` |
 
 #### `SingularNameFor<U>`
 
@@ -597,10 +597,10 @@ Multiplying or dividing `Constant<Unit>` with a `SingularNameFor<U>` produces a 
 
 | Operation | Resulting Type |
 | --------- | -------------- |
-| `Constant<Unit> * SingularNameFor<U>` | `SingularNameFor<UnitProductT<Unit, U>>` |
-| `Constant<Unit> / SingularNameFor<U>` | `SingularNameFor<UnitQuotientT<Unit, U>>` |
-| `SingularNameFor<U> * Constant<Unit>` | `SingularNameFor<UnitProductT<U, Unit>>` |
-| `SingularNameFor<U> / Constant<Unit>` | `SingularNameFor<UnitQuotientT<U, Unit>>` |
+| `Constant<Unit> * SingularNameFor<U>` | `SingularNameFor<UnitProduct<Unit, U>>` |
+| `Constant<Unit> / SingularNameFor<U>` | `SingularNameFor<UnitQuotient<Unit, U>>` |
+| `SingularNameFor<U> * Constant<Unit>` | `SingularNameFor<UnitProduct<U, Unit>>` |
+| `SingularNameFor<U> / Constant<Unit>` | `SingularNameFor<UnitQuotient<U, Unit>>` |
 
 #### `Magnitude<BPs...>`
 
@@ -614,7 +614,7 @@ In the following table, let `m` be an instance of `Magnitude<BPs...>`.
 | `Constant<Unit> * Magnitude<BPs...>` | `Constant<decltype(Unit{} * m)>` |
 | `Constant<Unit> / Magnitude<BPs...>` | `Constant<decltype(Unit{} / m)>` |
 | `Magnitude<BPs...> * Constant<Unit>` | `Constant<decltype(Unit{} * m)>` |
-| `Magnitude<BPs...> / Constant<Unit>` | `Constant<decltype(UnitInverseT<Unit>{} * m)>` |
+| `Magnitude<BPs...> / Constant<Unit>` | `Constant<decltype(UnitInverse<Unit>{} * m)>` |
 
 #### `Zero`
 

--- a/docs/reference/conversion_risk_policies.md
+++ b/docs/reference/conversion_risk_policies.md
@@ -70,7 +70,7 @@ from it:
     ```cpp
     template <class T, class UnitSlot, class U, class R, class Policy = decltype(check_for(ALL_RISKS))>
     constexpr auto clamped_convert_to(UnitSlot unit, Quantity<U, R> q, Policy policy = {}) {
-        using ResultLimits = std::numeric_limits<Quantity<AssociatedUnitT<UnitSlot>, T>>;
+        using ResultLimits = std::numeric_limits<Quantity<AssociatedUnit<UnitSlot>, T>>;
         return will_conversion_overflow<T>(q, unit)
                    ? (q > ZERO ? ResultLimits::max() : ResultLimits::lowest())
                    : q.template as<T>(unit, policy.but_ignoring(OVERFLOW_RISK))

--- a/docs/reference/detail/dimension.md
+++ b/docs/reference/detail/dimension.md
@@ -28,10 +28,6 @@ which each carry their own dimension information.  The main situation where an e
 - For _instances_ `d1` and `d2`:
     - `d1 * d2`
 
-!!! note
-    Older releases used `DimProductT` (with the `T` suffix) instead of `DimProduct`.  Prefer
-    `DimProduct`.  `DimProductT` is deprecated, and will be removed in future releases.
-
 ### Division
 
 **Result:** The quotient of two `Dimension` values.
@@ -43,10 +39,6 @@ which each carry their own dimension information.  The main situation where an e
 - For _instances_ `d1` and `d2`:
     - `d1 / d2`
 
-!!! note
-    Older releases used `DimQuotientT` (with the `T` suffix) instead of `DimQuotient`.  Prefer
-    `DimQuotient`.  `DimQuotientT` is deprecated, and will be removed in future releases.
-
 ### Powers
 
 **Result:** A `Dimension` raised to an integral power.
@@ -57,10 +49,6 @@ which each carry their own dimension information.  The main situation where an e
     - `DimPower<D, N>`
 - For an _instance_ `d`, and an integral power `N`:
     - `pow<N>(d)`
-
-!!! note
-    Older releases used `DimPowerT` (with the `T` suffix) instead of `DimPower`.  Prefer
-    `DimPower`.  `DimPowerT` is deprecated, and will be removed in future releases.
 
 ### Roots
 

--- a/docs/reference/magnitude.md
+++ b/docs/reference/magnitude.md
@@ -323,10 +323,6 @@ complicated, but it's still useful to think of it as essentially just negation.
 - `ZERO * m` equals `ZERO`
 - `m * ZERO` equals `ZERO`
 
-!!! note
-    Older releases used `MagProductT` (with the `T` suffix) instead of `MagProduct`.  Prefer
-    `MagProduct`.  `MagProductT` is deprecated, and will be removed in future releases.
-
 ### Division
 
 **Result:** The quotient of two `Magnitude` values.
@@ -341,10 +337,6 @@ complicated, but it's still useful to think of it as essentially just negation.
 `Zero` divided by any magnitude is `Zero`:
 
 - `ZERO / m` equals `ZERO`
-
-!!! note
-    Older releases used `MagQuotientT` (with the `T` suffix) instead of `MagQuotient`.  Prefer
-    `MagQuotient`.  `MagQuotientT` is deprecated, and will be removed in future releases.
 
 ### Addition †
 
@@ -460,10 +452,6 @@ if `q` is the truncated quotient, then `q * b + (a % b)` equals `a`.
     - `MagPower<M, N>`
 - For an _instance_ `m`, and an integral power `N`:
     - `pow<N>(m)`
-
-!!! note
-    Older releases used `MagPowerT` (with the `T` suffix) instead of `MagPower`.  Prefer
-    `MagPower`.  `MagPowerT` is deprecated, and will be removed in future releases.
 
 ### Roots
 
@@ -641,10 +629,6 @@ magnitudes, by breaking them into the same kinds of pieces that a human reader w
 - For an _instance_ `m`:
     - `integer_part(m)`
 
-!!! note
-    Older releases used `IntegerPartT` (with the `T` suffix) instead of `IntegerPart`.  Prefer
-    `IntegerPart`.  `IntegerPartT` is deprecated, and will be removed in future releases.
-
 ### Numerator (integer part)
 
 **Result:** The numerator we would have if a `Magnitude` were written as a fraction.  This result is
@@ -659,10 +643,6 @@ For example, the "numerator" of $\frac{3\sqrt{3}}{5\pi}$ would be $3\sqrt{3}$.
 - For an _instance_ `m`:
     - `numerator(m)`
 
-!!! note
-    Older releases used `NumeratorT` (with the `T` suffix) instead of `Numerator`.  Prefer
-    `Numerator`.  `NumeratorT` is deprecated, and will be removed in future releases.
-
 ### Denominator (integer part)
 
 **Result:** The denominator we would have if a `Magnitude` were written as a fraction.  This result is
@@ -676,10 +656,6 @@ For example, the "denominator" of $\frac{3\sqrt{3}}{5\pi}$ would be $5\pi$.
     - `Denominator<M>`
 - For an _instance_ `m`:
     - `denominator(m)`
-
-!!! note
-    Older releases used `DenominatorT` (with the `T` suffix) instead of `Denominator`.  Prefer
-    `Denominator`.  `DenominatorT` is deprecated, and will be removed in future releases.
 
 ### Absolute value
 

--- a/docs/reference/unit.md
+++ b/docs/reference/unit.md
@@ -130,11 +130,11 @@ There are two ways to create an instance of a unit symbol.
 
         ```cpp
         constexpr auto m = SymbolFor<Meters>{};
-        constexpr auto mps = SymbolFor<UnitQuotientT<Meters, Seconds>>{};
+        constexpr auto mps = SymbolFor<UnitQuotient<Meters, Seconds>>{};
         ```
 
         These are the fastest to compile, although they're a little more verbose, and composition
-        uses awkward type traits such as `UnitQuotientT`.
+        uses awkward type traits such as `UnitQuotient`.
 
 #### Bringing symbols into scope {#symbols-in-scope}
 
@@ -210,7 +210,7 @@ In the following table, we will use `x` to represent the value that was stored i
 | `SymbolFor<Unit> * T` | `Quantity<Unit, T>` | `x` | |
 | `SymbolFor<Unit> / T` | `Quantity<Unit, T>` | `T{1} / x` | Disallowed for integral `T` |
 | `T * SymbolFor<Unit>` | `Quantity<Unit, T>` | `x` | |
-| `T / SymbolFor<Unit>` | `Quantity<UnitInverseT<Unit>, T>` | `x` | |
+| `T / SymbolFor<Unit>` | `Quantity<UnitInverse<Unit>, T>` | `x` | |
 
 #### `Quantity<U, R>`
 
@@ -222,10 +222,10 @@ that is, if the input quantity was `q`, then `x` is `q.in(U{})`.
 
 | Operation | Resulting Type | Underlying Value | Notes |
 |-----------|----------------|-------------------|-------|
-| `SymbolFor<Unit> * Quantity<U, R>` | `Quantity<UnitProductT<Unit, U>, R>` | `x` | |
-| `SymbolFor<Unit> / Quantity<U, R>` | `Quantity<UnitQuotientT<Unit, U>, R>` | `R{1} / x` | Disallowed for integral `R` |
-| `Quantity<U, R> * SymbolFor<Unit>` | `Quantity<UnitProductT<U, Unit>, R>` | `x` | |
-| `Quantity<U, R> / SymbolFor<Unit>` | `Quantity<UnitQuotientT<U, Unit>, R>` | `x` | |
+| `SymbolFor<Unit> * Quantity<U, R>` | `Quantity<UnitProduct<Unit, U>, R>` | `x` | |
+| `SymbolFor<Unit> / Quantity<U, R>` | `Quantity<UnitQuotient<Unit, U>, R>` | `R{1} / x` | Disallowed for integral `R` |
+| `Quantity<U, R> * SymbolFor<Unit>` | `Quantity<UnitProduct<U, Unit>, R>` | `x` | |
+| `Quantity<U, R> / SymbolFor<Unit>` | `Quantity<UnitQuotient<U, Unit>, R>` | `x` | |
 
 #### `SymbolFor<OtherUnit>`
 
@@ -233,8 +233,8 @@ Symbols compose: the product or quotient of two `SymbolFor` instances is a new `
 
 | Operation | Resulting Type |
 |-----------|----------------|
-| `SymbolFor<Unit> * SymbolFor<OtherUnit>` | `SymbolFor<UnitProductT<Unit, OtherUnit>>` |
-| `SymbolFor<Unit> / SymbolFor<OtherUnit>` | `SymbolFor<UnitQuotientT<Unit, OtherUnit>>` |
+| `SymbolFor<Unit> * SymbolFor<OtherUnit>` | `SymbolFor<UnitProduct<Unit, OtherUnit>>` |
+| `SymbolFor<Unit> / SymbolFor<OtherUnit>` | `SymbolFor<UnitQuotient<Unit, OtherUnit>>` |
 
 ### Unit literals {#literals}
 
@@ -305,10 +305,6 @@ In what follows, we'll use this convention:
 - For _instances_ `u1` and `u2`:
     - `u1 * u2`
 
-!!! note
-    Older releases used `UnitProductT` (with the `T` suffix) instead of `UnitProduct`.  Prefer
-    `UnitProduct`.  `UnitProductT` is deprecated, and will be removed in future releases.
-
 ### Division
 
 **Result:** The quotient of two units.
@@ -320,10 +316,6 @@ In what follows, we'll use this convention:
 - For _instances_ `u1` and `u2`:
     - `u1 / u2`
 
-!!! note
-    Older releases used `UnitQuotientT` (with the `T` suffix) instead of `UnitQuotient`.  Prefer
-    `UnitQuotient`.  `UnitQuotientT` is deprecated, and will be removed in future releases.
-
 ### Powers
 
 **Result:** A unit raised to an integral power.
@@ -334,10 +326,6 @@ In what follows, we'll use this convention:
     - `UnitPower<U, N>`
 - For an _instance_ `u`, and an integral power `N`:
     - `pow<N>(u)`
-
-!!! note
-    Older releases used `UnitPowerT` (with the `T` suffix) instead of `UnitPower`.  Prefer
-    `UnitPower`.  `UnitPowerT` is deprecated, and will be removed in future releases.
 
 ### Roots
 
@@ -519,14 +507,9 @@ as an inch.
 **Syntax:**
 
 - For _types_ `U1` and `U2`:
-    - `UnitRatio<U1, U2>::value`
+    - `UnitRatio<U1, U2>`
 - For _instances_ `u1` and `u2`:
     - `unit_ratio(u1, u2)`
-
-!!! note
-    Formerly, this was `UnitRatioT`, not `UnitRatio` (note the extra `T` on the end).  `UnitRatioT`
-    currently still works, but it is deprecated, and will be removed in a future release.  Please
-    migrate all current instances of `UnitRatioT` to `UnitRatio`.
 
 ### Unit sign
 
@@ -615,11 +598,6 @@ The use case for this trait is to _implement_ the unit slot argument for a funct
 - For an _instance_ `u`:
     - `associated_unit(u)`
 
-!!! note
-    Formerly, this was `AssociatedUnitT`, not `AssociatedUnit` (note the extra `T` on the end).
-    `AssociatedUnitT` currently still works, but it is deprecated, and will be removed in a future
-    release.  Please migrate all current instances of `AssociatedUnitT` to `AssociatedUnit`.
-
 ### Associated unit (for points) {#associated-unit-for-points}
 
 **Result:** The actual unit associated with a [unit slot](../discussion/idioms/unit-slots.md) that
@@ -649,12 +627,6 @@ associated with quantity points.
     - `AssociatedUnitForPoints<U>`
 - For an _instance_ `u`:
     - `associated_unit_for_points(u)`
-
-!!! note
-    Formerly, this was `AssociatedUnitForPointsT`, not `AssociatedUnitForPoints` (note the extra `T`
-    on the end).  `AssociatedUnitForPointsT` currently still works, but it is deprecated, and will
-    be removed in a future release.  Please migrate all current instances of
-    `AssociatedUnitForPointsT` to `AssociatedUnitForPoints`.
 
 ### Appropriate associated unit {#appropriate-associated-unit}
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -935,11 +935,11 @@ approach: read the warning below first.
 
     ```cpp
     // `v1`: Original example above.
-    Quantity<UnitQuotientT<Miles, Hours>> v1
+    Quantity<UnitQuotient<Miles, Hours>> v1
         = miles(115) / unblock_int_div(hours(2));
 
     // `v2`: Changing the denominator's units.
-    Quantity<UnitQuotientT<Miles, Hours>> v2
+    Quantity<UnitQuotient<Miles, Hours>> v2
         = miles(115) / unblock_int_div(minutes(120));
     ```
 
@@ -1243,7 +1243,7 @@ the units inside that pack.
 If that sounds obscure, it is: ordering units inside packs is a deep library implementation detail,
 and we try to avoid letting end users encounter this.  To reach this error, you need two _distinct_
 units that have the _same_ Dimension, Magnitude, _and_ Origin.  That's a necessary but not
-sufficient condition: for example, even `UnitInverseT<Seconds>` and `Hertz` won't trigger this!
+sufficient condition: for example, even `UnitInverse<Seconds>` and `Hertz` won't trigger this!
 
 ??? info "More background info on why this error exists"
     In case you want to understand more, here is the gist.
@@ -1543,7 +1543,7 @@ ordering!
                 U1=au::Quarterfeet,
                 U2=au::Trinches
             ]
-    D:\a\au\au\au.hh(5241): note: see reference to alias template instantiation 'au::FlatDedupedTypeListT<au::CommonUnitPack,au::Quarterfeet,au::Trinches>' being compiled
+    D:\a\au\au\au.hh(5241): note: see reference to alias template instantiation 'au::FlatDedupedTypeList<au::CommonUnitPack,au::Quarterfeet,au::Trinches>' being compiled
     D:\a\au\au\au.hh(1718): note: see reference to alias template instantiation 'au::FlatDedupedTypeList<au::CommonUnitPack,au::Quarterfeet,au::Trinches>' being compiled
     D:\a\au\au\au.hh(1716): note: see reference to class template instantiation 'au::FlatDedupedTypeListImpl<au::CommonUnitPack,au::CommonUnitPack<T>,au::CommonUnitPack<au::Trinches>>' being compiled
             with


### PR DESCRIPTION
This is the future-proof release for #733 for 0.6.0.

This PR exists to run CI for the future-proof release, and so that the Au team members can do post hoc review once they are back from vacation.