### PR TITLE
Pull mag literal outside in unit literals

### DIFF
--- a/au/units/literals/amperes.hh
+++ b/au/units/literals/amperes.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_A` is a `Constant` equivalent to `make_constant(1.28e-4_mag * amperes)`.
+// `1.28e-4_A` is a `Constant` equivalent to `make_constant(amperes) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_A() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/amperes.hh
+++ b/au/units/literals/amperes.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_A() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(amperes * operator""_mag<Cs...>());
+    return make_constant(amperes) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/arcminutes.hh
+++ b/au/units/literals/arcminutes.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_am() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(arcminutes * operator""_mag<Cs...>());
+    return make_constant(arcminutes) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/arcminutes.hh
+++ b/au/units/literals/arcminutes.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_am` is a `Constant` equivalent to `make_constant(1.28e-4_mag * arcminutes)`.
+// `1.28e-4_am` is a `Constant` equivalent to `make_constant(arcminutes) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_am() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/arcseconds.hh
+++ b/au/units/literals/arcseconds.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_as` is a `Constant` equivalent to `make_constant(1.28e-4_mag * arcseconds)`.
+// `1.28e-4_as` is a `Constant` equivalent to `make_constant(arcseconds) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_as() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/arcseconds.hh
+++ b/au/units/literals/arcseconds.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_as() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(arcseconds * operator""_mag<Cs...>());
+    return make_constant(arcseconds) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/astronomical_units.hh
+++ b/au/units/literals/astronomical_units.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_AU() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(astronomical_units * operator""_mag<Cs...>());
+    return make_constant(astronomical_units) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/astronomical_units.hh
+++ b/au/units/literals/astronomical_units.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_AU` is a `Constant` equivalent to `make_constant(1.28e-4_mag * astronomical_units)`.
+// `1.28e-4_AU` is a `Constant` equivalent to `make_constant(astronomical_units) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_AU() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/bars.hh
+++ b/au/units/literals/bars.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_bar` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bars)`.
+// `1.28e-4_bar` is a `Constant` equivalent to `make_constant(bars) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_bar() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/bars.hh
+++ b/au/units/literals/bars.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_bar() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(bars * operator""_mag<Cs...>());
+    return make_constant(bars) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/becquerel.hh
+++ b/au/units/literals/becquerel.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_Bq` is a `Constant` equivalent to `make_constant(1.28e-4_mag * becquerel)`.
+// `1.28e-4_Bq` is a `Constant` equivalent to `make_constant(becquerel) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_Bq() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/becquerel.hh
+++ b/au/units/literals/becquerel.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_Bq() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(becquerel * operator""_mag<Cs...>());
+    return make_constant(becquerel) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/bits.hh
+++ b/au/units/literals/bits.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_b` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bits)`.
+// `1.28e-4_b` is a `Constant` equivalent to `make_constant(bits) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_b() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/bits.hh
+++ b/au/units/literals/bits.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_b() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(bits * operator""_mag<Cs...>());
+    return make_constant(bits) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/bytes.hh
+++ b/au/units/literals/bytes.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_B() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(bytes * operator""_mag<Cs...>());
+    return make_constant(bytes) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/bytes.hh
+++ b/au/units/literals/bytes.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_B` is a `Constant` equivalent to `make_constant(1.28e-4_mag * bytes)`.
+// `1.28e-4_B` is a `Constant` equivalent to `make_constant(bytes) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_B() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/candelas.hh
+++ b/au/units/literals/candelas.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_cd` is a `Constant` equivalent to `make_constant(1.28e-4_mag * candelas)`.
+// `1.28e-4_cd` is a `Constant` equivalent to `make_constant(candelas) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_cd() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/candelas.hh
+++ b/au/units/literals/candelas.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_cd() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(candelas * operator""_mag<Cs...>());
+    return make_constant(candelas) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/celsius.hh
+++ b/au/units/literals/celsius.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_degC_qty() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(celsius_qty * operator""_mag<Cs...>());
+    return make_constant(celsius_qty) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/celsius.hh
+++ b/au/units/literals/celsius.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_degC_qty` is a `Constant` equivalent to `make_constant(1.28e-4_mag * celsius_qty)`.
+// `1.28e-4_degC_qty` is a `Constant` equivalent to `make_constant(celsius_qty) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_degC_qty() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/coulombs.hh
+++ b/au/units/literals/coulombs.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_C` is a `Constant` equivalent to `make_constant(1.28e-4_mag * coulombs)`.
+// `1.28e-4_C` is a `Constant` equivalent to `make_constant(coulombs) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_C() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/coulombs.hh
+++ b/au/units/literals/coulombs.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_C() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(coulombs * operator""_mag<Cs...>());
+    return make_constant(coulombs) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/days.hh
+++ b/au/units/literals/days.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_d` is a `Constant` equivalent to `make_constant(1.28e-4_mag * days)`.
+// `1.28e-4_d` is a `Constant` equivalent to `make_constant(days) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_d() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/days.hh
+++ b/au/units/literals/days.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_d() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(days * operator""_mag<Cs...>());
+    return make_constant(days) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/degrees.hh
+++ b/au/units/literals/degrees.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_deg() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(degrees * operator""_mag<Cs...>());
+    return make_constant(degrees) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/degrees.hh
+++ b/au/units/literals/degrees.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_deg` is a `Constant` equivalent to `make_constant(1.28e-4_mag * degrees)`.
+// `1.28e-4_deg` is a `Constant` equivalent to `make_constant(degrees) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_deg() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/fahrenheit.hh
+++ b/au/units/literals/fahrenheit.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_degF_qty` is a `Constant` equivalent to `make_constant(1.28e-4_mag * fahrenheit_qty)`.
+// `1.28e-4_degF_qty` is a `Constant` equivalent to `make_constant(fahrenheit_qty) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_degF_qty() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/fahrenheit.hh
+++ b/au/units/literals/fahrenheit.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_degF_qty() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(fahrenheit_qty * operator""_mag<Cs...>());
+    return make_constant(fahrenheit_qty) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/farads.hh
+++ b/au/units/literals/farads.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_F() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(farads * operator""_mag<Cs...>());
+    return make_constant(farads) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/farads.hh
+++ b/au/units/literals/farads.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_F` is a `Constant` equivalent to `make_constant(1.28e-4_mag * farads)`.
+// `1.28e-4_F` is a `Constant` equivalent to `make_constant(farads) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_F() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/fathoms.hh
+++ b/au/units/literals/fathoms.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_ftm() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(fathoms * operator""_mag<Cs...>());
+    return make_constant(fathoms) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/fathoms.hh
+++ b/au/units/literals/fathoms.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_ftm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * fathoms)`.
+// `1.28e-4_ftm` is a `Constant` equivalent to `make_constant(fathoms) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_ftm() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/feet.hh
+++ b/au/units/literals/feet.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_ft() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(feet * operator""_mag<Cs...>());
+    return make_constant(feet) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/feet.hh
+++ b/au/units/literals/feet.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_ft` is a `Constant` equivalent to `make_constant(1.28e-4_mag * feet)`.
+// `1.28e-4_ft` is a `Constant` equivalent to `make_constant(feet) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_ft() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/football_fields.hh
+++ b/au/units/literals/football_fields.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_ftbl_fld() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(football_fields * operator""_mag<Cs...>());
+    return make_constant(football_fields) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/football_fields.hh
+++ b/au/units/literals/football_fields.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_ftbl_fld` is a `Constant` equivalent to `make_constant(1.28e-4_mag * football_fields)`.
+// `1.28e-4_ftbl_fld` is a `Constant` equivalent to `make_constant(football_fields) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_ftbl_fld() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/furlongs.hh
+++ b/au/units/literals/furlongs.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_fur` is a `Constant` equivalent to `make_constant(1.28e-4_mag * furlongs)`.
+// `1.28e-4_fur` is a `Constant` equivalent to `make_constant(furlongs) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_fur() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/furlongs.hh
+++ b/au/units/literals/furlongs.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_fur() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(furlongs * operator""_mag<Cs...>());
+    return make_constant(furlongs) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/grams.hh
+++ b/au/units/literals/grams.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_g() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(grams * operator""_mag<Cs...>());
+    return make_constant(grams) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/grams.hh
+++ b/au/units/literals/grams.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_g` is a `Constant` equivalent to `make_constant(1.28e-4_mag * grams)`.
+// `1.28e-4_g` is a `Constant` equivalent to `make_constant(grams) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_g() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/grays.hh
+++ b/au/units/literals/grays.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_Gy` is a `Constant` equivalent to `make_constant(1.28e-4_mag * grays)`.
+// `1.28e-4_Gy` is a `Constant` equivalent to `make_constant(grays) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_Gy() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/grays.hh
+++ b/au/units/literals/grays.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_Gy() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(grays * operator""_mag<Cs...>());
+    return make_constant(grays) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/henries.hh
+++ b/au/units/literals/henries.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_H() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(henries * operator""_mag<Cs...>());
+    return make_constant(henries) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/henries.hh
+++ b/au/units/literals/henries.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_H` is a `Constant` equivalent to `make_constant(1.28e-4_mag * henries)`.
+// `1.28e-4_H` is a `Constant` equivalent to `make_constant(henries) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_H() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/hertz.hh
+++ b/au/units/literals/hertz.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_Hz() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(hertz * operator""_mag<Cs...>());
+    return make_constant(hertz) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/hertz.hh
+++ b/au/units/literals/hertz.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_Hz` is a `Constant` equivalent to `make_constant(1.28e-4_mag * hertz)`.
+// `1.28e-4_Hz` is a `Constant` equivalent to `make_constant(hertz) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_Hz() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/hours.hh
+++ b/au/units/literals/hours.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_h() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(hours * operator""_mag<Cs...>());
+    return make_constant(hours) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/hours.hh
+++ b/au/units/literals/hours.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_h` is a `Constant` equivalent to `make_constant(1.28e-4_mag * hours)`.
+// `1.28e-4_h` is a `Constant` equivalent to `make_constant(hours) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_h() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/inches.hh
+++ b/au/units/literals/inches.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_in() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(inches * operator""_mag<Cs...>());
+    return make_constant(inches) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/inches.hh
+++ b/au/units/literals/inches.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_in` is a `Constant` equivalent to `make_constant(1.28e-4_mag * inches)`.
+// `1.28e-4_in` is a `Constant` equivalent to `make_constant(inches) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_in() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/joules.hh
+++ b/au/units/literals/joules.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_J` is a `Constant` equivalent to `make_constant(1.28e-4_mag * joules)`.
+// `1.28e-4_J` is a `Constant` equivalent to `make_constant(joules) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_J() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/joules.hh
+++ b/au/units/literals/joules.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_J() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(joules * operator""_mag<Cs...>());
+    return make_constant(joules) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/katals.hh
+++ b/au/units/literals/katals.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_kat` is a `Constant` equivalent to `make_constant(1.28e-4_mag * katals)`.
+// `1.28e-4_kat` is a `Constant` equivalent to `make_constant(katals) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_kat() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/katals.hh
+++ b/au/units/literals/katals.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_kat() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(katals * operator""_mag<Cs...>());
+    return make_constant(katals) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/kelvins.hh
+++ b/au/units/literals/kelvins.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_K` is a `Constant` equivalent to `make_constant(1.28e-4_mag * kelvins)`.
+// `1.28e-4_K` is a `Constant` equivalent to `make_constant(kelvins) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_K() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/kelvins.hh
+++ b/au/units/literals/kelvins.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_K() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(kelvins * operator""_mag<Cs...>());
+    return make_constant(kelvins) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/knots.hh
+++ b/au/units/literals/knots.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_kn() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(knots * operator""_mag<Cs...>());
+    return make_constant(knots) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/knots.hh
+++ b/au/units/literals/knots.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_kn` is a `Constant` equivalent to `make_constant(1.28e-4_mag * knots)`.
+// `1.28e-4_kn` is a `Constant` equivalent to `make_constant(knots) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_kn() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/liters.hh
+++ b/au/units/literals/liters.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_L` is a `Constant` equivalent to `make_constant(1.28e-4_mag * liters)`.
+// `1.28e-4_L` is a `Constant` equivalent to `make_constant(liters) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_L() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/liters.hh
+++ b/au/units/literals/liters.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_L() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(liters * operator""_mag<Cs...>());
+    return make_constant(liters) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/lumens.hh
+++ b/au/units/literals/lumens.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_lm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * lumens)`.
+// `1.28e-4_lm` is a `Constant` equivalent to `make_constant(lumens) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_lm() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/lumens.hh
+++ b/au/units/literals/lumens.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_lm() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(lumens * operator""_mag<Cs...>());
+    return make_constant(lumens) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/lux.hh
+++ b/au/units/literals/lux.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_lx() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(lux * operator""_mag<Cs...>());
+    return make_constant(lux) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/lux.hh
+++ b/au/units/literals/lux.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_lx` is a `Constant` equivalent to `make_constant(1.28e-4_mag * lux)`.
+// `1.28e-4_lx` is a `Constant` equivalent to `make_constant(lux) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_lx() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/meters.hh
+++ b/au/units/literals/meters.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_m() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(meters * operator""_mag<Cs...>());
+    return make_constant(meters) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/meters.hh
+++ b/au/units/literals/meters.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_m` is a `Constant` equivalent to `make_constant(1.28e-4_mag * meters)`.
+// `1.28e-4_m` is a `Constant` equivalent to `make_constant(meters) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_m() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/miles.hh
+++ b/au/units/literals/miles.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_mi` is a `Constant` equivalent to `make_constant(1.28e-4_mag * miles)`.
+// `1.28e-4_mi` is a `Constant` equivalent to `make_constant(miles) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_mi() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/miles.hh
+++ b/au/units/literals/miles.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_mi() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(miles * operator""_mag<Cs...>());
+    return make_constant(miles) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/minutes.hh
+++ b/au/units/literals/minutes.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_min` is a `Constant` equivalent to `make_constant(1.28e-4_mag * minutes)`.
+// `1.28e-4_min` is a `Constant` equivalent to `make_constant(minutes) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_min() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/minutes.hh
+++ b/au/units/literals/minutes.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_min() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(minutes * operator""_mag<Cs...>());
+    return make_constant(minutes) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/moles.hh
+++ b/au/units/literals/moles.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_mol` is a `Constant` equivalent to `make_constant(1.28e-4_mag * moles)`.
+// `1.28e-4_mol` is a `Constant` equivalent to `make_constant(moles) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_mol() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/moles.hh
+++ b/au/units/literals/moles.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_mol() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(moles * operator""_mag<Cs...>());
+    return make_constant(moles) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/nautical_miles.hh
+++ b/au/units/literals/nautical_miles.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_nmi` is a `Constant` equivalent to `make_constant(1.28e-4_mag * nautical_miles)`.
+// `1.28e-4_nmi` is a `Constant` equivalent to `make_constant(nautical_miles) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_nmi() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/nautical_miles.hh
+++ b/au/units/literals/nautical_miles.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_nmi() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(nautical_miles * operator""_mag<Cs...>());
+    return make_constant(nautical_miles) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/newtons.hh
+++ b/au/units/literals/newtons.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_N` is a `Constant` equivalent to `make_constant(1.28e-4_mag * newtons)`.
+// `1.28e-4_N` is a `Constant` equivalent to `make_constant(newtons) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_N() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/newtons.hh
+++ b/au/units/literals/newtons.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_N() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(newtons * operator""_mag<Cs...>());
+    return make_constant(newtons) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/ohms.hh
+++ b/au/units/literals/ohms.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_ohm() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(ohms * operator""_mag<Cs...>());
+    return make_constant(ohms) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/ohms.hh
+++ b/au/units/literals/ohms.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_ohm` is a `Constant` equivalent to `make_constant(1.28e-4_mag * ohms)`.
+// `1.28e-4_ohm` is a `Constant` equivalent to `make_constant(ohms) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_ohm() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/pascals.hh
+++ b/au/units/literals/pascals.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_Pa` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pascals)`.
+// `1.28e-4_Pa` is a `Constant` equivalent to `make_constant(pascals) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_Pa() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/pascals.hh
+++ b/au/units/literals/pascals.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_Pa() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(pascals * operator""_mag<Cs...>());
+    return make_constant(pascals) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/percent.hh
+++ b/au/units/literals/percent.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_pct` is a `Constant` equivalent to `make_constant(1.28e-4_mag * percent)`.
+// `1.28e-4_pct` is a `Constant` equivalent to `make_constant(percent) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_pct() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/percent.hh
+++ b/au/units/literals/percent.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_pct() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(percent * operator""_mag<Cs...>());
+    return make_constant(percent) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/pounds_force.hh
+++ b/au/units/literals/pounds_force.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_lbf() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(pounds_force * operator""_mag<Cs...>());
+    return make_constant(pounds_force) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/pounds_force.hh
+++ b/au/units/literals/pounds_force.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_lbf` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pounds_force)`.
+// `1.28e-4_lbf` is a `Constant` equivalent to `make_constant(pounds_force) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_lbf() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/pounds_mass.hh
+++ b/au/units/literals/pounds_mass.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_lb() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(pounds_mass * operator""_mag<Cs...>());
+    return make_constant(pounds_mass) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/pounds_mass.hh
+++ b/au/units/literals/pounds_mass.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_lb` is a `Constant` equivalent to `make_constant(1.28e-4_mag * pounds_mass)`.
+// `1.28e-4_lb` is a `Constant` equivalent to `make_constant(pounds_mass) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_lb() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/radians.hh
+++ b/au/units/literals/radians.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_rad() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(radians * operator""_mag<Cs...>());
+    return make_constant(radians) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/radians.hh
+++ b/au/units/literals/radians.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_rad` is a `Constant` equivalent to `make_constant(1.28e-4_mag * radians)`.
+// `1.28e-4_rad` is a `Constant` equivalent to `make_constant(radians) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_rad() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/rankine.hh
+++ b/au/units/literals/rankine.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_degR` is a `Constant` equivalent to `make_constant(1.28e-4_mag * rankine)`.
+// `1.28e-4_degR` is a `Constant` equivalent to `make_constant(rankine) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_degR() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/rankine.hh
+++ b/au/units/literals/rankine.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_degR() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(rankine * operator""_mag<Cs...>());
+    return make_constant(rankine) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/revolutions.hh
+++ b/au/units/literals/revolutions.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_rev() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(revolutions * operator""_mag<Cs...>());
+    return make_constant(revolutions) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/revolutions.hh
+++ b/au/units/literals/revolutions.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_rev` is a `Constant` equivalent to `make_constant(1.28e-4_mag * revolutions)`.
+// `1.28e-4_rev` is a `Constant` equivalent to `make_constant(revolutions) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_rev() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/seconds.hh
+++ b/au/units/literals/seconds.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_s` is a `Constant` equivalent to `make_constant(1.28e-4_mag * seconds)`.
+// `1.28e-4_s` is a `Constant` equivalent to `make_constant(seconds) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_s() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/seconds.hh
+++ b/au/units/literals/seconds.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_s() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(seconds * operator""_mag<Cs...>());
+    return make_constant(seconds) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/siemens.hh
+++ b/au/units/literals/siemens.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_S` is a `Constant` equivalent to `make_constant(1.28e-4_mag * siemens)`.
+// `1.28e-4_S` is a `Constant` equivalent to `make_constant(siemens) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_S() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/siemens.hh
+++ b/au/units/literals/siemens.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_S() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(siemens * operator""_mag<Cs...>());
+    return make_constant(siemens) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/slugs.hh
+++ b/au/units/literals/slugs.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_slug` is a `Constant` equivalent to `make_constant(1.28e-4_mag * slugs)`.
+// `1.28e-4_slug` is a `Constant` equivalent to `make_constant(slugs) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_slug() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/slugs.hh
+++ b/au/units/literals/slugs.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_slug() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(slugs * operator""_mag<Cs...>());
+    return make_constant(slugs) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/standard_gravity.hh
+++ b/au/units/literals/standard_gravity.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_g_0` is a `Constant` equivalent to `make_constant(1.28e-4_mag * standard_gravity)`.
+// `1.28e-4_g_0` is a `Constant` equivalent to `make_constant(standard_gravity) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_g_0() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/standard_gravity.hh
+++ b/au/units/literals/standard_gravity.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_g_0() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(standard_gravity * operator""_mag<Cs...>());
+    return make_constant(standard_gravity) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/steradians.hh
+++ b/au/units/literals/steradians.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_sr` is a `Constant` equivalent to `make_constant(1.28e-4_mag * steradians)`.
+// `1.28e-4_sr` is a `Constant` equivalent to `make_constant(steradians) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_sr() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/steradians.hh
+++ b/au/units/literals/steradians.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_sr() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(steradians * operator""_mag<Cs...>());
+    return make_constant(steradians) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/tesla.hh
+++ b/au/units/literals/tesla.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_T() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(tesla * operator""_mag<Cs...>());
+    return make_constant(tesla) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/tesla.hh
+++ b/au/units/literals/tesla.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_T` is a `Constant` equivalent to `make_constant(1.28e-4_mag * tesla)`.
+// `1.28e-4_T` is a `Constant` equivalent to `make_constant(tesla) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_T() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/us_gallons.hh
+++ b/au/units/literals/us_gallons.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_US_gal() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(us_gallons * operator""_mag<Cs...>());
+    return make_constant(us_gallons) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/us_gallons.hh
+++ b/au/units/literals/us_gallons.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_US_gal` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_gallons)`.
+// `1.28e-4_US_gal` is a `Constant` equivalent to `make_constant(us_gallons) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_US_gal() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/us_pints.hh
+++ b/au/units/literals/us_pints.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_US_pt() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(us_pints * operator""_mag<Cs...>());
+    return make_constant(us_pints) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/us_pints.hh
+++ b/au/units/literals/us_pints.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_US_pt` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_pints)`.
+// `1.28e-4_US_pt` is a `Constant` equivalent to `make_constant(us_pints) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_US_pt() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/us_quarts.hh
+++ b/au/units/literals/us_quarts.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_US_qt` is a `Constant` equivalent to `make_constant(1.28e-4_mag * us_quarts)`.
+// `1.28e-4_US_qt` is a `Constant` equivalent to `make_constant(us_quarts) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_US_qt() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/us_quarts.hh
+++ b/au/units/literals/us_quarts.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_US_qt() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(us_quarts * operator""_mag<Cs...>());
+    return make_constant(us_quarts) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/volts.hh
+++ b/au/units/literals/volts.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_V` is a `Constant` equivalent to `make_constant(1.28e-4_mag * volts)`.
+// `1.28e-4_V` is a `Constant` equivalent to `make_constant(volts) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_V() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/volts.hh
+++ b/au/units/literals/volts.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_V() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(volts * operator""_mag<Cs...>());
+    return make_constant(volts) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/watts.hh
+++ b/au/units/literals/watts.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_W` is a `Constant` equivalent to `make_constant(1.28e-4_mag * watts)`.
+// `1.28e-4_W` is a `Constant` equivalent to `make_constant(watts) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_W() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/watts.hh
+++ b/au/units/literals/watts.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_W() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(watts * operator""_mag<Cs...>());
+    return make_constant(watts) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/webers.hh
+++ b/au/units/literals/webers.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_Wb` is a `Constant` equivalent to `make_constant(1.28e-4_mag * webers)`.
+// `1.28e-4_Wb` is a `Constant` equivalent to `make_constant(webers) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_Wb() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/webers.hh
+++ b/au/units/literals/webers.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_Wb() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(webers * operator""_mag<Cs...>());
+    return make_constant(webers) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/au/units/literals/yards.hh
+++ b/au/units/literals/yards.hh
@@ -21,7 +21,7 @@
 namespace au {
 namespace au_literals {
 
-// `1.28e-4_yd` is a `Constant` equivalent to `make_constant(1.28e-4_mag * yards)`.
+// `1.28e-4_yd` is a `Constant` equivalent to `make_constant(yards) * 1.28e-4_mag`.
 template <char... Cs>
 constexpr auto operator""_yd() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135

--- a/au/units/literals/yards.hh
+++ b/au/units/literals/yards.hh
@@ -26,7 +26,7 @@ template <char... Cs>
 constexpr auto operator""_yd() {
     // clang-format mangles operator"" template-ids: llvm/llvm-project#210135
     // clang-format off
-    return make_constant(yards * operator""_mag<Cs...>());
+    return make_constant(yards) * operator""_mag<Cs...>();
     // clang-format on
 }
 

--- a/docs/howto/new-units.md
+++ b/docs/howto/new-units.md
@@ -43,7 +43,7 @@ a complete sample definition of a new Unit, with these features annotated and ex
     namespace literals {                                            //  [7]
     template <char... Cs>
     constexpr auto operator""_ftm() {
-        return au::make_constant(fathoms * au::au_literals::operator""_mag<Cs...>());
+        return au::make_constant(fathoms) * au::au_literals::operator""_mag<Cs...>();
     }
     }
 
@@ -73,7 +73,7 @@ a complete sample definition of a new Unit, with these features annotated and ex
     namespace literals {                                            //  [7]
     template <char... Cs>
     constexpr auto operator""_ftm() {
-        return au::make_constant(fathoms * au::au_literals::operator""_mag<Cs...>());
+        return au::make_constant(fathoms) * au::au_literals::operator""_mag<Cs...>();
     }
     }
     ```
@@ -148,9 +148,9 @@ Here are the features.
       (UDL)](https://en.cppreference.com/w/cpp/language/user_literal) whose suffix matches the unit
       symbol, and which produces a [`Constant`](../reference/constant.md).  It forwards the numeric
       part of the literal to the [`_mag` literal](../reference/magnitude.md#_mag-literal), so
-      `1.28e-4_ftm` is equivalent to `make_constant(fathoms * 1.28e-4_mag)`.  See [Unit
+      `1.28e-4_ftm` is equivalent to `make_constant(fathoms) * 1.28e-4_mag`.  See [Unit
       literals](../reference/constant.md#unit-literals).
-    - **If omitted:** Users can still write `make_constant(fathoms * 1.28e-4_mag)` explicitly; they
+    - **If omitted:** Users can still write `make_constant(fathoms) * 1.28e-4_mag` explicitly; they
       just won't have the concise literal form.
 
 !!! note

--- a/docs/reference/constant.md
+++ b/docs/reference/constant.md
@@ -175,7 +175,7 @@ forwarded to the [`_mag` literal](./magnitude.md#_mag-literal), and the result i
 get from `make_constant`.  For example, `1.28e-4_s` is equivalent to:
 
 ```cpp
-make_constant(seconds * 1.28e-4_mag)
+make_constant(seconds) * 1.28e-4_mag
 ```
 
 This makes very concise, readable constants:


### PR DESCRIPTION
This makes the implementations more flexible.  It means they will still
work if `operator""_mag` returns `Zero`, which it soon will be able to.

Helps #748.  (We still need to cherry pick to the release branch.)